### PR TITLE
Fix #836

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -58,6 +58,7 @@ func (a *Server) initRoutes() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Compress(5, "application/xml", "application/json", "application/javascript"))
 	r.Use(middleware.Heartbeat("/ping"))
+	r.Use(requestLogger)
 	r.Use(injectLogger)
 	r.Use(robotsTXT(ui.Assets()))
 

--- a/server/server.go
+++ b/server/server.go
@@ -38,7 +38,6 @@ func (a *Server) MountRouter(urlPath string, subRouter Handler) {
 	log.Info("Mounting routes", "path", urlPath)
 	subRouter.Setup(urlPath)
 	a.router.Group(func(r chi.Router) {
-		r.Use(requestLogger)
 		r.Mount(urlPath, subRouter)
 	})
 }
@@ -58,8 +57,8 @@ func (a *Server) initRoutes() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Compress(5, "application/xml", "application/json", "application/javascript"))
 	r.Use(middleware.Heartbeat("/ping"))
-	r.Use(requestLogger)
 	r.Use(injectLogger)
+	r.Use(requestLogger)
 	r.Use(robotsTXT(ui.Assets()))
 
 	indexHtml := path.Join(conf.Server.BaseURL, consts.URLPathUI, "index.html")


### PR DESCRIPTION
This pull request adds the requestLogger middleware to all routes so that invalid requests create a log message. It's a potential solution to issue #836.