### PR TITLE
Fix extra multiline Prop error

### DIFF
--- a/ui/src/album/AlbumListView.js
+++ b/ui/src/album/AlbumListView.js
@@ -58,7 +58,7 @@ const AlbumDetails = (props) => {
     genre: <TextField record={record} source="genre" />,
     compilation: <BooleanField record={record} source="compilation" />,
     updatedAt: <DateField record={record} source="updatedAt" showTime />,
-    comment: <MultiLineTextField record={record} source="comment" multiline />,
+    comment: <MultiLineTextField record={record} source="comment" />,
   }
   if (!record.comment) {
     delete data.comment

--- a/ui/src/common/SongDetails.js
+++ b/ui/src/common/SongDetails.js
@@ -32,7 +32,7 @@ export const SongDetails = (props) => {
     size: <SizeField record={record} source="size" />,
     updatedAt: <DateField record={record} source="updatedAt" showTime />,
     playCount: <TextField record={record} source="playCount" />,
-    comment: <MultiLineTextField record={record} source="comment" multiline />,
+    comment: <MultiLineTextField record={record} source="comment" />,
   }
   if (!record.discSubtitle) {
     delete data.discSubtitle


### PR DESCRIPTION
Currently, when previewing the album details, the following error is seen in the console.

![image](https://user-images.githubusercontent.com/53407417/113463214-3d2c5500-9442-11eb-9b46-74b08c21002e.png)

```Received `true` for a non-boolean attribute `multiline`.

If you want to write it to the DOM, pass a string instead: multiline="true" or multiline={value.toString()}.
    in span (created by ForwardRef(Typography))
    in ForwardRef(Typography) (created by WithStyles(ForwardRef(Typography)))
    in WithStyles(ForwardRef(Typography)) (at MultiLineTextField.js:25)
    in Unknown
    in Unknown (at SongDetails.js:35)
    in td (created by ForwardRef(TableCell))
    in ForwardRef(TableCell) (created by WithStyles(ForwardRef(TableCell)))
    in WithStyles(ForwardRef(TableCell)) (at SongDetails.js:63)
    in tr (created by ForwardRef(TableRow))
    in ForwardRef(TableRow) (created by WithStyles(ForwardRef(TableRow)))
    in WithStyles(ForwardRef(TableRow)) (at SongDetails.js:52)
    in tbody (created by ForwardRef(TableBody))
    in ForwardRef(TableBody) (created by WithStyles(ForwardRef(TableBody)))
    in WithStyles(ForwardRef(TableBody)) (at SongDetails.js:49)
    in table (created by ForwardRef(Table))
    in ForwardRef(Table) (created by WithStyles(ForwardRef(Table)))
    in WithStyles(ForwardRef(Table)) (at SongDetails.js:48)
    in div (created by ForwardRef(Paper))
    in ForwardRef(Paper) (created by WithStyles(ForwardRef(Paper)))
    in WithStyles(ForwardRef(Paper)) (created by ForwardRef(TableContainer))
    in ForwardRef(TableContainer) (created by WithStyles(ForwardRef(TableContainer)))
    in WithStyles(ForwardRef(TableContainer)) (at SongDetails.js:47)
    in SongDetails (at AlbumSongs.js:99)
    in td (created by ForwardRef(TableCell))```

This pr fixes the above warning.