### PR TITLE
Fix Navbar overlapping

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -5,6 +5,8 @@ body {
     sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow: auto!important;
+  padding-right: 0px!important;
 }
 
 code {

--- a/ui/src/layout/Layout.js
+++ b/ui/src/layout/Layout.js
@@ -9,7 +9,9 @@ import Notification from './Notification'
 import useCurrentTheme from '../themes/useCurrentTheme'
 
 const useStyles = makeStyles({
-  root: { paddingBottom: (props) => (props.addPadding ? '80px' : 0) },
+  root: { paddingBottom: (props) => (props.addPadding ? '80px' : 0),
+  '& .MuiAppBar-root': { paddingRight: '0!important' },
+ },
 })
 
 export default (props) => {

--- a/ui/src/layout/Layout.js
+++ b/ui/src/layout/Layout.js
@@ -9,9 +9,10 @@ import Notification from './Notification'
 import useCurrentTheme from '../themes/useCurrentTheme'
 
 const useStyles = makeStyles({
-  root: { paddingBottom: (props) => (props.addPadding ? '80px' : 0),
-  '& .MuiAppBar-root': { paddingRight: '0!important' },
- },
+  root: {
+    paddingBottom: (props) => (props.addPadding ? '80px' : 0),
+    '& .MuiAppBar-root': { paddingRight: '0!important' },
+  },
 })
 
 export default (props) => {

--- a/ui/src/user/UserEdit.js
+++ b/ui/src/user/UserEdit.js
@@ -20,7 +20,6 @@ const useStyles = makeStyles({
   toolbar: {
     display: 'flex',
     justifyContent: 'space-between',
-    paddingLeft: '51px',
   },
 })
 

--- a/ui/src/user/UserEdit.js
+++ b/ui/src/user/UserEdit.js
@@ -20,6 +20,7 @@ const useStyles = makeStyles({
   toolbar: {
     display: 'flex',
     justifyContent: 'space-between',
+    paddingLeft: '51px',
   },
 })
 


### PR DESCRIPTION
As mentioned in issue #919, the navbar and the player were overlapping the scrollbar; when the user icon was clicked, I tried to resolve this issue by modifying some of the CSS properties of the body.  (Fixes #919) 
 
Here are the screenshots after the changes,
![navid919](https://user-images.githubusercontent.com/61188295/112750467-684c1a00-8fe6-11eb-9653-7365ea7d9541.png)


Feedbacks are most welcomed. Thank you!