### PR TITLE
Fix default volume

### DIFF
--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -16,7 +16,7 @@ const initialState = {
   queue: [],
   current: {},
   clear: false,
-  volume: Math.pow(0.5, 2), // 50%
+  volume: 0.5, // 50%
   savedPlayIndex: 0,
 }
 


### PR DESCRIPTION
With the update in #1378, the default volume is now erroneously set to 25% instead of 50%. Remove the Math.pow and set it to 50% instead.