### PR TITLE
fix(albumListView)  prop undefined bug  #925

### DIFF
--- a/ui/src/album/AlbumListView.js
+++ b/ui/src/album/AlbumListView.js
@@ -40,7 +40,7 @@ const useStyles = makeStyles({
   },
 })
 
-const AlbumDetails = (props) => {
+const AlbumDetails = ({ syncWithLocation, ...props }) => {
   return (
     <Show {...props} title=" ">
       <SimpleShowLayout>

--- a/ui/src/album/AlbumListView.js
+++ b/ui/src/album/AlbumListView.js
@@ -40,7 +40,7 @@ const useStyles = makeStyles({
   },
 })
 
-const AlbumDetails = ({ syncWithLocation, ...props }) => {
+const AlbumDetails = (props) => {
   return (
     <Show {...props} title=" ">
       <SimpleShowLayout>
@@ -57,7 +57,13 @@ const AlbumDetails = ({ syncWithLocation, ...props }) => {
   )
 }
 
-const AlbumListView = ({ hasShow, hasEdit, hasList, ...rest }) => {
+const AlbumListView = ({
+  hasShow,
+  hasEdit,
+  hasList,
+  syncWithLocation,
+  ...rest
+}) => {
   const classes = useStyles()
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))


### PR DESCRIPTION
Closes #925 

This was the initial error message shown
```
Warning: React does not recognize the `syncWithLocation` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `syncwithlocation` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in table (created by ForwardRef(Table))
    in ForwardRef(Table) (created by WithStyles(ForwardRef(Table)))
    in WithStyles(ForwardRef(Table)) (created by ForwardRef)
    in ForwardRef (at AlbumListView.js:78)
    in AlbumListView (at AlbumList.js:96)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(Card))
    in ForwardRef(Card) (created by WithStyles(ForwardRef(Card)))
```
As shown in the error log, in AlbumListView component(line 80), the datagrid passes a bunch of props to AlbumDetails component which then passes them further into it's children. However, it's child component is not having a valid prop type set up for the syncWithLocation prop and hence the error arises.

### Solutions:
1. Destructure the syncWithLocation out of props and ensure that it doesn't get passed down to the child components
2. OR, delete syncWithLocation prop directly to ensure that it doesn't' get passed down to the child component where it will be unrecognized
https://github.com/navidrome/navidrome/blob/404253a88104c729069ce0ddd66502ecc871cd9e/ui/src/album/AlbumListView.js#L80

Reference: https://reactjs.org/warnings/unknown-prop.html