### PR TITLE
fix(ui): does not respect prefers-reduced-motion #2089

### DIFF
--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -32,6 +32,11 @@ const useStyle = makeStyles(
           display: 'none',
         },
       },
+      '@media (prefers-reduced-motion)': {
+        '& .music-player-panel .panel-content div.img-rotate': {
+          animation: 'none',
+        },
+      },
       '& .progress-bar-content': {
         display: 'flex',
         flexDirection: 'column',


### PR DESCRIPTION
Closes #2089.

Adds the media query and if reduced motion is preferred, sets `animation: none`.

Screenshots or Videos

![navidrome](https://user-images.githubusercontent.com/350021/212493297-58d20592-7b16-4fdd-b02e-7c2a2b6e1dbd.gif)


Related Issues and Pull Requests(if any) #2089 

