### PR TITLE
Make lyrics on Nord theme easier to read

### DIFF
--- a/ui/src/themes/nord.css.js
+++ b/ui/src/themes/nord.css.js
@@ -109,7 +109,7 @@ module.exports = `
 
 .react-jinke-music-player-main .music-player-lyric {
     color: #D8DEE9;
-    -webkit-text-stroke: 2px #2E3440;
+    -webkit-text-stroke: 0.5px #2E3440;
     font-weight: bolder;
 }
 


### PR DESCRIPTION
Personally, I found the shadow made it hard enough to read Latin characters. However, it is even harder to read other fonts (from my experience, Chinese and Japanese). This reduces the stroke weight to be clearer.
Original:
![hard-to-read](https://user-images.githubusercontent.com/17521368/216780951-d52fb7aa-a90d-40a5-a302-08fe93afdbb1.png)
Current:
![clearer](https://user-images.githubusercontent.com/17521368/216780959-dcf94776-2362-4307-9712-6cbb25b5e636.png)

I did want to preserve at least some of the shadow (since it's a cool effect). If that's not worth it, here is also how it looks without shadow
![no-shadow](https://user-images.githubusercontent.com/17521368/216780979-9e800b24-1250-4999-80ab-13617e2074ae.png)