### PR TITLE
move `</Link>` tag so that it only surrounds the album title

### DIFF
--- a/ui/src/album/AlbumGridView.js
+++ b/ui/src/album/AlbumGridView.js
@@ -129,18 +129,18 @@ const AlbumGridTile = ({ showArtist, record, basePath }) => {
         to={linkToRecord(basePath, record.id, 'show')}
       >
         <Typography className={classes.albumName}>{record.name}</Typography>
-        {showArtist ? (
-          <ArtistLinkField record={record} className={classes.albumSubtitle} />
-        ) : (
-          <RangeField
-            record={record}
-            source={'year'}
-            sortBy={'maxYear'}
-            sortByOrder={'DESC'}
-            className={classes.albumSubtitle}
-          />
-        )}
       </Link>
+      {showArtist ? (
+        <ArtistLinkField record={record} className={classes.albumSubtitle} />
+      ) : (
+        <RangeField
+          record={record}
+          source={'year'}
+          sortBy={'maxYear'}
+          sortByOrder={'DESC'}
+          className={classes.albumSubtitle}
+        />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
looks like theres an error about nested `<a>` tags in the album grid view:
```
Warning: validateDOMNesting(...): <a> cannot appear as a descendant of <a>.
    in a (created by LinkAnchor)
    in LinkAnchor (created by Context.Consumer)
    in Link (created by Link)
    in Link (at ArtistLinkField.js:18)
    in Unknown (created by WithWidth(Component))
    in WithWidth(Component) (at AlbumGridView.js:133)
    in a (created by LinkAnchor)
    in LinkAnchor (created by Context.Consumer)
    in Link (at AlbumGridView.js:127)
    in div (at AlbumGridView.js:115)
    in AlbumGridTile (at AlbumGridView.js:163)
    in div (created by ForwardRef(GridListTile))
    in li (created by ForwardRef(GridListTile))
...
```

This PR corrects the `<Link>` tag on line 127 of `AlbumGridView.js` (the link on the album title) so that it does not also contain the link to the artist on the line below.