### PR TITLE
Handle invalid theme in ui state

### DIFF
--- a/ui/src/themes/useCurrentTheme.js
+++ b/ui/src/themes/useCurrentTheme.js
@@ -12,7 +12,7 @@ const useCurrentTheme = () => {
       return prefersLightMode ? themes.LightTheme : themes.DarkTheme
     }
     const themeName =
-      state.theme ||
+      Object.keys(themes).find((t) => t === state.theme) ||
       Object.keys(themes).find(
         (t) => themes[t].themeName === config.defaultTheme
       ) ||


### PR DESCRIPTION
This allows the UI to gracefully recover from the state having an invalid theme set (for instance while developing a custom theme and then switching branches)