### PR TITLE
Fix: `DefaultLanguage` config doesn't work when set to Chinese - #1946

### DIFF
--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -38,7 +38,7 @@ func serveIndex(ds model.DataStore, fs fs.FS) http.HandlerFunc {
 			"enableFavourites":        conf.Server.EnableFavourites,
 			"enableStarRating":        conf.Server.EnableStarRating,
 			"defaultTheme":            conf.Server.DefaultTheme,
-			"defaultLanguage":         strings.ToLower(conf.Server.DefaultLanguage),
+			"defaultLanguage":         handleLanguageConfig(conf.Server.DefaultLanguage),
 			"enableCoverAnimation":    conf.Server.EnableCoverAnimation,
 			"gaTrackingId":            conf.Server.GATrackingID,
 			"losslessFormats":         strings.ToUpper(strings.Join(consts.LosslessFormats, ",")),
@@ -97,4 +97,18 @@ func getIndexTemplate(r *http.Request, fs fs.FS) (*template.Template, error) {
 		return nil, err
 	}
 	return t, nil
+}
+
+func handleLanguageConfig(v string) string {
+	lang := strings.ToLower(v)
+	replaceMap := map[string]string{
+		"zh":      "zh-Hans",
+		"zh-hans": "zh-Hans",
+		"zh-hant": "zh-Hant",
+	}
+	replace, ok := replaceMap[lang]
+	if ok {
+		lang = replace
+	}
+	return lang
 }


### PR DESCRIPTION
Closes #1946 

> I think the legal configuration value should be the same as i18n/xx.json,
Chinese needs to be set to zh-Hans or zh-Hant,
but due to the processing in this commit https://github.com/navidrome/navidrome/commit/bfeb8ef6b3e5756d72b230abdbb96f8a31b2e2fa
zh-Hans / zh-Hant will be converted to zh-hans / zh-hant, causing the language file cannot be loaded

Added judgment when reading configuration, if it is `zh-hans` / `zh-hant`, replace it with `zh-Hans` / `zh-Hant`