### PR TITLE
Extract version from directory name if .git dir is missing

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -127,9 +127,6 @@ jobs:
       - name: Show Version
         run: git describe --tags
 
-      - name: Generate .gitinfo
-        run: make .gitinfo
-
       - name: Run GoReleaser - SNAPSHOT
         if: startsWith(github.ref, 'refs/tags/') != true
         uses: docker://deluan/ci-goreleaser:1.16.4-1

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ GIT_SHA=$(shell git rev-parse --short HEAD)
 GIT_TAG=$(shell git describe --tags `git rev-list --tags --max-count=1`)
 else
 GIT_SHA=source_archive
-GIT_TAG=$(shell echo $${PWD##*-})
+GIT_TAG=$(patsubst navidrome-%,v%,$(notdir $(PWD)))
 endif
 
 CI_RELEASER_VERSION=1.16.4-1 ## https://github.com/navidrome/ci-goreleaser

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,9 @@ NODE_VERSION=$(shell cat .nvmrc)
 ifneq ("$(wildcard .git)","")
 GIT_SHA=$(shell git rev-parse --short HEAD)
 GIT_TAG=$(shell git describe --tags `git rev-list --tags --max-count=1`)
-else ifneq ("$(wildcard .gitinfo)","")
-include .gitinfo
+else
+GIT_SHA=source_archive
+GIT_TAG=$(shell echo $${PWD##*-})
 endif
 
 CI_RELEASER_VERSION=1.16.4-1 ## https://github.com/navidrome/ci-goreleaser
@@ -95,11 +96,6 @@ single: ##@Cross_Compilation Build binaries for a single supported platforms. It
 
 ##########################################
 #### Miscellaneous
-
-.gitinfo:
-	@echo "export GIT_SHA=${GIT_SHA}" > .gitinfo
-	@echo "export GIT_TAG=${GIT_TAG}" >> .gitinfo
-.PHONY: .gitinfo
 
 release:
 	@if [[ ! "${V}" =~ ^[0-9]+\.[0-9]+\.[0-9]+.*$$ ]]; then echo "Usage: make release V=X.X.X"; exit 1; fi


### PR DESCRIPTION
Do away with `.gitinfo` file and just do some path string transformations.  We won't know the git hash, but we will get the version correct.
Potential fix for #1302