### PR TITLE
Apply artist image placeholders in frontend instead of backend

### DIFF
--- a/core/agents/placeholders.go
+++ b/core/agents/placeholders.go
@@ -9,9 +9,9 @@ import (
 const PlaceholderAgentName = "placeholder"
 
 const (
-	placeholderArtistImageSmallUrl  = "https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png"
-	placeholderArtistImageMediumUrl = "https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png"
-	placeholderArtistImageLargeUrl  = "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"
+	placeholderArtistImageSmallUrl  = ""
+	placeholderArtistImageMediumUrl = ""
+	placeholderArtistImageLargeUrl  = ""
 	placeholderBiography            = "Biography not available"
 )
 

--- a/ui/src/artist/ArtistShow.js
+++ b/ui/src/artist/ArtistShow.js
@@ -20,7 +20,6 @@ const ArtistDetails = (props) => {
   const biography =
     artistInfo?.biography?.replace(new RegExp('<.*>', 'g'), '') ||
     record.biography
-  const img = artistInfo?.largeImageUrl || record.largeImageUrl
 
   useEffect(() => {
     subsonic
@@ -40,7 +39,6 @@ const ArtistDetails = (props) => {
   return (
     <>
       {createElement(component, {
-        img,
         artistInfo,
         record,
         biography,

--- a/ui/src/artist/ArtistShow.js
+++ b/ui/src/artist/ArtistShow.js
@@ -35,6 +35,19 @@ const ArtistDetails = (props) => {
       })
   }, [record])
 
+  if (artistInfo) {
+    // Assign placeholders if image is missing
+    artistInfo.largeImageUrl =
+      artistInfo.largeImageUrl ||
+      'https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png'
+    artistInfo.mediumImageUrl =
+      artistInfo.mediumImageUrl ||
+      'https://lastfm.freetls.fastly.net/i/u/174s/2a96cbd8b46e442fc41c2b86b821562f.png'
+    artistInfo.smallImageUrl =
+      artistInfo.smallImageUrl ||
+      'https://lastfm.freetls.fastly.net/i/u/64s/2a96cbd8b46e442fc41c2b86b821562f.png'
+  }
+
   const component = isDesktop ? DesktopArtistDetails : MobileArtistDetails
   return (
     <>

--- a/ui/src/artist/DesktopArtistDetails.js
+++ b/ui/src/artist/DesktopArtistDetails.js
@@ -64,9 +64,9 @@ const useStyles = makeStyles(
   { name: 'NDDesktopArtistDetails' }
 )
 
-const DesktopArtistDetails = ({ img, artistInfo, record, biography }) => {
+const DesktopArtistDetails = ({ artistInfo, record, biography }) => {
   const [expanded, setExpanded] = useState(false)
-  const classes = useStyles({ img, expanded })
+  const classes = useStyles({})
   const title = record.name
   const [isLightboxOpen, setLightboxOpen] = React.useState(false)
 

--- a/ui/src/artist/MobileArtistDetails.js
+++ b/ui/src/artist/MobileArtistDetails.js
@@ -74,9 +74,9 @@ const useStyles = makeStyles(
   { name: 'NDMobileArtistDetails' }
 )
 
-const MobileArtistDetails = ({ img, artistInfo, biography, record }) => {
+const MobileArtistDetails = ({ artistInfo, biography, record }) => {
   const [expanded, setExpanded] = useState(false)
-  const classes = useStyles({ img, expanded })
+  const classes = useStyles({ img: artistInfo?.largeImageUrl, expanded })
   const title = record.name
   const [isLightboxOpen, setLightboxOpen] = React.useState(false)
 


### PR DESCRIPTION
Possible fix for #1590 if the issue is considered worthwhile.

* Handle artist images more uniformly in DesktopArtistImage and MobileArtistImage
* Add placeholder images in frontend instead of backend.