### PR TITLE
Add devEnableShare config option

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -64,6 +64,7 @@ type configOptions struct {
 	DevFastAccessCoverArt      bool
 	DevOldCacheLayout          bool
 	DevActivityPanel           bool
+	DevEnableShare             bool
 }
 
 type scannerOptions struct {
@@ -211,6 +212,7 @@ func init() {
 	viper.SetDefault("devoldcachelayout", false)
 	viper.SetDefault("devFastAccessCoverArt", false)
 	viper.SetDefault("devactivitypanel", true)
+	viper.SetDefault("devenableshare", false)
 }
 
 func InitConfig(cfgFile string) {

--- a/server/app/serve_index.go
+++ b/server/app/serve_index.go
@@ -49,6 +49,7 @@ func serveIndex(ds model.DataStore, fs fs.FS) http.HandlerFunc {
 			"devActivityPanel":        conf.Server.DevActivityPanel,
 			"devFastAccessCoverArt":   conf.Server.DevFastAccessCoverArt,
 			"enableUserEditing":       conf.Server.EnableUserEditing,
+			"devEnableShare":          conf.Server.DevEnableShare,
 		}
 		j, err := json.Marshal(appConfig)
 		if err != nil {

--- a/server/app/serve_index_test.go
+++ b/server/app/serve_index_test.go
@@ -199,6 +199,16 @@ var _ = Describe("serveIndex", func() {
 		config := extractAppConfig(w.Body.String())
 		Expect(config).To(HaveKeyWithValue("enableUserEditing", true))
 	})
+
+	It("sets the devEnableShare", func() {
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		serveIndex(ds, fs)(w, r)
+
+		config := extractAppConfig(w.Body.String())
+		Expect(config).To(HaveKeyWithValue("devEnableShare", false))
+	})
 })
 
 var appConfigRegex = regexp.MustCompile(`(?m)window.__APP_CONFIG__="([^"]*)`)

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -18,7 +18,7 @@ const defaultConfig = {
   enableStarRating: true,
   defaultTheme: 'Dark',
   enableUserEditing: true,
-  devEnableShare: false,
+  devEnableShare: true,
 }
 
 let config

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -18,6 +18,7 @@ const defaultConfig = {
   enableStarRating: true,
   defaultTheme: 'Dark',
   enableUserEditing: true,
+  devEnableShare: false,
 }
 
 let config


### PR DESCRIPTION
This PR adds a `devEnableShare` flag for the in-progress share functionality. 

Follow-up to https://github.com/navidrome/navidrome/pull/930#issuecomment-850841845