### PR TITLE
explicitly set GOPROXY, add support for OpenSSL 3.0, both required for building on Fedora 36

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ GOPROXY=https://proxy.golang.org/
 setup: check_env download-deps setup-git ##@1_Run_First Install dependencies and prepare development environment
 	@echo Downloading Node dependencies...
 	@(cd ./ui && npm ci)
+	@(cd ./ui && grep -q crypto node_modules/react-scripts/config/webpack.config.js || patch -p0 < webpack-patch-for-openssl3.patch)
 .PHONY: setup
 
 dev: check_env   ##@Development Start Navidrome in development mode, with hot-reload for both frontend and backend

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ GIT_TAG=$(patsubst navidrome-%,v%,$(notdir $(PWD)))
 endif
 
 CI_RELEASER_VERSION=1.17.2-1 ## https://github.com/navidrome/ci-goreleaser
+GOPROXY=https://proxy.golang.org/
 
 setup: check_env download-deps setup-git ##@1_Run_First Install dependencies and prepare development environment
 	@echo Downloading Node dependencies...
@@ -111,7 +112,7 @@ release:
 
 download-deps:
 	@echo Downloading Go dependencies...
-	@go mod download -x
+	@GOPROXY=$(GOPROXY) go mod download -x
 	@go mod tidy # To revert any changes made by the `go mod download` command
 .PHONY: download-deps
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,6 @@ GIT_TAG=$(patsubst navidrome-%,v%,$(notdir $(PWD)))
 endif
 
 CI_RELEASER_VERSION=1.17.2-1 ## https://github.com/navidrome/ci-goreleaser
-GOPROXY=https://proxy.golang.org/
 
 setup: check_env download-deps setup-git ##@1_Run_First Install dependencies and prepare development environment
 	@echo Downloading Node dependencies...
@@ -113,7 +112,7 @@ release:
 
 download-deps:
 	@echo Downloading Go dependencies...
-	@GOPROXY=$(GOPROXY) go mod download -x
+	@go mod download -x
 	@go mod tidy # To revert any changes made by the `go mod download` command
 .PHONY: download-deps
 

--- a/ui/webpack-patch-for-openssl3.patch
+++ b/ui/webpack-patch-for-openssl3.patch
@@ -1,0 +1,11 @@
+--- node_modules/react-scripts/config/webpack.config.js.orig	2022-06-12 21:14:45.411754951 +0200
++++ node_modules/react-scripts/config/webpack.config.js	2022-06-12 21:14:19.397151014 +0200
+@@ -796,3 +796,8 @@
+     performance: false,
+   };
+ };
++
++// fix for OpenSSL 3.0, that no longer supports MD4
++const crypto = require("crypto");
++const crypto_orig_createHash = crypto.createHash;
++crypto.createHash = algorithm => crypto_orig_createHash(algorithm == "md4" ? "sha256" : algorithm);


### PR DESCRIPTION
Two fixes for building on Fedora 36:
--
Navidrome expects go to automatically use https://proxy.golang.org as go mod proxy.
This is not the case on all platforms and should be set explicitly.

Fixes [#1764](https://github.com/navidrome/navidrome/issues/1764)
--
Webpack 4 uses MD4 hashes, not supported on OpenSSL 3.0.
Patch provided to make it use sha256.

Fixes [#1768](https://github.com/navidrome/navidrome/issues/1768)
--