### PR TITLE
fix(SongTitleField.js): Fixed jumping of Title column in song lists due to play icon

### DIFF
--- a/ui/src/common/SongTitleField.js
+++ b/ui/src/common/SongTitleField.js
@@ -16,14 +16,13 @@ const useStyles = makeStyles({
     height: '32px',
     verticalAlign: 'text-top',
     marginLeft: '-8px',
-    marginTop:'-5px',
-    position:'absolute',
-    scale:'1.2'
-
+    marginTop: '-5px',
+    position: 'absolute',
+    scale: '1.2',
   },
   text: {
     verticalAlign: 'text-top',
-    paddingLeft:'32px',
+    paddingLeft: '32px',
   },
 })
 

--- a/ui/src/common/SongTitleField.js
+++ b/ui/src/common/SongTitleField.js
@@ -16,11 +16,14 @@ const useStyles = makeStyles({
     height: '32px',
     verticalAlign: 'text-top',
     marginLeft: '-8px',
-    marginTop: '-7px',
-    paddingRight: '3px',
+    marginTop:'-5px',
+    position:'absolute',
+    scale:'1.2'
+
   },
   text: {
     verticalAlign: 'text-top',
+    paddingLeft:'32px',
   },
 })
 

--- a/ui/src/themes/README.md
+++ b/ui/src/themes/README.md
@@ -1,2 +1,2 @@
-To create and contribute with new themes, please refer to 
+To create and contribute with new themes, please refer to
 https://www.navidrome.org/docs/developers/creating-themes/


### PR DESCRIPTION
This fixes the issue #998. The title column now does not jump in case of difference in song title lengths.

Play icon now doesn't displace the title whenever it is loaded, maintaining vertical alignment of the song titles. Scale of play icon slightly increased for visibility.