### PR TITLE
Optimizations to External Metadata refresh

### DIFF
--- a/server/public/public_endpoints.go
+++ b/server/public/public_endpoints.go
@@ -41,7 +41,7 @@ func (p *Router) routes() http.Handler {
 		r.Use(server.URLParamsMiddleware)
 		r.Group(func(r chi.Router) {
 			if conf.Server.DevArtworkMaxRequests > 0 {
-				log.Debug("Public images endpoint will be throttled", "maxRequests", conf.Server.DevArtworkMaxRequests,
+				log.Debug("Throttling public images endpoint", "maxRequests", conf.Server.DevArtworkMaxRequests,
 					"backlogLimit", conf.Server.DevArtworkThrottleBacklogLimit, "backlogTimeout",
 					conf.Server.DevArtworkThrottleBacklogTimeout)
 				r.Use(middleware.ThrottleBacklog(conf.Server.DevArtworkMaxRequests, conf.Server.DevArtworkThrottleBacklogLimit,

--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -146,7 +146,7 @@ func (api *Router) routes() http.Handler {
 	r.Group(func(r chi.Router) {
 		// configure request throttling
 		if conf.Server.DevArtworkMaxRequests > 0 {
-			log.Debug("Subsonic getCoverArt endpoint will be throttled", "maxRequests", conf.Server.DevArtworkMaxRequests,
+			log.Debug("Throttling Subsonic getCoverArt endpoint", "maxRequests", conf.Server.DevArtworkMaxRequests,
 				"backlogLimit", conf.Server.DevArtworkThrottleBacklogLimit, "backlogTimeout",
 				conf.Server.DevArtworkThrottleBacklogTimeout)
 			r.Use(middleware.ThrottleBacklog(conf.Server.DevArtworkMaxRequests, conf.Server.DevArtworkThrottleBacklogLimit,


### PR DESCRIPTION
When refreshing stale external metadata (from Last.fm or Spotify), limit concurrent refreshes to a just one and give some time between them. This will help with both rate limits and alleviating CPU usage.

This is done for both `artistInfo` and `albumInfo` (one queue for each).

Address issues in #2130 