### PR TITLE
Add lastUpdated to `coverArt` ids

### DIFF
--- a/core/artwork/artwork.go
+++ b/core/artwork/artwork.go
@@ -73,6 +73,10 @@ func (a *artwork) Get(ctx context.Context, artID model.ArtworkID, size int) (rea
 	return r, artReader.LastUpdated(), nil
 }
 
+type coverArtGetter interface {
+	CoverArtID() model.ArtworkID
+}
+
 func (a *artwork) getArtworkId(ctx context.Context, id string) (model.ArtworkID, error) {
 	if id == "" {
 		return model.ArtworkID{}, ErrUnavailable
@@ -87,18 +91,17 @@ func (a *artwork) getArtworkId(ctx context.Context, id string) (model.ArtworkID,
 	if err != nil {
 		return model.ArtworkID{}, err
 	}
+	if e, ok := entity.(coverArtGetter); ok {
+		artID = e.CoverArtID()
+	}
 	switch e := entity.(type) {
 	case *model.Artist:
-		artID = model.NewArtworkID(model.KindArtistArtwork, e.ID)
 		log.Trace(ctx, "ID is for an Artist", "id", id, "name", e.Name, "artist", e.Name)
 	case *model.Album:
-		artID = model.NewArtworkID(model.KindAlbumArtwork, e.ID)
 		log.Trace(ctx, "ID is for an Album", "id", id, "name", e.Name, "artist", e.AlbumArtist)
 	case *model.MediaFile:
-		artID = model.NewArtworkID(model.KindMediaFileArtwork, e.ID)
 		log.Trace(ctx, "ID is for a MediaFile", "id", id, "title", e.Title, "album", e.Album)
 	case *model.Playlist:
-		artID = model.NewArtworkID(model.KindPlaylistArtwork, e.ID)
 		log.Trace(ctx, "ID is for a Playlist", "id", id, "name", e.Name)
 	}
 	return artID, nil

--- a/core/artwork/artwork_internal_test.go
+++ b/core/artwork/artwork_internal_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Artwork", func() {
 	Describe("albumArtworkReader", func() {
 		Context("ID not found", func() {
 			It("returns ErrNotFound if album is not in the DB", func() {
-				_, err := newAlbumArtworkReader(ctx, aw, model.MustParseArtworkID("al-NOT_FOUND"), nil)
+				_, err := newAlbumArtworkReader(ctx, aw, model.MustParseArtworkID("al-NOT-FOUND"), nil)
 				Expect(err).To(MatchError(model.ErrNotFound))
 			})
 		})
@@ -157,14 +157,14 @@ var _ = Describe("Artwork", func() {
 				Expect(err).ToNot(HaveOccurred())
 				_, path, err := aw.Reader(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(path).To(Equal("al-444"))
+				Expect(path).To(Equal("al-444_0"))
 			})
 			It("returns album cover if media file has no cover art", func() {
 				aw, err := newMediafileArtworkReader(ctx, aw, model.MustParseArtworkID("mf-"+mfWithoutEmbed.ID))
 				Expect(err).ToNot(HaveOccurred())
 				_, path, err := aw.Reader(ctx)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(path).To(Equal("al-444"))
+				Expect(path).To(Equal("al-444_0"))
 			})
 		})
 	})

--- a/core/artwork/image_cache.go
+++ b/core/artwork/image_cache.go
@@ -20,8 +20,9 @@ type cacheKey struct {
 
 func (k *cacheKey) Key() string {
 	return fmt.Sprintf(
-		"%s.%d",
-		k.artID,
+		"%s-%s.%d",
+		k.artID.Kind,
+		k.artID.ID,
 		k.lastUpdate.UnixMilli(),
 	)
 }

--- a/model/artwork_id_test.go
+++ b/model/artwork_id_test.go
@@ -1,36 +1,59 @@
 package model_test
 
 import (
+	"time"
+
 	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("ParseArtworkID()", func() {
-	It("parses album artwork ids", func() {
-		id, err := model.ParseArtworkID("al-1234")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(id.Kind).To(Equal(model.KindAlbumArtwork))
-		Expect(id.ID).To(Equal("1234"))
+var _ = Describe("ArtworkID", func() {
+	Describe("NewArtworkID()", func() {
+		It("creates a valid parseable ArtworkID", func() {
+			now := time.Now()
+			id := model.NewArtworkID(model.KindAlbumArtwork, "1234", &now)
+			parsedId, err := model.ParseArtworkID(id.String())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsedId.Kind).To(Equal(id.Kind))
+			Expect(parsedId.ID).To(Equal(id.ID))
+			Expect(parsedId.LastUpdate.Unix()).To(Equal(id.LastUpdate.Unix()))
+		})
+		It("creates a valid ArtworkID without lastUpdate info", func() {
+			id := model.NewArtworkID(model.KindPlaylistArtwork, "1234", nil)
+			parsedId, err := model.ParseArtworkID(id.String())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsedId.Kind).To(Equal(id.Kind))
+			Expect(parsedId.ID).To(Equal(id.ID))
+			Expect(parsedId.LastUpdate.Unix()).To(Equal(id.LastUpdate.Unix()))
+		})
 	})
-	It("parses media file artwork ids", func() {
-		id, err := model.ParseArtworkID("mf-a6f8d2b1")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(id.Kind).To(Equal(model.KindMediaFileArtwork))
-		Expect(id.ID).To(Equal("a6f8d2b1"))
-	})
-	It("parses playlists artwork ids", func() {
-		id, err := model.ParseArtworkID("pl-18690de0-151b-4d86-81cb-f418a907315a")
-		Expect(err).ToNot(HaveOccurred())
-		Expect(id.Kind).To(Equal(model.KindPlaylistArtwork))
-		Expect(id.ID).To(Equal("18690de0-151b-4d86-81cb-f418a907315a"))
-	})
-	It("fails to parse malformed ids", func() {
-		_, err := model.ParseArtworkID("a6f8d2b1")
-		Expect(err).To(MatchError("invalid artwork id"))
-	})
-	It("fails to parse ids with invalid kind", func() {
-		_, err := model.ParseArtworkID("xx-a6f8d2b1")
-		Expect(err).To(MatchError("invalid artwork kind"))
+	Describe("ParseArtworkID()", func() {
+		It("parses album artwork ids", func() {
+			id, err := model.ParseArtworkID("al-1234")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id.Kind).To(Equal(model.KindAlbumArtwork))
+			Expect(id.ID).To(Equal("1234"))
+		})
+		It("parses media file artwork ids", func() {
+			id, err := model.ParseArtworkID("mf-a6f8d2b1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id.Kind).To(Equal(model.KindMediaFileArtwork))
+			Expect(id.ID).To(Equal("a6f8d2b1"))
+		})
+		It("parses playlists artwork ids", func() {
+			id, err := model.ParseArtworkID("pl-18690de0-151b-4d86-81cb-f418a907315a")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(id.Kind).To(Equal(model.KindPlaylistArtwork))
+			Expect(id.ID).To(Equal("18690de0-151b-4d86-81cb-f418a907315a"))
+		})
+		It("fails to parse malformed ids", func() {
+			_, err := model.ParseArtworkID("a6f8d2b1")
+			Expect(err).To(MatchError("invalid artwork id"))
+		})
+		It("fails to parse ids with invalid kind", func() {
+			_, err := model.ParseArtworkID("xx-a6f8d2b1")
+			Expect(err).To(MatchError("invalid artwork kind"))
+		})
 	})
 })

--- a/server/public/encode_id_test.go
+++ b/server/public/encode_id_test.go
@@ -14,7 +14,7 @@ var _ = Describe("encodeArtworkID", func() {
 			auth.TokenAuth = jwtauth.New("HS256", []byte("super secret"), nil)
 		})
 		It("returns a reversible string representation", func() {
-			id := model.NewArtworkID(model.KindArtistArtwork, "1234")
+			id := model.NewArtworkID(model.KindArtistArtwork, "1234", nil)
 			encoded := encodeArtworkID(id)
 			decoded, err := decodeArtworkID(encoded)
 			Expect(err).ToNot(HaveOccurred())

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -193,9 +193,10 @@ func (api *Router) GetAlbumInfo(r *http.Request) (*responses.Subsonic, error) {
 	response := newResponse()
 	response.AlbumInfo = &responses.AlbumInfo{}
 	response.AlbumInfo.Notes = album.Description
-	response.AlbumInfo.SmallImageUrl = album.SmallImageUrl
-	response.AlbumInfo.MediumImageUrl = album.MediumImageUrl
-	response.AlbumInfo.LargeImageUrl = album.LargeImageUrl
+	response.AlbumInfo.SmallImageUrl = public.ImageURL(r, album.CoverArtID(), 150)
+	response.AlbumInfo.MediumImageUrl = public.ImageURL(r, album.CoverArtID(), 300)
+	response.AlbumInfo.LargeImageUrl = public.ImageURL(r, album.CoverArtID(), 600)
+
 	response.AlbumInfo.LastFmUrl = album.ExternalUrl
 	response.AlbumInfo.MusicBrainzID = album.MbzAlbumID
 
@@ -257,9 +258,9 @@ func (api *Router) GetArtistInfo(r *http.Request) (*responses.Subsonic, error) {
 	response := newResponse()
 	response.ArtistInfo = &responses.ArtistInfo{}
 	response.ArtistInfo.Biography = artist.Biography
-	response.ArtistInfo.SmallImageUrl = public.ImageURL(r, artist.CoverArtID(), 160)
-	response.ArtistInfo.MediumImageUrl = public.ImageURL(r, artist.CoverArtID(), 320)
-	response.ArtistInfo.LargeImageUrl = public.ImageURL(r, artist.CoverArtID(), 0)
+	response.ArtistInfo.SmallImageUrl = public.ImageURL(r, artist.CoverArtID(), 150)
+	response.ArtistInfo.MediumImageUrl = public.ImageURL(r, artist.CoverArtID(), 300)
+	response.ArtistInfo.LargeImageUrl = public.ImageURL(r, artist.CoverArtID(), 600)
 	response.ArtistInfo.LastFmUrl = artist.ExternalUrl
 	response.ArtistInfo.MusicBrainzID = artist.MbzArtistID
 	for _, s := range artist.SimilarArtists {

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -88,7 +88,7 @@ func toArtist(r *http.Request, a model.Artist) responses.Artist {
 		AlbumCount:     a.AlbumCount,
 		UserRating:     a.Rating,
 		CoverArt:       a.CoverArtID().String(),
-		ArtistImageUrl: public.ImageURL(r, a.CoverArtID(), 0),
+		ArtistImageUrl: public.ImageURL(r, a.CoverArtID(), 600),
 	}
 	if a.Starred {
 		artist.Starred = &a.StarredAt
@@ -102,7 +102,7 @@ func toArtistID3(r *http.Request, a model.Artist) responses.ArtistID3 {
 		Name:           a.Name,
 		AlbumCount:     a.AlbumCount,
 		CoverArt:       a.CoverArtID().String(),
-		ArtistImageUrl: public.ImageURL(r, a.CoverArtID(), 0),
+		ArtistImageUrl: public.ImageURL(r, a.CoverArtID(), 600),
 		UserRating:     a.Rating,
 	}
 	if a.Starred {

--- a/server/subsonic/searching.go
+++ b/server/subsonic/searching.go
@@ -107,7 +107,7 @@ func (api *Router) Search2(r *http.Request) (*responses.Subsonic, error) {
 			AlbumCount:     artist.AlbumCount,
 			UserRating:     artist.Rating,
 			CoverArt:       artist.CoverArtID().String(),
-			ArtistImageUrl: public.ImageURL(r, artist.CoverArtID(), 0),
+			ArtistImageUrl: public.ImageURL(r, artist.CoverArtID(), 600),
 		}
 		if artist.Starred {
 			searchResult2.Artist[i].Starred = &as[i].StarredAt


### PR DESCRIPTION
This should help with invalidating artwork cache client-side.

Ref: https://support.symfonium.app/t/refresh-cover-for-single-albums/1434