### PR TITLE
clear the ServiceWorker cache on logout

### DIFF
--- a/ui/src/authProvider.js
+++ b/ui/src/authProvider.js
@@ -99,10 +99,9 @@ const removeItems = () => {
 }
 
 const clearServiceWorkerCache = () => {
-  caches.keys().then(function(keyList) {
-    for (let key of keyList)
-        caches.delete(key)
-   })
+  caches.keys().then(function (keyList) {
+    for (let key of keyList) caches.delete(key)
+  })
 }
 
 const generateSubsonicSalt = () => {

--- a/ui/src/authProvider.js
+++ b/ui/src/authProvider.js
@@ -59,6 +59,7 @@ const authProvider = {
   logout: () => {
     stopEventStream()
     removeItems()
+    clearServiceWorkerCache()
     return Promise.resolve()
   },
 
@@ -95,6 +96,13 @@ const removeItems = () => {
   localStorage.removeItem('role')
   localStorage.removeItem('subsonic-salt')
   localStorage.removeItem('subsonic-token')
+}
+
+const clearServiceWorkerCache = () => {
+  caches.keys().then(function(keyList) {
+    for (let key of keyList)
+        caches.delete(key)
+   })
 }
 
 const generateSubsonicSalt = () => {


### PR DESCRIPTION
This fixes https://github.com/navidrome/navidrome/issues/613 by clearing the ServiceWorker cache on logout. Based on this code: https://developer.mozilla.org/en-US/docs/Web/API/CacheStorage/keys . Seems to work on macOS and iOS, but please test on other platforms.