### PR TITLE
fix: send content type header in listenbrainz requests - #1944

### DIFF
--- a/core/agents/listenbrainz/client.go
+++ b/core/agents/listenbrainz/client.go
@@ -143,6 +143,7 @@ func (c *Client) makeRequest(method string, endpoint string, r *listenBrainzRequ
 		return nil, err
 	}
 	req, _ := http.NewRequest(method, uri, bytes.NewBuffer(b))
+	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
 
 	if r.ApiKey != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Token %s", r.ApiKey))

--- a/core/agents/listenbrainz/client_test.go
+++ b/core/agents/listenbrainz/client_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Client", func() {
 			Expect(httpClient.SavedRequest.Method).To(Equal(http.MethodGet))
 			Expect(httpClient.SavedRequest.URL.String()).To(Equal("BASE_URL/validate-token"))
 			Expect(httpClient.SavedRequest.Header.Get("Authorization")).To(Equal("Token LB-TOKEN"))
+			Expect(httpClient.SavedRequest.Header.Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
 		})
 
 		It("parses and returns the response", func() {
@@ -88,6 +89,7 @@ var _ = Describe("Client", func() {
 				Expect(httpClient.SavedRequest.Method).To(Equal(http.MethodPost))
 				Expect(httpClient.SavedRequest.URL.String()).To(Equal("BASE_URL/submit-listens"))
 				Expect(httpClient.SavedRequest.Header.Get("Authorization")).To(Equal("Token LB-TOKEN"))
+				Expect(httpClient.SavedRequest.Header.Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
 
 				body, _ := io.ReadAll(httpClient.SavedRequest.Body)
 				f, _ := os.ReadFile("tests/fixtures/listenbrainz.nowplaying.request.json")
@@ -105,6 +107,7 @@ var _ = Describe("Client", func() {
 				Expect(httpClient.SavedRequest.Method).To(Equal(http.MethodPost))
 				Expect(httpClient.SavedRequest.URL.String()).To(Equal("BASE_URL/submit-listens"))
 				Expect(httpClient.SavedRequest.Header.Get("Authorization")).To(Equal("Token LB-TOKEN"))
+				Expect(httpClient.SavedRequest.Header.Get("Content-Type")).To(Equal("application/json; charset=UTF-8"))
 
 				body, _ := io.ReadAll(httpClient.SavedRequest.Body)
 				f, _ := os.ReadFile("tests/fixtures/listenbrainz.scrobble.request.json")


### PR DESCRIPTION
This sends the content type header with all requests to Listenbrainz servers.

The lack of this header causes some listenbrainz implementations (e.g. the one in [maloja](https://github.com/krateng/maloja)) to interpret the body as a string.

For example, in maloja the request would be interpreted as:

```js
{
	'{"listen_type":"playing_now","payload":[{"track_metadata":{"artist_name":"TootArd","track_name":"Laissez Passer","release_name":"Laissez Passer","additional_info":{"tracknumber":1,"track_mbid":"c6a62b3f-a225-4ead-a71d-dc3119f3f7d4","artist_mbids":["f991e662-1ed9-45e9-9cd1-84eee4529146"],"release_mbid":"c97ea6f9-15c6-4508-a0f2-d4ce8e02383e"}}}]}': '',
}
```

instead of

```js
{

	"listen_type": "playing_now",
	"payload": [{
		"track_metadata": {
			"artist_name": "TootArd",
			"track_name": "Laissez Passer",
			"release_name": "Laissez Passer",
			"additional_info": {
				"tracknumber": 1,
				"track_mbid": "c6a62b3f-a225-4ead-a71d-dc3119f3f7d4",
				"artist_mbids": ["f991e662-1ed9-45e9-9cd1-84eee4529146"],
				"release_mbid": "c97ea6f9-15c6-4508-a0f2-d4ce8e02383e"
			}
		}
	}],
	"Content-Type": "application/json; charset=UTF-8"
}
```

fixes #1944

Signed-off-by: Raghd Hamzeh <raghd@rhamzeh.com>