### PR TITLE
Add Submenu Icon for Indication of List

### DIFF
--- a/ui/src/layout/SubMenu.js
+++ b/ui/src/layout/SubMenu.js
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import ExpandMore from '@material-ui/icons/ExpandMore'
+import ExpandLessIcon from '@material-ui/icons/ExpandLess'
 import List from '@material-ui/core/List'
 import MenuItem from '@material-ui/core/MenuItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
@@ -9,6 +9,7 @@ import Collapse from '@material-ui/core/Collapse'
 import Tooltip from '@material-ui/core/Tooltip'
 import { makeStyles } from '@material-ui/core/styles'
 import { useTranslate } from 'react-admin'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -42,7 +43,17 @@ const SubMenu = ({
   const header = (
     <MenuItem dense={dense} button onClick={handleToggle}>
       <ListItemIcon className={classes.icon}>
-        {isOpen ? <ExpandMore /> : icon}
+        {sidebarIsOpen ? (
+          isOpen ? (
+            <ExpandLessIcon />
+          ) : (
+            <ChevronRightIcon />
+          )
+        ) : isOpen ? (
+          <ExpandLessIcon />
+        ) : (
+          icon
+        )}
       </ListItemIcon>
       <Typography variant="inherit" color="textSecondary">
         {translate(name)}


### PR DESCRIPTION
Fixes #430. As suggested in the issue, there was no clear indication of submenu; in this PR, when the Sidebar is open, there is ArrowIcon in place of AlbumIcon, for indication of Submenu, whereas no changes when Sidebar is closed. Also, the ExpandMore Icon is replaced by ExpandLess Icon. Here are the screenshots after the changes,

SideBar open,
![image](https://user-images.githubusercontent.com/61188295/117171097-36e61b80-ade8-11eb-911b-5067ea68adb6.png)

SideBar closed,
![image](https://user-images.githubusercontent.com/61188295/117171304-63019c80-ade8-11eb-89a1-df00ce6d41cb.png)

Feedbacks are most welcomed. Thank You!
P.S: This branch was mistakenly deleted, so reopening a new PR.