### PR TITLE
improved makefile message to developer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ setup: download-deps
 .PHONY: setup
 
 download-deps:
-	@echo Download Go dependencies
+	@echo Downloading Go dependencies...
 	@go mod download
 	@go mod tidy # To revert any changes made by the `go mod download` command
-	@echo Download Node dependencies
+	@echo Downloading Node dependencies...
 	@(cd ./ui && npm ci)
 .PHONY: download-deps
 


### PR DESCRIPTION
as of now makefile shows a message
```Download go dependencies```
which can be changed to
```downloading go dependencies```