### PR TITLE
Properly fix AudioContext on Safari

### DIFF
--- a/ui/src/album/AlbumActions.js
+++ b/ui/src/album/AlbumActions.js
@@ -27,6 +27,7 @@ import {
 import { formatBytes } from '../utils'
 import config from '../config'
 import { ToggleFieldsMenu } from '../common'
+import useResumeContext from '../common/useResumeContext'
 
 const useStyles = makeStyles({
   toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
@@ -45,22 +46,27 @@ const AlbumActions = ({
   const classes = useStyles()
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
+  const resumeContext = useResumeContext()
 
   const handlePlay = React.useCallback(() => {
+    resumeContext()
     dispatch(playTracks(data, ids))
-  }, [dispatch, data, ids])
+  }, [resumeContext, dispatch, data, ids])
 
   const handlePlayNext = React.useCallback(() => {
+    resumeContext()
     dispatch(playNext(data, ids))
-  }, [dispatch, data, ids])
+  }, [resumeContext, dispatch, data, ids])
 
   const handlePlayLater = React.useCallback(() => {
+    resumeContext()
     dispatch(addTracks(data, ids))
-  }, [dispatch, data, ids])
+  }, [resumeContext, dispatch, data, ids])
 
   const handleShuffle = React.useCallback(() => {
+    resumeContext()
     dispatch(shuffleTracks(data, ids))
-  }, [dispatch, data, ids])
+  }, [resumeContext, dispatch, data, ids])
 
   const handleAddToPlaylist = React.useCallback(() => {
     dispatch(openAddToPlaylist({ selectedIds: ids }))

--- a/ui/src/album/AlbumSongs.js
+++ b/ui/src/album/AlbumSongs.js
@@ -30,6 +30,7 @@ import {
 } from '../common'
 import config from '../config'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import useResumeContext from '../common/useResumeContext'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -91,6 +92,7 @@ const AlbumSongs = (props) => {
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
   const version = useVersion()
+  const resumeContext = useResumeContext()
   useResourceRefresh('song', 'album')
 
   const toggleableFields = useMemo(() => {
@@ -167,7 +169,10 @@ const AlbumSongs = (props) => {
             <SongBulkActions />
           </BulkActionsToolbar>
           <SongDatagrid
-            rowClick={(id) => dispatch(playTracks(data, ids, id))}
+            rowClick={(id) => {
+              resumeContext()
+              dispatch(playTracks(data, ids, id))
+            }}
             {...props}
             hasBulkActions={true}
             showDiscSubtitles={true}

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -71,7 +71,7 @@ const Player = () => {
     if (context && gainNode === null && audioInstance) {
       if (gainMode && gainMode !== 'none') {
         // we need this to support radios in firefox
-        // audioInstance.crossOrigin = 'anonymous'
+        audioInstance.crossOrigin = 'anonymous'
         const source = context.createMediaElementSource(audioInstance)
         const gain = context.createGain()
 

--- a/ui/src/common/ContextMenus.js
+++ b/ui/src/common/ContextMenus.js
@@ -23,6 +23,7 @@ import {
 import { LoveButton } from './LoveButton'
 import config from '../config'
 import { formatBytes } from '../utils'
+import useResumeContext from './useResumeContext'
 
 const useStyles = makeStyles({
   noWrap: {
@@ -47,6 +48,7 @@ const ContextMenu = ({
   const dispatch = useDispatch()
   const translate = useTranslate()
   const notify = useNotify()
+  const resumeContext = useResumeContext()
   const [anchorEl, setAnchorEl] = useState(null)
 
   const options = {
@@ -54,25 +56,37 @@ const ContextMenu = ({
       enabled: true,
       needData: true,
       label: translate('resources.album.actions.playAll'),
-      action: (data, ids) => dispatch(playTracks(data, ids)),
+      action: (data, ids) => {
+        resumeContext()
+        dispatch(playTracks(data, ids))
+      },
     },
     playNext: {
       enabled: true,
       needData: true,
       label: translate('resources.album.actions.playNext'),
-      action: (data, ids) => dispatch(playNext(data, ids)),
+      action: (data, ids) => {
+        resumeContext()
+        dispatch(playNext(data, ids))
+      },
     },
     addToQueue: {
       enabled: true,
       needData: true,
       label: translate('resources.album.actions.addToQueue'),
-      action: (data, ids) => dispatch(addTracks(data, ids)),
+      action: (data, ids) => {
+        resumeContext()
+        dispatch(addTracks(data, ids))
+      },
     },
     shuffle: {
       enabled: true,
       needData: true,
       label: translate('resources.album.actions.shuffle'),
-      action: (data, ids) => dispatch(shuffleTracks(data, ids)),
+      action: (data, ids) => {
+        resumeContext()
+        dispatch(shuffleTracks(data, ids))
+      },
     },
     addToPlaylist: {
       enabled: true,

--- a/ui/src/common/PlayButton.js
+++ b/ui/src/common/PlayButton.js
@@ -5,6 +5,7 @@ import { IconButton } from '@material-ui/core'
 import { useDispatch } from 'react-redux'
 import { useDataProvider } from 'react-admin'
 import { playTracks } from '../actions'
+import useResumeContext from './useResumeContext'
 
 export const PlayButton = ({ record, size, className }) => {
   let extractSongsData = function (response) {
@@ -17,7 +18,10 @@ export const PlayButton = ({ record, size, className }) => {
   }
   const dataProvider = useDataProvider()
   const dispatch = useDispatch()
+  const resumeContext = useResumeContext()
+
   const playAlbum = (record) => {
+    resumeContext()
     dataProvider
       .getList('song', {
         pagination: { page: 1, perPage: -1 },

--- a/ui/src/common/ShuffleAllButton.js
+++ b/ui/src/common/ShuffleAllButton.js
@@ -4,14 +4,17 @@ import { useDispatch } from 'react-redux'
 import ShuffleIcon from '@material-ui/icons/Shuffle'
 import { playTracks } from '../actions'
 import PropTypes from 'prop-types'
+import useResumeContext from './useResumeContext'
 
 export const ShuffleAllButton = ({ filters }) => {
   const translate = useTranslate()
   const dataProvider = useDataProvider()
   const dispatch = useDispatch()
   const notify = useNotify()
+  const resumeContext = useResumeContext()
 
   const handleOnClick = () => {
+    resumeContext()
     dataProvider
       .getList('song', {
         pagination: { page: 1, perPage: 500 },

--- a/ui/src/common/SongBulkActions.js
+++ b/ui/src/common/SongBulkActions.js
@@ -8,6 +8,7 @@ import { AddToPlaylistButton } from './AddToPlaylistButton'
 import { makeStyles } from '@material-ui/core/styles'
 import { BatchShareButton } from './BatchShareButton'
 import config from '../config'
+import useResumeContext from './useResumeContext'
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -18,28 +19,39 @@ const useStyles = makeStyles((theme) => ({
 export const SongBulkActions = (props) => {
   const classes = useStyles()
   const unselectAll = useUnselectAll()
+  const resumeContext = useResumeContext()
   useEffect(() => {
     unselectAll(props.resource)
   }, [unselectAll, props.resource])
+
   return (
     <Fragment>
       <BatchPlayButton
         {...props}
-        action={playTracks}
+        action={(args) => {
+          resumeContext()
+          playTracks(args)
+        }}
         label={'resources.song.actions.playNow'}
         icon={<PlayArrowIcon />}
         className={classes.button}
       />
       <BatchPlayButton
         {...props}
-        action={playNext}
+        action={(args) => {
+          resumeContext()
+          playNext(args)
+        }}
         label={'resources.song.actions.playNext'}
         icon={<RiPlayList2Fill />}
         className={classes.button}
       />
       <BatchPlayButton
         {...props}
-        action={addTracks}
+        action={(args) => {
+          resumeContext()
+          addTracks(args)
+        }}
         label={'resources.song.actions.addToQueue'}
         icon={<RiPlayListAddFill />}
         className={classes.button}

--- a/ui/src/common/SongContextMenu.js
+++ b/ui/src/common/SongContextMenu.js
@@ -19,6 +19,7 @@ import {
 import { LoveButton } from './LoveButton'
 import config from '../config'
 import { formatBytes } from '../utils'
+import useResumeContext from './useResumeContext'
 
 const useStyles = makeStyles({
   noWrap: {
@@ -36,22 +37,32 @@ export const SongContextMenu = ({
   const classes = useStyles()
   const dispatch = useDispatch()
   const translate = useTranslate()
+  const resumeContext = useResumeContext()
   const [anchorEl, setAnchorEl] = useState(null)
   const options = {
     playNow: {
       enabled: true,
       label: translate('resources.song.actions.playNow'),
-      action: (record) => dispatch(setTrack(record)),
+      action: (record) => {
+        resumeContext()
+        dispatch(setTrack(record))
+      },
     },
     playNext: {
       enabled: true,
       label: translate('resources.song.actions.playNext'),
-      action: (record) => dispatch(playNext({ [record.id]: record })),
+      action: (record) => {
+        resumeContext()
+        dispatch(playNext({ [record.id]: record }))
+      },
     },
     addToQueue: {
       enabled: true,
       label: translate('resources.song.actions.addToQueue'),
-      action: (record) => dispatch(addTracks({ [record.id]: record })),
+      action: (record) => {
+        resumeContext()
+        dispatch(addTracks({ [record.id]: record }))
+      },
     },
     addToPlaylist: {
       enabled: true,

--- a/ui/src/common/SongDatagrid.js
+++ b/ui/src/common/SongDatagrid.js
@@ -15,6 +15,7 @@ import { useDrag } from 'react-dnd'
 import { playTracks } from '../actions'
 import { AlbumContextMenu } from '../common'
 import { DraggableTypes } from '../consts'
+import useResumeContext from './useResumeContext'
 
 const useStyles = makeStyles({
   subtitle: {
@@ -172,14 +173,16 @@ const SongDatagridBody = ({
   ...rest
 }) => {
   const dispatch = useDispatch()
+  const resumeContext = useResumeContext()
   const { ids, data } = rest
 
   const playDisc = useCallback(
     (discNumber) => {
       const idsToPlay = ids.filter((id) => data[id].discNumber === discNumber)
+      resumeContext()
       dispatch(playTracks(data, idsToPlay))
     },
-    [dispatch, data, ids]
+    [ids, resumeContext, dispatch, data]
   )
 
   const firstTracks = useMemo(() => {

--- a/ui/src/common/SongSimpleList.js
+++ b/ui/src/common/SongSimpleList.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import PropTypes from 'prop-types'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
@@ -11,6 +11,7 @@ import { DurationField, SongContextMenu, RatingField } from './index'
 import { setTrack } from '../actions'
 import { useDispatch } from 'react-redux'
 import config from '../config'
+import useResumeContext from './useResumeContext'
 
 const useStyles = makeStyles(
   {
@@ -65,13 +66,23 @@ export const SongSimpleList = ({
 }) => {
   const dispatch = useDispatch()
   const classes = useStyles({ classes: classesOverride })
+  const resumeContext = useResumeContext()
+
+  const doSetTrack = useCallback(
+    (id) => {
+      resumeContext()
+      dispatch(setTrack(data[id]))
+    },
+    [data, dispatch, resumeContext]
+  )
+
   return (
     (loading || total > 0) && (
       <List className={className} {...sanitizeListRestProps(rest)}>
         {ids.map(
           (id) =>
             data[id] && (
-              <span key={id} onClick={() => dispatch(setTrack(data[id]))}>
+              <span key={id} onClick={doSetTrack}>
                 <ListItem className={classes.listItem} button={true}>
                   <ListItemText
                     primary={

--- a/ui/src/common/useResumeContext.js
+++ b/ui/src/common/useResumeContext.js
@@ -1,0 +1,18 @@
+import { useSelector } from 'react-redux'
+import config from '../config'
+
+const useResumeContext = () => {
+  const { context } = useSelector((state) => state.replayGain || {})
+
+  if (config.enableReplayGain) {
+    return () => {
+      if (context && context.state !== 'running') {
+        context.resume()
+      }
+    }
+  } else {
+    return () => {}
+  }
+}
+
+export default useResumeContext

--- a/ui/src/playlist/PlaylistActions.js
+++ b/ui/src/playlist/PlaylistActions.js
@@ -30,6 +30,7 @@ import PropTypes from 'prop-types'
 import { formatBytes } from '../utils'
 import config from '../config'
 import { ToggleFieldsMenu } from '../common'
+import useResumeContext from '../common/useResumeContext'
 
 const useStyles = makeStyles({
   toolbar: { display: 'flex', justifyContent: 'space-between', width: '100%' },
@@ -41,6 +42,7 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
   const classes = useStyles()
   const dataProvider = useDataProvider()
   const notify = useNotify()
+  const resumeContext = useResumeContext()
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
 
@@ -71,20 +73,24 @@ const PlaylistActions = ({ className, ids, data, record, ...rest }) => {
   )
 
   const handlePlay = React.useCallback(() => {
+    resumeContext()
     getAllSongsAndDispatch(playTracks)
-  }, [getAllSongsAndDispatch])
+  }, [getAllSongsAndDispatch, resumeContext])
 
   const handlePlayNext = React.useCallback(() => {
+    resumeContext()
     getAllSongsAndDispatch(playNext)
-  }, [getAllSongsAndDispatch])
+  }, [getAllSongsAndDispatch, resumeContext])
 
   const handlePlayLater = React.useCallback(() => {
+    resumeContext()
     getAllSongsAndDispatch(addTracks)
-  }, [getAllSongsAndDispatch])
+  }, [getAllSongsAndDispatch, resumeContext])
 
   const handleShuffle = React.useCallback(() => {
+    resumeContext()
     getAllSongsAndDispatch(shuffleTracks)
-  }, [getAllSongsAndDispatch])
+  }, [getAllSongsAndDispatch, resumeContext])
 
   const handleShare = React.useCallback(() => {
     dispatch(openShareMenu([record.id], 'playlist', record.name))

--- a/ui/src/playlist/PlaylistSongs.js
+++ b/ui/src/playlist/PlaylistSongs.js
@@ -31,6 +31,7 @@ import { AlbumLinkField } from '../song/AlbumLinkField'
 import { playTracks } from '../actions'
 import PlaylistSongBulkActions from './PlaylistSongBulkActions'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import useResumeContext from '../common/useResumeContext'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -91,6 +92,7 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   const dataProvider = useDataProvider()
   const notify = useNotify()
   const version = useVersion()
+  const resumeContext = useResumeContext()
   useResourceRefresh('song', 'playlist')
 
   const onAddToPlaylist = useCallback(
@@ -196,7 +198,10 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
             nodeSelector={'tr'}
           >
             <SongDatagrid
-              rowClick={(id) => dispatch(playTracks(data, ids, id))}
+              rowClick={(id) => {
+                resumeContext()
+                dispatch(playTracks(data, ids, id))
+              }}
               {...listContext}
               hasBulkActions={!readOnly}
               contextAlwaysVisible={!isDesktop}

--- a/ui/src/radio/RadioList.js
+++ b/ui/src/radio/RadioList.js
@@ -20,6 +20,7 @@ import { StreamField } from './StreamField'
 import { setTrack } from '../actions'
 import { songFromRadio } from './helper'
 import { useDispatch } from 'react-redux'
+import useResumeContext from '../common/useResumeContext'
 
 const useStyles = makeStyles({
   row: {
@@ -77,6 +78,8 @@ const RadioList = ({ permissions, ...props }) => {
   const classes = useStyles()
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const dispatch = useDispatch()
+  const resumeContext = useResumeContext()
+
   const isAdmin = permissions === 'admin'
 
   const toggleableFields = {
@@ -101,6 +104,7 @@ const RadioList = ({ permissions, ...props }) => {
   })
 
   const handleRowClick = async (id, basePath, record) => {
+    resumeContext()
     dispatch(setTrack(await songFromRadio(record)))
   }
 

--- a/ui/src/radio/StreamField.js
+++ b/ui/src/radio/StreamField.js
@@ -6,6 +6,7 @@ import { useDispatch } from 'react-redux'
 import { setTrack } from '../actions'
 import { songFromRadio } from './helper'
 import PlayArrowIcon from '@material-ui/icons/PlayArrow'
+import useResumeContext from '../common/useResumeContext'
 
 const useStyles = makeStyles((theme) => ({
   button: {
@@ -19,14 +20,16 @@ export const StreamField = (props) => {
   const record = useRecordContext(props)
   const dispatch = useDispatch()
   const classes = useStyles()
+  const resumeContext = useResumeContext()
 
   const playTrack = useCallback(
     async (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
+      resumeContext()
       dispatch(setTrack(await songFromRadio(record)))
     },
-    [dispatch, record]
+    [dispatch, record, resumeContext]
   )
 
   return (

--- a/ui/src/reducers/replayGainReducer.js
+++ b/ui/src/reducers/replayGainReducer.js
@@ -1,4 +1,18 @@
 import { CHANGE_GAIN, CHANGE_PREAMP } from '../actions'
+import config from '../config'
+
+function initialState() {
+  const state = {
+    gainMode: localStorage.getItem('gainMode') || 'none',
+    preAmp: getPreAmp(),
+  }
+
+  if (config.enableReplayGain && 'AudioContext' in window) {
+    state.context = new AudioContext()
+  }
+
+  return state
+}
 
 const getPreAmp = () => {
   const storage = localStorage.getItem('preamp')
@@ -11,13 +25,8 @@ const getPreAmp = () => {
   }
 }
 
-const initialState = {
-  gainMode: localStorage.getItem('gainMode') || 'none',
-  preAmp: getPreAmp(),
-}
-
 export const replayGainReducer = (
-  previousState = initialState,
+  previousState = initialState(),
   { type, payload }
 ) => {
   switch (type) {

--- a/ui/src/song/SongList.js
+++ b/ui/src/song/SongList.js
@@ -34,6 +34,7 @@ import { AlbumLinkField } from './AlbumLinkField'
 import { SongBulkActions, QualityInfo, useSelectedFields } from '../common'
 import config from '../config'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import useResumeContext from '../common/useResumeContext'
 
 const useStyles = makeStyles({
   contextHeader: {
@@ -91,8 +92,10 @@ const SongList = (props) => {
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   useResourceRefresh('song')
+  const resumeContext = useResumeContext()
 
   const handleRowClick = (id, basePath, record) => {
+    resumeContext()
     dispatch(setTrack(record))
   }
 


### PR DESCRIPTION
Safari requires an AudioContext to be resumed only by user action. This PR makes every action that could enqueue a track resume the context. 
Other things that could be done instead:
- move the resume logic to the definitions of `playNext`, `shuffleAll`...
- patch the player to have the click events directly cal the handler
- not use audio contexts at all and just have ffmpeg transcode