### PR TITLE
Fixes a coloring glitch with the Monokai theme "unauthorized" popup

### DIFF
--- a/ui/src/themes/monokai.js
+++ b/ui/src/themes/monokai.js
@@ -18,6 +18,17 @@ export default {
       root: {
         color: '#f8f8f2',
         backgroundColor: '#3b3a32',
+        MuiSnackbarContent: {
+            root: {
+                color: '#f8f8f2',
+                backgroundColor: '#f92672',
+            },
+            message: {
+              color: '#f8f8f2',
+              backgroundColor: '#f92672',
+            },
+          },
+        },
       },
     },
     MuiButton: {
@@ -61,12 +72,6 @@ export default {
       head: {
         color: '#f8f8f2',
         background: '#3b3a32 !important',
-      },
-    },
-    MuiSnackbarContent: {
-      message: {
-        color: '#f8f8f2',
-        backgroundColor: '#f92672',
       },
     },
     NDLogin: {

--- a/ui/src/themes/monokai.js
+++ b/ui/src/themes/monokai.js
@@ -19,14 +19,13 @@ export default {
         color: '#f8f8f2',
         backgroundColor: '#3b3a32',
         MuiSnackbarContent: {
-            root: {
-                color: '#f8f8f2',
-                backgroundColor: '#f92672',
-            },
-            message: {
-              color: '#f8f8f2',
-              backgroundColor: '#f92672',
-            },
+          root: {
+            color: '#f8f8f2',
+            backgroundColor: '#f92672',
+          },
+          message: {
+            color: '#f8f8f2',
+            backgroundColor: '#f92672',
           },
         },
       },


### PR DESCRIPTION
Contains a pretty simple styling fix to accompany the new Monokai theme introduced in https://github.com/navidrome/navidrome/pull/1669.