### PR TITLE
Don't cache transcoded files if the request was cancelled 

### DIFF
--- a/core/transcoder/transcoder.go
+++ b/core/transcoder/transcoder.go
@@ -57,13 +57,13 @@ func (j *Cmd) start() error {
 }
 
 func (j *Cmd) wait() {
-	var exitErr *exec.ExitError
-	if err := j.cmd.Wait(); err != nil && !errors.As(err, &exitErr) {
-		_ = j.out.CloseWithError(fmt.Errorf("waiting cmd: %w", err))
-		return
-	}
-	if code := j.cmd.ProcessState.ExitCode(); code > 1 {
-		_ = j.out.CloseWithError(fmt.Errorf("%s exited with non-zero status code: %d", j.args[0], code))
+	if err := j.cmd.Wait(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			_ = j.out.CloseWithError(fmt.Errorf("%s exited with non-zero status code: %d", j.args[0], exitErr.ExitCode()))
+		} else {
+			_ = j.out.CloseWithError(fmt.Errorf("waiting %s cmd: %w", j.args[0], err))
+		}
 		return
 	}
 	if j.ctx.Err() != nil {

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/golangci/golangci-lint v1.50.1
 	github.com/google/uuid v1.3.0
 	github.com/google/wire v0.5.0
+	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kennygrant/sanitize v0.0.0-20170120101633-6a0bfdde8629
 	github.com/kr/pretty v0.3.1
 	github.com/lestrrat-go/jwx/v2 v2.0.8
@@ -127,7 +128,6 @@ require (
 	github.com/gostaticanalysis/forcetypeassert v0.1.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -122,9 +122,9 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 		}
 		go func() {
 			if err := copyAndClose(w, reader); err != nil {
-				log.Warn(ctx, "Error populating cache", "key", key, err)
+				log.Debug(ctx, "Error populating cache", "key", key, err)
 				if err = fc.invalidate(ctx, key); err != nil {
-					log.Warn(ctx, "Could not remote key from cache", "key", key, err)
+					log.Warn(ctx, "Error removing key from cache", "key", key, err)
 				}
 			}
 		}()

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -28,7 +28,7 @@ type FileCache interface {
 	Available(ctx context.Context) bool
 }
 
-func NewFileCache(name, cacheSize, cacheFolder string, maxItems int, getReader ReadFunc) *fileCache {
+func NewFileCache(name, cacheSize, cacheFolder string, maxItems int, getReader ReadFunc) FileCache {
 	fc := &fileCache{
 		name:        name,
 		cacheSize:   cacheSize,
@@ -130,7 +130,7 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 		}()
 	}
 
-	// If it is in the cache, check if the stream is done being written. If so, return a ReaderSeeker
+	// If it is in the cache, check if the stream is done being written. If so, return a ReadSeeker
 	if cached {
 		size := getFinalCachedSize(r)
 		if size >= 0 {
@@ -158,7 +158,6 @@ type CachedStream struct {
 	Cached bool
 }
 
-func (s *CachedStream) Seekable() bool { return s.Seeker != nil }
 func (s *CachedStream) Close() error {
 	if s.Closer != nil {
 		return s.Closer.Close()

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -122,9 +122,9 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 		}
 		go func() {
 			if err := copyAndClose(w, reader); err != nil {
-				log.Warn("Error populating cache", "key", key, err)
+				log.Warn(ctx, "Error populating cache", "key", key, err)
 				if err = fc.invalidate(ctx, key); err != nil {
-					log.Warn("Could not remote key from cache", "key", key, err)
+					log.Warn(ctx, "Could not remote key from cache", "key", key, err)
 				}
 			}
 		}()

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -15,7 +16,7 @@ import (
 // Call NewFileCache and wait for it to be ready
 func callNewFileCache(name, cacheSize, cacheFolder string, maxItems int, getReader ReadFunc) *fileCache {
 	fc := NewFileCache(name, cacheSize, cacheFolder, maxItems, getReader)
-	Eventually(func() bool { return fc.Ready(context.TODO()) }).Should(BeTrue())
+	Eventually(func() bool { return fc.Ready(context.Background()) }).Should(BeTrue())
 	return fc
 }
 
@@ -56,7 +57,7 @@ var _ = Describe("File Caches", func() {
 				return strings.NewReader(arg.Key()), nil
 			})
 			// First call is a MISS
-			s, err := fc.Get(context.TODO(), &testArg{"test"})
+			s, err := fc.Get(context.Background(), &testArg{"test"})
 			Expect(err).To(BeNil())
 			Expect(s.Cached).To(BeFalse())
 			Expect(s.Closer).To(BeNil())
@@ -64,7 +65,7 @@ var _ = Describe("File Caches", func() {
 
 			// Second call is a HIT
 			called = false
-			s, err = fc.Get(context.TODO(), &testArg{"test"})
+			s, err = fc.Get(context.Background(), &testArg{"test"})
 			Expect(err).To(BeNil())
 			Expect(io.ReadAll(s)).To(Equal([]byte("test")))
 			Expect(s.Cached).To(BeTrue())
@@ -79,18 +80,70 @@ var _ = Describe("File Caches", func() {
 				return strings.NewReader(arg.Key()), nil
 			})
 			// First call is a MISS
-			s, err := fc.Get(context.TODO(), &testArg{"test"})
+			s, err := fc.Get(context.Background(), &testArg{"test"})
 			Expect(err).To(BeNil())
 			Expect(s.Cached).To(BeFalse())
 			Expect(io.ReadAll(s)).To(Equal([]byte("test")))
 
 			// Second call is also a MISS
 			called = false
-			s, err = fc.Get(context.TODO(), &testArg{"test"})
+			s, err = fc.Get(context.Background(), &testArg{"test"})
 			Expect(err).To(BeNil())
 			Expect(io.ReadAll(s)).To(Equal([]byte("test")))
 			Expect(s.Cached).To(BeFalse())
 			Expect(called).To(BeTrue())
+		})
+
+		Context("reader errors", func() {
+			When("creating a reader fails", func() {
+				It("does not cache", func() {
+					fc := callNewFileCache("test", "1KB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+						return nil, errors.New("failed")
+					})
+
+					_, err := fc.Get(context.Background(), &testArg{"test"})
+					Expect(err).To(MatchError("failed"))
+				})
+			})
+			When("reader returns error", func() {
+				It("does not cache", func() {
+					fc := callNewFileCache("test", "1KB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+						return errFakeReader{errors.New("read failure")}, nil
+					})
+
+					s, err := fc.Get(context.Background(), &testArg{"test"})
+					Expect(err).ToNot(HaveOccurred())
+					_, _ = io.Copy(io.Discard, s)
+					// TODO How to make the fscache reader return the error?
+					//Expect(err).To(MatchError("read failure"))
+
+					// Data should not be cached
+					s, err = fc.Get(context.Background(), &testArg{"test"})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Cached).To(BeFalse())
+				})
+			})
+			When("context is canceled", func() {
+				It("does not cache", func() {
+					ctx, cancel := context.WithCancel(context.Background())
+					fc := callNewFileCache("test", "1KB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+						return &ctxFakeReader{ctx}, nil
+					})
+
+					s, err := fc.Get(ctx, &testArg{"test"})
+					Expect(err).ToNot(HaveOccurred())
+					cancel()
+					b := make([]byte, 10)
+					_, err = s.Read(b)
+					// TODO Should be context.Canceled error
+					Expect(err).To(MatchError(io.EOF))
+
+					// Data should not be cached
+					s, err = fc.Get(context.Background(), &testArg{"test"})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(s.Cached).To(BeFalse())
+				})
+			})
 		})
 	})
 })
