### PR TITLE
Fix #855

### DIFF
--- a/ui/src/album/AlbumDetails.js
+++ b/ui/src/album/AlbumDetails.js
@@ -74,6 +74,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'inline-block',
     marginTop: '1em',
     float: 'left',
+    wordBreak: 'break-all',
   },
   pointerCursor: {
     cursor: 'pointer',


### PR DESCRIPTION
Make Album Detail Screen Responsive on smaller screen devices

## Before Fix
- not responsive sometimes ( when the album name is long )
![navidrome_album_detail_before](https://user-images.githubusercontent.com/48797475/111750961-e6f3d980-88b9-11eb-8560-21ba2b869c38.gif)

- Extra padding issue causing horizontal scrolling
![navidrome_album_detail_extrapadding](https://user-images.githubusercontent.com/48797475/111751063-0a1e8900-88ba-11eb-8858-334996509e09.gif)

## After Fix
- ![navidrome_ablum_detail_after](https://user-images.githubusercontent.com/48797475/111750974-eb1ff700-88b9-11eb-99ad-c02182ef2ec8.gif)

***Any suggestion or changes are welcome***


