### PR TITLE
fix(various): random album pagination fix - #749

### DIFF
--- a/model/request/request.go
+++ b/model/request/request.go
@@ -9,12 +9,13 @@ import (
 type contextKey string
 
 const (
-	User        = contextKey("user")
-	Username    = contextKey("username")
-	Client      = contextKey("client")
-	Version     = contextKey("version")
-	Player      = contextKey("player")
-	Transcoding = contextKey("transcoding")
+	User            = contextKey("user")
+	Username        = contextKey("username")
+	Client          = contextKey("client")
+	Version         = contextKey("version")
+	Player          = contextKey("player")
+	Transcoding     = contextKey("transcoding")
+	AlbumRandomSeed = contextKey("albumRandomSeed")
 )
 
 func WithUser(ctx context.Context, u model.User) context.Context {

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -130,7 +130,7 @@ func (r *albumRepository) GetAll(options ...model.QueryOptions) (model.Albums, e
 
 // TODO Keep order when paginating
 func (r *albumRepository) GetRandom(options ...model.QueryOptions) (model.Albums, error) {
-	sq := r.selectAlbum(options...).OrderByClause(r.sortMappings["random"])
+	sq := r.selectAlbum(options...).OrderByClause(r.sortMappings["random-true"])
 	results := model.Albums{}
 	err := r.queryAll(sq, &results)
 	return results, err

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -144,6 +144,9 @@ func (r sqlRepository) queryAll(sq Sqlizer, response interface{}) error {
 	if err != nil {
 		return err
 	}
+	if _, ok := r.sortMappings["random-true"]; ok {
+		query = strings.Replace(query, r.sortMappings["random"]+" asc", r.sortMappings["random-true"], 1)
+	}
 	start := time.Now()
 	c, err := r.ormer.Raw(query, args...).QueryRows(response)
 	if err == orm.ErrNoRows {

--- a/server/server.go
+++ b/server/server.go
@@ -59,6 +59,7 @@ func (a *Server) initRoutes() {
 	r.Use(middleware.Heartbeat("/ping"))
 	r.Use(injectLogger)
 	r.Use(requestLogger)
+	r.Use(randomSeedMiddleware)
 	r.Use(robotsTXT(ui.Assets()))
 
 	indexHtml := path.Join(conf.Server.BaseURL, consts.URLPathUI)


### PR DESCRIPTION
# Closes
#749 

# Description
Added a way to seed the random sort used to order albums. 

# Changes
Added a middleware to handle random seeds in the form of cookies and add them to request's context when sorting albums by random. Added a context key to request. Implemented a pseudo-random function. Added a workaround for cases where random order mapping could not contain a comma (Example: "substr(id, 7)" turns into "order by substr(id asc, 7) asc" instead of "order by substr(id, 7) asc") by using a placeholder. 

# Notes
Currently the user stores the seed for 5 minutes since there is no way to differentiate between the api requests when the user has requested an album shuffle, and when the user just goes back to the first page (both requests only contain start and end). To get around this, the middleware looks for a "_shuffle" query. If found, it will generate a new seed. Once this is implemented, we may get rid of the 5 min expiry on the random seed. 