@@ -98,3 +151,11 @@ var _ = Describe("File Caches", func() {
 type testArg struct{ s string }
 
 func (t *testArg) Key() string { return t.s }
+
+type errFakeReader struct{ err error }
+
+func (e errFakeReader) Read([]byte) (int, error) { return 0, e.err }
+
+type ctxFakeReader struct{ ctx context.Context }
+
+func (e *ctxFakeReader) Read([]byte) (int, error) { return 0, e.ctx.Err() }

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -22,10 +23,12 @@ func callNewFileCache(name, cacheSize, cacheFolder string, maxItems int, getRead
 
 var _ = Describe("File Caches", func() {
 	BeforeEach(func() {
-		conf.Server.DataFolder, _ = os.MkdirTemp("", "file_caches")
-	})
-	AfterEach(func() {
-		_ = os.RemoveAll(conf.Server.DataFolder)
+		tmpDir, _ := os.MkdirTemp("", "file_caches")
+		DeferCleanup(func() {
+			configtest.SetupConfig()
+			_ = os.RemoveAll(tmpDir)
+		})
+		conf.Server.DataFolder = tmpDir
 	})
 
 	Describe("NewFileCache", func() {
@@ -114,7 +117,7 @@ var _ = Describe("File Caches", func() {
 					s, err := fc.Get(context.Background(), &testArg{"test"})
 					Expect(err).ToNot(HaveOccurred())
 					_, _ = io.Copy(io.Discard, s)
-					// TODO How to make the fscache reader return the error?
+					// TODO How to make the fscache reader return the underlying reader error?
 					//Expect(err).To(MatchError("read failure"))
 
 					// Data should not be cached

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -120,10 +120,14 @@ var _ = Describe("File Caches", func() {
 					// TODO How to make the fscache reader return the underlying reader error?
 					//Expect(err).To(MatchError("read failure"))
 
-					// Data should not be cached
-					s, err = fc.Get(context.Background(), &testArg{"test"})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(s.Cached).To(BeFalse())
+					// Data should not be cached (or eventually be removed from cache)
+					Eventually(func() bool {
+						s, _ = fc.Get(context.Background(), &testArg{"test"})
+						if s != nil {
+							return s.Cached
+						}
+						return false
+					}).Should(BeFalse())
 				})
 			})
 			When("context is canceled", func() {
@@ -141,10 +145,14 @@ var _ = Describe("File Caches", func() {
 					// TODO Should be context.Canceled error
 					Expect(err).To(MatchError(io.EOF))
 
-					// Data should not be cached
-					s, err = fc.Get(context.Background(), &testArg{"test"})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(s.Cached).To(BeFalse())
+					// Data should not be cached (or eventually be removed from cache)
+					Eventually(func() bool {
+						s, _ = fc.Get(context.Background(), &testArg{"test"})
+						if s != nil {
+							return s.Cached
+						}
+						return false
+					}).Should(BeFalse())
 				})
 			})
 		})

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -18,7 +18,7 @@ import (
 func callNewFileCache(name, cacheSize, cacheFolder string, maxItems int, getReader ReadFunc) *fileCache {
 	fc := NewFileCache(name, cacheSize, cacheFolder, maxItems, getReader)
 	Eventually(func() bool { return fc.Ready(context.Background()) }).Should(BeTrue())
-	return fc
+	return fc.(*fileCache)
 }
 
 var _ = Describe("File Caches", func() {


### PR DESCRIPTION
Don't cache transcoded files if the request was cancelled or when there was a transcoding error. 

There's no way for `fscache` to detect errors while writing to the cache, so I had to use an 'invalidate cache' approach similar to @FoxBuru's PR #1996

Fix #1950 