### PR TITLE
Add support for Styling the player

### DIFF
--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -117,7 +117,8 @@ const Player = () => {
   )
 
   const visible = authenticated && queue.queue.length > 0
-  const classes = useStyle({ visible })
+  const playprops = { theme, visible }
+  const classes = useStyle(playprops)
   // Match the medium breakpoint defined in the material-ui theme
   // See https://material-ui.com/customization/breakpoints/#breakpoints
   const isDesktop = useMediaQuery('(min-width:810px)')

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -62,6 +62,21 @@ const useStyle = makeStyles(
       '& .play-mode-title': {
         'pointer-events': 'none',
       },
+      '& .music-player-panel': {
+        background: (props) => props.theme?.player.bgcolor,
+        '& .audio-main': {
+          color: (props) => props.theme?.player.durcolor,
+        },
+        '& svg': {
+          color: (props) => props.theme?.player.btncolor,
+          '&:hover': {
+            color: (props) => props.theme?.player.hovbtncolor,
+          },
+        },
+        '& .rc-slider-handle': {
+          background: (props) => `${props.theme?.player.durcolor} !important`,
+        },
+      },
     },
     artistAlbum: {
       marginTop: '2px',


### PR DESCRIPTION
This PR introduces a method to style the player by adding some of the pre-defined properties in the `player{}` object in the theme file; they are as follows:
```
overrides:{...},

player: {
    theme: 'light',
    bgcolor: '',        //style background color of the player
    durcolor: '',       //style the duration and duration slider color
    btncolor: '',       //style the button colors
    hovbtncolor: '',    // style the button color in hover state  
  }
```
At the moment, only these few styles can be modified, but the other style modifications could be added as per future needs.

Feedbacks are most welcomed. Thank you!