### PR TITLE
feat(AlbumDetails): Extract urls from comments and link them to their corresponding sites - #1053

### DIFF
--- a/ui/src/album/AlbumDetails.js
+++ b/ui/src/album/AlbumDetails.js
@@ -1,4 +1,5 @@
 import React, { useMemo, useCallback } from 'react'
+
 import {
   Card,
   CardContent,
@@ -101,6 +102,10 @@ const useStyles = makeStyles(
     },
     externalLinks: {
       marginTop: theme.spacing(1.5),
+      color: theme.palette.text.primary,
+      '&:hover': {
+        color: theme.palette.primary.dark,
+      },
     },
   }),
   {
@@ -112,11 +117,21 @@ const AlbumComment = ({ record }) => {
   const classes = useStyles()
   const [expanded, setExpanded] = React.useState(false)
 
+  var urlRegex =
+    /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi
+  const reqClassName = classes.externalLinks
+  console.log(reqClassName)
+  function linkify(text) {
+    return text.replace(urlRegex, function (url) {
+      return '<a class=' + reqClassName + ' href="' + url + '">' + url + '</a>'
+    })
+  }
+
   const lines = record.comment.split('\n')
   const formatted = useMemo(() => {
     return lines.map((line, idx) => (
       <span key={record.id + '-comment-' + idx}>
-        <span dangerouslySetInnerHTML={{ __html: line }} />
+        <span dangerouslySetInnerHTML={{ __html: linkify(line) }} />
         <br />
       </span>
     ))

--- a/ui/src/album/AlbumDetails.js
+++ b/ui/src/album/AlbumDetails.js
@@ -117,15 +117,22 @@ const AlbumComment = ({ record }) => {
   const classes = useStyles()
   const [expanded, setExpanded] = React.useState(false)
 
-  var urlRegex =
-    /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi
   const reqClassName = classes.externalLinks
   console.log(reqClassName)
-  function linkify(text) {
-    return text.replace(urlRegex, function (url) {
-      return '<a class=' + reqClassName + ' href="' + url + '">' + url + '</a>'
-    })
-  }
+  const linkify = useCallback(
+    (text) => {
+      // eslint-disable-next-line
+      const urlRegex =
+        // eslint-disable-next-line
+        /(\b(https?|ftp|file):\/\/[-A-Z0-9+&@#\/%?=~_|!:,.;]*[-A-Z0-9+&@#\/%=~_|])/gi
+      return text.replace(urlRegex, function (url) {
+        return (
+          '<a class=' + reqClassName + ' href="' + url + '">' + url + '</a>'
+        )
+      })
+    },
+    [reqClassName]
+  )
 
   const lines = record.comment.split('\n')
   const formatted = useMemo(() => {
@@ -135,7 +142,7 @@ const AlbumComment = ({ record }) => {
         <br />
       </span>
     ))
-  }, [lines, record.id])
+  }, [lines, record.id, linkify])
 
   const handleExpandClick = useCallback(() => {
     setExpanded(!expanded)


### PR DESCRIPTION
Closes [#1053](https://github.com/navidrome/navidrome/issues/1053) 

Description: Detect URLs from the comment body and link them to their respective site. 

Changes: URL-detection in javascript clientside with regex and styled the links

![image](https://user-images.githubusercontent.com/66196840/149278914-fc57197e-946d-41cf-a566-7d5fc0b3f1f3.png)
When the user hovers over the links, the color changes.
![image](https://user-images.githubusercontent.com/66196840/149279104-9ae2a994-13c9-4889-99c0-f88f5c22b6f0.png)
