### PR TITLE
[Spotify-ish] Login consistent with other themes

### DIFF
--- a/ui/src/themes/spotify.js
+++ b/ui/src/themes/spotify.js
@@ -255,25 +255,13 @@ export default {
     },
     NDLogin: {
       main: {
-        boxShadow: 'inset 0 0 0 2000px rgba(0, 0, 0, .8)',
+        boxShadow: 'inset 0 0 0 2000px rgba(0, 0, 0, .75)',
       },
       systemNameLink: {
         color: '#fff',
       },
-      systemName: {
-        marginTop: '0.5em',
-        marginBottom: '1em',
-      },
-      icon: {
-        backgroundColor: 'inherit',
-        width: '5em',
-        height: '5em',
-      },
       card: {
-        background: 'none',
-        boxShadow: 'none',
-        padding: '10px 0',
-        minWidth: 360,
+        border: '1px solid #282828',
       },
       avatar: {
         marginBottom: 0,


### PR DESCRIPTION
- https://github.com/navidrome/navidrome/pull/953 added some improvements to the login window. Ensure that spotify-ish doesn't override the good parts
- Possibly Fix https://github.com/navidrome/navidrome/issues/1072 (can't reproduce)

**Screenshot**

<img width="1440" alt="Screenshot 2021-05-01 at 4 27 57 PM" src="https://user-images.githubusercontent.com/2987087/116780457-98ca1c80-aa9a-11eb-9949-32ec0b00f6cc.png">
