### PR TITLE
feat(github): add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug Report
+about: Use this template for submitting a bug report.
+title: ""
+labels: bug
+assignees: ""
+---
+<!-- Please check that another issue for the same bug has not been already made by searching the [issues](https://github.com/navidrome/navidrome/issues) -->
+
+### Description
+
+A clear and concise description of what the bug is.
+
+### Expected Behaviour
+
+What you would have expected to happen instead.
+
+### Steps to reproduce
+
+1. Open the '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+### Platform information
+
+ - Navidrome version: <!-- e.g. v0.40.0 -->
+ - Browser and version: <!-- e.g. Firefox v87.0b9 -->
+ - Operating System: <!-- e.g. Ubuntu 20.04 and whether using a binary, docker or built from source  -->
+
+### Additional information
+
+Any other information that may be relevant or give context to the problem.
+
+ - Screenshots (if applicable)?
+ - Logs? <!-- Turn the log level up to trace -->
+ - Client used? <!-- e.g. DSub v5.5.2R2 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Use this template to request for a feature.
+title: ""
+labels: enhancement
+assignees: ""
+---
+<!-- Please check that another issue for the same feature request has not been already made by searching the [issues](https://github.com/navidrome/navidrome/issues) -->
+
+### Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. For e.g. I'm always frustrated when '...'
+
+### Describe the solution you'd like
+
+A clear and concise description of what you would like to happen.
+
+### Describe alternative solutions that would also satisfy this problem
+
+A clear and concise description of any alternative solutions or features you've considered.
+
+### Additional context
+
+Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
This adds 2 issue templates; one for bug reports and another one for feature requests.

After #831 is merged, I can also then remove the redundant issue template mentioned in the contributing docs and link to the issue template instead.