### PR TITLE
Fix server 404s

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -48,6 +48,7 @@ func (s *Server) Run(addr string) error {
 	server := &http.Server{
 		Addr:              addr,
 		ReadHeaderTimeout: consts.ServerReadHeaderTimeout,
+		Handler:           s.router,
 	}
 
 	return server.ListenAndServe()


### PR DESCRIPTION
Changes were made in https://github.com/navidrome/navidrome/commit/2a3cd08f201d30385f3e2b76b6b11d5f5e1d70b2 to add `ReadHeaderTimeout`, but the router was not added to the new server, resulting in 404s for every access. This fix restores prior functionality.