### PR TITLE
fix(UI): Warn if track is already present when adding to playlist - 1604

### DIFF
--- a/ui/src/dialogs/AddToPlaylistDialog.js
+++ b/ui/src/dialogs/AddToPlaylistDialog.js
@@ -20,6 +20,8 @@ import {
 } from '../actions'
 import { SelectPlaylistInput } from './SelectPlaylistInput'
 import DuplicateSongDialog from './DuplicateSongDialog'
+import { httpClient } from '../dataProvider'
+import { REST_URL } from '../consts'
 
 export const AddToPlaylistDialog = () => {
   const { open, selectedIds, onSuccess, duplicateSong, duplicateIds } =
@@ -44,34 +46,37 @@ export const AddToPlaylistDialog = () => {
 
   const addToPlaylist = (playlistId, distinctIds) => {
     const trackIds = Array.isArray(distinctIds) ? distinctIds : selectedIds
-    dataProvider
-      .create('playlistTrack', {
-        data: { ids: trackIds },
-        filter: { playlist_id: playlistId },
-      })
-      .then(() => {
-        const len = trackIds.length
-        notify('message.songsAddedToPlaylist', 'info', { smart_count: len })
-        onSuccess && onSuccess(value, len)
-        refresh()
-      })
-      .catch(() => {
-        notify('ra.page.error', 'warning')
-      })
+    if (trackIds.length) {
+      dataProvider
+        .create('playlistTrack', {
+          data: { ids: trackIds },
+          filter: { playlist_id: playlistId },
+        })
+        .then(() => {
+          const len = trackIds.length
+          notify('message.songsAddedToPlaylist', 'info', { smart_count: len })
+          onSuccess && onSuccess(value, len)
+          refresh()
+        })
+        .catch(() => {
+          notify('ra.page.error', 'warning')
+        })
+    } else {
+      notify('message.songsAddedToPlaylist', 'info', { smart_count: 0 })
+    }
   }
 
   const checkDuplicateSong = (playlistObject) => {
-    dataProvider
-      .getOne('playlist', { id: playlistObject.id })
+    httpClient(`${REST_URL}/playlist/${playlistObject.id}/tracks`)
       .then((res) => {
-        const tracks = res.data.tracks
+        const tracks = res.json
         if (tracks) {
           const dupSng = tracks.filter((song) =>
-            selectedIds.some((id) => id === song.id)
+            selectedIds.some((id) => id === song.mediaFileId)
           )
 
           if (dupSng.length) {
-            const dupIds = dupSng.map((song) => song.id)
+            const dupIds = dupSng.map((song) => song.mediaFileId)
             dispatch(openDuplicateSongWarning(dupIds))
           }
         }

--- a/ui/src/dialogs/AddToPlaylistDialog.test.js
+++ b/ui/src/dialogs/AddToPlaylistDialog.test.js
@@ -62,11 +62,19 @@ const createTestUtils = (mockDataProvider) =>
     </DataProviderContext.Provider>
   )
 
+jest.mock('../dataProvider', () => ({
+  ...jest.requireActual('../dataProvider'),
+  httpClient: jest.fn(),
+}))
+
 describe('AddToPlaylistDialog', () => {
   beforeAll(() => localStorage.setItem('userId', 'admin'))
   afterEach(cleanup)
 
   it('adds distinct songs to already existing playlists', async () => {
+    const dataProvider = require('../dataProvider')
+    jest.spyOn(dataProvider, 'httpClient').mockResolvedValue({ data: mockData })
+
     const mockDataProvider = {
       getList: jest
         .fn()


### PR DESCRIPTION
Closes #1604 

Fixes previously existing functionality of showing a warning if a track is already present when adding it to a playlist.

Behavior when skipping a song already in a playlist

![skip](https://user-images.githubusercontent.com/24394068/193015030-54020f86-7f3f-4f07-b85a-b28983a2a7c0.gif)

Behavior when adding a song already in a playlist

![add](https://user-images.githubusercontent.com/24394068/193015050-5bb8c4cc-ffe3-4943-ab19-ad77b213ec7f.gif)
