### PR TITLE
Fix BulkAction Button style

### DIFF
--- a/ui/src/themes/spotify.js
+++ b/ui/src/themes/spotify.js
@@ -284,7 +284,7 @@ export default {
         backgroundColor: spotifyGreen['500'],
         '& button:hover': {
           border: '1px solid',
-          background: 'inherit',
+          background: '#0088272e !important',
         },
       },
     },

--- a/ui/src/themes/spotify.js
+++ b/ui/src/themes/spotify.js
@@ -281,12 +281,10 @@ export default {
     },
     RaBulkActionsToolbar: {
       toolbar: {
-        '& button': {
-          backgroundColor: 'inherit',
-          '&:hover': {
-            border: '1px solid',
-            background: 'inherit',
-          },
+        backgroundColor: spotifyGreen['500'],
+        '& button:hover': {
+          border: '1px solid',
+          background: 'inherit',
         },
       },
     },

--- a/ui/src/themes/spotify.js
+++ b/ui/src/themes/spotify.js
@@ -279,13 +279,13 @@ export default {
         marginBottom: 0,
       },
     },
-    RaTopToolbar: {
-      root: {
+    RaBulkActionsToolbar: {
+      toolbar: {
         '& button': {
           backgroundColor: 'inherit',
           '&:hover': {
             border: '1px solid',
-            background: 'inherit!important',
+            background: 'inherit',
           },
         },
       },

--- a/ui/src/themes/spotify.js
+++ b/ui/src/themes/spotify.js
@@ -279,6 +279,17 @@ export default {
         marginBottom: 0,
       },
     },
+    RaTopToolbar: {
+      root: {
+        '& button': {
+          backgroundColor: 'inherit',
+          '&:hover': {
+            border: '1px solid',
+            background: 'inherit!important',
+          },
+        },
+      },
+    },
     RaLayout: {
       content: {
         padding: '0 !important',


### PR DESCRIPTION
As mentioned in issue #1031, the BulkActionsToolbar button was looking too cramped. In this PR, the background color of buttons is similar to the parent element, and on hover, there is a border around the buttons.
Here is the screenshot of the changes,
![image](https://user-images.githubusercontent.com/61188295/116436250-d6942e80-a869-11eb-9956-eac2817ae531.png)
(Fixes #1031)

Feedbacks are most welcomed. Thank you!
~~Edit: There were some style errors in different buttons, so it is not ready for review; sorry for the trouble; it will be fixed soon.~~
@samarsault, could you please review this PR