### PR TITLE
feat: Avoid cache poisoning on transcode fail

### DIFF
--- a/core/artwork.go
+++ b/core/artwork.go
@@ -25,6 +25,7 @@ import (
 	"github.com/navidrome/navidrome/resources"
 	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/cache/item"
 	_ "golang.org/x/image/webp"
 )
 
@@ -217,7 +218,7 @@ var (
 func GetImageCache() ArtworkCache {
 	onceImageCache.Do(func() {
 		instanceImageCache = cache.NewFileCache("Image", conf.Server.ImageCacheSize, consts.ImageCacheDir, consts.DefaultImageCacheMaxItems,
-			func(ctx context.Context, arg cache.Item) (io.Reader, error) {
+			func(ctx context.Context, arg item.Item) (io.Reader, error) {
 				info := arg.(*imageInfo)
 				reader, err := info.a.getArtwork(ctx, info.id, info.path, info.size)
 				if err != nil {

--- a/core/media_streamer_test.go
+++ b/core/media_streamer_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/core/transcoder"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
@@ -199,9 +200,11 @@ type fakeFFmpeg struct {
 	closed bool
 }
 
-func (ff *fakeFFmpeg) Start(ctx context.Context, cmd, path string, maxBitRate int) (f io.ReadCloser, err error) {
+func (ff *fakeFFmpeg) Start(ctx context.Context, cmd, path string, maxBitRate int, invalidator transcoder.Invalidator) (f transcoder.TranscoderWaiter, err error) {
+	var tw transcoder.TranscoderWaiter
 	ff.r = strings.NewReader(ff.Data)
-	return ff, nil
+	tw.ReadCloser = ff
+	return tw, nil
 }
 
 func (ff *fakeFFmpeg) Read(p []byte) (n int, err error) {

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/golangci/golangci-lint v1.49.0
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kennygrant/sanitize v0.0.0-20170120101633-6a0bfdde8629
 	github.com/kr/pretty v0.3.0
 	github.com/lestrrat-go/jwx v1.2.25
@@ -124,7 +125,6 @@ require (
 	github.com/gostaticanalysis/forcetypeassert v0.1.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/server/subsonic/stream.go
+++ b/server/subsonic/stream.go
@@ -56,7 +56,13 @@ func (c *StreamController) Stream(w http.ResponseWriter, r *http.Request) (*resp
 	} else {
 		// If the stream doesn't provide a size (i.e. is not seekable), we can't support ranges/content-length
 		w.Header().Set("Accept-Ranges", "none")
-		w.Header().Set("Content-Type", stream.ContentType())
+		contentType := stream.ContentType()
+		switch contentType {
+		case "audio/mp4":
+			// If we send audio/mp4 directly to Safari, it will blatantly ignores the stream
+			contentType = "audio/aac"
+		}
+		w.Header().Set("Content-Type", contentType)
 
 		// if Client requests the estimated content-length, send it
 		if estimateContentLength {

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/utils/cache/item"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -51,7 +52,7 @@ var _ = Describe("File Caches", func() {
 	Describe("FileCache", func() {
 		It("caches data if cache is enabled", func() {
 			called := false
-			fc := callNewFileCache("test", "1KB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+			fc := callNewFileCache("test", "1KB", "test", 0, func(ctx context.Context, arg item.Item) (io.Reader, error) {
 				called = true
 				return strings.NewReader(arg.Key()), nil
 			})
@@ -74,7 +75,7 @@ var _ = Describe("File Caches", func() {
 
 		It("does not cache data if cache is disabled", func() {
 			called := false
-			fc := callNewFileCache("test", "0", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+			fc := callNewFileCache("test", "0", "test", 0, func(ctx context.Context, arg item.Item) (io.Reader, error) {
 				called = true
 				return strings.NewReader(arg.Key()), nil
 			})
@@ -91,6 +92,77 @@ var _ = Describe("File Caches", func() {
 			Expect(io.ReadAll(s)).To(Equal([]byte("test")))
 			Expect(s.Cached).To(BeFalse())
 			Expect(called).To(BeTrue())
+		})
+	})
+
+	Describe("InvalidateCache", func() {
+		It("caches data if cache is enabled", func() {
+			called := false
+			fc := callNewFileCache("test", "1KB", "test", 0, func(ctx context.Context, arg item.Item) (io.Reader, error) {
+				called = true
+				return strings.NewReader(arg.Key()), nil
+			})
+			// First call is a MISS
+			s1, err := fc.Get(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+			Expect(s1.Cached).To(BeFalse())
+			Expect(s1.Closer).To(BeNil())
+			Expect(io.ReadAll(s1)).To(Equal([]byte("test")))
+
+			// Second call is a HIT
+			called = false
+			s2, err := fc.Get(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+			Expect(io.ReadAll(s2)).To(Equal([]byte("test")))
+			Expect(s2.Cached).To(BeTrue())
+			Expect(s2.Closer).ToNot(BeNil())
+			Expect(called).To(BeFalse())
+
+			// Third call, invalidate
+			err = s1.Close()
+			Expect(err).To(BeNil())
+			err = s2.Close()
+			Expect(err).To(BeNil())
+			err = fc.Invalidate(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+
+			// Fourth call is MISS again
+			s3, err := fc.Get(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+			Expect(s3.Cached).To(BeFalse())
+			Expect(s3.Closer).To(BeNil())
+			Expect(io.ReadAll(s3)).To(Equal([]byte("test")))
+		})
+
+		It("does not cache data if cache is disabled", func() {
+			called := false
+			fc := callNewFileCache("test", "0", "test", 0, func(ctx context.Context, arg item.Item) (io.Reader, error) {
+				called = true
+				return strings.NewReader(arg.Key()), nil
+			})
+			// First call is a MISS
+			s, err := fc.Get(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+			Expect(s.Cached).To(BeFalse())
+			Expect(io.ReadAll(s)).To(Equal([]byte("test")))
+
+			// Second call is also a MISS
+			called = false
+			s, err = fc.Get(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+			Expect(io.ReadAll(s)).To(Equal([]byte("test")))
+			Expect(s.Cached).To(BeFalse())
+			Expect(called).To(BeTrue())
+
+			// Third call, invalidate
+			err = fc.Invalidate(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+
+			// Fourth call is MISS again
+			s, err = fc.Get(context.TODO(), &testArg{"test"})
+			Expect(err).To(BeNil())
+			Expect(s.Cached).To(BeFalse())
+			Expect(io.ReadAll(s)).To(Equal([]byte("test")))
 		})
 	})
 })

--- a/utils/cache/item/itemizer.go
+++ b/utils/cache/item/itemizer.go
@@ -1,0 +1,5 @@
+package item
+
+type Item interface {
+	Key() string
+}


### PR DESCRIPTION
From the description on #1950, it seems the transcode part had two different problems to be tackled on:

- What to do if an error was detected on the async transcode cmd execution? By adding some way of notifying back the transcoder goroutine (by adding a channel to signal either EOF or file closure on the CachedStream instance), we can enforce a proper execution flow, according to StdoutPipe suggested ergonomics:

> Wait will close the pipe after seeing the command exit, so most callers need not close the pipe themselves. It is thus incorrect to call Wait before all reads from the pipe have completed.

Once we have this notification channel, we can put a request (via a callback to an invalidation to the cache instance) to purge a specific cache entry in relation to the current transcoding work, if cmd.Wait() returns an error by any reason. In that same reasoning, I've implemented a simple `Invalidate` method with some tests to provide guidance on what to expect when trying to invalidate a cache entry.

As a bonus, I've added a small check to assess if the `Content-Type` to be delivered matches to `audio/mp4`; and instead of the mime detected, try to return always `audio/aac` (Seems Safari is quite pungent on what mime types are streamable per se)