### PR TITLE
Fix versioning releases in the pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -125,11 +125,12 @@ jobs:
           name: js-bundle
           path: ui/build
 
-      - name: Show Tags
-        run: git tag
-
-      - name: Show Version
-        run: git describe --tags
+      - name: Config /github/workspace folder as trusted
+        uses: docker://deluan/ci-goreleaser:1.19.5-1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: /bin/bash -c "git config --global --add safe.directory /github/workspace;  git describe --dirty --always --tags"
 
       - name: Run GoReleaser - SNAPSHOT
         if: startsWith(github.ref, 'refs/tags/') != true

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,10 +1,6 @@
 # GoReleaser config
 project_name: navidrome
 
-before:
-  hooks:
-    - go env -w GOFLAGS="-buildvcs=false"
-
 builds:
   - id: navidrome_linux_amd64
     env:


### PR DESCRIPTION
This reverts commit 1374dab08775d3fefff96dbe707675e0d1a766d3 and fix the issue with `goreleaser` not able to get the version from Git, resulting in versions like `v0.0.0`