### PR TITLE
playlist bulkActionsToolbar bug

### DIFF
--- a/ui/src/playlist/PlaylistSongBulkActions.js
+++ b/ui/src/playlist/PlaylistSongBulkActions.js
@@ -7,7 +7,12 @@ import {
 import PropTypes from 'prop-types'
 
 // Replace original resource with "fake" one for removing tracks from playlist
-const PlaylistSongBulkActions = ({ playlistId, resource, ...rest }) => {
+const PlaylistSongBulkActions = ({
+  playlistId,
+  resource,
+  onUnselectItems,
+  ...rest
+}) => {
   const unselectAll = useUnselectAll()
   useEffect(() => {
     unselectAll('playlistTrack')
@@ -18,7 +23,11 @@ const PlaylistSongBulkActions = ({ playlistId, resource, ...rest }) => {
   return (
     <ResourceContextProvider value={mappedResource}>
       <Fragment>
-        <BulkDeleteButton {...rest} resource={mappedResource} />
+        <BulkDeleteButton
+          {...rest}
+          resource={mappedResource}
+          onClick={onUnselectItems}
+        />
       </Fragment>
     </ResourceContextProvider>
   )

--- a/ui/src/playlist/PlaylistSongs.js
+++ b/ui/src/playlist/PlaylistSongs.js
@@ -77,7 +77,7 @@ const ReorderableList = ({ readOnly, children, ...rest }) => {
 }
 
 const PlaylistSongs = ({ playlistId, readOnly, ...props }) => {
-  const { data, ids } = props
+  const { data, ids, onUnselectItems } = props
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
@@ -139,7 +139,10 @@ const PlaylistSongs = ({ playlistId, readOnly, ...props }) => {
           key={version}
         >
           <BulkActionsToolbar {...props}>
-            <PlaylistSongBulkActions playlistId={playlistId} />
+            <PlaylistSongBulkActions
+              playlistId={playlistId}
+              onUnselectItems={onUnselectItems}
+            />
           </BulkActionsToolbar>
           <ReorderableList
             readOnly={readOnly}


### PR DESCRIPTION
#896 Bug Fixed :

![navidromeBugFixed](https://user-images.githubusercontent.com/57366926/112258646-d6ae7680-8c8c-11eb-9529-ff8779c3e5fb.gif)


`BulkDeleteButton` call `unselectAll` function which dispatch action to list reducer and unselect all selected ids from state, but list state of resource 'playlistTrack' have nothing in it because  `<List>`  or  `<ListBase>` components are not used.  I have fixed the bug by passing `onUnselectItems` function in `onClick`  prop of `BulkDeleteButton`.

Requesting review 
@deluan  @jvoisin 