### PR TITLE
fix:(middlewares.go) - Set Cookie SameSite mode to Strict - 1776

### DIFF
--- a/server/middlewares.go
+++ b/server/middlewares.go
@@ -112,7 +112,7 @@ func clientUniqueIdAdder(next http.Handler) http.Handler {
 				MaxAge:   consts.CookieExpiry,
 				HttpOnly: true,
 				Secure:   true,
-				SameSite: http.SameSiteNoneMode,
+				SameSite: http.SameSiteStrictMode,
 				Path:     "/",
 			}
 			http.SetCookie(w, c)

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -161,6 +161,7 @@ func getPlayer(players core.Players) func(next http.Handler) http.Handler {
 					Value:    player.ID,
 					MaxAge:   consts.CookieExpiry,
 					HttpOnly: true,
+					SameSite: http.SameSiteStrictMode,
 					Path:     "/",
 				}
 				http.SetCookie(w, cookie)


### PR DESCRIPTION
Closes Issue #1776 

Description:
* None is deprecated and will fallback to Lax in the future, it currently throws a warning on Firefox. [Details on MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)
* Using Strict is future proof and provides additional CSR protection
* Using Strict caused no regressions in my tests

Changes
* Change SameSite from None to Strict in server/middlewares.go for `X-ND-Client-Unique-Id` cookie
* Add SameSite Strict setting to server/subsonic/middlewares.go (was unset) for `nd-player` cookie