### PR TITLE
Make the version number in the about dialog clickable

### DIFF
--- a/ui/src/dialogs/AboutDialog.js
+++ b/ui/src/dialogs/AboutDialog.js
@@ -45,7 +45,7 @@ const AboutDialog = ({ open, onClose }) => {
                 <TableCell align="right" component="th" scope="row">
                   {translate('menu.version')}:
                 </TableCell>
-                {config.version == 'dev' ? (
+                {config.version === 'dev' ? (
                   <TableCell align="left"> {config.version} </TableCell>
                 ) : (
                   <TableCell align="left">

--- a/ui/src/dialogs/AboutDialog.js
+++ b/ui/src/dialogs/AboutDialog.js
@@ -49,14 +49,16 @@ const AboutDialog = ({ open, onClose }) => {
                   <TableCell align="left"> {config.version} </TableCell>
                 ) : (
                   <TableCell align="left">
-                    <Link 
-                    href={`https://github.com/navidrome/navidrome/releases/tag/v${config.version.split(' ')[0]}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
+                    <Link
+                      href={`https://github.com/navidrome/navidrome/releases/tag/v${
+                        config.version.split(' ')[0]
+                      }`}
+                      target="_blank"
+                      rel="noopener noreferrer"
                     >
                       {config.version.split(' ')[0]}
                     </Link>
-                    {' '+config.version.split(' ')[1]}
+                    {' ' + config.version.split(' ')[1]}
                   </TableCell>
                 )}
               </TableRow>

--- a/ui/src/dialogs/AboutDialog.js
+++ b/ui/src/dialogs/AboutDialog.js
@@ -45,7 +45,20 @@ const AboutDialog = ({ open, onClose }) => {
                 <TableCell align="right" component="th" scope="row">
                   {translate('menu.version')}:
                 </TableCell>
-                <TableCell align="left">{config.version}</TableCell>
+                {config.version == 'dev' ? (
+                  <TableCell align="left"> {config.version} </TableCell>
+                ) : (
+                  <TableCell align="left">
+                    <Link 
+                    href={`https://github.com/navidrome/navidrome/releases/tag/v${config.version.split(' ')[0]}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >
+                      {config.version.split(' ')[0]}
+                    </Link>
+                    {' '+config.version.split(' ')[1]}
+                  </TableCell>
+                )}
               </TableRow>
               {Object.keys(links).map((key) => {
                 return (


### PR DESCRIPTION
Referring to the issue:- https://github.com/navidrome/navidrome/issues/815

![Screenshot from 2021-03-12 02-59-59](https://user-images.githubusercontent.com/57208018/110859316-41e96780-82e1-11eb-9b6a-d5faf18640a3.png)
![Screenshot from 2021-03-12 03-02-17](https://user-images.githubusercontent.com/57208018/110859319-431a9480-82e1-11eb-8a8a-cb74bdb94f13.png)


