### PR TITLE
Hide LastFM icons if `config.lastFMEnabled` is false

### DIFF
--- a/ui/src/album/AlbumExternalLinks.js
+++ b/ui/src/album/AlbumExternalLinks.js
@@ -4,6 +4,7 @@ import { IconButton, Tooltip, Link } from '@material-ui/core'
 import { ImLastfm2 } from 'react-icons/im'
 import MusicBrainz from '../icons/MusicBrainz'
 import { intersperse } from '../utils'
+import config from '../config'
 
 const AlbumExternalLinks = (props) => {
   const { className } = props
@@ -26,15 +27,17 @@ const AlbumExternalLinks = (props) => {
     links.push(<span key={`link-${record.id}-${id}`}>{link}</span>)
   }
 
-  addLink(
-    `https://last.fm/music/${
-      encodeURIComponent(record.albumArtist) +
-      '/' +
-      encodeURIComponent(record.name)
-    }`,
-    'message.openIn.lastfm',
-    <ImLastfm2 className="lastfm-icon" />
-  )
+  if (config.lastFMEnabled) {
+    addLink(
+      `https://last.fm/music/${
+        encodeURIComponent(record.albumArtist) +
+        '/' +
+        encodeURIComponent(record.name)
+      }`,
+      'message.openIn.lastfm',
+      <ImLastfm2 className="lastfm-icon" />
+    )
+  }
 
   record.mbzAlbumId &&
     addLink(

--- a/ui/src/artist/ArtistExternalLink.js
+++ b/ui/src/artist/ArtistExternalLink.js
@@ -5,6 +5,7 @@ import { IconButton, Tooltip, Link } from '@material-ui/core'
 import { ImLastfm2 } from 'react-icons/im'
 import MusicBrainz from '../icons/MusicBrainz'
 import { intersperse } from '../utils'
+import config from '../config'
 
 const ArtistExternalLinks = ({ artistInfo, record }) => {
   const translate = useTranslate()
@@ -36,11 +37,14 @@ const ArtistExternalLinks = ({ artistInfo, record }) => {
     linkButtons.push(<span key={`link-${record.id}-${id}`}>{link}</span>)
   }
 
-  addLink(
-    links[0],
-    'message.openIn.lastfm',
-    <ImLastfm2 className="lastfm-icon" />
-  )
+  if (config.lastFMEnabled) {
+    addLink(
+      links[0],
+      'message.openIn.lastfm',
+      <ImLastfm2 className="lastfm-icon" />
+    )
+  }
+
   artistInfo?.musicBrainzId &&
     addLink(
       links[1],


### PR DESCRIPTION
This PR refers to #1513.
If the config option `lastFMEnabled` is set to false, the LastFM icons on the artist and album pages will not be shown.

Although in #1488, @deluan [mentions](https://github.com/navidrome/navidrome/issues/1488#issuecomment-979462507) that showing these buttons is intended behaviour, as it's not an 'integration' and if the user doesn't click on them, then there's technically no connection to LastFM. However, this is not very clear for users, and there's talk in #1513 of making a separate 'External services' toggle instead.