### PR TITLE
Addresses a bug that would prevent users from changing their own passwords, introduced as part of #1187.

### DIFF
--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -180,6 +180,11 @@ func (r *userRepository) Update(entity interface{}, cols ...string) error {
 		u.IsAdmin = false
 		u.UserName = usr.UserName
 	}
+
+	// Decrypt the user's existing password before validating. This is required otherwise the existing password entered by the user will never match.
+	if err := r.decryptPassword(usr); err != nil {
+		return err
+	}
 	if err := validatePasswordChange(u, usr); err != nil {
 		return err
 	}


### PR DESCRIPTION
After #1187, if you try to change your own password you get a "Password does not match" error. This is because the user is entering their current password in plain text, but it is being compared against an encrypted version of the password stored in the database.

This change fixes this issue by decrypting the password stored in the database and comparing it against the plaintext version provided by the user.