### PR TITLE
Fix 'undefined variant prop' in DateField warning

### DIFF
--- a/ui/src/user/UserEdit.js
+++ b/ui/src/user/UserEdit.js
@@ -44,10 +44,10 @@ const UserEdit = (props) => (
       <TextInput source="email" validate={[email()]} />
       <PasswordInput source="password" validate={[required()]} />
       <BooleanInput source="isAdmin" initialValue={false} />
-      <DateField source="lastLoginAt" showTime />
+      <DateField variant="body1" source="lastLoginAt" showTime />
       {/*<DateField source="lastAccessAt" showTime />*/}
-      <DateField source="updatedAt" showTime />
-      <DateField source="createdAt" showTime />
+      <DateField variant="body1" source="updatedAt" showTime />
+      <DateField variant="body1" source="createdAt" showTime />
     </SimpleForm>
   </Edit>
 )


### PR DESCRIPTION
Currrently selecting a user and  going to the UserEdit page, shows a warning in the console.

![image](https://user-images.githubusercontent.com/53407417/113594693-a89a4080-9655-11eb-95be-1a45cca78085.png)
 
> Warning: Failed prop type: Invalid prop `variant` of value `outlined` supplied to `ForwardRef(Typography)`, expected one of ["h1","h2","h3","h4","h5","h6","subtitle1","subtitle2","body1","body2","caption","button","overline","srOnly","inherit"].
>     in ForwardRef(Typography) (created by WithStyles(ForwardRef(Typography)))
>     in WithStyles(ForwardRef(Typography))
>     in Unknown
>     in Unknown (at UserEdit.js:47)
>     in div (created by Labeled)
>     in div (created by ForwardRef(FormControl))
>     in ForwardRef(FormControl) (created by WithStyles(ForwardRef(FormControl)))
>     in WithStyles(ForwardRef(FormControl)) (created by Labeled)
>     in Labeled (created by FormInput)
>     in div (created by FormInput)
>     in FormInput (created by SimpleFormView)
>     in div (created by ForwardRef(CardContent))
>     in ForwardRef(CardContent) (created by WithStyles(ForwardRef(CardContent)))
>     in WithStyles(ForwardRef(CardContent)) (created by CardContentInner)
>     in CardContentInner (created by SimpleFormView)
>     in form (created by SimpleFormView)
>     in SimpleFormView (created by FormView)
>     in FormView (created by ReactFinalForm)
>     in ReactFinalForm (created by FormWithRedirect)
>     in FormContextProvider (created by FormWithRedirect)
>     in FormWithRedirect (created by SimpleForm)
>     in SimpleForm (at UserEdit.js:41)

Reason: The variant prop in SimpleForm for [UserEdit.js](https://github.com/navidrome/navidrome/blob/cdfdf78c734d8d9a3b6fb209656eb79bd9d51ec2/ui/src/user/UserEdit.js#L41) is given a value of `outlined` which passes it down to all the input field children. However, DateField is a Typography component at its base and not really a TextField. The variant values acceptable for [Typography](https://material-ui.com/api/typography/) and [TextField](https://material-ui.com/api/text-field/) are different and hence this warning shows up.
The default variant value of Typography is 'body1'  as per the Material Ui [docs](https://material-ui.com/api/typography/). Passing the variant as body1 to the Datefields removes the warning.


