### PR TITLE
Update robots.txt

### DIFF
--- a/tests/fixtures/robots.txt
+++ b/tests/fixtures/robots.txt
@@ -1,4 +1,4 @@
 User-agent: bingbot
-Disallow: /manifest.json
+Disallow: /manifest.webmanifest
 
 User-agent: *


### PR DESCRIPTION
browser consoles keep complaining that the manifest doesn't have the `.webmanifest` extension.