### PR TITLE
Add missing song information to players and apply EnableCoverAnimation to mobile player.

### DIFF
--- a/ui/src/audioplayer/AudioTitle.js
+++ b/ui/src/audioplayer/AudioTitle.js
@@ -28,9 +28,10 @@ const AudioTitle = React.memo(({ audioInfo, isMobile }) => {
         )}
       </span>
       {!isMobile && (
-          <span className={clsx(classes.songInfo)}>
-            {`${song.artist} - ${song.album}` + (song.year ? ` - ${song.year}` : '')}
-          </span>
+        <span className={clsx(classes.songInfo)}>
+          {`${song.artist} - ${song.album}` +
+            (song.year ? ` - ${song.year}` : '')}
+        </span>
       )}
       {isMobile && (
         <>

--- a/ui/src/audioplayer/AudioTitle.js
+++ b/ui/src/audioplayer/AudioTitle.js
@@ -29,7 +29,7 @@ const AudioTitle = React.memo(({ audioInfo, isMobile }) => {
       </span>
       {!isMobile && (
           <span className={clsx(classes.songInfo)}>
-            {`${song.artist} - ${song.album}`}
+            {`${song.artist} - ${song.album}` + (song.year ? ` - ${song.year}` : '')}
           </span>
       )}
       {isMobile && (

--- a/ui/src/audioplayer/AudioTitle.js
+++ b/ui/src/audioplayer/AudioTitle.js
@@ -38,7 +38,7 @@ const AudioTitle = React.memo(({ audioInfo, isMobile }) => {
             {`${song.artist}`}
           </span>
           <span className={clsx(classes.songInfo, classes.songAlbum)}>
-            {`${song.album} - ${song.year}`}
+            {song.year ? `${song.album} - ${song.year}` : `${song.album}`}
           </span>
         </>
       )}

--- a/ui/src/audioplayer/AudioTitle.js
+++ b/ui/src/audioplayer/AudioTitle.js
@@ -28,11 +28,19 @@ const AudioTitle = React.memo(({ audioInfo, isMobile }) => {
         )}
       </span>
       {!isMobile && (
-        <div className={classes.artistAlbum}>
-          <span className={clsx(classes.songInfo, 'songInfo')}>
+          <span className={clsx(classes.songInfo)}>
             {`${song.artist} - ${song.album}`}
           </span>
-        </div>
+      )}
+      {isMobile && (
+        <>
+          <span className={clsx(classes.songInfo, classes.songArtist)}>
+            {`${song.artist}`}
+          </span>
+          <span className={clsx(classes.songInfo, classes.songAlbum)}>
+            {`${song.album} - ${song.year}`}
+          </span>
+        </>
       )}
     </Link>
   )

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -16,8 +16,6 @@ const useStyle = makeStyles(
       display: 'block',
       marginTop: '2px',
     },
-    songArtist: {
-    },
     songAlbum: {
       fontStyle: 'italic',
       fontSize: 'smaller',

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -38,6 +38,14 @@ const useStyle = makeStyles(
         animationDuration: (props) => !props.enableCoverAnimation && '0s',
         borderRadius: (props) => !props.enableCoverAnimation && '0',
       },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover': {
+        borderRadius: (props) => !props.enableCoverAnimation && '0',
+        width: (props) => !props.enableCoverAnimation && '80%',
+        height: (props) => !props.enableCoverAnimation && 'auto',
+      },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover': {
+        animationDuration: (props) => !props.enableCoverAnimation && '0s',
+      },
     },
     artistAlbum: {
       marginTop: '2px',

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -53,6 +53,12 @@ const useStyle = makeStyles(
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover': {
         animationDuration: (props) => !props.enableCoverAnimation && '0s',
       },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-singer': {
+        display: 'none',
+      },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-switch': {
+        display: 'none',
+      },
     },
   }),
   { name: 'NDAudioPlayer' }

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -39,10 +39,13 @@ const useStyle = makeStyles(
       '& .play-mode-title': {
         'pointer-events': 'none',
       },
-      // Customize desktop player when cover animation is disabled
       '& .music-player-panel .panel-content div.img-rotate': {
+        // Customize desktop player when cover animation is disabled
         animationDuration: (props) => !props.enableCoverAnimation && '0s',
         borderRadius: (props) => !props.enableCoverAnimation && '0',
+        // Fix cover display when image is not square
+        backgroundSize: 'contain',
+        backgroundPosition: 'center',
       },
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover':
         {

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -45,23 +45,27 @@ const useStyle = makeStyles(
         borderRadius: (props) => !props.enableCoverAnimation && '0',
       },
       // Customize mobile player when cover animation is disabled
-      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover': {
-        borderRadius: (props) => !props.enableCoverAnimation && '0',
-        width: (props) => !props.enableCoverAnimation && '85%',
-        maxWidth: (props) => !props.enableCoverAnimation && '600px',
-        height: (props) => !props.enableCoverAnimation && 'auto',
-      },
-      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover': {
-        animationDuration: (props) => !props.enableCoverAnimation && '0s',
-      },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover':
+        {
+          borderRadius: (props) => !props.enableCoverAnimation && '0',
+          width: (props) => !props.enableCoverAnimation && '85%',
+          maxWidth: (props) => !props.enableCoverAnimation && '600px',
+          height: (props) => !props.enableCoverAnimation && 'auto',
+        },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover':
+        {
+          animationDuration: (props) => !props.enableCoverAnimation && '0s',
+        },
       // Hide old singer display
