### PR TITLE
fix(AlbumGrid): fix LinkWrapping Error #921

### DIFF
--- a/ui/src/album/AlbumGridView.js
+++ b/ui/src/album/AlbumGridView.js
@@ -129,18 +129,18 @@ const AlbumGridTile = ({ showArtist, record, basePath }) => {
         to={linkToRecord(basePath, record.id, 'show')}
       >
         <Typography className={classes.albumName}>{record.name}</Typography>
-        {showArtist ? (
-          <ArtistLinkField record={record} className={classes.albumSubtitle} />
-        ) : (
-          <RangeField
-            record={record}
-            source={'year'}
-            sortBy={'maxYear'}
-            sortByOrder={'DESC'}
-            className={classes.albumSubtitle}
-          />
-        )}
       </Link>
+      {showArtist ? (
+        <ArtistLinkField record={record} className={classes.albumSubtitle} />
+      ) : (
+        <RangeField
+          record={record}
+          source={'year'}
+          sortBy={'maxYear'}
+          sortByOrder={'DESC'}
+          className={classes.albumSubtitle}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Closes #921 

Prevented link from wrapping over both the artistLinkField andRangeField.
The artistLinkField already has link inside, so wrapping another link tag over it caused the error.

