### PR TITLE
Fix signaler not exiting on cancel

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,7 +111,7 @@ func startSignaler() (func() error, func(err error)) {
 					}
 					log.Info(ctx, "Triggered scan complete", "elapsed", time.Since(start).Round(100*time.Millisecond))
 				case <-ctx.Done():
-					break
+					return nil
 				}
 			}
 		}, func(err error) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,7 @@ func runNavidrome() {
 
 	if err := g.Run(); err != nil {
 		log.Error("Fatal error in Navidrome. Aborting", err)
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
`break` is incorrect here, as it just breaks out of the select.
`return` to exit the function instead.

Fixes #1636.