### PR TITLE
fix(authProvider.js) fix cacheUndefined bug - #901

### DIFF
--- a/ui/src/authProvider.js
+++ b/ui/src/authProvider.js
@@ -99,9 +99,10 @@ const removeItems = () => {
 }
 
 const clearServiceWorkerCache = () => {
-  caches.keys().then(function (keyList) {
-    for (let key of keyList) caches.delete(key)
-  })
+  window.caches &&
+    caches.keys().then(function (keyList) {
+      for (let key of keyList) caches.delete(key)
+    })
 }
 
 const generateSubsonicSalt = () => {


### PR DESCRIPTION

Closes #901 

### Description
- The cache storage is not available to chromium based browsers in Android
- so throws up error when trying to delete it (the error happens only for chromium based browsers in android)

 ### Change Made
- added a check to see if cache is available before trying to delete it

### Screenshots
#### Before
![errorLogMain](https://user-images.githubusercontent.com/53407417/112714931-f353e400-8f02-11eb-9b3e-7d4c710fe296.jpeg)
#### After
![fix](https://user-images.githubusercontent.com/53407417/112714665-4af15000-8f01-11eb-82fa-f981bdabdaa7.jpeg)


Related to #906 
