### PR TITLE
<style>(Login.js): Changes-light-theme - #927

### DIFF
--- a/ui/src/layout/Login.js
+++ b/ui/src/layout/Login.js
@@ -11,7 +11,6 @@ import { createMuiTheme, makeStyles } from '@material-ui/core/styles'
 import { ThemeProvider } from '@material-ui/styles'
 import Logo from '../icons/android-icon-72x72.png'
 import { useLogin, useNotify, useTranslate } from 'react-admin'
-
 import Notification from './Notification'
 import LightTheme from '../themes/light'
 import config from '../config'
@@ -24,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
     minHeight: '100vh',
     alignItems: 'center',
     justifyContent: 'flex-start',
-    background: `url(${config.loginBackgroundURL})`,
+    background: `linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(${config.loginBackgroundURL})`,
     backgroundRepeat: 'no-repeat',
     backgroundSize: 'cover',
     backgroundPosition: 'center',
@@ -32,6 +31,7 @@ const useStyles = makeStyles((theme) => ({
   card: {
     minWidth: 300,
     marginTop: '6em',
+    backgroundColor: theme.palette.background.default,
   },
   avatar: {
     margin: '1em',
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
     justifyContent: 'center',
   },
   icon: {
-    backgroundColor: 'white',
+    //backgroundColor: 'white',
     width: '40px',
   },
   systemName: {

--- a/ui/src/themes/light.js
+++ b/ui/src/themes/light.js
@@ -7,6 +7,12 @@ export default {
       main: '#3f51b5',
       contrastText: '#fff',
     },
+    background: {
+      default: 'rgba(255, 255, 255, 0.8)',
+    },
+    error: {
+      main: '#ff9800',
+    },
   },
   overrides: {
     MuiFilledInput: {


### PR DESCRIPTION
Closes #927 

Changes:
1. Added a gradient to darken the background image a bit.
2. Made the card translucent to look more appealing for the light theme. 
3. Removed the unnecessary white background behind the logo.
4. Changed the error color to orange for the light theme. 

Before:

![Screenshot from 2021-03-29 12-04-26](https://user-images.githubusercontent.com/51775341/112942259-79636b00-914d-11eb-81f8-a3e657b11375.png)

Now: 

![Screenshot from 2021-03-30 09-44-25](https://user-images.githubusercontent.com/51775341/112942301-86805a00-914d-11eb-8828-44102363544c.png)

Signed-off-by: KaramveerSidhu <karamveersidhu14@gmail.com>


