### PR TITLE
feat(various): obfuscate file path in response for non admins - #959

### DIFF
--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -9,6 +9,51 @@ type MediaFile struct {
 	Annotations
 	Bookmarkable
 
+	ID                   string `json:"id"            orm:"pk;column(id)"`
+	Path                 string
+	Title                string    `json:"title"`
+	Album                string    `json:"album"`
+	ArtistID             string    `json:"artistId"      orm:"pk;column(artist_id)"`
+	Artist               string    `json:"artist"`
+	AlbumArtistID        string    `json:"albumArtistId" orm:"pk;column(album_artist_id)"`
+	AlbumArtist          string    `json:"albumArtist"`
+	AlbumID              string    `json:"albumId"       orm:"pk;column(album_id)"`
+	HasCoverArt          bool      `json:"hasCoverArt"`
+	TrackNumber          int       `json:"trackNumber"`
+	DiscNumber           int       `json:"discNumber"`
+	DiscSubtitle         string    `json:"discSubtitle"`
+	Year                 int       `json:"year"`
+	Size                 int64     `json:"size"`
+	Suffix               string    `json:"suffix"`
+	Duration             float32   `json:"duration"`
+	BitRate              int       `json:"bitRate"`
+	Genre                string    `json:"genre"`
+	FullText             string    `json:"fullText"`
+	SortTitle            string    `json:"sortTitle"`
+	SortAlbumName        string    `json:"sortAlbumName"`
+	SortArtistName       string    `json:"sortArtistName"`
+	SortAlbumArtistName  string    `json:"sortAlbumArtistName"`
+	OrderAlbumName       string    `json:"orderAlbumName"`
+	OrderArtistName      string    `json:"orderArtistName"`
+	OrderAlbumArtistName string    `json:"orderAlbumArtistName"`
+	Compilation          bool      `json:"compilation"`
+	Comment              string    `json:"comment"`
+	Lyrics               string    `json:"lyrics"`
+	CatalogNum           string    `json:"catalogNum"`
+	MbzTrackID           string    `json:"mbzTrackId"         orm:"column(mbz_track_id)"`
+	MbzAlbumID           string    `json:"mbzAlbumId"         orm:"column(mbz_album_id)"`
+	MbzArtistID          string    `json:"mbzArtistId"        orm:"column(mbz_artist_id)"`
+	MbzAlbumArtistID     string    `json:"mbzAlbumArtistId"   orm:"column(mbz_album_artist_id)"`
+	MbzAlbumType         string    `json:"mbzAlbumType"`
+	MbzAlbumComment      string    `json:"mbzAlbumComment"`
+	CreatedAt            time.Time `json:"createdAt"` // Time this entry was created in the DB
+	UpdatedAt            time.Time `json:"updatedAt"` // Time of file last update (mtime)
+}
+
+type AdminMediaFile struct {
+	Annotations
+	Bookmarkable
+
 	ID                   string    `json:"id"            orm:"pk;column(id)"`
 	Path                 string    `json:"path"`
 	Title                string    `json:"title"`
@@ -55,6 +100,8 @@ func (mf *MediaFile) ContentType() string {
 }
 
 type MediaFiles []MediaFile
+
+type AdminMediaFiles []AdminMediaFile
 
 type MediaFileRepository interface {
 	CountAll(options ...QueryOptions) (int64, error)

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -40,7 +40,16 @@ type PlaylistTrack struct {
 	MediaFile
 }
 
+type AdminPlaylistTrack struct {
+	ID          string `json:"id"          orm:"column(id)"`
+	MediaFileID string `json:"mediaFileId" orm:"column(media_file_id)"`
+	PlaylistID  string `json:"playlistId" orm:"column(playlist_id)"`
+	AdminMediaFile
+}
+
 type PlaylistTracks []PlaylistTrack
+
+type AdminPlaylistTracks []AdminPlaylistTrack
 
 type PlaylistTrackRepository interface {
 	ResourceRepository


### PR DESCRIPTION
# Closes
#959 

# Description
Non admin users no longer receive file path of music tracks.

# Changes
Replaced deluan/rest calls where it was necessary to serve different responses to admins and non-admin users. Removed path JSON field for default structs and added equivalent structs with path JSON field. Default structs are typecasted  into equivalent structs with path JSON field when the user requesting information is an admin. 