### PR TITLE
Playlist view: optionally show genre and comment columns

### DIFF
--- a/ui/src/playlist/PlaylistList.js
+++ b/ui/src/playlist/PlaylistList.js
@@ -106,6 +106,8 @@ const PlaylistList = (props) => {
       public: !isXsmall && (
         <TogglePublicInput source="public" sortByOrder={'DESC'} />
       ),
+      genre: <TextField source="genre" />,
+      comment: <TextField source="comment" />,
     }),
     [isDesktop, isXsmall]
   )
@@ -113,6 +115,7 @@ const PlaylistList = (props) => {
   const columns = useSelectedFields({
     resource: 'playlist',
     columns: toggleableFields,
+    defaultOff: ['genre', 'comment'],
   })
 
   return (

--- a/ui/src/playlist/PlaylistList.js
+++ b/ui/src/playlist/PlaylistList.js
@@ -106,7 +106,6 @@ const PlaylistList = (props) => {
       public: !isXsmall && (
         <TogglePublicInput source="public" sortByOrder={'DESC'} />
       ),
-      genre: <TextField source="genre" />,
       comment: <TextField source="comment" />,
     }),
     [isDesktop, isXsmall]
@@ -115,7 +114,7 @@ const PlaylistList = (props) => {
   const columns = useSelectedFields({
     resource: 'playlist',
     columns: toggleableFields,
-    defaultOff: ['genre', 'comment'],
+    defaultOff: ['comment'],
   })
 
   return (


### PR DESCRIPTION
This PR is modeled after https://github.com/navidrome/navidrome/pull/1219. Unlike song view, playlist view doesn't have comment and genre columns available, so this PR adds it.