### PR TITLE
Fix min-width in AlbumDetails

### DIFF
--- a/ui/src/album/AlbumDetails.js
+++ b/ui/src/album/AlbumDetails.js
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme) => ({
   root: {
     [theme.breakpoints.down('xs')]: {
       padding: '0.7em',
-      minWidth: '24em',
+      minWidth: '20em',
     },
     [theme.breakpoints.up('sm')]: {
       padding: '1em',


### PR DESCRIPTION
@deluan, I tried to reproduce issue #647 but could not reproduce the same for the Albums; however, I found a similar issue of the horizontal scroll on AlbumDetail, and have done a few edits in the min-width of AlbumDetails.js.
Screenshot of the error page:
<img width="211" alt="navid_error" src="https://user-images.githubusercontent.com/61188295/111179394-0c3eca00-85d2-11eb-9386-40369c3a8116.png">

Page after the fix:
<img width="211" alt="navid_errf" src="https://user-images.githubusercontent.com/61188295/111179478-21b3f400-85d2-11eb-8b7f-be5bab494224.png">

Please feel free to provide feedback.

Thank you!