### PR TITLE
Improve performance of placeholder images

### DIFF
--- a/core/artwork.go
+++ b/core/artwork.go
@@ -178,7 +178,7 @@ func resizeImage(reader io.Reader, size int, usePng bool) (io.ReadCloser, error)
 	}
 
 	buf := new(bytes.Buffer)
-	if usePng == true {
+	if usePng {
 		err = png.Encode(buf, m)
 	} else {
 		err = jpeg.Encode(buf, m, &jpeg.Options{Quality: conf.Server.CoverJpegQuality})

--- a/core/artwork.go
+++ b/core/artwork.go
@@ -129,7 +129,7 @@ func (a *artwork) getArtwork(ctx context.Context, id string, path string, size i
 			log.Warn(ctx, "Error extracting image", "path", path, "size", size, err)
 			reader, err = resources.FS.Open(consts.PlaceholderAlbumArt)
 
-			if size != 0 {
+			if size != 0 && err == nil {
 				var r io.ReadCloser
 				r, err = resources.FS.Open(consts.PlaceholderAlbumArt)
 				reader, err = resizeImage(r, size, true)

--- a/core/artwork.go
+++ b/core/artwork.go
@@ -8,6 +8,7 @@ import (
 	"image"
 	_ "image/gif"
 	"image/jpeg"
+	"image/png"
 	_ "image/png"
 	"io"
 	"os"
@@ -127,6 +128,12 @@ func (a *artwork) getArtwork(ctx context.Context, id string, path string, size i
 		if err != nil {
 			log.Warn(ctx, "Error extracting image", "path", path, "size", size, err)
 			reader, err = resources.FS.Open(consts.PlaceholderAlbumArt)
+
+			if size != 0 {
+				var r io.ReadCloser
+				r, err = resources.FS.Open(consts.PlaceholderAlbumArt)
+				reader, err = resizeImage(r, size, true)
+			}
 		}
 	}()
 
@@ -149,13 +156,13 @@ func (a *artwork) getArtwork(ctx context.Context, id string, path string, size i
 			return
 		}
 		defer r.Close()
-		reader, err = resizeImage(r, size)
+		reader, err = resizeImage(r, size, false)
 	}
 
 	return
 }
 
-func resizeImage(reader io.Reader, size int) (io.ReadCloser, error) {
+func resizeImage(reader io.Reader, size int, usePng bool) (io.ReadCloser, error) {
 	img, _, err := image.Decode(reader)
 	if err != nil {
 		return nil, err
@@ -171,7 +178,11 @@ func resizeImage(reader io.Reader, size int) (io.ReadCloser, error) {
 	}
 
 	buf := new(bytes.Buffer)
-	err = jpeg.Encode(buf, m, &jpeg.Options{Quality: conf.Server.CoverJpegQuality})
+	if usePng == true {
+		err = png.Encode(buf, m)
+	} else {
+		err = jpeg.Encode(buf, m, &jpeg.Options{Quality: conf.Server.CoverJpegQuality})
+	}
 	return io.NopCloser(buf), err
 }
 

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -51,8 +51,7 @@ const getCoverArtUrl = (record, size) => {
   }
   if (record.coverArtId)
     return baseUrl(url('getCoverArt', record.coverArtId, options))
-  else
-    return baseUrl(url('getCoverArt', 'not_found', (size && { size })))
+  else return baseUrl(url('getCoverArt', 'not_found', size && { size }))
 }
 
 const streamUrl = (id) => {

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -49,9 +49,11 @@ const getCoverArtUrl = (record, size) => {
     ...(record.updatedAt && { _: record.updatedAt }),
     ...(size && { size }),
   }
-  if (record.coverArtId)
+  if (record.coverArtId) {
     return baseUrl(url('getCoverArt', record.coverArtId, options))
-  else return baseUrl(url('getCoverArt', 'not_found', size && { size }))
+  } else {
+    return baseUrl(url('getCoverArt', 'not_found', size && { size }))
+  }
 }
 
 const streamUrl = (id) => {

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -49,7 +49,10 @@ const getCoverArtUrl = (record, size) => {
     ...(record.updatedAt && { _: record.updatedAt }),
     ...(size && { size }),
   }
-  return baseUrl(url('getCoverArt', record.coverArtId || 'not_found', options))
+  if (record.coverArtId)
+    return baseUrl(url('getCoverArt', record.coverArtId, options))
+  else
+    return baseUrl(url('getCoverArt', 'not_found', (size && { size })))
 }
 
 const streamUrl = (id) => {


### PR DESCRIPTION
This PR improves performance for placeholder images:
- Use a common URL for placeholder images allowing browsers to cache the image
- Applies requested size to the placeholder image reducing transfer size

I'm leaving this as a draft for now as I don't know if there are negative impacts from removing the `updatedAt` field from the getCoverArt requests for placeholders. 

**Original behavior**
Original behavior has to make a request for each placeholder image at original size. My system/internet has lousy upload performance resulting in noticeable delay in fetching placeholders.
![original requests](https://user-images.githubusercontent.com/6924622/132102354-a024e453-baa8-42c0-b972-701d593a8baf.png)

**New behavior**
With the following changes only a single request for the place holder is performed, and at a reduced size.
![new requests](https://user-images.githubusercontent.com/6924622/132102256-7ff83dee-4502-4da1-b070-d40c011ddfca.png)
