### PR TITLE
remove deprecated linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,9 @@
 run:
-  go: '1.19'
+  go: "1.19"
 
 linters:
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -17,11 +16,9 @@ linters:
     - misspell
     - rowserrcheck
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unused
-    - varcheck
     - whitespace
 
 issues:


### PR DESCRIPTION
I get the following when `go run github.com/golangci/golangci-lint/cmd/golangci-lint run -v` is ran 

>WARN [runner] The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 
WARN [runner] The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused. 