### PR TITLE
New service worker

### DIFF
--- a/ui/public/navidrome-service-worker.js
+++ b/ui/public/navidrome-service-worker.js
@@ -1,0 +1,48 @@
+// documentation: https://developers.google.com/web/tools/workbox/modules/workbox-sw
+importScripts("https://storage.googleapis.com/workbox-cdn/releases/6.1.2/workbox-sw.js");
+
+workbox.loadModule('workbox-core');
+workbox.loadModule('workbox-strategies');
+workbox.loadModule('workbox-routing');
+workbox.loadModule('workbox-navigation-preload');
+
+workbox.core.clientsClaim();
+self.skipWaiting();
+
+addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'SKIP_WAITING') {
+    skipWaiting();
+  }
+});
+
+
+const CACHE_NAME = 'offline-html';
+// This assumes /offline.html is a URL for your self-contained
+// (no external images or styles) offline page.
+const FALLBACK_HTML_URL = './offline.html';
+// Populate the cache with the offline HTML page when the
+// service worker is installed.
+self.addEventListener('install', async (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME)
+      .then((cache) => cache.add(FALLBACK_HTML_URL))
+  );
+});
+
+const networkOnly = new workbox.strategies.NetworkOnly();
+const navigationHandler = async (params) => {
+  try {
+    // Attempt a network request.
+    return await networkOnly.handle(params);
+  } catch (error) {
+    // If it fails, return the cached HTML.
+    return caches.match(FALLBACK_HTML_URL, {
+      cacheName: CACHE_NAME,
+    });
+  }
+};
+
+// Register this strategy to handle all navigations.
+workbox.routing.registerRoute(
+  new workbox.routing.NavigationRoute(navigationHandler)
+);

--- a/ui/public/offline.html
+++ b/ui/public/offline.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><title>Navidrome</title></head>
+<body style="margin:0">
+<p id="errorMessageDescription" style="text-align:center;font-size:21px;font-family:arial;margin-top:28px">
+It looks like we are having trouble connecting.
+<br/>
+Please check your internet connection and try again.</p>
+</body>
+</html>

--- a/ui/src/serviceWorker.js
+++ b/ui/src/serviceWorker.js
@@ -32,7 +32,7 @@ export function register(config) {
     }
 
     window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`
+      const swUrl = `${process.env.PUBLIC_URL}/navidrome-service-worker.js`
 
       if (isLocalhost) {
         // This is running on localhost. Let's check if a service worker still exists or not.


### PR DESCRIPTION
This PR gives the Navidrome web UI a 'proper' own service worker, not just the current boilerplate `service-worker.js` that gets auto-generated during the build process by CRA, which is outdated anyway since it loads Workbox v3 libraries instead of the current v6.1.2. Plus, that service worker caches stuff for offline usage, which breaks things.

Workbox, by the way, is pretty cool stuff: basically it's a set of Google libraries to make service workers easy. See: https://developers.google.com/web/tools/workbox

Changes in this PR:
- updated serviceWorker.js to load this new service worker
- named the new service worker `navidrome-service-worker.js` so it doesn't get overwritten by the CRA generated one
- added a new file `offline.html` containing an error message

So what does the service worker do?
- loads the Workbox libraries from a Google CDN (note: we don't _have_ to load it from an external website, but this is also how Navidromes' current CRA-generated service worker does it)
- it installs itself, claims all clients (ie, Navidrome in other tabs) and immediately takes over from any previously running service worker (skipWaiting)
- it caches `offline.html` on install
- runs Navidrome with a "network-only" caching strategy (=fixes https://github.com/navidrome/navidrome/issues/904 )
- serves `offline.html` when the server is unreachable (=fixes https://github.com/navidrome/navidrome/issues/911 )

Please test this, for example:
- by changing between two different builds of the server and see if the fresh service-worker gets loaded
- log out, close tab, log in on various browsers / PWA platforms
- go offline, with both desktop and mobile browsers, check if `offline.html` gets displayed
