### PR TITLE
Add support for multiple genres.

### DIFF
--- a/db/migration/20210504125343_create_genre.go
+++ b/db/migration/20210504125343_create_genre.go
@@ -1,0 +1,39 @@
+package migrations
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(Up20210430125343, Down20210430125343)
+}
+
+func Up20210430125343(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+create table if not exists genre
+(		
+	name varchar(255) not null
+		primary key,
+	song_count integer default 0 not null,
+	album_count integer default 0 not null
+);
+
+create table if not exists genre_type
+(
+	genre_id varchar(255) not null
+		references genre
+			on update cascade on delete cascade,
+	item_id varchar(255) not null,
+	item_type varchar(255) not null,
+	unique (genre_id, item_id, item_type)
+);
+	`)
+
+	return err
+}
+
+func Down20210430125343(tx *sql.Tx) error {
+	return nil
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -25,6 +25,7 @@ type DataStore interface {
 	MediaFile(ctx context.Context) MediaFileRepository
 	MediaFolder(ctx context.Context) MediaFolderRepository
 	Genre(ctx context.Context) GenreRepository
+	GenreType(ctx context.Context) GenreTypeRepository
 	Playlist(ctx context.Context) PlaylistRepository
 	PlayQueue(ctx context.Context) PlayQueueRepository
 	Property(ctx context.Context) PropertyRepository

--- a/model/genres.go
+++ b/model/genres.go
@@ -1,13 +1,30 @@
 package model
 
 type Genre struct {
-	Name       string
-	SongCount  int
-	AlbumCount int
+	Name       string `json:"name"`
+	SongCount  int    `json:"song_count"`
+	AlbumCount int    `json:"album_count"`
 }
 
 type Genres []Genre
 
 type GenreRepository interface {
+	ResourceRepository
 	GetAll() (Genres, error)
+	Refresh(ids ...string) error
+}
+
+type GenreType struct {
+	GenreID  string `json:"genreId"  orm:"column(genre_id)"`
+	ItemID   string `json:"itemId"   orm:"column(item_id)"`
+	ItemType string `json:"itemType"`
+}
+
+type GenreTypes []GenreType
+
+type GenreTypeRepository interface {
+	EntityName() string
+	NewInstance() interface{}
+	GetGenres(itemID string, itemType string) ([]string, error)
+	Refresh(ids ...string) error
 }

--- a/persistence/genre_repository.go
+++ b/persistence/genre_repository.go
@@ -2,14 +2,19 @@ package persistence
 
 import (
 	"context"
+	"strings"
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/astaxie/beego/orm"
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils"
 )
 
 type genreRepository struct {
 	sqlRepository
+	sqlRestful
 }
 
 func NewGenreRepository(ctx context.Context, o orm.Ormer) model.GenreRepository {
@@ -20,10 +25,93 @@ func NewGenreRepository(ctx context.Context, o orm.Ormer) model.GenreRepository 
 	return r
 }
 
-func (r genreRepository) GetAll() (model.Genres, error) {
+func (r *genreRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	return r.count(Select(), r.parseRestOptions(options...))
+}
+
+func (r *genreRepository) EntityName() string {
+	return "genre"
+}
+
+func (r *genreRepository) NewInstance() interface{} {
+	return &model.Genre{}
+}
+
+func (r *genreRepository) Read(id string) (interface{}, error) {
+	sel := r.newSelect().Columns("*").Where(Eq{"id": id})
+	var res model.Genre
+	err := r.queryOne(sel, &res)
+	return &res, err
+}
+
+func (r *genreRepository) ReadAll(options ...rest.QueryOptions) (interface{}, error) {
+	sel := r.newSelect(r.parseRestOptions(options...)).Columns("*")
+	res := model.Genres{}
+	err := r.queryAll(sel, &res)
+	return res, err
+}
+
+func (r *genreRepository) GetAll() (model.Genres, error) {
 	sq := Select("genre as name", "count(distinct album_id) as album_count", "count(distinct id) as song_count").
 		From("media_file").GroupBy("genre")
 	res := model.Genres{}
 	err := r.queryAll(sq, &res)
 	return res, err
 }
+
+func (r *genreRepository) Refresh(ids ...string) error {
+	chunks := utils.BreakUpStringSlice(ids, 100)
+	for _, chunk := range chunks {
+		err := r.refresh(chunk...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *genreRepository) refresh(cids ...string) error {
+	var ids []string
+	for _, id := range cids {
+		ids = append(ids, strings.Split(id, ",")...)
+	}
+	type refreshGenre struct {
+		model.Genre
+		CurrentId string
+	}
+	var genres []refreshGenre
+	sel := Select(`f.genre as name, count(distinct f.album_id) as album_count, count(distinct f.id) as song_count,
+		g.name as current_id`).
+		From("media_file f").
+		LeftJoin("genre g on f.genre = g.name").
+		Where(Eq{"f.genre": ids}).GroupBy("f.genre")
+	err := r.queryAll(sel, &genres)
+	if err != nil {
+		return err
+	}
+
+	toInsert := 0
+	toUpdate := 0
+
+	for _, g := range genres {
+		if g.CurrentId != "" {
+			toUpdate++
+		} else {
+			toInsert++
+		}
+
+		_, err := r.put(g.Name, g.Genre)
+		if err != nil {
+			return err
+		}
+	}
+	if toInsert > 0 {
+		log.Debug(r.ctx, "Inserted new genres", "totalInserted", toInsert)
+	}
+	if toUpdate > 0 {
+		log.Debug(r.ctx, "Updated genres", "totalUpdated", toUpdate)
+	}
+	return err
+}
+
+var _ model.GenreRepository = (*genreRepository)(nil)

--- a/persistence/genretype_repository.go
+++ b/persistence/genretype_repository.go
@@ -1,0 +1,116 @@
+package persistence
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/astaxie/beego/orm"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils"
+)
+
+type genreTypeRepository struct {
+	sqlRepository
+	sqlRestful
+	genreRepo model.GenreRepository
+}
+
+func NewGenreTypeRepository(ctx context.Context, o orm.Ormer) model.GenreTypeRepository {
+	r := &genreTypeRepository{}
+	r.ctx = ctx
+	r.ormer = o
+	r.tableName = "genre_type"
+	return r
+}
+
+func (r *genreTypeRepository) GetGenres(itemID string, itemType string) ([]string, error) {
+	all := r.newSelect().Columns("genre_id").Where(And{Eq{"item_id": itemID}, Eq{"item_type": itemType}}).OrderBy("genre_id")
+	var genres model.GenreTypes
+	err := r.queryAll(all, &genres)
+	if err != nil {
+		log.Error("Error querying genres from", itemType, "ID", itemID, err)
+		return nil, err
+	}
+	genre_ids := make([]string, len(genres))
+	for i := range genre_ids {
+		genre_ids[i] = genres[i].GenreID
+	}
+	return genre_ids, nil
+}
+
+func (r *genreTypeRepository) EntityName() string {
+	return "genre_type"
+}
+
+func (r *genreTypeRepository) NewInstance() interface{} {
+	return &model.GenreType{}
+}
+
+func (r *genreTypeRepository) Refresh(ids ...string) error {
+	chunks := utils.BreakUpStringSlice(ids, 100)
+	for _, chunk := range chunks {
+		err := r.refresh(chunk...)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *genreTypeRepository) refresh(cids ...string) error {
+	var ids []string
+	for _, id := range cids {
+		ids = append(ids, strings.Split(id, ",")...)
+	}
+	del := Delete(r.tableName).Where(Eq{"genre_id": ids})
+	_, err := r.executeSQL(del)
+	if err != nil {
+		return err
+	}
+
+	sel := Select(`genre as genre_id, id as item_id`).
+		From("media_file").
+		Where(Eq{"genre": ids})
+	err = r.insertRelations(sel, "media_file")
+
+	sel = Select(`f.genre as genre_id, a.id as item_id`).
+		From("media_file as f").
+		Distinct().
+		LeftJoin("album a on f.album_id = a.id").
+		Where(Eq{"f.genre": ids})
+	err = r.insertRelations(sel, "album")
+
+	sel = Select(`f.genre as genre_id, a.id as item_id`).
+		From("media_file as f").
+		Distinct().
+		LeftJoin("artist a on f.artist_id = a.id").
+		Where(Eq{"f.genre": ids})
+	err = r.insertRelations(sel, "artist")
+
+	return err
+}
+
+func (r *genreTypeRepository) insertRelations(sel SelectBuilder, itemType string) error {
+	var genres model.GenreTypes
+	err := r.queryAll(sel, &genres)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(genres); {
+		ins := Insert(r.tableName).Columns("genre_id", "item_id", "item_type")
+		for j := 0; j < 50 && i < len(genres); i, j = i+1, j+1 {
+			genres[i].ItemType = itemType
+			ins = ins.Values(genres[i].GenreID, genres[i].ItemID, genres[i].ItemType)
+		}
+		_, err = r.executeSQL(ins)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+var _ model.GenreTypeRepository = (*genreTypeRepository)(nil)

--- a/persistence/genretype_repository.go
+++ b/persistence/genretype_repository.go
@@ -13,8 +13,6 @@ import (
 
 type genreTypeRepository struct {
 	sqlRepository
-	sqlRestful
-	genreRepo model.GenreRepository
 }
 
 func NewGenreTypeRepository(ctx context.Context, o orm.Ormer) model.GenreTypeRepository {
@@ -74,6 +72,9 @@ func (r *genreTypeRepository) refresh(cids ...string) error {
 		From("media_file").
 		Where(Eq{"genre": ids})
 	err = r.insertRelations(sel, "media_file")
+	if err != nil {
+		return err
+	}
 
 	sel = Select(`f.genre as genre_id, a.id as item_id`).
 		From("media_file as f").
@@ -81,6 +82,9 @@ func (r *genreTypeRepository) refresh(cids ...string) error {
 		LeftJoin("album a on f.album_id = a.id").
 		Where(Eq{"f.genre": ids})
 	err = r.insertRelations(sel, "album")
+	if err != nil {
+		return err
+	}
 
 	sel = Select(`f.genre as genre_id, a.id as item_id`).
 		From("media_file as f").
@@ -88,8 +92,11 @@ func (r *genreTypeRepository) refresh(cids ...string) error {
 		LeftJoin("artist a on f.artist_id = a.id").
 		Where(Eq{"f.genre": ids})
 	err = r.insertRelations(sel, "artist")
+	if err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }
 
 func (r *genreTypeRepository) insertRelations(sel SelectBuilder, itemType string) error {
@@ -110,7 +117,7 @@ func (r *genreTypeRepository) insertRelations(sel SelectBuilder, itemType string
 			return err
 		}
 	}
-	return err
+	return nil
 }
 
 var _ model.GenreTypeRepository = (*genreTypeRepository)(nil)

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -38,6 +38,10 @@ func (s *SQLStore) Genre(ctx context.Context) model.GenreRepository {
 	return NewGenreRepository(ctx, s.getOrmer())
 }
 
+func (s *SQLStore) GenreType(ctx context.Context) model.GenreTypeRepository {
+	return NewGenreTypeRepository(ctx, s.getOrmer())
+}
+
 func (s *SQLStore) PlayQueue(ctx context.Context) model.PlayQueueRepository {
 	return NewPlayQueueRepository(ctx, s.getOrmer())
 }
@@ -78,6 +82,8 @@ func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRe
 		return s.MediaFile(ctx).(model.ResourceRepository)
 	case model.Playlist:
 		return s.Playlist(ctx).(model.ResourceRepository)
+	case model.Genre:
+		return s.Genre(ctx).(model.ResourceRepository)
 	}
 	log.Error("Resource not implemented", "model", reflect.TypeOf(m).Name())
 	return nil

--- a/scanner/refresh_buffer.go
+++ b/scanner/refresh_buffer.go
@@ -9,10 +9,12 @@ import (
 )
 
 type refreshBuffer struct {
-	ctx    context.Context
-	ds     model.DataStore
-	album  map[string]struct{}
-	artist map[string]struct{}
+	ctx       context.Context
+	ds        model.DataStore
+	album     map[string]struct{}
+	artist    map[string]struct{}
+	genre     map[string]struct{}
+	genretype map[string]struct{}
 }
 
 func newRefreshBuffer(ctx context.Context, ds model.DataStore) *refreshBuffer {
@@ -30,6 +32,10 @@ func (f *refreshBuffer) accumulate(mf model.MediaFile) {
 	}
 	if mf.AlbumArtistID != "" {
 		f.artist[mf.AlbumArtistID] = struct{}{}
+	}
+	if mf.Genre != "" {
+		f.genre[mf.Genre] = struct{}{}
+		f.genretype[mf.Genre] = struct{}{}
 	}
 }
 
@@ -57,6 +63,14 @@ func (f *refreshBuffer) flush() error {
 		return err
 	}
 	err = f.flushMap(f.artist, "artist", f.ds.Artist(f.ctx).Refresh)
+	if err != nil {
+		return err
+	}
+	err = f.flushMap(f.genre, "genre", f.ds.Genre(f.ctx).Refresh)
+	if err != nil {
+		return err
+	}
+	err = f.flushMap(f.genretype, "genre_type", f.ds.GenreType(f.ctx).Refresh)
 	if err != nil {
 		return err
 	}

--- a/tests/mock_persistence.go
+++ b/tests/mock_persistence.go
@@ -14,6 +14,7 @@ type MockDataStore struct {
 	MockedUser        model.UserRepository
 	MockedPlayer      model.PlayerRepository
 	MockedTranscoding model.TranscodingRepository
+	MockedGenreType   model.GenreTypeRepository
 }
 
 func (db *MockDataStore) Album(context.Context) model.AlbumRepository {
@@ -79,6 +80,13 @@ func (db *MockDataStore) Player(context.Context) model.PlayerRepository {
 		return db.MockedPlayer
 	}
 	return struct{ model.PlayerRepository }{}
+}
+
+func (db *MockDataStore) GenreType(context.Context) model.GenreTypeRepository {
+	if db.MockedPlayer != nil {
+		return db.MockedGenreType
+	}
+	return struct{ model.GenreTypeRepository }{}
 }
 
 func (db *MockDataStore) WithTx(block func(db model.DataStore) error) error {


### PR DESCRIPTION
This PR adds support for multiple genres by establishing M2M relationships between `genre` and `album`, `artist` and `media_file`. This is a draft PR as suggested by @deluan and only creates backend support, and does not provide an API to consume the endpoints, the implementation of which can change according to changes being done to the underlying database schema.

A summary of what has been done till now:

- A `genre` table is created in the database.
- A `genre_type` table to store M2M relations is also made.
- The schema of `genre_type` is as follows - the `genre_id` is the ID (name) of the genre, `item_id` and `item_type` are the details of the 'item' (`album`, `artist` or `media_file`) 
- The genres associated with a 'type' can be obtained through the `GetGenres` method in `GenreTypeRepository`.

Fixes #119.