### PR TITLE
Parse ParamBool case-insensitively

### DIFF
--- a/utils/request_helpers.go
+++ b/utils/request_helpers.go
@@ -84,7 +84,7 @@ func ParamInts(r *http.Request, param string) []int {
 }
 
 func ParamBool(r *http.Request, param string, def bool) bool {
-	p := ParamString(r, param)
+	p := strings.ToLower(ParamString(r, param))
 	if p == "" {
 		return def
 	}

--- a/utils/request_helpers_test.go
+++ b/utils/request_helpers_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Request Helpers", func() {
 	Describe("ParamBool", func() {
 		Context("value is true", func() {
 			BeforeEach(func() {
-				r = httptest.NewRequest("GET", "/ping?b=true&c=on&d=1", nil)
+				r = httptest.NewRequest("GET", "/ping?b=true&c=on&d=1&e=True", nil)
 			})
 
 			It("parses 'true'", func() {
@@ -160,6 +160,10 @@ var _ = Describe("Request Helpers", func() {
 
 			It("parses '1'", func() {
 				Expect(ParamBool(r, "d", false)).To(BeTrue())
+			})
+
+			It("parses 'True'", func() {
+				Expect(ParamBool(r, "e", false)).To(BeTrue())
 			})
 		})
 


### PR DESCRIPTION
This will allow boolean query parameters to parse as true for the value `True` (for compatibility with Python)