### PR TITLE
Use Go 1.16 fs package for FS interaction

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -49,12 +49,13 @@ func CreateSubsonicAPIRouter() *subsonic.Router {
 }
 
 func createScanner() scanner.Scanner {
+	fs := core.NewFS()
 	dataStore := persistence.New()
 	artworkCache := core.GetImageCache()
 	artwork := core.NewArtwork(dataStore, artworkCache)
 	cacheWarmer := core.NewCacheWarmer(artwork, artworkCache)
 	broker := GetBroker()
-	scannerScanner := scanner.New(dataStore, cacheWarmer, broker)
+	scannerScanner := scanner.New(fs, dataStore, cacheWarmer, broker)
 	return scannerScanner
 }
 

--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -35,11 +35,12 @@ func CreateAppRouter() *app.Router {
 
 func CreateSubsonicAPIRouter() *subsonic.Router {
 	dataStore := persistence.New()
+	fs := core.NewFS()
 	artworkCache := core.GetImageCache()
-	artwork := core.NewArtwork(dataStore, artworkCache)
+	artwork := core.NewArtwork(dataStore, fs, artworkCache)
 	transcoderTranscoder := transcoder.New()
 	transcodingCache := core.GetTranscodingCache()
-	mediaStreamer := core.NewMediaStreamer(dataStore, transcoderTranscoder, transcodingCache)
+	mediaStreamer := core.NewMediaStreamer(dataStore, fs, transcoderTranscoder, transcodingCache)
 	archiver := core.NewArchiver(dataStore)
 	players := core.NewPlayers(dataStore)
 	externalMetadata := core.NewExternalMetadata(dataStore)
@@ -52,7 +53,7 @@ func createScanner() scanner.Scanner {
 	fs := core.NewFS()
 	dataStore := persistence.New()
 	artworkCache := core.GetImageCache()
-	artwork := core.NewArtwork(dataStore, artworkCache)
+	artwork := core.NewArtwork(dataStore, fs, artworkCache)
 	cacheWarmer := core.NewCacheWarmer(artwork, artworkCache)
 	broker := GetBroker()
 	scannerScanner := scanner.New(fs, dataStore, cacheWarmer, broker)

--- a/cmd/wire_injectors.go
+++ b/cmd/wire_injectors.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/google/wire"
+
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/persistence"
 	"github.com/navidrome/navidrome/scanner"

--- a/core/archiver.go
+++ b/core/archiver.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
+	"io/fs"
 	"path/filepath"
 
 	"github.com/Masterminds/squirrel"
@@ -24,7 +24,8 @@ func NewArchiver(ds model.DataStore) Archiver {
 }
 
 type archiver struct {
-	ds model.DataStore
+	ds   model.DataStore
+	fsys fs.FS
 }
 
 type createHeader func(idx int, mf model.MediaFile) *zip.FileHeader
@@ -95,7 +96,7 @@ func (a *archiver) addFileToZip(ctx context.Context, z *zip.Writer, mf model.Med
 		log.Error(ctx, "Error creating zip entry", "file", mf.Path, err)
 		return err
 	}
-	f, err := os.Open(mf.Path)
+	f, err := a.fsys.Open(mf.Path)
 	defer func() { _ = f.Close() }()
 	if err != nil {
 		log.Error(ctx, "Error opening file for zipping", "file", mf.Path, err)

--- a/core/artwork_test.go
+++ b/core/artwork_test.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"image"
 	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Artwork", func() {
+	dirFS := os.DirFS(".")
 	var artwork Artwork
 	var ds model.DataStore
 	ctx := log.NewContext(context.TODO())
@@ -37,7 +40,7 @@ var _ = Describe("Artwork", func() {
 			conf.Server.ImageCacheSize = "100MB"
 			cache := GetImageCache()
 			Eventually(func() bool { return cache.Ready(context.TODO()) }).Should(BeTrue())
-			artwork = NewArtwork(ds, cache)
+			artwork = NewArtwork(ds, dirFS, cache)
 		})
 
 		It("retrieves the external artwork art for an album", func() {

--- a/core/fs.go
+++ b/core/fs.go
@@ -1,0 +1,10 @@
+package core
+
+import (
+	"io/fs"
+	"os"
+)
+
+func NewFS() fs.FS {
+	return os.DirFS(".")
+}

--- a/core/media_streamer_test.go
+++ b/core/media_streamer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"os"
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
@@ -20,6 +21,7 @@ var _ = Describe("MediaStreamer", func() {
 	var ds model.DataStore
 	ffmpeg := &fakeFFmpeg{Data: "fake data"}
 	ctx := log.NewContext(context.TODO())
+	dirFS := os.DirFS(".")
 
 	BeforeEach(func() {
 		conf.Server.DataFolder, _ = ioutil.TempDir("", "file_caches")
@@ -30,7 +32,7 @@ var _ = Describe("MediaStreamer", func() {
 		})
 		testCache := GetTranscodingCache()
 		Eventually(func() bool { return testCache.Ready(context.TODO()) }).Should(BeTrue())
-		streamer = NewMediaStreamer(ds, ffmpeg, testCache)
+		streamer = NewMediaStreamer(ds, dirFS, ffmpeg, testCache)
 	})
 
 	Context("NewStream", func() {

--- a/core/wire_providers.go
+++ b/core/wire_providers.go
@@ -16,4 +16,5 @@ var Set = wire.NewSet(
 	NewCacheWarmer,
 	NewPlayers,
 	transcoder.New,
+	NewFS,
 )

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -17,10 +17,11 @@ import (
 
 var _ = Describe("AlbumRepository", func() {
 	var repo model.AlbumRepository
+	dirFS := os.DirFS(".")
 
 	BeforeEach(func() {
 		ctx := request.WithUser(log.NewContext(context.TODO()), model.User{ID: "userid", UserName: "johndoe"})
-		repo = NewAlbumRepository(ctx, orm.NewOrm())
+		repo = NewAlbumRepository(ctx, dirFS, orm.NewOrm())
 	})
 
 	Describe("Get", func() {
@@ -117,32 +118,32 @@ var _ = Describe("AlbumRepository", func() {
 		embeddedPath := filepath.Join(testFolder, "somefile.mp3")
 		It("returns audio file for embedded cover", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.*, front.*"
-			Expect(getCoverFromPath(testPath, embeddedPath)).To(Equal(""))
+			Expect(getCoverFromPath(dirFS, testPath, embeddedPath)).To(Equal(""))
 		})
 
 		It("returns external file when no embedded cover exists", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.*, front.*"
-			Expect(getCoverFromPath(testPath, "")).To(Equal(filepath.Join(testFolder, "Cover.jpeg")))
+			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(filepath.Join(testFolder, "Cover.jpeg")))
 		})
 
 		It("returns embedded cover even if not first choice", func() {
 			conf.Server.CoverArtPriority = "something.png, embedded, cover.*, front.*"
-			Expect(getCoverFromPath(testPath, embeddedPath)).To(Equal(""))
+			Expect(getCoverFromPath(dirFS, testPath, embeddedPath)).To(Equal(""))
 		})
 
 		It("returns first correct match case-insensitively", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.jpg, front.svg, front.png"
-			Expect(getCoverFromPath(testPath, "")).To(Equal(filepath.Join(testFolder, "FRONT.PNG")))
+			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(filepath.Join(testFolder, "FRONT.PNG")))
 		})
 
 		It("returns match for embedded pattern", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.jp?g, front.png"
-			Expect(getCoverFromPath(testPath, "")).To(Equal(filepath.Join(testFolder, "Cover.jpeg")))
+			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(filepath.Join(testFolder, "Cover.jpeg")))
 		})
 
 		It("returns empty string if no match was found", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.jpg, front.apng"
-			Expect(getCoverFromPath(testPath, "")).To(Equal(""))
+			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(""))
 		})
 
 		// Reset configuration to default.

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -7,12 +7,13 @@ import (
 	"path/filepath"
 
 	"github.com/astaxie/beego/orm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("AlbumRepository", func() {
@@ -114,36 +115,37 @@ var _ = Describe("AlbumRepository", func() {
 			panic(err)
 		}
 
-		testPath := filepath.Join(testFolder, "somefile.test")
-		embeddedPath := filepath.Join(testFolder, "somefile.mp3")
+		testFS := os.DirFS(testFolder)
+		testPath := "somefile.test"
+		embeddedPath := "somefile.mp3"
 		It("returns audio file for embedded cover", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.*, front.*"
-			Expect(getCoverFromPath(dirFS, testPath, embeddedPath)).To(Equal(""))
+			Expect(getCoverFromPath(testFS, testPath, embeddedPath)).To(Equal(""))
 		})
 
 		It("returns external file when no embedded cover exists", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.*, front.*"
-			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(filepath.Join(testFolder, "Cover.jpeg")))
+			Expect(getCoverFromPath(testFS, testPath, "")).To(Equal("Cover.jpeg"))
 		})
 
 		It("returns embedded cover even if not first choice", func() {
 			conf.Server.CoverArtPriority = "something.png, embedded, cover.*, front.*"
-			Expect(getCoverFromPath(dirFS, testPath, embeddedPath)).To(Equal(""))
+			Expect(getCoverFromPath(testFS, testPath, embeddedPath)).To(Equal(""))
 		})
 
 		It("returns first correct match case-insensitively", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.jpg, front.svg, front.png"
-			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(filepath.Join(testFolder, "FRONT.PNG")))
+			Expect(getCoverFromPath(testFS, testPath, "")).To(Equal("FRONT.PNG"))
 		})
 
 		It("returns match for embedded pattern", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.jp?g, front.png"
-			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(filepath.Join(testFolder, "Cover.jpeg")))
+			Expect(getCoverFromPath(testFS, testPath, "")).To(Equal("Cover.jpeg"))
 		})
 
 		It("returns empty string if no match was found", func() {
 			conf.Server.CoverArtPriority = "embedded, cover.jpg, front.apng"
-			Expect(getCoverFromPath(dirFS, testPath, "")).To(Equal(""))
+			Expect(getCoverFromPath(testFS, testPath, "")).To(Equal(""))
 		})
 
 		// Reset configuration to default.

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"io/fs"
 	"reflect"
 
 	"github.com/astaxie/beego/orm"
@@ -11,7 +12,8 @@ import (
 )
 
 type SQLStore struct {
-	orm orm.Ormer
+	orm  orm.Ormer
+	fsys fs.FS
 }
 
 func New() model.DataStore {
@@ -19,7 +21,7 @@ func New() model.DataStore {
 }
 
 func (s *SQLStore) Album(ctx context.Context) model.AlbumRepository {
-	return NewAlbumRepository(ctx, s.getOrmer())
+	return NewAlbumRepository(ctx, s.fsys, s.getOrmer())
 }
 
 func (s *SQLStore) Artist(ctx context.Context) model.ArtistRepository {

--- a/persistence/persistence_suite_test.go
+++ b/persistence/persistence_suite_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -81,6 +82,7 @@ func P(path string) string {
 }
 
 var _ = Describe("Initialize test DB", func() {
+	dirFS := os.DirFS(".")
 
 	// TODO Load this data setup from file(s)
 	BeforeSuite(func() {
@@ -96,7 +98,7 @@ var _ = Describe("Initialize test DB", func() {
 			}
 		}
 
-		alr := NewAlbumRepository(ctx, o).(*albumRepository)
+		alr := NewAlbumRepository(ctx, dirFS, o).(*albumRepository)
 		for i := range testAlbums {
 			a := testAlbums[i]
 			_, err := alr.put(a.ID, &a)

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -3,7 +3,6 @@ package persistence
 import (
 	"context"
 	"fmt"
-	"io/fs"
 	"strings"
 	"time"
 
@@ -18,7 +17,6 @@ import (
 
 type sqlRepository struct {
 	ctx          context.Context
-	fsys         fs.FS
 	tableName    string
 	ormer        orm.Ormer
 	sortMappings map[string]string

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -3,12 +3,14 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"strings"
 	"time"
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/astaxie/beego/orm"
 	"github.com/google/uuid"
+
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
@@ -16,6 +18,7 @@ import (
 
 type sqlRepository struct {
 	ctx          context.Context
+	fsys         fs.FS
 	tableName    string
 	ormer        orm.Ormer
 	sortMappings map[string]string

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -2,6 +2,7 @@ package metadata
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"regexp"
@@ -18,8 +19,10 @@ type Extractor interface {
 	Extract(files ...string) (map[string]Metadata, error)
 }
 
-func Extract(files ...string) (map[string]Metadata, error) {
+func Extract(fsys fs.FS, files ...string) (map[string]Metadata, error) {
 	var e Extractor
+
+	//panic("not implemented")
 
 	switch conf.Server.Scanner.Extractor {
 	case "taglib":

--- a/scanner/metadata/taglib.go
+++ b/scanner/metadata/taglib.go
@@ -1,83 +1,13 @@
+//+build !cgo
+
 package metadata
 
 import (
-	"errors"
-	"os"
-
-	"github.com/dhowden/tag"
-	"github.com/navidrome/navidrome/log"
-	"github.com/navidrome/navidrome/scanner/metadata/taglib"
+	"fmt"
 )
-
-type taglibMetadata struct {
-	baseMetadata
-	hasPicture bool
-}
-
-func (m *taglibMetadata) Title() string  { return m.getTag("title", "titlesort", "_track") }
-func (m *taglibMetadata) Album() string  { return m.getTag("album", "albumsort", "_album") }
-func (m *taglibMetadata) Artist() string { return m.getTag("artist", "artistsort", "_artist") }
-func (m *taglibMetadata) Genre() string  { return m.getTag("genre", "_genre") }
-func (m *taglibMetadata) Year() int      { return m.parseYear("date", "_year") }
-func (m *taglibMetadata) TrackNumber() (int, int) {
-	return m.parseTuple("track", "tracknumber", "_track")
-}
-func (m *taglibMetadata) Duration() float32 { return m.parseFloat("length") }
-func (m *taglibMetadata) BitRate() int      { return m.parseInt("bitrate") }
-func (m *taglibMetadata) HasPicture() bool  { return m.hasPicture }
 
 type taglibExtractor struct{}
 
 func (e *taglibExtractor) Extract(paths ...string) (map[string]Metadata, error) {
-	mds := map[string]Metadata{}
-	for _, path := range paths {
-		md, err := e.extractMetadata(path)
-		if err == nil {
-			mds[path] = md
-		}
-	}
-	return mds, nil
+	return nil, fmt.Errorf("compiled without CGO")
 }
-
-func (e *taglibExtractor) extractMetadata(filePath string) (*taglibMetadata, error) {
-	var err error
-	md := &taglibMetadata{}
-	md.filePath = filePath
-	md.fileInfo, err = os.Stat(filePath)
-	if err != nil {
-		log.Warn("Error stating file. Skipping", "filePath", filePath, err)
-		return nil, errors.New("error stating file")
-	}
-	md.tags, err = taglib.Read(filePath)
-	if err != nil {
-		log.Warn("Error reading metadata from file. Skipping", "filePath", filePath, err)
-		return nil, errors.New("error reading tags")
-	}
-	md.hasPicture = hasEmbeddedImage(filePath)
-	return md, nil
-}
-
-func hasEmbeddedImage(path string) bool {
-	defer func() {
-		if r := recover(); r != nil {
-			log.Error("Panic while checking for images. Please report this error with a copy of the file", "path", path, r)
-		}
-	}()
-	f, err := os.Open(path)
-	if err != nil {
-		log.Warn("Error opening file", "filePath", path, err)
-		return false
-	}
-	defer f.Close()
-
-	m, err := tag.ReadFrom(f)
-	if err != nil {
-		log.Warn("Error reading picture tag from file", "filePath", path, err)
-		return false
-	}
-
-	return m.Picture() != nil
-}
-
-var _ Metadata = (*taglibMetadata)(nil)
-var _ Extractor = (*taglibExtractor)(nil)

--- a/scanner/metadata/taglib/taglib_parser.go
+++ b/scanner/metadata/taglib/taglib_parser.go
@@ -1,3 +1,5 @@
+//+build cgo
+
 package taglib
 
 /*

--- a/scanner/metadata/taglib_cgo.go
+++ b/scanner/metadata/taglib_cgo.go
@@ -1,0 +1,85 @@
+//+build cgo
+
+package metadata
+
+import (
+	"errors"
+	"os"
+
+	"github.com/dhowden/tag"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/scanner/metadata/taglib"
+)
+
+type taglibMetadata struct {
+	baseMetadata
+	hasPicture bool
+}
+
+func (m *taglibMetadata) Title() string  { return m.getTag("title", "titlesort", "_track") }
+func (m *taglibMetadata) Album() string  { return m.getTag("album", "albumsort", "_album") }
+func (m *taglibMetadata) Artist() string { return m.getTag("artist", "artistsort", "_artist") }
+func (m *taglibMetadata) Genre() string  { return m.getTag("genre", "_genre") }
+func (m *taglibMetadata) Year() int      { return m.parseYear("date", "_year") }
+func (m *taglibMetadata) TrackNumber() (int, int) {
+	return m.parseTuple("track", "tracknumber", "_track")
+}
+func (m *taglibMetadata) Duration() float32 { return m.parseFloat("length") }
+func (m *taglibMetadata) BitRate() int      { return m.parseInt("bitrate") }
+func (m *taglibMetadata) HasPicture() bool  { return m.hasPicture }
+
+type taglibExtractor struct{}
+
+func (e *taglibExtractor) Extract(paths ...string) (map[string]Metadata, error) {
+	mds := map[string]Metadata{}
+	for _, path := range paths {
+		md, err := e.extractMetadata(path)
+		if err == nil {
+			mds[path] = md
+		}
+	}
+	return mds, nil
+}
+
+func (e *taglibExtractor) extractMetadata(filePath string) (*taglibMetadata, error) {
+	var err error
+	md := &taglibMetadata{}
+	md.filePath = filePath
+	md.fileInfo, err = os.Stat(filePath)
+	if err != nil {
+		log.Warn("Error stating file. Skipping", "filePath", filePath, err)
+		return nil, errors.New("error stating file")
+	}
+	md.tags, err = taglib.Read(filePath)
+	if err != nil {
+		log.Warn("Error reading metadata from file. Skipping", "filePath", filePath, err)
+		return nil, errors.New("error reading tags")
+	}
+	md.hasPicture = hasEmbeddedImage(filePath)
+	return md, nil
+}
+
+func hasEmbeddedImage(path string) bool {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("Panic while checking for images. Please report this error with a copy of the file", "path", path, r)
+		}
+	}()
+	f, err := os.Open(path)
+	if err != nil {
+		log.Warn("Error opening file", "filePath", path, err)
+		return false
+	}
+	defer f.Close()
+
+	m, err := tag.ReadFrom(f)
+	if err != nil {
+		log.Warn("Error reading picture tag from file", "filePath", path, err)
+		return false
+	}
+
+	return m.Picture() != nil
+}
+
+var _ Metadata = (*taglibMetadata)(nil)
+var _ Extractor = (*taglibExtractor)(nil)

--- a/scanner/playlist_sync.go
+++ b/scanner/playlist_sync.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,7 +17,8 @@ import (
 )
 
 type playlistSync struct {
-	ds model.DataStore
+	ds   model.DataStore
+	fsys fs.FS
 }
 
 func newPlaylistSync(ds model.DataStore) *playlistSync {
@@ -26,7 +27,7 @@ func newPlaylistSync(ds model.DataStore) *playlistSync {
 
 func (s *playlistSync) processPlaylists(ctx context.Context, dir string) int64 {
 	var count int64
-	files, err := ioutil.ReadDir(dir)
+	files, err := fs.ReadDir(s.fsys, dir)
 	if err != nil {
 		log.Error(ctx, "Error reading files", "dir", dir, err)
 		return count
@@ -52,7 +53,7 @@ func (s *playlistSync) processPlaylists(ctx context.Context, dir string) int64 {
 
 func (s *playlistSync) parsePlaylist(ctx context.Context, playlistFile string, baseDir string) (*model.Playlist, error) {
 	playlistPath := filepath.Join(baseDir, playlistFile)
-	file, err := os.Open(playlistPath)
+	file, err := s.fsys.Open(playlistPath)
 	if err != nil {
 		return nil, err
 	}

--- a/scanner/playlist_sync.go
+++ b/scanner/playlist_sync.go
@@ -21,8 +21,8 @@ type playlistSync struct {
 	fsys fs.FS
 }
 
-func newPlaylistSync(ds model.DataStore) *playlistSync {
-	return &playlistSync{ds: ds}
+func newPlaylistSync(ds model.DataStore, fsys fs.FS) *playlistSync {
+	return &playlistSync{ds: ds, fsys: fsys}
 }
 
 func (s *playlistSync) processPlaylists(ctx context.Context, dir string) int64 {

--- a/scanner/playlist_sync_test.go
+++ b/scanner/playlist_sync_test.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"os"
 
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
@@ -10,6 +11,7 @@ import (
 )
 
 var _ = Describe("playlistSync", func() {
+	dirFS := os.DirFS(".")
 	Describe("parsePlaylist", func() {
 		var ds model.DataStore
 		var ps *playlistSync
@@ -18,7 +20,7 @@ var _ = Describe("playlistSync", func() {
 			ds = &tests.MockDataStore{
 				MockedMediaFile: &mockedMediaFile{},
 			}
-			ps = newPlaylistSync(ds)
+			ps = newPlaylistSync(ds, dirFS)
 		})
 
 		It("parses well-formed playlists", func() {

--- a/scanner/tag_scanner.go
+++ b/scanner/tag_scanner.go
@@ -33,7 +33,7 @@ func NewTagScanner(fsys fs.FS, rootFolder string, ds model.DataStore, cacheWarme
 		fsys:        fsys,
 		rootFolder:  rootFolder,
 		mapper:      newMediaFileMapper(rootFolder),
-		plsSync:     newPlaylistSync(ds),
+		plsSync:     newPlaylistSync(ds, fsys),
 		ds:          ds,
 		cacheWarmer: cacheWarmer,
 	}

--- a/scanner/tag_scanner_test.go
+++ b/scanner/tag_scanner_test.go
@@ -1,14 +1,18 @@
 package scanner
 
 import (
+	"os"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("TagScanner", func() {
+	dirFS := os.DirFS(".")
+
 	Describe("loadAllAudioFiles", func() {
 		It("return all audio files from the folder", func() {
-			files, err := loadAllAudioFiles("tests/fixtures")
+			files, err := loadAllAudioFiles(dirFS, "tests/fixtures")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(files).To(HaveLen(3))
 			Expect(files).To(HaveKey("tests/fixtures/test.ogg"))
@@ -19,12 +23,12 @@ var _ = Describe("TagScanner", func() {
 		})
 
 		It("returns error if path does not exist", func() {
-			_, err := loadAllAudioFiles("./INVALID/PATH")
+			_, err := loadAllAudioFiles(dirFS, "./INVALID/PATH")
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns empty map if there are no audio files in path", func() {
-			Expect(loadAllAudioFiles("tests/fixtures/empty_folder")).To(BeEmpty())
+			Expect(loadAllAudioFiles(dirFS, "tests/fixtures/empty_folder")).To(BeEmpty())
 		})
 	})
 })

--- a/scanner/walk_dir_tree.go
+++ b/scanner/walk_dir_tree.go
@@ -2,7 +2,7 @@ package scanner
 
 import (
 	"context"
-	"io/ioutil"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -24,8 +24,8 @@ type (
 	walkResults = chan dirStats
 )
 
-func walkDirTree(ctx context.Context, rootFolder string, results walkResults) error {
-	err := walkFolder(ctx, rootFolder, rootFolder, results)
+func walkDirTree(ctx context.Context, fsys fs.FS, rootFolder string, results walkResults) error {
+	err := walkFolder(ctx, fsys, rootFolder, rootFolder, results)
 	if err != nil {
 		log.Error(ctx, "Error loading directory tree", err)
 	}
@@ -33,13 +33,13 @@ func walkDirTree(ctx context.Context, rootFolder string, results walkResults) er
 	return err
 }
 
-func walkFolder(ctx context.Context, rootPath string, currentFolder string, results walkResults) error {
-	children, stats, err := loadDir(ctx, currentFolder)
+func walkFolder(ctx context.Context, fsys fs.FS, rootPath string, currentFolder string, results walkResults) error {
+	children, stats, err := loadDir(ctx, fsys, currentFolder)
 	if err != nil {
 		return err
 	}
 	for _, c := range children {
-		err := walkFolder(ctx, rootPath, c, results)
+		err := walkFolder(ctx, fsys, rootPath, c, results)
 		if err != nil {
 			return err
 		}
@@ -54,31 +54,41 @@ func walkFolder(ctx context.Context, rootPath string, currentFolder string, resu
 	return nil
 }
 
-func loadDir(ctx context.Context, dirPath string) (children []string, stats dirStats, err error) {
-	dirInfo, err := os.Stat(dirPath)
+func loadDir(ctx context.Context, fsys fs.FS, dirPath string) (children []string, stats dirStats, err error) {
+	dirInfo, err := fs.Stat(fsys, dirPath)
 	if err != nil {
 		log.Error(ctx, "Error stating dir", "path", dirPath, err)
 		return
 	}
 	stats.ModTime = dirInfo.ModTime()
 
-	files, err := ioutil.ReadDir(dirPath)
+	files, err := fs.ReadDir(fsys, dirPath)
 	if err != nil {
 		log.Error(ctx, "Error reading dir", "path", dirPath, err)
 		return
 	}
 	for _, f := range files {
-		isDir, err := isDirOrSymlinkToDir(dirPath, f)
+		info, err := f.Info()
+		if err != nil {
+			log.Error(ctx, "Error reading dir entry", "dir", f.Name())
+			continue
+		}
+		isDir, err := isDirOrSymlinkToDir(fsys, dirPath, info)
 		// Skip invalid symlinks
 		if err != nil {
 			log.Error(ctx, "Invalid symlink", "dir", dirPath)
 			continue
 		}
-		if isDir && !isDirIgnored(dirPath, f) && isDirReadable(dirPath, f) {
+		if isDir && !isDirIgnored(fsys, dirPath, info) && isDirReadable(fsys, dirPath, info) {
 			children = append(children, filepath.Join(dirPath, f.Name()))
 		} else {
-			if f.ModTime().After(stats.ModTime) {
-				stats.ModTime = f.ModTime()
+			info, err := f.Info()
+			if err != nil {
+				log.Error(ctx, "Error dirEntry", "entry", filepath.Join(dirPath, f.Name()))
+				continue
+			}
+			if info.ModTime().After(stats.ModTime) {
+				stats.ModTime = info.ModTime()
 			}
 			if utils.IsAudioFile(f.Name()) {
 				stats.AudioFilesCount++
@@ -96,35 +106,35 @@ func loadDir(ctx context.Context, dirPath string) (children []string, stats dirS
 // is not a directory but is a symbolic link, this method will resolve by
 // sending a request to the operating system to follow the symbolic link.
 // Copied from github.com/karrick/godirwalk
-func isDirOrSymlinkToDir(baseDir string, dirInfo os.FileInfo) (bool, error) {
-	if dirInfo.IsDir() {
+func isDirOrSymlinkToDir(fsys fs.FS, baseDir string, dirEntry fs.FileInfo) (bool, error) {
+	if dirEntry.IsDir() {
 		return true, nil
 	}
-	if dirInfo.Mode()&os.ModeSymlink == 0 {
+	if dirEntry.Mode().Type()&os.ModeSymlink == 0 {
 		return false, nil
 	}
 	// Does this symlink point to a directory?
-	dirInfo, err := os.Stat(filepath.Join(baseDir, dirInfo.Name()))
+	fileInfo, err := fs.Stat(fsys, filepath.Join(baseDir, dirEntry.Name()))
 	if err != nil {
 		return false, err
 	}
-	return dirInfo.IsDir(), nil
+	return fileInfo.IsDir(), nil
 }
 
 // isDirIgnored returns true if the directory represented by dirInfo contains an
 // `ignore` file (named after consts.SkipScanFile)
-func isDirIgnored(baseDir string, dirInfo os.FileInfo) bool {
+func isDirIgnored(fsys fs.FS, baseDir string, dirInfo fs.FileInfo) bool {
 	if strings.HasPrefix(dirInfo.Name(), ".") {
 		return true
 	}
-	_, err := os.Stat(filepath.Join(baseDir, dirInfo.Name(), consts.SkipScanFile))
+	_, err := fs.Stat(fsys, filepath.Join(baseDir, dirInfo.Name(), consts.SkipScanFile))
 	return err == nil
 }
 
 // isDirReadable returns true if the directory represented by dirInfo is readable
-func isDirReadable(baseDir string, dirInfo os.FileInfo) bool {
+func isDirReadable(fsys fs.FS, baseDir string, dirInfo fs.FileInfo) bool {
 	path := filepath.Join(baseDir, dirInfo.Name())
-	res, err := utils.IsDirReadable(path)
+	res, err := utils.IsDirReadable(fsys, path)
 	if !res {
 		log.Debug("Warning: Skipping unreadable directory", "path", path, err)
 	}

--- a/scanner/walk_dir_tree_test.go
+++ b/scanner/walk_dir_tree_test.go
@@ -2,6 +2,7 @@ package scanner
 
 import (
 	"context"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -11,6 +12,7 @@ import (
 )
 
 var _ = Describe("load_tree", func() {
+	dirFS := os.DirFS(".")
 
 	Describe("walkDirTree", func() {
 		It("reads all info correctly", func() {
@@ -18,7 +20,7 @@ var _ = Describe("load_tree", func() {
 			results := make(walkResults, 5000)
 			var err error
 			go func() {
-				err = walkDirTree(context.TODO(), "tests/fixtures", results)
+				err = walkDirTree(context.TODO(), dirFS, "tests/fixtures", results)
 			}()
 
 			for {
@@ -43,36 +45,36 @@ var _ = Describe("load_tree", func() {
 
 	Describe("isDirOrSymlinkToDir", func() {
 		It("returns true for normal dirs", func() {
-			dir, _ := os.Stat("tests/fixtures")
-			Expect(isDirOrSymlinkToDir("tests", dir)).To(BeTrue())
+			dir, _ := fs.Stat(dirFS, "tests/fixtures")
+			Expect(isDirOrSymlinkToDir(dirFS, "tests", dir)).To(BeTrue())
 		})
 		It("returns true for symlinks to dirs", func() {
-			dir, _ := os.Stat("tests/fixtures/symlink2dir")
-			Expect(isDirOrSymlinkToDir("tests/fixtures", dir)).To(BeTrue())
+			dir, _ := fs.Stat(dirFS, "tests/fixtures/symlink2dir")
+			Expect(isDirOrSymlinkToDir(dirFS, "tests/fixtures", dir)).To(BeTrue())
 		})
 		It("returns false for files", func() {
-			dir, _ := os.Stat("tests/fixtures/test.mp3")
-			Expect(isDirOrSymlinkToDir("tests/fixtures", dir)).To(BeFalse())
+			dir, _ := fs.Stat(dirFS, "tests/fixtures/test.mp3")
+			Expect(isDirOrSymlinkToDir(dirFS, "tests/fixtures", dir)).To(BeFalse())
 		})
 		It("returns false for symlinks to files", func() {
-			dir, _ := os.Stat("tests/fixtures/symlink")
-			Expect(isDirOrSymlinkToDir("tests/fixtures", dir)).To(BeFalse())
+			dir, _ := fs.Stat(dirFS, "tests/fixtures/symlink")
+			Expect(isDirOrSymlinkToDir(dirFS, "tests/fixtures", dir)).To(BeFalse())
 		})
 	})
 
 	Describe("isDirIgnored", func() {
 		baseDir := filepath.Join("tests", "fixtures")
 		It("returns false for normal dirs", func() {
-			dir, _ := os.Stat(filepath.Join(baseDir, "empty_folder"))
-			Expect(isDirIgnored(baseDir, dir)).To(BeFalse())
+			dir, _ := fs.Stat(dirFS, filepath.Join(baseDir, "empty_folder"))
+			Expect(isDirIgnored(dirFS, baseDir, dir)).To(BeFalse())
 		})
 		It("returns true when folder contains .ndignore file", func() {
-			dir, _ := os.Stat(filepath.Join(baseDir, "ignored_folder"))
-			Expect(isDirIgnored(baseDir, dir)).To(BeTrue())
+			dir, _ := fs.Stat(dirFS, filepath.Join(baseDir, "ignored_folder"))
+			Expect(isDirIgnored(dirFS, baseDir, dir)).To(BeTrue())
 		})
 		It("returns true when folder name starts with a `.`", func() {
-			dir, _ := os.Stat(filepath.Join(baseDir, ".hidden_folder"))
-			Expect(isDirIgnored(baseDir, dir)).To(BeTrue())
+			dir, _ := fs.Stat(dirFS, filepath.Join(baseDir, ".hidden_folder"))
+			Expect(isDirIgnored(dirFS, baseDir, dir)).To(BeTrue())
 		})
 	})
 })

--- a/utils/fs.go
+++ b/utils/fs.go
@@ -1,0 +1,51 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"os"
+)
+
+type cachedFile struct {
+	*os.File
+	f fs.File
+}
+
+func NewCachedFile(fsys fs.FS, path string) (*cachedFile, error) {
+	f, err := fsys.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	tmp, err := ioutil.TempFile(os.TempDir(), "navidrome-")
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := io.Copy(tmp, f); err != nil {
+		return nil, err
+	}
+
+	return &cachedFile{tmp, f}, err
+}
+
+func (fc *cachedFile) Close() error {
+	err := fc.File.Close()
+	if err != nil {
+		return fmt.Errorf("closing tmpfile %q: %v", fc.File.Name(), err)
+	}
+
+	err = os.Remove(fc.File.Name())
+	if err != nil {
+		return fmt.Errorf("removing tmpfile %q: %v", fc.File.Name(), err)
+	}
+
+	return nil
+}
+
+var (
+	_ io.ReadSeekCloser = (*cachedFile)(nil)
+)

--- a/utils/paths.go
+++ b/utils/paths.go
@@ -1,13 +1,13 @@
 package utils
 
 import (
-	"os"
+	"io/fs"
 
 	"github.com/navidrome/navidrome/log"
 )
 
-func IsDirReadable(path string) (bool, error) {
-	dir, err := os.Open(path)
+func IsDirReadable(fsys fs.FS, path string) (bool, error) {
+	dir, err := fsys.Open(path)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
This PR replaces the direct calls to the Filesystem with the fs.FS wrapper provided by Go 1.16. This allows to replace the FS in the future to support rclone, S3, etc.

This PR closes #832
