### PR TITLE
Handle subdirectories without rx permission and allow ogg files w/o metadata

### DIFF
--- a/scanner/metadata/taglib.go
+++ b/scanner/metadata/taglib.go
@@ -51,7 +51,6 @@ func (e *taglibExtractor) extractMetadata(filePath string) (*taglibMetadata, err
 	md.tags, err = taglib.Read(filePath)
 	if err != nil {
 		log.Warn("Error reading metadata from file. Skipping", "filePath", filePath, err)
-		return nil, errors.New("error reading tags")
 	}
 	md.hasPicture = hasEmbeddedImage(filePath)
 	return md, nil

--- a/scanner/walk_dir_tree_test.go
+++ b/scanner/walk_dir_tree_test.go
@@ -3,7 +3,6 @@ package scanner
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -43,36 +42,70 @@ var _ = Describe("load_tree", func() {
 
 	Describe("isDirOrSymlinkToDir", func() {
 		It("returns true for normal dirs", func() {
-			dir, _ := os.Stat("tests/fixtures")
-			Expect(isDirOrSymlinkToDir("tests", dir)).To(BeTrue())
+			dirents, _ := os.ReadDir("tests")
+			for _, d := range dirents {
+				if d.Name() == "fixtures" {
+					Expect(isDirOrSymlinkToDir("tests", d)).To(BeTrue())
+				}
+			}
 		})
 		It("returns true for symlinks to dirs", func() {
-			dir, _ := os.Stat("tests/fixtures/symlink2dir")
-			Expect(isDirOrSymlinkToDir("tests/fixtures", dir)).To(BeTrue())
+			dirents, _ := os.ReadDir("tests/fixtures")
+			for _, d := range dirents {
+				if d.Name() == "symlink2dir" {
+					Expect(isDirOrSymlinkToDir("tests/fixtures", d)).To(BeTrue())
+				}
+			}
 		})
 		It("returns false for files", func() {
-			dir, _ := os.Stat("tests/fixtures/test.mp3")
-			Expect(isDirOrSymlinkToDir("tests/fixtures", dir)).To(BeFalse())
+			dirents, _ := os.ReadDir("tests/fixtures")
+			for _, d := range dirents {
+				if d.Name() == "test.mp3" {
+					Expect(isDirOrSymlinkToDir("tests/fixtures", d)).To(BeFalse())
+				}
+			}
 		})
 		It("returns false for symlinks to files", func() {
-			dir, _ := os.Stat("tests/fixtures/symlink")
-			Expect(isDirOrSymlinkToDir("tests/fixtures", dir)).To(BeFalse())
+			dirents, _ := os.ReadDir("tests/fixtures")
+			for _, d := range dirents {
+				if d.Name() == "symlink" {
+					Expect(isDirOrSymlinkToDir("tests/fixtures", d)).To(BeFalse())
+				}
+			}
 		})
 	})
-
 	Describe("isDirIgnored", func() {
-		baseDir := filepath.Join("tests", "fixtures")
 		It("returns false for normal dirs", func() {
-			dir, _ := os.Stat(filepath.Join(baseDir, "empty_folder"))
-			Expect(isDirIgnored(baseDir, dir)).To(BeFalse())
+			dirents, _ := os.ReadDir("tests/fixtures")
+			for _, d := range dirents {
+				if d.Name() == "empty_folder" {
+					Expect(isDirIgnored("tests/fixtures", d)).To(BeFalse())
+				}
+			}
 		})
 		It("returns true when folder contains .ndignore file", func() {
-			dir, _ := os.Stat(filepath.Join(baseDir, "ignored_folder"))
-			Expect(isDirIgnored(baseDir, dir)).To(BeTrue())
+			dirents, _ := os.ReadDir("tests/fixtures")
+			for _, d := range dirents {
+				if d.Name() == "ignored_folder" {
+					Expect(isDirIgnored("tests/fixtures", d)).To(BeTrue())
+				}
+			}
 		})
 		It("returns true when folder name starts with a `.`", func() {
-			dir, _ := os.Stat(filepath.Join(baseDir, ".hidden_folder"))
-			Expect(isDirIgnored(baseDir, dir)).To(BeTrue())
+			dirents, _ := os.ReadDir("tests/fixtures")
+			for _, d := range dirents {
+				if d.Name() == ".hidden_folder" {
+					Expect(isDirIgnored("tests/fixtures", d)).To(BeTrue())
+				}
+			}
+		})
+		It("returns false when folder name starts with ellipses", func() {
+			dirents, _ := os.ReadDir("tests/fixtures")
+			for _, d := range dirents {
+				if d.Name() == "...unhidden_folder" {
+					Expect(isDirIgnored("tests/fixtures", d)).To(BeFalse())
+				}
+			}
 		})
 	})
 })

--- a/scanner/walk_dir_tree_test.go
+++ b/scanner/walk_dir_tree_test.go
@@ -3,21 +3,33 @@ package scanner
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 )
 
