### PR TITLE
feat(hotkeys): keyboard-shortcut-for-current-song - #1336

### DIFF
--- a/ui/src/audioplayer/keyHandlers.js
+++ b/ui/src/audioplayer/keyHandlers.js
@@ -25,7 +25,12 @@ const keyHandlers = (audioInstance, playerState) => {
     PREV_SONG: (e) => {
       if (!e.metaKey && prevSong()) audioInstance && audioInstance.playPrev()
     },
-
+    CURRENT_SONG: () => {
+      console.log(playerState)
+      if (playerState.queue[0]?.song?.albumId) {
+        window.location.href = `#/album/${playerState.queue[0].song.albumId}/show`
+      }
+    },
     NEXT_SONG: (e) => {
       if (!e.metaKey && nextSong()) audioInstance && audioInstance.playNext()
     },

--- a/ui/src/hotkeys.js
+++ b/ui/src/hotkeys.js
@@ -5,6 +5,7 @@ const keyMap = {
   TOGGLE_PLAY: { name: 'toggle_play', sequence: 'space', group: 'Player' },
   PREV_SONG: { name: 'prev_song', sequence: 'left', group: 'Player' },
   NEXT_SONG: { name: 'next_song', sequence: 'right', group: 'Player' },
+  CURRENT_SONG: { name: 'current_song', sequence: 'c', group: 'Player' },
   VOL_UP: { name: 'vol_up', sequence: '=', group: 'Player' },
   VOL_DOWN: { name: 'vol_down', sequence: '-', group: 'Player' },
   ...(config.enableFavourites && {


### PR DESCRIPTION
Closes [#1336](https://github.com/navidrome/navidrome/issues/1336)

Description: Keyboard shortcut that takes you to the currently playing track in an album.

Changes: Changes were made to 'ui/src/hotkeys.js' and 'ui/src/audioplayer/keyHandlers.js'

![image](https://user-images.githubusercontent.com/66196840/149190897-b47a87a5-ea86-41bc-ad35-539eb205af3f.png)


Signed-off-by: Pavithra Nair <pmpavithranair@gmail.com>