### PR TITLE
Mount devcontainer workspace in a SELinux compatible way

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,10 +10,12 @@
 			"NODE_VERSION": "v16"
 		}
 	},
+	"workspaceMount": "",
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
 		"--security-opt",
-		"seccomp=unconfined"
+		"seccomp=unconfined",
+		"--volume=${localWorkspaceFolder}:/workspaces/${localWorkspaceFolderBasename}:Z"
 	],
 	// Set *default* container specific settings.json values on container create.
 	"settings": {


### PR DESCRIPTION
Docker requires volumes to be mounted with a SELinux flag (on SELinux enabled systems) to make sure, the volume directory gets SELinux context accessible inside the container. This PR changes the devcontainer config to disable the default workspace mount and adds a custom one that includes the SELinux flag.

`:Z` stands for a volume that cannot be shared between different contains (and `:z` is for shared volumes).

Additional information:  
https://docs.docker.com/storage/bind-mounts/#configure-the-selinux-label