### PR TITLE
Prevent the exposure of song paths for regular users

### DIFF
--- a/ui/src/common/SongDetails.js
+++ b/ui/src/common/SongDetails.js
@@ -34,6 +34,9 @@ export const SongDetails = (props) => {
     playCount: <TextField record={record} source="playCount" />,
     comment: <MultiLineTextField record={record} source="comment" />,
   }
+  if (localStorage.getItem('role') === 'regular') {
+    delete data.path
+  }
   if (!record.discSubtitle) {
     delete data.discSubtitle
   }


### PR DESCRIPTION
Referring to: https://github.com/navidrome/navidrome/issues/959
I have fixed the UI to show the song `path` in the song details.
For the admin:

![Screenshot from 2021-04-03 15-36-32](https://user-images.githubusercontent.com/57208018/113475477-940e4a80-9493-11eb-8ade-91e175e76314.png)

For the regular users:

![Screenshot from 2021-04-03 15-37-12](https://user-images.githubusercontent.com/57208018/113475478-953f7780-9493-11eb-984f-adb254f59dc1.png)