### PR TITLE
Add created at column for albums, songs table

### DIFF
--- a/ui/src/album/AlbumList.js
+++ b/ui/src/album/AlbumList.js
@@ -94,14 +94,19 @@ const AlbumList = (props) => {
   // Workaround to force album columns to appear the first time.
   // See https://github.com/navidrome/navidrome/pull/923#issuecomment-833004842
   // TODO: Find a better solution
-  useSetToggleableFields('album', [
-    'artist',
-    'songCount',
-    'playCount',
-    'year',
-    'duration',
-    'rating',
-  ])
+  useSetToggleableFields(
+    'album',
+    [
+      'artist',
+      'songCount',
+      'playCount',
+      'year',
+      'duration',
+      'rating',
+      'createdAt',
+    ],
+    ['createdAt']
+  )
 
   // If it does not have filter/sort params (usually coming from Menu),
   // reload with correct filter/sort params

--- a/ui/src/album/AlbumTableView.js
+++ b/ui/src/album/AlbumTableView.js
@@ -3,6 +3,7 @@ import {
   Datagrid,
   DatagridBody,
   DatagridRow,
+  DateField,
   NumberField,
   TextField,
 } from 'react-admin'
@@ -102,12 +103,14 @@ const AlbumTableView = ({
           className={classes.ratingField}
         />
       ),
+      createdAt: isDesktop && <DateField source="createdAt" showTime />,
     }
   }, [classes.ratingField, isDesktop])
 
   const columns = useSelectedFields({
     resource: 'album',
     columns: toggleableFields,
+    defaultOff: ['createdAt'],
   })
 
   return isXsmall ? (

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -25,7 +25,8 @@
                 "rating": "Rating",
                 "quality": "Quality",
                 "bpm": "BPM",
-                "playDate": "Last Played"
+                "playDate": "Last Played",
+                "createdAt": "Date added"
             },
             "actions": {
                 "addToQueue": "Play Later",
@@ -51,7 +52,8 @@
                 "year": "Year",
                 "updatedAt": "Updated at",
                 "comment": "Comment",
-                "rating": "Rating"
+                "rating": "Rating",
+                "createdAt": "Date added"
             },
             "actions": {
                 "playAll": "Play",

--- a/ui/src/song/SongList.js
+++ b/ui/src/song/SongList.js
@@ -139,6 +139,7 @@ const SongList = (props) => {
       bpm: isDesktop && <NumberField source="bpm" />,
       genre: <TextField source="genre" />,
       comment: <TextField source="comment" />,
+      createdAt: <DateField source="createdAt" showTime />,
     }
   }, [isDesktop, classes.ratingField])
 
@@ -152,6 +153,7 @@ const SongList = (props) => {
       'albumArtist',
       'genre',
       'comment',
+      'createdAt',
     ],
   })
 


### PR DESCRIPTION
Resolves #1974. Adds createdAt as a `DateField` with times shown, and modifies all translation files that already had a `createdAt` key.