### PR TITLE
Login backgrounds from unsplash collection

### DIFF
--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -5,7 +5,8 @@ const defaultConfig = {
   version: 'dev',
   firstTime: false,
   baseURL: '',
-  loginBackgroundURL: 'https://source.unsplash.com/random/1600x900?music',
+  // Login backgrounds from https://unsplash.com/collections/1065384/music-wallpapers
+  loginBackgroundURL: 'https://source.unsplash.com/collection/1065384/1600x900',
   enableTranscodingConfig: true,
   enableDownloads: true,
   welcomeMessage: '',


### PR DESCRIPTION
~~Fixes~~ Relates to https://github.com/navidrome/navidrome/issues/928, unrelated background images

Fetches random photos from a defined collection instead of searching for keywords, which turns out to be somewhat inacurrate.

I've used the Music Wallpapers collection in this case - https://unsplash.com/collections/1065384/music-wallpapers, we can easily incorporate any other collection.