### PR TITLE
Make the version number clickable for the SNAPSHOT version in development docker build

### DIFF
--- a/ui/src/dialogs/AboutDialog.js
+++ b/ui/src/dialogs/AboutDialog.js
@@ -51,7 +51,7 @@ const AboutDialog = ({ open, onClose }) => {
                   <TableCell align="left">
                     <Link
                       href={`https://github.com/navidrome/navidrome/releases/tag/v${
-                        config.version.split(' ')[0]
+                        config.version.split(' ')[0].split('-')[0]
                       }`}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/ui/src/dialogs/AboutDialog.js
+++ b/ui/src/dialogs/AboutDialog.js
@@ -25,28 +25,24 @@ const links = {
   featureRequests: 'github.com/navidrome/navidrome/issues',
 }
 
-const LinkToVersion = ({ version, commitID, snapshotVersion }) => {
-  return version === 'dev' ? (
-    <TableCell align="left"> {version} </TableCell>
-  ) : (
+const LinkToVersion = ({ version }) => {
+  if (version === 'dev') {
+    return <TableCell align="left">{version}</TableCell>
+  }
+
+  const parts = version.split(' ')
+  const commitID = parts[1].replace(/[()]/g, '')
+  const isSnapshot = version.includes('SNAPSHOT')
+  const url = isSnapshot
+    ? `https://github.com/navidrome/navidrome/compare/v${
+        parts[0].split('-')[0]
+      }...${commitID}`
+    : `https://github.com/navidrome/navidrome/releases/tag/v${parts[0]}`
+  return (
     <TableCell align="left">
-      {version.includes('SNAPSHOT') ? (
-        <Link
-          href={`https://github.com/navidrome/navidrome/compare/v${snapshotVersion}...${commitID}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {version}
-        </Link>
-      ) : (
-        <Link
-          href={`https://github.com/navidrome/navidrome/releases/tag/v${version}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {version}
-        </Link>
-      )}
+      <Link href={url} target="_blank" rel="noopener noreferrer">
+        {parts[0]}
+      </Link>
       {' (' + commitID + ')'}
     </TableCell>
   )
@@ -54,13 +50,6 @@ const LinkToVersion = ({ version, commitID, snapshotVersion }) => {
 
 const AboutDialog = ({ open, onClose }) => {
   const translate = useTranslate()
-  const version =
-    config.version === 'dev' ? config.version : config.version.split(' ')[0]
-  const commitID =
-    version === 'dev' ? '' : config.version.split(' ')[1].replace(/[()]/g, '')
-  const snapshotVersion = version.includes('SNAPSHOT')
-    ? version.split('-')[0]
-    : ''
   return (
     <Dialog
       onClose={onClose}
@@ -79,11 +68,7 @@ const AboutDialog = ({ open, onClose }) => {
                 <TableCell align="right" component="th" scope="row">
                   {translate('menu.version')}:
                 </TableCell>
-                <LinkToVersion
-                  version={version}
-                  commitID={commitID}
-                  snapshotVersion={snapshotVersion}
-                />
+                <LinkToVersion version={config.version} />
               </TableRow>
               {Object.keys(links).map((key) => {
                 return (
@@ -141,4 +126,4 @@ AboutDialog.propTypes = {
   onClose: PropTypes.func.isRequired,
 }
 
-export { AboutDialog }
+export { AboutDialog, LinkToVersion }

--- a/ui/src/dialogs/AboutDialog.js
+++ b/ui/src/dialogs/AboutDialog.js
@@ -49,15 +49,29 @@ const AboutDialog = ({ open, onClose }) => {
                   <TableCell align="left"> {config.version} </TableCell>
                 ) : (
                   <TableCell align="left">
-                    <Link
-                      href={`https://github.com/navidrome/navidrome/releases/tag/v${
-                        config.version.split(' ')[0].split('-')[0]
-                      }`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      {config.version.split(' ')[0]}
-                    </Link>
+                    {config.version.includes('SNAPSHOT') ? (
+                      <Link
+                        href={`https://github.com/navidrome/navidrome/compare/v${
+                          config.version.split(' ')[0].split('-')[0]
+                        }...${config.version
+                          .split(' ')[1]
+                          .replace(/[()]/g, '')}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {config.version.split(' ')[0]}
+                      </Link>
+                    ) : (
+                      <Link
+                        href={`https://github.com/navidrome/navidrome/releases/tag/v${
+                          config.version.split(' ')[0].split('-')[0]
+                        }`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        {config.version.split(' ')[0]}
+                      </Link>
+                    )}
                     {' ' + config.version.split(' ')[1]}
                   </TableCell>
                 )}

--- a/ui/src/dialogs/AboutDialog.js
+++ b/ui/src/dialogs/AboutDialog.js
@@ -25,8 +25,42 @@ const links = {
   featureRequests: 'github.com/navidrome/navidrome/issues',
 }
 
+const LinkToVersion = ({ version, commitID, snapshotVersion }) => {
+  return version === 'dev' ? (
+    <TableCell align="left"> {version} </TableCell>
+  ) : (
+    <TableCell align="left">
+      {version.includes('SNAPSHOT') ? (
+        <Link
+          href={`https://github.com/navidrome/navidrome/compare/v${snapshotVersion}...${commitID}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {version}
+        </Link>
+      ) : (
+        <Link
+          href={`https://github.com/navidrome/navidrome/releases/tag/v${version}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {version}
+        </Link>
+      )}
+      {' (' + commitID + ')'}
+    </TableCell>
+  )
+}
+
 const AboutDialog = ({ open, onClose }) => {
   const translate = useTranslate()
+  const version =
+    config.version === 'dev' ? config.version : config.version.split(' ')[0]
+  const commitID =
+    version === 'dev' ? '' : config.version.split(' ')[1].replace(/[()]/g, '')
+  const snapshotVersion = version.includes('SNAPSHOT')
+    ? version.split('-')[0]
+    : ''
   return (
     <Dialog
       onClose={onClose}
@@ -45,36 +79,11 @@ const AboutDialog = ({ open, onClose }) => {
                 <TableCell align="right" component="th" scope="row">
                   {translate('menu.version')}:
                 </TableCell>
-                {config.version === 'dev' ? (
-                  <TableCell align="left"> {config.version} </TableCell>
-                ) : (
-                  <TableCell align="left">
-                    {config.version.includes('SNAPSHOT') ? (
-                      <Link
-                        href={`https://github.com/navidrome/navidrome/compare/v${
-                          config.version.split(' ')[0].split('-')[0]
-                        }...${config.version
-                          .split(' ')[1]
-                          .replace(/[()]/g, '')}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {config.version.split(' ')[0]}
-                      </Link>
-                    ) : (
-                      <Link
-                        href={`https://github.com/navidrome/navidrome/releases/tag/v${
-                          config.version.split(' ')[0].split('-')[0]
-                        }`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {config.version.split(' ')[0]}
-                      </Link>
-                    )}
-                    {' ' + config.version.split(' ')[1]}
-                  </TableCell>
-                )}
+                <LinkToVersion
+                  version={version}
+                  commitID={commitID}
+                  snapshotVersion={snapshotVersion}
+                />
               </TableRow>
               {Object.keys(links).map((key) => {
                 return (

--- a/ui/src/dialogs/AboutDialog.test.js
+++ b/ui/src/dialogs/AboutDialog.test.js
@@ -1,0 +1,54 @@
+import * as React from 'react'
+import { cleanup, render } from '@testing-library/react'
+import { LinkToVersion } from './AboutDialog'
+import TableBody from '@material-ui/core/TableBody'
+import TableRow from '@material-ui/core/TableRow'
+import Table from '@material-ui/core/Table'
+
+const Wrapper = ({ version }) => (
+  <Table>
+    <TableBody>
+      <TableRow>
+        <LinkToVersion version={version} />
+      </TableRow>
+    </TableBody>
+  </Table>
+)
+
+describe('<LinkToVersion />', () => {
+  afterEach(cleanup)
+
+  it('should not render any link for "dev" version', () => {
+    const version = 'dev'
+    const { queryByRole } = render(<Wrapper version={version} />)
+    expect(queryByRole('link')).toBeNull()
+  })
+
+  it('should render link to GH tag page for full releases', () => {
+    const version = '0.40.0 (300a0292)'
+    const { queryByRole } = render(<Wrapper version={version} />)
+
+    const link = queryByRole('link')
+    expect(link.href).toBe(
+      'https://github.com/navidrome/navidrome/releases/tag/v0.40.0'
+    )
+    expect(link.textContent).toBe('0.40.0')
+
+    const cell = queryByRole('cell')
+    expect(cell.textContent).toBe('0.40.0 (300a0292)')
+  })
+
+  it('should render link to GH comparison page for snapshot releases', () => {
+    const version = '0.40.0-SNAPSHOT (300a0292)'
+    const { queryByRole } = render(<Wrapper version={version} />)
+
+    const link = queryByRole('link')
+    expect(link.href).toBe(
+      'https://github.com/navidrome/navidrome/compare/v0.40.0...300a0292'
+    )
+    expect(link.textContent).toBe('0.40.0-SNAPSHOT')
+
+    const cell = queryByRole('cell')
+    expect(cell.textContent).toBe('0.40.0-SNAPSHOT (300a0292)')
+  })
+})


### PR DESCRIPTION
Referring to https://github.com/navidrome/navidrome/issues/815

![Screenshot from 2021-03-15 17-39-03](https://user-images.githubusercontent.com/57208018/111151367-5e252700-85b5-11eb-8a9e-6433fa901b36.png)
