### PR TITLE
Only reset player scrobbled state on track change or end

### DIFF
--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -146,7 +146,6 @@ const Player = () => {
         document.title = `${song.title} - ${song.artist} - Navidrome`
         subsonic.nowPlaying(info.trackId)
         setPreload(false)
-        setScrobbled(false)
         if (config.gaTrackingId) {
           ReactGA.event({
             category: 'Player',
@@ -166,6 +165,12 @@ const Player = () => {
     [dispatch, showNotifications]
   )
 
+  const onAudioPlayTrackChange = useCallback(() => {
+    if (scrobbled) {
+      setScrobbled(false)
+    }
+  }, [scrobbled])
+
   const onAudioPause = useCallback(
     (info) => dispatch(currentPlaying(info)),
     [dispatch]
@@ -173,6 +178,7 @@ const Player = () => {
 
   const onAudioEnded = useCallback(
     (currentPlayId, audioLists, info) => {
+      setScrobbled(false)
       dispatch(currentPlaying(info))
       dataProvider
         .getOne('keepalive', { id: info.trackId })
@@ -212,6 +218,7 @@ const Player = () => {
         onAudioVolumeChange={onAudioVolumeChange}
         onAudioProgress={onAudioProgress}
         onAudioPlay={onAudioPlay}
+        onAudioPlayTrackChange={onAudioPlayTrackChange}
         onAudioPause={onAudioPause}
         onAudioEnded={onAudioEnded}
         onCoverClick={onCoverClick}

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -140,7 +140,9 @@ const Player = () => {
   const onAudioPlay = useCallback(
     (info) => {
       dispatch(currentPlaying(info))
-      setStartTime(Date.now())
+      if (startTime === null) {
+        setStartTime(Date.now())
+      }
       if (info.duration) {
         const song = info.song
         document.title = `${song.title} - ${song.artist} - Navidrome`
@@ -162,14 +164,17 @@ const Player = () => {
         }
       }
     },
-    [dispatch, showNotifications]
+    [dispatch, showNotifications, startTime]
   )
 
   const onAudioPlayTrackChange = useCallback(() => {
     if (scrobbled) {
       setScrobbled(false)
     }
-  }, [scrobbled])
+    if (startTime !== null) {
+      setStartTime(null)
+    }
+  }, [scrobbled, startTime])
 
   const onAudioPause = useCallback(
     (info) => dispatch(currentPlaying(info)),
@@ -179,6 +184,7 @@ const Player = () => {
   const onAudioEnded = useCallback(
     (currentPlayId, audioLists, info) => {
       setScrobbled(false)
+      setStartTime(null)
       dispatch(currentPlaying(info))
       dataProvider
         .getOne('keepalive', { id: info.trackId })


### PR DESCRIPTION
Fixes #1397.

Currently the state of `scrobbled` will be set to `false` every time the player begins playing (including it being unpaused) which will cause duplicate scrobbles.

This fix has `scrobbled` only be reset in the `onAudioPlayTrackChange` and `onAudioEnded` events. The reason both events are needed is that `onAudioEnded` will not fire when the player moves to the next track and `onAudioPlayTrackChange` will not fire if the player is set to repeat.