### PR TITLE
Call resumeContext directly

### DIFF
--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -69,7 +69,8 @@ const Player = () => {
       context === null &&
       audioInstance &&
       config.enableReplayGain &&
-      'AudioContext' in window
+      'AudioContext' in window &&
+      (gainInfo.gainMode === 'album' || gainInfo.gainMode === 'track')
     ) {
       const ctx = new AudioContext()
       // we need this to support radios in firefox
@@ -83,7 +84,7 @@ const Player = () => {
       setContext(ctx)
       setGainNode(gain)
     }
-  }, [audioInstance, context])
+  }, [audioInstance, context, gainInfo.gainMode])
 
   useEffect(() => {
     if (gainNode) {


### PR DESCRIPTION
Addresses #2167

Safari expects audioContext.resume() to be called in a function that is _directly_ related. For Navidrome, this means that any click that could start playing tracks should first call resume. This also includes the player itself, which happens when you refresh the page. Unfortunately, because react-jinke-player's onAUdioPlay isn't a direct user action, I had to manually add an event listener.

Additionally, we don't connect the audio context in the first place if replaygain is not enabled for the user.