### PR TITLE
Capture "musicbrainz_releasetrackid" tag

### DIFF
--- a/db/migration/20220724231849_add_musicbrainz_release_track_id.go
+++ b/db/migration/20220724231849_add_musicbrainz_release_track_id.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(upAddMusicbrainzReleaseTrackId, downAddMusicbrainzReleaseTrackId)
+}
+
+func upAddMusicbrainzReleaseTrackId(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+alter table media_file
+	add mbz_release_track_id varchar(255);
+`)
+	if err != nil {
+		return err
+	}
+	notice(tx, "A full rescan needs to be performed to import more tags")
+	return forceFullRescan(tx)
+}
+
+func downAddMusicbrainzReleaseTrackId(tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+	return nil
+}

--- a/db/migration/migration.go
+++ b/db/migration/migration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/navidrome/navidrome/consts"
 )
 
-// Use this in migrations that need to communicate something important (braking changes, forced reindexes, etc...)
+// Use this in migrations that need to communicate something important (breaking changes, forced reindexes, etc...)
 func notice(tx *sql.Tx, msg string) {
 	if isDBInitialized(tx) {
 		fmt.Printf(`

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -45,6 +45,7 @@ type MediaFile struct {
 	Bpm                  int       `structs:"bpm" json:"bpm,omitempty"`
 	CatalogNum           string    `structs:"catalog_num" json:"catalogNum,omitempty"`
 	MbzTrackID           string    `structs:"mbz_track_id" json:"mbzTrackId,omitempty"         orm:"column(mbz_track_id)"`
+	MbzReleaseTrackID    string    `structs:"mbz_release_track_id" json:"mbzReleaseTrackId,omitempty" orm:"column(mbz_release_track_id)"`
 	MbzAlbumID           string    `structs:"mbz_album_id" json:"mbzAlbumId,omitempty"         orm:"column(mbz_album_id)"`
 	MbzArtistID          string    `structs:"mbz_artist_id" json:"mbzArtistId,omitempty"        orm:"column(mbz_artist_id)"`
 	MbzAlbumArtistID     string    `structs:"mbz_album_artist_id" json:"mbzAlbumArtistId,omitempty"   orm:"column(mbz_album_artist_id)"`

--- a/scanner/mapping.go
+++ b/scanner/mapping.go
@@ -63,6 +63,7 @@ func (s mediaFileMapper) toMediaFile(md metadata.Tags) model.MediaFile {
 	mf.OrderAlbumArtistName = sanitizeFieldForSorting(mf.AlbumArtist)
 	mf.CatalogNum = md.CatalogNum()
 	mf.MbzTrackID = md.MbzTrackID()
+	mf.MbzReleaseTrackID = md.MbzReleaseTrackID()
 	mf.MbzAlbumID = md.MbzAlbumID()
 	mf.MbzArtistID = md.MbzArtistID()
 	mf.MbzAlbumArtistID = md.MbzAlbumArtistID()

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -91,6 +91,9 @@ func (t Tags) Bpm() int           { return (int)(math.Round(t.getFloat("tbpm", "
 func (t Tags) HasPicture() bool   { return t.getFirstTagValue("has_picture") != "" }
 
 // MusicBrainz Identifiers
+func (t Tags) MbzReleaseTrackID() string {
+	return t.getMbzID("musicbrainz_releasetrackid", "musicbrainz release track id")
+}
 
 func (t Tags) MbzTrackID() string { return t.getMbzID("musicbrainz_trackid", "musicbrainz track id") }
 func (t Tags) MbzAlbumID() string { return t.getMbzID("musicbrainz_albumid", "musicbrainz album id") }

--- a/scanner/metadata/metadata_test.go
+++ b/scanner/metadata/metadata_test.go
@@ -83,12 +83,14 @@ var _ = Describe("Tags", func() {
 		It("return a valid MBID", func() {
 			md := &Tags{}
 			md.tags = map[string][]string{
-				"musicbrainz_trackid":       {"8f84da07-09a0-477b-b216-cc982dabcde1"},
-				"musicbrainz_albumid":       {"f68c985d-f18b-4f4a-b7f0-87837cf3fbf9"},
-				"musicbrainz_artistid":      {"89ad4ac3-39f7-470e-963a-56509c546377"},
-				"musicbrainz_albumartistid": {"ada7a83c-e3e1-40f1-93f9-3e73dbc9298a"},
+				"musicbrainz_trackid":        {"8f84da07-09a0-477b-b216-cc982dabcde1"},
+				"musicbrainz_releasetrackid": {"6caf16d3-0b20-3fe6-8020-52e31831bc11"},
+				"musicbrainz_albumid":        {"f68c985d-f18b-4f4a-b7f0-87837cf3fbf9"},
+				"musicbrainz_artistid":       {"89ad4ac3-39f7-470e-963a-56509c546377"},
+				"musicbrainz_albumartistid":  {"ada7a83c-e3e1-40f1-93f9-3e73dbc9298a"},
 			}
 			Expect(md.MbzTrackID()).To(Equal("8f84da07-09a0-477b-b216-cc982dabcde1"))
+			Expect(md.MbzReleaseTrackID()).To(Equal("6caf16d3-0b20-3fe6-8020-52e31831bc11"))
 			Expect(md.MbzAlbumID()).To(Equal("f68c985d-f18b-4f4a-b7f0-87837cf3fbf9"))
 			Expect(md.MbzArtistID()).To(Equal("89ad4ac3-39f7-470e-963a-56509c546377"))
 			Expect(md.MbzAlbumArtistID()).To(Equal("ada7a83c-e3e1-40f1-93f9-3e73dbc9298a"))


### PR DESCRIPTION
Uniquely identifies the track within an album, unlike `musicbrainz_trackid`. See https://picard-docs.musicbrainz.org/downloads/MusicBrainz_Picard_Tag_Map.html.

Prerequisite for https://github.com/navidrome/navidrome/pull/1363, but is good to have anyway.

Includes a bonus typo fix.