+func getDirEntry(baseDir, name string) (os.DirEntry, error) {
+	dirents, _ := os.ReadDir(baseDir)
+	for _, d := range dirents {
+		if d.Name() == name {
+			return d, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}
+
 var _ = Describe("load_tree", func() {
 
 	Describe("walkDirTree", func() {
 		It("reads all info correctly", func() {
+			baseDir := filepath.Join("tests", "fixtures")
 			var collected = dirMap{}
 			results := make(walkResults, 5000)
 			var err error
 			go func() {
-				err = walkDirTree(context.TODO(), "tests/fixtures", results)
+				err = walkDirTree(context.TODO(), baseDir, results)
 			}()
 
 			for {
@@ -29,83 +41,53 @@ var _ = Describe("load_tree", func() {
 			}
 
 			Expect(err).To(BeNil())
-			Expect(collected["tests/fixtures"]).To(MatchFields(IgnoreExtras, Fields{
+			Expect(collected[baseDir]).To(MatchFields(IgnoreExtras, Fields{
 				"HasImages":       BeTrue(),
 				"HasPlaylist":     BeFalse(),
 				"AudioFilesCount": BeNumerically("==", 4),
 			}))
-			Expect(collected["tests/fixtures/playlists"].HasPlaylist).To(BeTrue())
-			Expect(collected).To(HaveKey("tests/fixtures/symlink2dir"))
-			Expect(collected).To(HaveKey("tests/fixtures/empty_folder"))
+			Expect(collected[filepath.Join(baseDir, "playlists")].HasPlaylist).To(BeTrue())
+			Expect(collected).To(HaveKey(filepath.Join(baseDir, "symlink2dir")))
+			Expect(collected).To(HaveKey(filepath.Join(baseDir, "empty_folder")))
 		})
 	})
 
 	Describe("isDirOrSymlinkToDir", func() {
+		baseDir := filepath.Join("tests", "fixtures")
 		It("returns true for normal dirs", func() {
-			dirents, _ := os.ReadDir("tests")
-			for _, d := range dirents {
-				if d.Name() == "fixtures" {
-					Expect(isDirOrSymlinkToDir("tests", d)).To(BeTrue())
-				}
-			}
+			dirent, _ := getDirEntry("tests", "fixtures")
+			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeTrue())
 		})
 		It("returns true for symlinks to dirs", func() {
-			dirents, _ := os.ReadDir("tests/fixtures")
-			for _, d := range dirents {
-				if d.Name() == "symlink2dir" {
-					Expect(isDirOrSymlinkToDir("tests/fixtures", d)).To(BeTrue())
-				}
-			}
+			dirent, _ := getDirEntry(baseDir, "symlink2dir")
+			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeTrue())
 		})
 		It("returns false for files", func() {
-			dirents, _ := os.ReadDir("tests/fixtures")
-			for _, d := range dirents {
-				if d.Name() == "test.mp3" {
-					Expect(isDirOrSymlinkToDir("tests/fixtures", d)).To(BeFalse())
-				}
-			}
+			dirent, _ := getDirEntry(baseDir, "test.mp3")
+			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeFalse())
 		})
 		It("returns false for symlinks to files", func() {
-			dirents, _ := os.ReadDir("tests/fixtures")
-			for _, d := range dirents {
-				if d.Name() == "symlink" {
-					Expect(isDirOrSymlinkToDir("tests/fixtures", d)).To(BeFalse())
-				}
-			}
+			dirent, _ := getDirEntry(baseDir, "symlink")
+			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeFalse())
 		})
 	})
 	Describe("isDirIgnored", func() {
+		baseDir := filepath.Join("tests", "fixtures")
 		It("returns false for normal dirs", func() {
-			dirents, _ := os.ReadDir("tests/fixtures")
-			for _, d := range dirents {
-				if d.Name() == "empty_folder" {
-					Expect(isDirIgnored("tests/fixtures", d)).To(BeFalse())
-				}
-			}
+			dirent, _ := getDirEntry(baseDir, "empty_folder")
+			Expect(isDirIgnored(baseDir, dirent)).To(BeFalse())
 		})
 		It("returns true when folder contains .ndignore file", func() {
-			dirents, _ := os.ReadDir("tests/fixtures")
-			for _, d := range dirents {
-				if d.Name() == "ignored_folder" {
-					Expect(isDirIgnored("tests/fixtures", d)).To(BeTrue())
-				}
-			}
+			dirent, _ := getDirEntry(baseDir, "ignored_folder")
+			Expect(isDirIgnored(baseDir, dirent)).To(BeTrue())
 		})
 		It("returns true when folder name starts with a `.`", func() {
-			dirents, _ := os.ReadDir("tests/fixtures")
-			for _, d := range dirents {
-				if d.Name() == ".hidden_folder" {
-					Expect(isDirIgnored("tests/fixtures", d)).To(BeTrue())
-				}
-			}
+			dirent, _ := getDirEntry(baseDir, ".hidden_folder")
+			Expect(isDirIgnored(baseDir, dirent)).To(BeTrue())
 		})
 		It("returns false when folder name starts with ellipses", func() {
-			dirents, _ := os.ReadDir("tests/fixtures")
-			for _, d := range dirents {
-				if d.Name() == "...unhidden_folder" {
-					Expect(isDirIgnored("tests/fixtures", d)).To(BeFalse())
-				}
-			}
+			dirent, _ := getDirEntry(baseDir, "...unhidden_folder")
+			Expect(isDirIgnored(baseDir, dirent)).To(BeFalse())
 		})
 	})
 })

--- a/scanner/walk_dir_tree_test.go
+++ b/scanner/walk_dir_tree_test.go
@@ -10,21 +10,11 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 )
 
-func getDirEntry(baseDir, name string) (os.DirEntry, error) {
-	dirents, _ := os.ReadDir(baseDir)
-	for _, d := range dirents {
-		if d.Name() == name {
-			return d, nil
-		}
-	}
-	return nil, os.ErrNotExist
-}
-
-var _ = Describe("load_tree", func() {
+var _ = Describe("walk_dir_tree", func() {
+	baseDir := filepath.Join("tests", "fixtures")
 
 	Describe("walkDirTree", func() {
 		It("reads all info correctly", func() {
-			baseDir := filepath.Join("tests", "fixtures")
 			var collected = dirMap{}
 			results := make(walkResults, 5000)
 			var err error
@@ -53,41 +43,49 @@ var _ = Describe("load_tree", func() {
 	})
 
 	Describe("isDirOrSymlinkToDir", func() {
-		baseDir := filepath.Join("tests", "fixtures")
 		It("returns true for normal dirs", func() {
-			dirent, _ := getDirEntry("tests", "fixtures")
-			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeTrue())
+			dirEntry, _ := getDirEntry("tests", "fixtures")
+			Expect(isDirOrSymlinkToDir(baseDir, dirEntry)).To(BeTrue())
 		})
 		It("returns true for symlinks to dirs", func() {
-			dirent, _ := getDirEntry(baseDir, "symlink2dir")
-			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeTrue())
+			dirEntry, _ := getDirEntry(baseDir, "symlink2dir")
+			Expect(isDirOrSymlinkToDir(baseDir, dirEntry)).To(BeTrue())
 		})
 		It("returns false for files", func() {
-			dirent, _ := getDirEntry(baseDir, "test.mp3")
-			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeFalse())
+			dirEntry, _ := getDirEntry(baseDir, "test.mp3")
+			Expect(isDirOrSymlinkToDir(baseDir, dirEntry)).To(BeFalse())
 		})
 		It("returns false for symlinks to files", func() {
-			dirent, _ := getDirEntry(baseDir, "symlink")
-			Expect(isDirOrSymlinkToDir(baseDir, dirent)).To(BeFalse())
+			dirEntry, _ := getDirEntry(baseDir, "symlink")
+			Expect(isDirOrSymlinkToDir(baseDir, dirEntry)).To(BeFalse())
 		})
 	})
 	Describe("isDirIgnored", func() {
-		baseDir := filepath.Join("tests", "fixtures")
 		It("returns false for normal dirs", func() {
-			dirent, _ := getDirEntry(baseDir, "empty_folder")
-			Expect(isDirIgnored(baseDir, dirent)).To(BeFalse())
+			dirEntry, _ := getDirEntry(baseDir, "empty_folder")
+			Expect(isDirIgnored(baseDir, dirEntry)).To(BeFalse())
 		})
 		It("returns true when folder contains .ndignore file", func() {
-			dirent, _ := getDirEntry(baseDir, "ignored_folder")
-			Expect(isDirIgnored(baseDir, dirent)).To(BeTrue())
+			dirEntry, _ := getDirEntry(baseDir, "ignored_folder")
+			Expect(isDirIgnored(baseDir, dirEntry)).To(BeTrue())
 		})
 		It("returns true when folder name starts with a `.`", func() {
-			dirent, _ := getDirEntry(baseDir, ".hidden_folder")
-			Expect(isDirIgnored(baseDir, dirent)).To(BeTrue())
+			dirEntry, _ := getDirEntry(baseDir, ".hidden_folder")
+			Expect(isDirIgnored(baseDir, dirEntry)).To(BeTrue())
 		})
 		It("returns false when folder name starts with ellipses", func() {
-			dirent, _ := getDirEntry(baseDir, "...unhidden_folder")
-			Expect(isDirIgnored(baseDir, dirent)).To(BeFalse())
+			dirEntry, _ := getDirEntry(baseDir, "...unhidden_folder")
+			Expect(isDirIgnored(baseDir, dirEntry)).To(BeFalse())
 		})
 	})
 })
+
+func getDirEntry(baseDir, name string) (os.DirEntry, error) {
+	dirEntries, _ := os.ReadDir(baseDir)
+	for _, entry := range dirEntries {
+		if entry.Name() == name {
+			return entry, nil
+		}
+	}
+	return nil, os.ErrNotExist
+}


### PR DESCRIPTION
First off - thanks for `navidrome`!  It is so excellent - fast, easy on the eyes, and very straightforward to use and deploy.  The code is a pleasure to peruse.  

I use directory/ACL permissions to handle which folders I wish to allow media servers to access.
I noticed that upon hitting the first subdir without permission, navidrome would just abandon scanning entirely:
```
ERRO[0004] Error reading dir                             error="lstat /tank/whorfin/Audio/Synth: permission denied" path=/tank/whorfin/Audio
ERRO[0004] Error loading directory tree                  error="lstat /tank/whorfin/Audio/Synth: permission denied"
ERRO[0004] There were errors reading directories from filesystem  error="lstat /tank/whorfin/Audio/Synth: permission denied"
ERRO[0004] Scan was interrupted by error. See errors above  error="lstat /tank/whorfin/Audio/Synth: permission denied"
ERRO[0004] Error importing MediaFolder                   error="lstat /tank/whorfin/Audio/Synth: permission denied" folder=/tank/whorfin/Audio
ERRO[0004] Errors while scanning media. Please check the logs
ERRO[0004] scan error
```
This change aims to fix that.  There is a subtle bit here where we don't bail on ReadDir, which is important.
While I was in there I cleaned up the "Invalid symlink" error message to actually report the symlink path, as opposed to the directory we were in while noticing.
And since we're at Go 1.16 and `ioutil.ReadDir` is deprecated, I swapped it to `os.ReadDir` per recommendations.  This might yield a teeny performance improvement - the docs say:
```
As of Go 1.16, os.ReadDir is a more efficient and correct choice: it returns a list of fs.DirEntry instead of fs.FileInfo, and it returns partial results in the case of an error midway through reading a directory.
```
"efficient and correct" FTW

Also I noticed that while untagged `mp3` files were added to a mega-album of Untitled by artist Untitled [which is thumbs up from me until browse-by-folder is ever supported], `ogg` files were not.  They were completely skipped.
Allowing `ogg` files w/o metadata means a simple change to allow the taglib metadata code to behave more like the ffmpeg branch.