### PR TITLE
Global RA-button text align

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -11,3 +11,7 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.RaButton-label-14 {
+  margin-top: 4px;
+}


### PR DESCRIPTION
RA-button icon and text
![image](https://user-images.githubusercontent.com/55398806/112335483-48fd7600-8ce2-11eb-80c1-1cb5bf7810d9.png)

with CSS "fix"
![image](https://user-images.githubusercontent.com/55398806/112335591-616d9080-8ce2-11eb-8c0e-63e0bd457d1c.png)


However this leads to alignment issues on the Home page
![image](https://user-images.githubusercontent.com/55398806/112335760-8104b900-8ce2-11eb-86ac-6bebfc60cf6d.png)

@deluan i tried using Material-ui btns instead of the RA ones, however this issue still persists? Any Clue as to why this is happening?