-      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-singer': {
-        display: 'none',
-      },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-singer':
+        {
+          display: 'none',
+        },
       // Hide extra whitespace from switch div
-      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-switch': {
-        display: 'none',
-      },
+      '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-switch':
+        {
+          display: 'none',
+        },
     },
   }),
   { name: 'NDAudioPlayer' }

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -47,7 +47,8 @@ const useStyle = makeStyles(
       },
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover': {
         borderRadius: (props) => !props.enableCoverAnimation && '0',
-        width: (props) => !props.enableCoverAnimation && '80%',
+        width: (props) => !props.enableCoverAnimation && '85%',
+        maxWidth: (props) => !props.enableCoverAnimation && '600px',
         height: (props) => !props.enableCoverAnimation && 'auto',
       },
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover': {

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -44,17 +44,21 @@ const useStyle = makeStyles(
         animationDuration: (props) => !props.enableCoverAnimation && '0s',
         borderRadius: (props) => !props.enableCoverAnimation && '0',
       },
-      // Customize mobile player when cover animation is disabled
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover':
         {
+          // Customize mobile player when cover animation is disabled
           borderRadius: (props) => !props.enableCoverAnimation && '0',
           width: (props) => !props.enableCoverAnimation && '85%',
           maxWidth: (props) => !props.enableCoverAnimation && '600px',
           height: (props) => !props.enableCoverAnimation && 'auto',
+          // Fix cover display when image is not square
+          aspectRatio: '1/1',
+          display: 'flex',
         },
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover':
         {
           animationDuration: (props) => !props.enableCoverAnimation && '0s',
+          objectFit: 'contain', // Fix cover display when image is not square
         },
       // Hide old singer display
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-singer':

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -41,10 +41,12 @@ const useStyle = makeStyles(
       '& .play-mode-title': {
         'pointer-events': 'none',
       },
+      // Customize desktop player when cover animation is disabled
       '& .music-player-panel .panel-content div.img-rotate': {
         animationDuration: (props) => !props.enableCoverAnimation && '0s',
         borderRadius: (props) => !props.enableCoverAnimation && '0',
       },
+      // Customize mobile player when cover animation is disabled
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover': {
         borderRadius: (props) => !props.enableCoverAnimation && '0',
         width: (props) => !props.enableCoverAnimation && '85%',
@@ -54,9 +56,11 @@ const useStyle = makeStyles(
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover': {
         animationDuration: (props) => !props.enableCoverAnimation && '0s',
       },
+      // Hide old singer display
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-singer': {
         display: 'none',
       },
+      // Hide extra whitespace from switch div
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-switch': {
         display: 'none',
       },

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -14,6 +14,13 @@ const useStyle = makeStyles(
     },
     songInfo: {
       display: 'block',
+      marginTop: '2px',
+    },
+    songArtist: {
+    },
+    songAlbum: {
+      fontStyle: 'italic',
+      fontSize: 'smaller',
     },
     qualityInfo: {
       marginTop: '-4px',
@@ -46,9 +53,6 @@ const useStyle = makeStyles(
       '& .react-jinke-music-player-mobile .react-jinke-music-player-mobile-cover img.cover': {
         animationDuration: (props) => !props.enableCoverAnimation && '0s',
       },
-    },
-    artistAlbum: {
-      marginTop: '2px',
     },
   }),
   { name: 'NDAudioPlayer' }


### PR DESCRIPTION
Modifies the mobile and desktop players to add missing basic song info and create a more uniform look. The changes are (obviously) aligned with my preferences and may not fit the project's vision.  I figured I'd at least put them out here as a point of discussion.

## Mobile Player
- Hides the original artist field and adds a new artist field with style matching song title.
- Adds album and song year (if present) to player under artist field, with matching style.

![New mobile player fields](https://user-images.githubusercontent.com/6924622/127783349-1a345740-88c8-42c1-9d9f-1a5e70568858.png)

- `EnableCoverAnimation` is now applied to the mobile player. When animations are disabled, the cover is displayed square with a width up to 85%. For large mobile screens (e.g. iPad) the maximum width is capped at 600 px. Closes #1265.

![Mobile player with cover animations disabled](https://user-images.githubusercontent.com/6924622/127783335-a101b05a-5862-4902-8dd2-bade2098c3d7.png)

## Desktop Player
- Song year is added to song info when present in the format of "Artist - Album - Year".

![Desktop player with song year](https://user-images.githubusercontent.com/6924622/127783270-16755c7b-0a13-4d3b-a968-d5b155a6bfa0.png)
