### PR TITLE
Limit share size while handling theme properly

### DIFF
--- a/ui/src/SharePlayer.js
+++ b/ui/src/SharePlayer.js
@@ -10,6 +10,10 @@ const useStyle = makeStyles({
       pointerEvents: (props) => props.single && 'none',
       opacity: (props) => props.single && 0.65,
     },
+    '& .react-jinke-music-player-mobile': {
+      maxWidth: 768,
+      margin: 'auto',
+    },
   },
 })
 

--- a/ui/src/SharePlayer.js
+++ b/ui/src/SharePlayer.js
@@ -10,9 +10,14 @@ const useStyle = makeStyles({
       pointerEvents: (props) => props.single && 'none',
       opacity: (props) => props.single && 0.65,
     },
-    '& .react-jinke-music-player-mobile': {
-      maxWidth: 768,
-      margin: 'auto',
+    '@media (min-width: 768px)': {
+      '& .react-jinke-music-player-mobile > div': {
+        width: 768,
+        margin: 'auto',
+      },
+      '& .react-jinke-music-player-mobile-cover': {
+        width: 'auto !important',
+      },
     },
   },
 })


### PR DESCRIPTION
When testing the original fix, I did not notice that the background was impacted (it was always light). This PR is a more proper fix that preserves the background. New view (I had to delete `.light-view` from `.react-jinke-music-player-main`). Sorry for the bugged first attempt .-.

![image](https://user-images.githubusercontent.com/17521368/218325464-6fbd6967-a876-4545-a5ca-a5bd935d487f.png)
