### PR TITLE
Proxy Internet Radios! 

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -89,6 +89,7 @@ type configOptions struct {
 	DevArtworkThrottleBacklogTimeout time.Duration
 	DevArtistInfoTimeToLive          time.Duration
 	DevAlbumInfoTimeToLive           time.Duration
+	DevMaxRadioStreams               int
 }
 
 type scannerOptions struct {
@@ -297,6 +298,7 @@ func init() {
 	viper.SetDefault("devartworkthrottlebacklogtimeout", consts.RequestThrottleBacklogTimeout)
 	viper.SetDefault("devartistinfotimetolive", consts.ArtistInfoTimeToLive)
 	viper.SetDefault("devalbuminfotimetolive", consts.AlbumInfoTimeToLive)
+	viper.SetDefault("devmaxradiostreams", consts.MaxRadioStreams)
 }
 
 func InitConfig(cfgFile string) {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -90,7 +90,7 @@ type configOptions struct {
 	DevArtistInfoTimeToLive          time.Duration
 	DevAlbumInfoTimeToLive           time.Duration
 	EnableProxy                      bool
-	DevMaxRadioStreams               int
+	MaxRadioStreams                  int
 }
 
 type scannerOptions struct {
@@ -300,7 +300,7 @@ func init() {
 	viper.SetDefault("devartistinfotimetolive", consts.ArtistInfoTimeToLive)
 	viper.SetDefault("devalbuminfotimetolive", consts.AlbumInfoTimeToLive)
 	viper.SetDefault("enableproxy", true)
-	viper.SetDefault("devmaxradiostreams", consts.MaxRadioStreams)
+	viper.SetDefault("maxradiostreams", consts.MaxRadioStreams)
 }
 
 func InitConfig(cfgFile string) {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -89,6 +89,7 @@ type configOptions struct {
 	DevArtworkThrottleBacklogTimeout time.Duration
 	DevArtistInfoTimeToLive          time.Duration
 	DevAlbumInfoTimeToLive           time.Duration
+	EnableProxy                      bool
 	DevMaxRadioStreams               int
 }
 
@@ -298,6 +299,7 @@ func init() {
 	viper.SetDefault("devartworkthrottlebacklogtimeout", consts.RequestThrottleBacklogTimeout)
 	viper.SetDefault("devartistinfotimetolive", consts.ArtistInfoTimeToLive)
 	viper.SetDefault("devalbuminfotimetolive", consts.AlbumInfoTimeToLive)
+	viper.SetDefault("enableproxy", true)
 	viper.SetDefault("devmaxradiostreams", consts.MaxRadioStreams)
 }
 

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -67,6 +67,8 @@ const (
 	DefaultScannerExtractor = "taglib"
 
 	Zwsp = string('\u200b')
+
+	MaxRadioStreams = -1 // Unlimited
 )
 
 // Cache options

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -68,7 +68,7 @@ const (
 
 	Zwsp = string('\u200b')
 
-	MaxRadioStreams = -1 // Unlimited
+	MaxRadioStreams = 100 // Unlimited
 )
 
 // Cache options

--- a/core/scrobbler/buffered_scrobbler.go
+++ b/core/scrobbler/buffered_scrobbler.go
@@ -12,6 +12,7 @@ import (
 func newBufferedScrobbler(ds model.DataStore, s Scrobbler, service string) *bufferedScrobbler {
 	b := &bufferedScrobbler{ds: ds, wrapped: s, service: service}
 	b.wakeSignal = make(chan struct{}, 1)
+	b.wakeRadio = make(chan struct{}, 1)
 	go b.run(context.TODO())
 	return b
 }
@@ -21,6 +22,7 @@ type bufferedScrobbler struct {
 	wrapped    Scrobbler
 	service    string
 	wakeSignal chan struct{}
+	wakeRadio  chan struct{}
 }
 
 func (b *bufferedScrobbler) IsAuthorized(ctx context.Context, userId string) bool {
@@ -32,32 +34,60 @@ func (b *bufferedScrobbler) NowPlaying(ctx context.Context, userId string, track
 }
 
 func (b *bufferedScrobbler) Scrobble(ctx context.Context, userId string, s Scrobble) error {
-	err := b.ds.ScrobbleBuffer(ctx).Enqueue(b.service, userId, s.ID, s.TimeStamp)
+	var err error
+	isRadio := s.ID == ""
+
+	if isRadio {
+		err = b.ds.ScrobbleRadio(ctx).Enqueue(b.service, userId, s.Artist, s.Title, s.TimeStamp)
+	} else {
+		err = b.ds.ScrobbleBuffer(ctx).Enqueue(b.service, userId, s.ID, s.TimeStamp)
+	}
+
 	if err != nil {
 		return err
 	}
 
-	b.sendWakeSignal()
+	b.sendWakeSignal(isRadio)
 	return nil
 }
 
-func (b *bufferedScrobbler) sendWakeSignal() {
+func (b *bufferedScrobbler) sendWakeSignal(isRadio bool) {
 	// Don't block if the previous signal was not read yet
+	var channel chan struct{}
+	if isRadio {
+		channel = b.wakeRadio
+	} else {
+		channel = b.wakeSignal
+	}
 	select {
-	case b.wakeSignal <- struct{}{}:
+	case channel <- struct{}{}:
 	default:
 	}
 }
 
 func (b *bufferedScrobbler) run(ctx context.Context) {
+	nextIsRadio := false
+
 	for {
-		if !b.processQueue(ctx) {
-			time.AfterFunc(5*time.Second, func() {
-				b.sendWakeSignal()
-			})
+		if nextIsRadio {
+			if !b.processRadio(ctx) {
+				time.AfterFunc(10*time.Second, func() {
+					b.sendWakeSignal(true)
+				})
+			}
+		} else {
+			if !b.processQueue(ctx) {
+				time.AfterFunc(5*time.Second, func() {
+					b.sendWakeSignal(false)
+				})
+			}
 		}
 		select {
 		case <-b.wakeSignal:
+			nextIsRadio = false
+			continue
+		case <-b.wakeRadio:
+			nextIsRadio = true
 			continue
 		case <-ctx.Done():
 			return
@@ -95,6 +125,59 @@ func (b *bufferedScrobbler) processUserQueue(ctx context.Context, userId string)
 		log.Debug(ctx, "Sending scrobble", "scrobbler", b.service, "track", entry.Title, "artist", entry.Artist)
 		err = b.wrapped.Scrobble(ctx, entry.UserID, Scrobble{
 			MediaFile: entry.MediaFile,
+			TimeStamp: entry.PlayTime,
+		})
+		if errors.Is(err, ErrRetryLater) {
+			log.Warn(ctx, "Could not send scrobble. Will be retried", "userId", entry.UserID,
+				"track", entry.Title, "artist", entry.Artist, "scrobbler", b.service, err)
+			return false
+		}
+		if err != nil {
+			log.Error(ctx, "Error sending scrobble to service. Discarding", "scrobbler", b.service,
+				"userId", entry.UserID, "artist", entry.Artist, "track", entry.Title, err)
+		}
+		err = buffer.Dequeue(entry)
+		if err != nil {
+			log.Error(ctx, "Error removing entry from scrobble buffer", "userId", entry.UserID,
+				"track", entry.Title, "artist", entry.Artist, "scrobbler", b.service, err)
+			return false
+		}
+	}
+}
+
+func (b *bufferedScrobbler) processRadio(ctx context.Context) bool {
+	buffer := b.ds.ScrobbleRadio(ctx)
+	userIds, err := buffer.UserIDs(b.service)
+	if err != nil {
+		log.Error(ctx, "Error retrieving userIds from scrobble buffer", "scrobbler", b.service, err)
+		return false
+	}
+	result := true
+	for _, userId := range userIds {
+		if !b.processUserRadioQueue(ctx, userId) {
+			result = false
+		}
+	}
+	return result
+}
+
+func (b *bufferedScrobbler) processUserRadioQueue(ctx context.Context, userId string) bool {
+	buffer := b.ds.ScrobbleRadio(ctx)
+	for {
+		entry, err := buffer.Next(b.service, userId)
+		if err != nil {
+			log.Error(ctx, "Error reading from scrobble buffer", "scrobbler", b.service, err)
+			return false
+		}
+		if entry == nil {
+			return true
+		}
+		log.Debug(ctx, "Sending scrobble", "scrobbler", b.service, "track", entry.Title, "artist", entry.Artist)
+		err = b.wrapped.Scrobble(ctx, entry.UserID, Scrobble{
+			MediaFile: model.MediaFile{
+				Artist: entry.Artist,
+				Title:  entry.Title,
+			},
 			TimeStamp: entry.PlayTime,
 		})
 		if errors.Is(err, ErrRetryLater) {

--- a/db/migration/20230212220934_add_buffered_radio_scrobble.go
+++ b/db/migration/20230212220934_add_buffered_radio_scrobble.go
@@ -1,0 +1,38 @@
+package migrations
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(upAddRadioScrobble, downAddRadioScrobble)
+}
+
+func upAddRadioScrobble(tx *sql.Tx) error {
+	// This code is executed when the migration is applied.
+	_, err := tx.Exec(`
+create table if not exists scrobble_radio
+(
+	user_id varchar not null
+	constraint scrobble_radio_user_id_fk
+		references user
+			on update cascade on delete cascade,
+	service varchar not null,
+	play_time datetime not null,
+	enqueue_time datetime not null default current_timestamp,
+	artist varchar not null,
+	title varchar not null,
+	constraint scrobble_radio_pk
+		unique (user_id, service, play_time, artist, title)
+);
+	`)
+
+	return err
+}
+
+func downAddRadioScrobble(tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+	return nil
+}

--- a/db/migration/20230221223342_add_radio_links.go
+++ b/db/migration/20230221223342_add_radio_links.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(upAddRadioLinks, downAddRadioLinks)
+}
+
+func upAddRadioLinks(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+create table if not exists radio_link
+(
+	id       varchar(255) primary key,
+	name     varchar not null,
+	url      varchar not null,
+	radio_id varchar(255) not null 
+		references radio (id)
+			on update cascade on delete cascade
+);
+
+alter table radio add column is_playlist bool default false not null;
+`)
+
+	return err
+}
+
+func downAddRadioLinks(tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+	return nil
+}

--- a/model/datastore.go
+++ b/model/datastore.go
@@ -35,6 +35,7 @@ type DataStore interface {
 	User(ctx context.Context) UserRepository
 	UserProps(ctx context.Context) UserPropsRepository
 	ScrobbleBuffer(ctx context.Context) ScrobbleBufferRepository
+	ScrobbleRadio(ctx context.Context) ScrobbleRadioRepository
 
 	Resource(ctx context.Context, model interface{}) ResourceRepository
 

--- a/model/radio.go
+++ b/model/radio.go
@@ -1,17 +1,42 @@
 package model
 
-import "time"
+import (
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
 
 type Radio struct {
-	ID          string    `structs:"id"            json:"id" orm:"pk;column(id)"`
-	StreamUrl   string    `structs:"stream_url"    json:"streamUrl"`
-	Name        string    `structs:"name"          json:"name"`
-	HomePageUrl string    `structs:"home_page_url" json:"homePageUrl" orm:"column(home_page_url)"`
-	CreatedAt   time.Time `structs:"created_at"    json:"createdAt"`
-	UpdatedAt   time.Time `structs:"updated_at"    json:"updatedAt"`
+	ID          string     `structs:"id"            json:"id" orm:"pk;column(id)"`
+	StreamUrl   string     `structs:"stream_url"    json:"streamUrl"`
+	Name        string     `structs:"name"          json:"name"`
+	HomePageUrl string     `structs:"home_page_url" json:"homePageUrl" orm:"column(home_page_url)"`
+	CreatedAt   time.Time  `structs:"created_at" json:"createdAt"`
+	UpdatedAt   time.Time  `structs:"updated_at" json:"updatedAt"`
+	IsPlaylist  bool       `structs:"is_playlist" json:"isPlaylist"`
+	Links       RadioLinks `structs:"-" json:"links,omitempty"`
 }
 
 type Radios []Radio
+
+type RadioLink struct {
+	ID      string `structs:"id"   json:"id" orm:"column(id)"`
+	RadioId string `structs:"id"   json:"radioId,omitempty" orm:"column(radio_id)"`
+	Name    string `structs:"name" json:"name"`
+	Url     string `structs:"url"  json:"url"`
+}
+
+func NewRadioLink(radioId string, name string, url string) RadioLink {
+	return RadioLink{
+		ID:      strings.ReplaceAll(uuid.NewString(), "-", ""),
+		Name:    name,
+		RadioId: radioId,
+		Url:     url,
+	}
+}
+
+type RadioLinks []RadioLink
 
 type RadioRepository interface {
 	ResourceRepository

--- a/model/scrobble_radio.go
+++ b/model/scrobble_radio.go
@@ -1,0 +1,22 @@
+package model
+
+import "time"
+
+type ScrobleRadioEntry struct {
+	Artist      string
+	Title       string
+	Service     string
+	UserID      string `structs:"user_id" orm:"column(user_id)"`
+	PlayTime    time.Time
+	EnqueueTime time.Time
+}
+
+type ScrobbleRadioEntries []ScrobleRadioEntry
+
+type ScrobbleRadioRepository interface {
+	UserIDs(service string) ([]string, error)
+	Enqueue(service, userId, artist, title string, playTime time.Time) error
+	Next(service string, userId string) (*ScrobleRadioEntry, error)
+	Dequeue(entry *ScrobleRadioEntry) error
+	Length() (int64, error)
+}

--- a/persistence/persistence.go
+++ b/persistence/persistence.go
@@ -80,6 +80,10 @@ func (s *SQLStore) ScrobbleBuffer(ctx context.Context) model.ScrobbleBufferRepos
 	return NewScrobbleBufferRepository(ctx, s.getOrmer())
 }
 
+func (s *SQLStore) ScrobbleRadio(ctx context.Context) model.ScrobbleRadioRepository {
+	return NewScrobbleRadioRepository(ctx, s.getOrmer())
+}
+
 func (s *SQLStore) Resource(ctx context.Context, m interface{}) model.ResourceRepository {
 	switch m.(type) {
 	case model.User:

--- a/persistence/persistence_suite_test.go
+++ b/persistence/persistence_suite_test.go
@@ -139,7 +139,7 @@ func SetupRadio(repo *radioRepository, client *tests.FakeHttpClient) {
 
 	f, _ := os.Open("tests/fixtures/radios/radio.m3u")
 	header := http.Header{}
-	header.Set("Content-Type", M3U_TYPE)
+	header.Set("Content-Type", "application/mpegurl")
 	client.Res = http.Response{
 		Body: f, StatusCode: 200, Header: header,
 	}
@@ -158,7 +158,7 @@ func SetupRadio(repo *radioRepository, client *tests.FakeHttpClient) {
 	}
 
 	f, _ = os.Open("tests/fixtures/radios/radio.pls")
-	header.Set("Content-Type", PLS_TYPE)
+	header.Set("Content-Type", "audio/x-scpls")
 	client.Res = http.Response{
 		Body: f, StatusCode: 200, Header: header,
 	}

--- a/persistence/radio_repository.go
+++ b/persistence/radio_repository.go
@@ -14,6 +14,7 @@ import (
 	"github.com/deluan/rest"
 	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 )
 
@@ -94,6 +95,8 @@ func (r *radioRepository) Put(radio *model.Radio) error {
 	if !r.isPermitted() {
 		return rest.ErrPermissionDenied
 	}
+
+	log.Info(r.ctx, "PUT", "Radio", radio)
 
 	var values map[string]interface{}
 
@@ -208,13 +211,13 @@ func (r *radioRepository) refreshLinks(radio *model.Radio) error {
 	defer req.Body.Close()
 
 	contentType := strings.TrimSpace(req.Header.Get("Content-Type"))
-	pls, isPls := M3U_TYPES[contentType]
+	pls, isPlaylist := M3U_TYPES[contentType]
 
-	if !isPls {
+	if !isPlaylist {
 		return nil
 	}
 
-	if req.ContentLength == -1 || req.ContentLength > MAX_PLS_BODY {
+	if req.ContentLength > MAX_PLS_BODY {
 		return ErrLargePlaylistBody
 	}
 

--- a/persistence/radio_repository.go
+++ b/persistence/radio_repository.go
@@ -1,8 +1,11 @@
 package persistence
 
 import (
+	"bufio"
 	"context"
 	"errors"
+	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -10,12 +13,18 @@ import (
 	"github.com/beego/beego/v2/client/orm"
 	"github.com/deluan/rest"
 	"github.com/google/uuid"
+	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/model"
 )
+
+type httpDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
 
 type radioRepository struct {
 	sqlRepository
 	sqlRestful
+	client httpDoer
 }
 
 func NewRadioRepository(ctx context.Context, o orm.QueryExecutor) model.RadioRepository {
@@ -25,6 +34,9 @@ func NewRadioRepository(ctx context.Context, o orm.QueryExecutor) model.RadioRep
 	r.tableName = "radio"
 	r.filterMappings = map[string]filterFunc{
 		"name": containsFilter,
+	}
+	r.client = &http.Client{
+		Timeout: consts.DefaultHttpClientTimeOut,
 	}
 	return r
 }
@@ -51,7 +63,24 @@ func (r *radioRepository) Get(id string) (*model.Radio, error) {
 	sel := r.newSelect().Where(Eq{"id": id}).Columns("*")
 	res := model.Radio{}
 	err := r.queryOne(sel, &res)
-	return &res, err
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res.IsPlaylist {
+		sel = Select("id", "name", "url").From("radio_link").Where(Eq{"radio_id": id})
+		links := model.RadioLinks{}
+		err = r.queryAll(sel, &links)
+
+		if err != nil {
+			return nil, err
+		}
+
+		res.Links = links
+	}
+
+	return &res, nil
 }
 
 func (r *radioRepository) GetAll(options ...model.QueryOptions) (model.Radios, error) {
@@ -77,18 +106,25 @@ func (r *radioRepository) Put(radio *model.Radio) error {
 	} else {
 		values, _ = toSqlArgs(*radio)
 		update := Update(r.tableName).Where(Eq{"id": radio.ID}).SetMap(values)
+
 		count, err := r.executeSQL(update)
 
 		if err != nil {
 			return err
 		} else if count > 0 {
-			return nil
+			return r.refreshLinks(radio)
 		}
 	}
 
 	values["created_at"] = time.Now()
 	insert := Insert(r.tableName).SetMap(values)
 	_, err := r.executeSQL(insert)
+
+	if err != nil {
+		return err
+	}
+
+	err = r.refreshLinks(radio)
 	return err
 }
 
@@ -135,6 +171,207 @@ func (r *radioRepository) Update(id string, entity interface{}, cols ...string) 
 		return rest.ErrNotFound
 	}
 	return err
+}
+
+const (
+	M3U_X_TYPE           = "audio/x-mpegurl"
+	M3U_TYPE             = "audio/mpegurl"
+	PLS_TYPE             = "audio/x-scpls"
+	APPLICATION_PLS_TYPE = "application/pls+xml"
+	MAX_PLS_BODY         = 1024 * 1024 // 1 MiB
+)
+
+var (
+	ErrLargePlaylistBody = errors.New("upstream playlist larger than 1 MB")
+)
+
+func (r *radioRepository) refreshLinks(radio *model.Radio) error {
+	newReq, _ := http.NewRequestWithContext(r.ctx, "GET", radio.StreamUrl, nil)
+	req, err := r.client.Do(newReq)
+
+	if err != nil {
+		return err
+	}
+
+	defer req.Body.Close()
+
+	var links *model.RadioLinks
+
+	switch req.Header.Get("Content-Type") {
+	case M3U_X_TYPE, M3U_TYPE:
+		if req.ContentLength == -1 || req.ContentLength > MAX_PLS_BODY {
+			return ErrLargePlaylistBody
+		}
+
+		links = r.parseM3u(radio.ID, req)
+	case PLS_TYPE, APPLICATION_PLS_TYPE:
+		if req.ContentLength == -1 || req.ContentLength > MAX_PLS_BODY {
+			return ErrLargePlaylistBody
+		}
+
+		links, err = r.parsePls(radio.ID, *req)
+		if err != nil {
+			return err
+		}
+	default:
+		return nil
+	}
+
+	del := Delete("radio_link").Where(Eq{"radio_id": radio.ID})
+	_, err = r.executeSQL(del)
+	if err != nil {
+		return err
+	}
+
+	ins := Insert("radio_link").Columns("id", "name", "radio_id", "url")
+
+	for _, link := range *links {
+		ins = ins.Values(link.ID, link.Name, link.RadioId, link.Url)
+	}
+
+	_, err = r.executeSQL(ins)
+
+	if err != nil {
+		return err
+	}
+
+	now := time.Now()
+
+	upd := Update(r.tableName).
+		Set("is_playlist", true).
+		Set("updated_at", now).
+		Where(Eq{"id": radio.ID})
+
+	_, err = r.executeSQL(upd)
+	return err
+}
+
+func (r *radioRepository) parseM3u(id string, req *http.Response) *model.RadioLinks {
+	scanner := bufio.NewScanner(req.Body)
+
+	name := ""
+	streamCount := 0
+
+	var links model.RadioLinks
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Skip empty lines
+		if line == "" {
+			continue
+		}
+
+		if strings.HasPrefix(line, "#EXTINF") {
+			// Extended info can tell us the stream name. Otherwise, just
+			// numbered 1...
+			name = strings.Split(line, ",")[1]
+		} else if !strings.HasPrefix(line, "#") {
+			streamCount += 1
+
+			if name == "" {
+				name = strconv.Itoa(streamCount)
+			}
+
+			link := model.NewRadioLink(id, name, line)
+
+			name = ""
+			links = append(links, link)
+		}
+	}
+
+	return &links
+}
+
+func (r *radioRepository) parsePls(id string, req http.Response) (*model.RadioLinks, error) {
+	scanner := bufio.NewScanner(req.Body)
+
+	file := ""
+	title := ""
+	idx := 1
+
+	var links model.RadioLinks
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		if line == "" {
+			continue
+		}
+
+		isFile := false
+		isTitle := false
+
+		if strings.HasPrefix(line, "File") {
+			isFile = true
+		} else if strings.HasPrefix(line, "Title") {
+			isTitle = true
+		}
+
+		if !isFile && !isTitle {
+			continue
+		}
+
+		data := strings.Split(line, "=")
+		var idxString string
+
+		if isFile {
+			idxString = strings.TrimPrefix(data[0], "File")
+		} else {
+			idxString = strings.TrimPrefix(data[0], "Title")
+		}
+
+		curIdx, err := strconv.Atoi(idxString)
+		if err != nil {
+			return nil, err
+		}
+
+		if curIdx > idx {
+			if file != "" {
+				if title == "" {
+					title = strconv.Itoa(idx)
+				}
+
+				link := model.RadioLink{
+					ID:      strings.ReplaceAll(uuid.NewString(), "-", ""),
+					Name:    title,
+					RadioId: id,
+					Url:     file,
+				}
+				links = append(links, link)
+			}
+
+			idx = curIdx
+
+			if isTitle {
+				file = ""
+			} else {
+				title = ""
+			}
+		}
+
+		if isTitle {
+			title = data[1]
+		} else {
+			file = data[1]
+		}
+	}
+
+	if file != "" {
+		if title == "" {
+			title = strconv.Itoa(idx)
+		}
+
+		link := model.RadioLink{
+			ID:      strings.ReplaceAll(uuid.NewString(), "-", ""),
+			Name:    title,
+			RadioId: id,
+			Url:     file,
+		}
+		links = append(links, link)
+	}
+
+	return &links, nil
 }
 
 var _ model.RadioRepository = (*radioRepository)(nil)

--- a/persistence/radio_repository_test.go
+++ b/persistence/radio_repository_test.go
@@ -202,9 +202,9 @@ var _ = Describe("RadioRepository", func() {
 				})
 			}
 
-			testCreate("radio.m3u", M3U_TYPE, &m3uLinks)
-			testCreate("radio-extended.m3u", M3U_X_TYPE, &m3uExtendedLinks)
-			testCreate("radio.pls", PLS_TYPE, &plsLinks)
+			testCreate("radio.m3u", "audio/mpegurl", &m3uLinks)
+			testCreate("radio-extended.m3u", "audio/x-mpegurl", &m3uExtendedLinks)
+			testCreate("radio.pls", "audio/x-scpls", &plsLinks)
 
 			testUpdate := func(id string, filename string, contentType string, links *model.RadioLinks) {
 				ext := path.Ext(filename)
@@ -245,9 +245,9 @@ var _ = Describe("RadioRepository", func() {
 				})
 			}
 
-			testUpdate("3456", "radio.m3u", M3U_TYPE, &m3uLinks)
-			testUpdate("1234", "radio-extended.m3u", M3U_X_TYPE, &m3uExtendedLinks)
-			testUpdate("2345", "radio.pls", PLS_TYPE, &plsLinks)
+			testUpdate("3456", "radio.m3u", "application/vnd.apple.mpegurl", &m3uLinks)
+			testUpdate("1234", "radio-extended.m3u", "application/vnd.apple.mpegurl.audio", &m3uExtendedLinks)
+			testUpdate("2345", "radio.pls", "audio/x-scpls", &plsLinks)
 		})
 	})
 

--- a/persistence/radio_repository_test.go
+++ b/persistence/radio_repository_test.go
@@ -1,13 +1,19 @@
 package persistence
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net/http"
+	"os"
+	"path"
 
 	"github.com/beego/beego/v2/client/orm"
 	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -17,14 +23,38 @@ var (
 )
 
 var _ = Describe("RadioRepository", func() {
+	var httpClient *tests.FakeHttpClient
 	var repo model.RadioRepository
+
+	testRadio := func(idx int, message string) {
+		It(message, func() {
+			radio := testRadios[idx]
+
+			res, err := repo.Get(radio.ID)
+
+			Expect(err).To(BeNil())
+			Expect(res.ID).To(Equal(radio.ID))
+			Expect(res.Links).To(HaveLen(len(radio.Links)))
+
+			for i, link := range res.Links {
+				Expect(link.Name).To(Equal(radio.Links[i].Name))
+				Expect(link.Url).To(Equal(radio.Links[i].Url))
+			}
+		})
+	}
 
 	Describe("Admin User", func() {
 		BeforeEach(func() {
+			httpClient = &tests.FakeHttpClient{}
+			httpClient.Res = http.Response{
+				Body:       io.NopCloser(bytes.NewBufferString("")),
+				StatusCode: 200,
+			}
+
 			ctx := log.NewContext(context.TODO())
 			ctx = request.WithUser(ctx, model.User{ID: "userid", UserName: "userid", IsAdmin: true})
 			repo = NewRadioRepository(ctx, orm.NewOrm())
-			_ = repo.Put(&radioWithHomePage)
+			repo.(*radioRepository).client = httpClient
 		})
 
 		AfterEach(func() {
@@ -34,18 +64,12 @@ var _ = Describe("RadioRepository", func() {
 				_ = repo.Delete(radio.ID)
 			}
 
-			for i := range testRadios {
-				r := testRadios[i]
-				err := repo.Put(&r)
-				if err != nil {
-					panic(err)
-				}
-			}
+			SetupRadio(repo.(*radioRepository), httpClient)
 		})
 
 		Describe("Count", func() {
 			It("returns the number of radios in the DB", func() {
-				Expect(repo.CountAll()).To(Equal(int64(2)))
+				Expect(repo.CountAll()).To(Equal(int64(5)))
 			})
 		})
 
@@ -61,12 +85,17 @@ var _ = Describe("RadioRepository", func() {
 		})
 
 		Describe("Get", func() {
-			It("returns an existing item", func() {
+			It("returns an existing playlist (no links)", func() {
 				res, err := repo.Get(radioWithHomePage.ID)
 
 				Expect(err).To(BeNil())
 				Expect(res.ID).To(Equal(radioWithHomePage.ID))
+				Expect(res.Links).To(HaveLen(0))
 			})
+
+			testRadio(2, "returns links from m3u playlist")
+			testRadio(3, "returns links from m3u extended playlist")
+			testRadio(4, "returns links from pls playlist")
 
 			It("errors when missing", func() {
 				_, err := repo.Get("notanid")
@@ -79,40 +108,146 @@ var _ = Describe("RadioRepository", func() {
 			It("returns all items from the DB", func() {
 				all, err := repo.GetAll()
 				Expect(err).To(BeNil())
-				Expect(all[0].ID).To(Equal(radioWithoutHomePage.ID))
-				Expect(all[1].ID).To(Equal(radioWithHomePage.ID))
+
+				for i, radio := range testRadios {
+					Expect(all[i].ID).To(Equal(radio.ID))
+					Expect(all[i].StreamUrl).To(Equal(radio.StreamUrl))
+					Expect(all[i].IsPlaylist).To(Equal(radio.IsPlaylist))
+					Expect(all[i].Name).To(Equal(radio.Name))
+				}
 			})
 		})
 
 		Describe("Put", func() {
-			It("successfully updates item", func() {
-				err := repo.Put(&model.Radio{
-					ID:        radioWithHomePage.ID,
-					Name:      "New Name",
-					StreamUrl: "https://example.com:4533/app",
+			Describe("Regular stream", func() {
+				It("successfully updates item", func() {
+					httpClient.Res = http.Response{
+						Body:       io.NopCloser(bytes.NewBufferString("")),
+						StatusCode: 200,
+					}
+
+					err := repo.Put(&model.Radio{
+						ID:        radioWithHomePage.ID,
+						Name:      "New Name",
+						StreamUrl: "https://example.com:4533/app",
+					})
+
+					Expect(err).To(BeNil())
+
+					item, err := repo.Get(radioWithHomePage.ID)
+					Expect(err).To(BeNil())
+
+					Expect(item.HomePageUrl).To(Equal(""))
 				})
 
-				Expect(err).To(BeNil())
+				It("successfully creates item", func() {
+					httpClient.Res = http.Response{
+						Body:       io.NopCloser(bytes.NewBufferString("")),
+						StatusCode: 200,
+					}
 
-				item, err := repo.Get(radioWithHomePage.ID)
-				Expect(err).To(BeNil())
+					err := repo.Put(&model.Radio{
+						Name:      "New radio",
+						StreamUrl: "https://example.com:4533/app",
+					})
 
-				Expect(item.HomePageUrl).To(Equal(""))
-			})
+					Expect(err).To(BeNil())
+					Expect(repo.CountAll()).To(Equal(int64(6)))
 
-			It("successfully creates item", func() {
-				err := repo.Put(&model.Radio{
-					Name:      "New radio",
-					StreamUrl: "https://example.com:4533/app",
+					all, err := repo.GetAll()
+					Expect(err).To(BeNil())
+					Expect(all[5].StreamUrl).To(Equal("https://example.com:4533/app"))
 				})
-
-				Expect(err).To(BeNil())
-				Expect(repo.CountAll()).To(Equal(int64(3)))
-
-				all, err := repo.GetAll()
-				Expect(err).To(BeNil())
-				Expect(all[2].StreamUrl).To(Equal("https://example.com:4533/app"))
 			})
+		})
+
+		Describe("Playlist stream", func() {
+			testCreate := func(filename string, contentType string, links *model.RadioLinks) {
+				ext := path.Ext(filename)
+
+				It("Successfully creates an "+ext+" stream", func() {
+					f, _ := os.Open("tests/fixtures/radios/" + filename)
+					header := http.Header{}
+					header.Set("Content-Type", contentType)
+					httpClient.Res = http.Response{
+						Body: f, StatusCode: 200, Header: header,
+					}
+
+					name := ext + " stream"
+					url := "https://example.com:1234/" + filename
+
+					err := repo.Put(&model.Radio{
+						Name:      name,
+						StreamUrl: url,
+					})
+
+					Expect(err).To(BeNil())
+					Expect(repo.CountAll()).To(Equal(int64(6)))
+
+					all, err := repo.GetAll()
+					Expect(err).To(BeNil())
+					Expect(all[5].Name).To(Equal(name))
+					Expect(all[5].StreamUrl).To(Equal(url))
+					Expect(all[5].IsPlaylist).To(BeTrue())
+
+					radio, err := repo.Get(all[5].ID)
+					Expect(err).To(BeNil())
+
+					Expect(radio.Links).To(HaveLen(len(*links)))
+
+					for i, link := range *links {
+						Expect(radio.Links[i].Name).To(Equal(link.Name))
+						Expect(radio.Links[i].Url).To(Equal(link.Url))
+					}
+				})
+			}
+
+			testCreate("radio.m3u", M3U_TYPE, &m3uLinks)
+			testCreate("radio-extended.m3u", M3U_X_TYPE, &m3uExtendedLinks)
+			testCreate("radio.pls", PLS_TYPE, &plsLinks)
+
+			testUpdate := func(id string, filename string, contentType string, links *model.RadioLinks) {
+				ext := path.Ext(filename)
+
+				It("Successfully updates an "+ext+" stream", func() {
+					f, _ := os.Open("tests/fixtures/radios/" + filename)
+					header := http.Header{}
+					header.Set("Content-Type", contentType)
+					httpClient.Res = http.Response{
+						Body: f, StatusCode: 200, Header: header,
+					}
+
+					name := ext + " stream"
+					url := "https://example.com:1234/" + filename
+
+					err := repo.Put(&model.Radio{
+						ID:        id,
+						Name:      name,
+						StreamUrl: url,
+					})
+
+					Expect(err).To(BeNil())
+					Expect(repo.CountAll()).To(Equal(int64(5)))
+
+					radio, err := repo.Get(id)
+					Expect(err).To(BeNil())
+					Expect(radio.IsPlaylist).To(BeTrue())
+
+					Expect(radio.Name).To(Equal(name))
+					Expect(radio.StreamUrl).To(Equal(url))
+					Expect(radio.IsPlaylist).To(BeTrue())
+					Expect(radio.Links).To(HaveLen(len(*links)))
+
+					for i, link := range *links {
+						Expect(radio.Links[i].Name).To(Equal(link.Name))
+						Expect(radio.Links[i].Url).To(Equal(link.Url))
+					}
+				})
+			}
+
+			testUpdate("3456", "radio.m3u", M3U_TYPE, &m3uLinks)
+			testUpdate("1234", "radio-extended.m3u", M3U_X_TYPE, &m3uExtendedLinks)
+			testUpdate("2345", "radio.pls", PLS_TYPE, &plsLinks)
 		})
 	})
 
@@ -125,7 +260,7 @@ var _ = Describe("RadioRepository", func() {
 
 		Describe("Count", func() {
 			It("returns the number of radios in the DB", func() {
-				Expect(repo.CountAll()).To(Equal(int64(2)))
+				Expect(repo.CountAll()).To(Equal(int64(5)))
 			})
 		})
 
@@ -138,12 +273,17 @@ var _ = Describe("RadioRepository", func() {
 		})
 
 		Describe("Get", func() {
-			It("returns an existing item", func() {
+			It("returns an existing playlist (no links)", func() {
 				res, err := repo.Get(radioWithHomePage.ID)
 
-				Expect(err).To((BeNil()))
+				Expect(err).To(BeNil())
 				Expect(res.ID).To(Equal(radioWithHomePage.ID))
+				Expect(res.Links).To(HaveLen(0))
 			})
+
+			testRadio(2, "returns links from m3u playlist")
+			testRadio(3, "returns links from m3u extended playlist")
+			testRadio(4, "returns links from pls playlist")
 
 			It("errors when missing", func() {
 				_, err := repo.Get("notanid")
@@ -156,8 +296,13 @@ var _ = Describe("RadioRepository", func() {
 			It("returns all items from the DB", func() {
 				all, err := repo.GetAll()
 				Expect(err).To(BeNil())
-				Expect(all[0].ID).To(Equal(radioWithoutHomePage.ID))
-				Expect(all[1].ID).To(Equal(radioWithHomePage.ID))
+
+				for i, radio := range testRadios {
+					Expect(all[i].ID).To(Equal(radio.ID))
+					Expect(all[i].StreamUrl).To(Equal(radio.StreamUrl))
+					Expect(all[i].IsPlaylist).To(Equal(radio.IsPlaylist))
+					Expect(all[i].Name).To(Equal(radio.Name))
+				}
 			})
 		})
 

--- a/persistence/scrobble_radio_repository.go
+++ b/persistence/scrobble_radio_repository.go
@@ -1,0 +1,84 @@
+package persistence
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/beego/beego/v2/client/orm"
+	"github.com/navidrome/navidrome/model"
+)
+
+type scrobbleRadioRepository struct {
+	sqlRepository
+}
+
+func NewScrobbleRadioRepository(ctx context.Context, o orm.QueryExecutor) model.ScrobbleRadioRepository {
+	r := &scrobbleRadioRepository{}
+	r.ctx = ctx
+	r.ormer = o
+	r.tableName = "scrobble_radio"
+	return r
+}
+
+func (r *scrobbleRadioRepository) UserIDs(service string) ([]string, error) {
+	sql := Select().Columns("user_id").
+		From(r.tableName).
+		Where(And{
+			Eq{"service": service},
+		}).
+		GroupBy("user_id").
+		OrderBy("count(*)")
+	var userIds []string
+	err := r.queryAll(sql, &userIds)
+	return userIds, err
+}
+
+func (r *scrobbleRadioRepository) Enqueue(service, userId, artist, title string, playTime time.Time) error {
+	ins := Insert(r.tableName).SetMap(map[string]interface{}{
+		"artist":       artist,
+		"enqueue_time": time.Now(),
+		"play_time":    playTime,
+		"service":      service,
+		"title":        title,
+		"user_id":      userId,
+	})
+	_, err := r.executeSQL(ins)
+	return err
+}
+
+func (r *scrobbleRadioRepository) Next(service string, userId string) (*model.ScrobleRadioEntry, error) {
+	sql := Select().Columns("*").
+		From(r.tableName+" s").
+		Where(And{
+			Eq{"service": service},
+			Eq{"user_id": userId},
+		}).
+		OrderBy("play_time", "s.rowid").Limit(1)
+
+	res := model.ScrobleRadioEntry{}
+	err := r.queryOne(sql, &res)
+	if errors.Is(err, model.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (r *scrobbleRadioRepository) Dequeue(entry *model.ScrobleRadioEntry) error {
+	return r.delete(And{
+		Eq{"artist": entry.Artist},
+		Eq{"play_time": entry.PlayTime},
+		Eq{"title": entry.Title},
+		Eq{"service": entry.Service},
+	})
+}
+
+func (r *scrobbleRadioRepository) Length() (int64, error) {
+	return r.count(Select())
+}
+
+var _ model.ScrobbleRadioRepository = (*scrobbleRadioRepository)(nil)

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -66,6 +66,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"enableExternalServices":    conf.Server.EnableExternalServices,
 			"enableReplayGain":          conf.Server.EnableReplayGain,
 			"defaultDownsamplingFormat": conf.Server.DefaultDownsamplingFormat,
+			"enableProxy":               conf.Server.EnableProxy,
 		}
 		if strings.HasPrefix(conf.Server.UILoginBackgroundURL, "/") {
 			appConfig["loginBackgroundURL"] = path.Join(conf.Server.BaseURL, conf.Server.UILoginBackgroundURL)

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -332,6 +332,18 @@ var _ = Describe("serveIndex", func() {
 		Expect(config).To(HaveKeyWithValue("enableExternalServices", true))
 	})
 
+	It("sets the enableProxy", func() {
+		conf.Server.EnableProxy = false
+		conf.Server.EnableExternalServices = true
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		serveIndex(ds, fs, nil)(w, r)
+
+		config := extractAppConfig(w.Body.String())
+		Expect(config).To(HaveKeyWithValue("enableProxy", false))
+	})
+
 	Describe("loginBackgroundURL", func() {
 		Context("empty BaseURL", func() {
 			BeforeEach(func() {

--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -359,24 +359,26 @@ func proxyRadio(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set(header, headResp.Header.Get(header))
 	}
 
-	// Basically, the question is how do we copy mainResp (the internet radio)
-	// over to the output writer, w. This leads to a choppy mess
 	defer mainResp.Body.Close()
 	reader := bufio.NewReader(mainResp.Body)
-	buf := make([]byte, 10000)
+	buf := make([]byte, 8192)
 	for {
 		count, err := reader.Read(buf)
 
 		if count == 0 {
+			log.Info(r, "Done")
 			break
 		}
 
 		if err != nil {
+			log.Error(r, "Error reading data", "url", streamUrl, err)
 			break
 		}
-		_, err = w.Write(buf)
+
+		_, err = w.Write(buf[0:count])
 
 		if err != nil {
+			log.Error(r, "Error writing data", "url", streamUrl, err)
 			break
 		}
 	}

--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -185,7 +185,7 @@ func (api *Router) routes() http.Handler {
 				// These are not official subsonic routes. However, they use subsonic
 				// as opposed to native API because it makes authentication easier from the
 				// client side (namely, fetching audio and images)
-				throttle := conf.Server.DevMaxRadioStreams
+				throttle := conf.Server.MaxRadioStreams
 
 				if throttle == 0 {
 					return

--- a/server/subsonic/media_annotation.go
+++ b/server/subsonic/media_annotation.go
@@ -189,6 +189,29 @@ func (api *Router) Scrobble(r *http.Request) (*responses.Subsonic, error) {
 	return newResponse(), nil
 }
 
+func (api *Router) ScrobbleRadio(r *http.Request) (*responses.Subsonic, error) {
+	artist, err := requiredParamString(r, "artist")
+	if err != nil {
+		return nil, err
+	}
+
+	title, err := requiredParamString(r, "title")
+	if err != nil {
+		return nil, err
+	}
+
+	submission := utils.ParamBool(r, "submission", true)
+	ctx := r.Context()
+
+	if submission {
+		api.scrobbler.SubmitRadio(ctx, artist, title)
+	} else {
+		api.scrobbler.NowPlayingRadio(ctx, artist, title)
+	}
+
+	return newResponse(), nil
+}
+
 func (api *Router) scrobblerSubmit(ctx context.Context, ids []string, times []time.Time) error {
 	var submissions []scrobbler.Submission
 	log.Debug(ctx, "Scrobbling tracks", "ids", ids, "times", times)

--- a/server/subsonic/media_annotation_test.go
+++ b/server/subsonic/media_annotation_test.go
@@ -100,9 +100,15 @@ var _ = Describe("MediaAnnotationController", func() {
 	})
 })
 
+type radioInfo struct {
+	Artist  string
+	Playing bool
+}
+
 type fakePlayTracker struct {
 	Submissions []scrobbler.Submission
 	Playing     map[string]string
+	Radio       map[string]radioInfo
 	Error       error
 }
 
@@ -117,6 +123,19 @@ func (f *fakePlayTracker) NowPlaying(_ context.Context, playerId string, _ strin
 	return nil
 }
 
+func (f *fakePlayTracker) NowPlayingRadio(_ context.Context, artist, title string) {
+	if f.Error != nil {
+		return
+	}
+	if f.Radio == nil {
+		f.Radio = make(map[string]radioInfo)
+	}
+	f.Radio[title] = radioInfo{
+		Artist:  artist,
+		Playing: true,
+	}
+}
+
 func (f *fakePlayTracker) GetNowPlaying(_ context.Context) ([]scrobbler.NowPlayingInfo, error) {
 	return nil, f.Error
 }
@@ -127,6 +146,19 @@ func (f *fakePlayTracker) Submit(_ context.Context, submissions []scrobbler.Subm
 	}
 	f.Submissions = append(f.Submissions, submissions...)
 	return nil
+}
+
+func (f *fakePlayTracker) SubmitRadio(_ context.Context, artist, title string) {
+	if f.Error != nil {
+		return
+	}
+	if f.Radio == nil {
+		f.Radio = make(map[string]radioInfo)
+	}
+	f.Radio[title] = radioInfo{
+		Artist:  artist,
+		Playing: false,
+	}
 }
 
 var _ scrobbler.PlayTracker = (*fakePlayTracker)(nil)

--- a/server/subsonic/radio.go
+++ b/server/subsonic/radio.go
@@ -151,7 +151,7 @@ func (api *Router) proxyIcon(w http.ResponseWriter, r *http.Request) {
 }
 
 var (
-	headers = []string{"content-type", "icy-br", "icy-genre", "icy-name", "icy-pub", "icy-sr", "icy-url", "icy-metaint"}
+	headers = []string{"ice-audio-info", "icy-br", "icy-description", "icy-genre", "icy-name", "icy-pub", "icy-sr", "icy-url", "icy-vbr", "icy-metaint"}
 )
 
 func (api *Router) proxyRadio(w http.ResponseWriter, r *http.Request) {
@@ -203,8 +203,13 @@ func (api *Router) proxyRadio(w http.ResponseWriter, r *http.Request) {
 	}
 
 	for _, header := range headers {
-		w.Header().Set(header, headResp.Header.Get(header))
+		val := headResp.Header.Get(header)
+		if val != "" {
+			w.Header().Set(header, val)
+		}
 	}
+
+	w.Header().Set("Content-Type", mainResp.Header.Get("Content-Type"))
 
 	defer mainResp.Body.Close()
 	reader := bufio.NewReader(mainResp.Body)

--- a/server/subsonic/radio.go
+++ b/server/subsonic/radio.go
@@ -141,7 +141,13 @@ func (api *Router) proxyIcon(w http.ResponseWriter, r *http.Request) {
 	}
 
 	defer resp.Body.Close()
-	io.Copy(w, resp.Body)
+	_, err = io.Copy(w, resp.Body)
+
+	if err != nil {
+		log.Error(r, "Error fetching icon", "url", iconUrl, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 var (

--- a/server/subsonic/radio.go
+++ b/server/subsonic/radio.go
@@ -1,8 +1,12 @@
 package subsonic
 
 import (
+	"bufio"
+	"io"
 	"net/http"
+	"net/url"
 
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
 	"github.com/navidrome/navidrome/utils"
@@ -105,4 +109,125 @@ func (api *Router) UpdateInternetRadio(r *http.Request) (*responses.Subsonic, er
 		return nil, err
 	}
 	return newResponse(), nil
+}
+
+// The following endpoints are not part of the subsonic spec, but are part of the
+// Subsonic router (as opposed to native) because it makes authentication easier
+
+func (api *Router) proxyIcon(w http.ResponseWriter, r *http.Request) {
+	iconUrl, err := requiredParamString(r, "url")
+
+	if err != nil {
+		log.Error(r, "Bad stream url", "url", iconUrl, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	client := http.Client{}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", iconUrl, nil)
+	if err != nil {
+		log.Error(r, "Error creating request", "url", iconUrl, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Error(r, "Error fetching icon", "url", iconUrl, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	defer resp.Body.Close()
+	io.Copy(w, resp.Body)
+}
+
+var (
+	headers = []string{"content-type", "icy-br", "icy-genre", "icy-name", "icy-pub", "icy-sr", "icy-url", "icy-metaint"}
+)
+
+func (api *Router) proxyRadio(w http.ResponseWriter, r *http.Request) {
+	requestedUrl, err := requiredParamString(r, "url")
+
+	if err != nil {
+		log.Error(r, "Bad stream url", "url", requestedUrl, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	ctx := r.Context()
+	client := http.Client{}
+
+	streamUrl, err := url.QueryUnescape(requestedUrl)
+
+	if err != nil {
+		log.Error(r, "Bad stream url", "url", requestedUrl, err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "HEAD", streamUrl, nil)
+
+	if err != nil {
+		log.Error(r, "Error creating request", "url", streamUrl, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	req.Header.Set("Icy-Metadata", "1")
+	headResp, err := client.Do(req)
+
+	if err != nil {
+		log.Error(r, "Error fetching stream", "url", streamUrl, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	headResp.Body.Close()
+
+	req, _ = http.NewRequestWithContext(ctx, "GET", streamUrl, nil)
+	req.Header.Set("Icy-Metadata", "1")
+	mainResp, err := client.Do(req)
+
+	if err != nil {
+		log.Error(r, "Error fetching stream", "url", streamUrl, err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	for _, header := range headers {
+		w.Header().Set(header, headResp.Header.Get(header))
+	}
+
+	defer mainResp.Body.Close()
+	reader := bufio.NewReader(mainResp.Body)
+	buf := make([]byte, 8192)
+
+	done := false
+
+	go func() {
+		<-r.Context().Done()
+		done = true
+	}()
+
+	for {
+		count, err := reader.Read(buf)
+
+		if count == 0 || done {
+			break
+		}
+
+		if err != nil {
+			log.Error(r, "Error reading data", "url", streamUrl, err)
+			break
+		}
+
+		_, err = w.Write(buf[0:count])
+
+		if err != nil {
+			log.Error(r, "Error writing data", "url", streamUrl, err)
+			break
+		}
+	}
 }

--- a/tests/fixtures/radios/radio-extended.m3u
+++ b/tests/fixtures/radios/radio-extended.m3u
@@ -1,0 +1,14 @@
+#EXTM#U
+
+#EXTINF:1,Sample Radio 10
+https://example.com:8000/stream
+
+#EXTINF:1,Sample Radio 100
+https://example.com:8000/stream/20
+
+
+https://example.com:8000/stream/40
+
+
+
+https://example.com:8000/stream/100

--- a/tests/fixtures/radios/radio.m3u
+++ b/tests/fixtures/radios/radio.m3u
@@ -1,0 +1,10 @@
+#EXTM#U
+
+https://example.com:6000/stream
+https://example.com:6000/stream/20
+
+https://example.com:6000/stream/40
+
+
+
+https://example.com:6000/stream/100

--- a/tests/fixtures/radios/radio.pls
+++ b/tests/fixtures/radios/radio.pls
@@ -1,0 +1,21 @@
+[playlist]
+NumberOfEntries=4
+
+Title1=Sample Radio 1
+File1=https://example.com:1000/stream
+Length1=-1
+
+File2=https://example.com:1000/stream/4
+
+File3=https://example.com:1000/stream/2
+Title3=Sample Radio 2
+
+
+Title4=A radio without a file
+
+
+File6=http://example.com:1000/stream/1000
+
+
+
+Version=2

--- a/tests/mock_persistence.go
+++ b/tests/mock_persistence.go
@@ -20,6 +20,7 @@ type MockDataStore struct {
 	MockedUserProps      model.UserPropsRepository
 	MockedScrobbleBuffer model.ScrobbleBufferRepository
 	MockedRadioBuffer    model.RadioRepository
+	MockedScrobbleRadio  model.ScrobbleRadioRepository
 }
 
 func (db *MockDataStore) Album(context.Context) model.AlbumRepository {
@@ -112,6 +113,13 @@ func (db *MockDataStore) ScrobbleBuffer(ctx context.Context) model.ScrobbleBuffe
 		db.MockedScrobbleBuffer = CreateMockedScrobbleBufferRepo()
 	}
 	return db.MockedScrobbleBuffer
+}
+
+func (db *MockDataStore) ScrobbleRadio(ctx context.Context) model.ScrobbleRadioRepository {
+	if db.MockedScrobbleRadio == nil {
+		db.MockedScrobbleRadio = CreateMockedScrobbleRadioRepo()
+	}
+	return db.MockedScrobbleRadio
 }
 
 func (db *MockDataStore) Radio(ctx context.Context) model.RadioRepository {

--- a/tests/mock_scrobble_radio.go
+++ b/tests/mock_scrobble_radio.go
@@ -1,0 +1,86 @@
+package tests
+
+import (
+	"time"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+type MockedScrobbleRadioRepo struct {
+	Error error
+	data  model.ScrobbleRadioEntries
+}
+
+func CreateMockedScrobbleRadioRepo() *MockedScrobbleRadioRepo {
+	return &MockedScrobbleRadioRepo{}
+}
+
+func (m *MockedScrobbleRadioRepo) UserIDs(service string) ([]string, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
+	userIds := make(map[string]struct{})
+	for _, e := range m.data {
+		if e.Service == service {
+			userIds[e.UserID] = struct{}{}
+		}
+	}
+	var result []string
+	for uid := range userIds {
+		result = append(result, uid)
+	}
+	return result, nil
+}
+
+func (m *MockedScrobbleRadioRepo) Enqueue(service, userId, artist, title string, playTime time.Time) error {
+	if m.Error != nil {
+		return m.Error
+	}
+	m.data = append(m.data, model.ScrobleRadioEntry{
+		Artist:      artist,
+		EnqueueTime: time.Now(),
+		PlayTime:    playTime,
+		Title:       title,
+		Service:     service,
+		UserID:      userId,
+	})
+	return nil
+}
+
+func (m *MockedScrobbleRadioRepo) Next(service, userId string) (*model.ScrobleRadioEntry, error) {
+	if m.Error != nil {
+		return nil, m.Error
+	}
+	for _, e := range m.data {
+		if e.Service == service && e.UserID == userId {
+			return &e, nil
+		}
+	}
+	return nil, nil
+}
+
+func (m *MockedScrobbleRadioRepo) Dequeue(entry *model.ScrobleRadioEntry) error {
+	if m.Error != nil {
+		return m.Error
+	}
+	newData := model.ScrobbleRadioEntries{}
+	for _, e := range m.data {
+		if e.Service == entry.Service &&
+			e.UserID == entry.UserID &&
+			e.PlayTime == entry.PlayTime &&
+			e.Artist == entry.Artist &&
+			e.Title == entry.Title {
+			continue
+		}
+		newData = append(newData, e)
+	}
+	m.data = newData
+	return nil
+}
+
+func (m *MockedScrobbleRadioRepo) Length() (int64, error) {
+	if m.Error != nil {
+		return 0, m.Error
+	}
+	return int64(len(m.data)), nil
+}

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,6 +17,7 @@
         "connected-react-router": "^6.9.1",
         "deepmerge": "^4.2.2",
         "history": "^4.10.1",
+        "icecast-metadata-player": "^1.14.2",
         "inflection": "^1.13.1",
         "jwt-decode": "^3.1.2",
         "lodash.pick": "^4.4.0",
@@ -2349,6 +2350,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
+    "node_modules/@eshaz/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eshaz/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-HWobmNKFZ8eARo39vEjkviTIISudgzrTyAqab9pOB/qNfnUPIUUMZv6+eEUUfXnkqWCLS3zreTn9YzaRvO8vIA=="
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -4599,6 +4605,27 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@wasm-audio-decoders/common": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/common/-/common-6.0.2.tgz",
+      "integrity": "sha512-1FRASCwG7Mcngurp6K/6FpDRCJr3mHim2ZjPX9wEJdEclKx/O/2hBC+2yw4TGrqybgWdkB4QLssosg6hKYIx/w==",
+      "dependencies": {
+        "@eshaz/web-worker": "1.2.0"
+      }
+    },
+    "node_modules/@wasm-audio-decoders/flac": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/flac/-/flac-0.1.2.tgz",
+      "integrity": "sha512-yJcfcWK7txhvc9PVUhj4mroCskqGOWV+oJzXcgI/fyVtJIlY5IEBac4COuBRMfH0YEs+vZ9wf7kJfl8bvA0o6w==",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "6.0.2",
+        "codec-parser": "2.2.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -6266,6 +6293,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/codec-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/codec-parser/-/codec-parser-2.2.0.tgz",
+      "integrity": "sha512-dD1VU8I7rmBhyWNYcwqlHIhVJ9ct3fiYRTJX8siuOxc9MMhpn0W3zuI1BUH0wtZWByb6Afe4tvM20Hcev5xqfQ=="
     },
     "node_modules/collect-v8-coverage": {
       "version": "1.0.1",
@@ -10037,6 +10069,33 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
+    "node_modules/icecast-metadata-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/icecast-metadata-js/-/icecast-metadata-js-1.1.2.tgz",
+      "integrity": "sha512-GkqavZAryuCSQ9otdcRk51rxre20RM+M9iI2lYNvI73VxQIOO4gHPUB65lpfliKUf4T2Iwd+EMFbX3iIx/Vm6w==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
+    "node_modules/icecast-metadata-player": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/icecast-metadata-player/-/icecast-metadata-player-1.14.2.tgz",
+      "integrity": "sha512-Icc8RXGAZ/InFxmn9+Bja9p0tEwnamYb2SaH/hREsNyWnM3BMKGnvZi2f3s7ivipfI7EgIDggG5nxhhHo7Xg/A==",
+      "dependencies": {
+        "@wasm-audio-decoders/flac": "0.1.2",
+        "codec-parser": "2.2.0",
+        "icecast-metadata-js": "1.1.2",
+        "mpg123-decoder": "0.4.2",
+        "mse-audio-wrapper": "1.4.7",
+        "opus-decoder": "0.6.2",
+        "synaudio": "0.3.2"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -13876,11 +13935,35 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/mpg123-decoder": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/mpg123-decoder/-/mpg123-decoder-0.4.2.tgz",
+      "integrity": "sha512-/LG+OdAGIlU+mrFA7IpQgiAc1NUWMTHfh8tHgRs3MZzlCSlKusZcByOBKnqHJ07JP1sZ2lDVquo1RjPLO9JBBw==",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "6.0.2"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/mse-audio-wrapper": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/mse-audio-wrapper/-/mse-audio-wrapper-1.4.7.tgz",
+      "integrity": "sha512-wRO8wWUMQAQsiRtR1MDE6mVnbnI8cpxLf7/drpPm5YuImAvYG4GSyNQlatYuLgERUEqRj9f6Rj5GfwhzFXW80A==",
+      "dependencies": {
+        "codec-parser": "2.2.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
     },
     "node_modules/multicast-dns": {
       "version": "7.2.5",
@@ -14290,6 +14373,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/opus-decoder": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/opus-decoder/-/opus-decoder-0.6.2.tgz",
+      "integrity": "sha512-jqq9Jr1WrNJkD5yP2+BSUeJhkCSldOtDQrjzyOt2SkMc1oEB8Phv6zx/Wngxc+UQeftvLlAHL//BgXU4qbjc9Q==",
+      "dependencies": {
+        "@wasm-audio-decoders/common": "6.0.2"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
       }
     },
     "node_modules/ora": {
@@ -18217,6 +18312,15 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "node_modules/simple-yenc": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-0.2.3.tgz",
+      "integrity": "sha512-LGufdReGRgj0dXpqpF7j/MQ8SKu4pXAzpkHxQSDI0/GMOlmGY6oivl2hhsyMfAaOGYC6iqcxiDtBy+1MmM4JSA==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -18811,6 +18915,19 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "node_modules/synaudio": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/synaudio/-/synaudio-0.3.2.tgz",
+      "integrity": "sha512-Vciq/I2LilGSmPVQmRSOod4HW0/d2dUFb5u3xdIrEoRFXNmEOF0bNF76X9Sn9pkpaQDR0yYU487tijVPYhCDsw==",
+      "dependencies": {
+        "@eshaz/web-worker": "1.2.0",
+        "simple-yenc": "^0.2.3"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/eshaz"
+      }
     },
     "node_modules/tailwindcss": {
       "version": "3.1.8",
@@ -22325,6 +22442,11 @@
       "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
       "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
+    "@eshaz/web-worker": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eshaz/web-worker/-/web-worker-1.2.0.tgz",
+      "integrity": "sha512-HWobmNKFZ8eARo39vEjkviTIISudgzrTyAqab9pOB/qNfnUPIUUMZv6+eEUUfXnkqWCLS3zreTn9YzaRvO8vIA=="
+    },
     "@eslint/eslintrc": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.2.tgz",
@@ -24126,6 +24248,23 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@wasm-audio-decoders/common": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/common/-/common-6.0.2.tgz",
+      "integrity": "sha512-1FRASCwG7Mcngurp6K/6FpDRCJr3mHim2ZjPX9wEJdEclKx/O/2hBC+2yw4TGrqybgWdkB4QLssosg6hKYIx/w==",
+      "requires": {
+        "@eshaz/web-worker": "1.2.0"
+      }
+    },
+    "@wasm-audio-decoders/flac": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@wasm-audio-decoders/flac/-/flac-0.1.2.tgz",
+      "integrity": "sha512-yJcfcWK7txhvc9PVUhj4mroCskqGOWV+oJzXcgI/fyVtJIlY5IEBac4COuBRMfH0YEs+vZ9wf7kJfl8bvA0o6w==",
+      "requires": {
+        "@wasm-audio-decoders/common": "6.0.2",
+        "codec-parser": "2.2.0"
+      }
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.1.tgz",
@@ -25453,6 +25592,11 @@
           }
         }
       }
+    },
+    "codec-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/codec-parser/-/codec-parser-2.2.0.tgz",
+      "integrity": "sha512-dD1VU8I7rmBhyWNYcwqlHIhVJ9ct3fiYRTJX8siuOxc9MMhpn0W3zuI1BUH0wtZWByb6Afe4tvM20Hcev5xqfQ=="
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -28328,6 +28472,25 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
       "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
+    },
+    "icecast-metadata-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/icecast-metadata-js/-/icecast-metadata-js-1.1.2.tgz",
+      "integrity": "sha512-GkqavZAryuCSQ9otdcRk51rxre20RM+M9iI2lYNvI73VxQIOO4gHPUB65lpfliKUf4T2Iwd+EMFbX3iIx/Vm6w=="
+    },
+    "icecast-metadata-player": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/icecast-metadata-player/-/icecast-metadata-player-1.14.2.tgz",
+      "integrity": "sha512-Icc8RXGAZ/InFxmn9+Bja9p0tEwnamYb2SaH/hREsNyWnM3BMKGnvZi2f3s7ivipfI7EgIDggG5nxhhHo7Xg/A==",
+      "requires": {
+        "@wasm-audio-decoders/flac": "0.1.2",
+        "codec-parser": "2.2.0",
+        "icecast-metadata-js": "1.1.2",
+        "mpg123-decoder": "0.4.2",
+        "mse-audio-wrapper": "1.4.7",
+        "opus-decoder": "0.6.2",
+        "synaudio": "0.3.2"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -31332,11 +31495,27 @@
         "minimist": "^1.2.5"
       }
     },
+    "mpg123-decoder": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/mpg123-decoder/-/mpg123-decoder-0.4.2.tgz",
+      "integrity": "sha512-/LG+OdAGIlU+mrFA7IpQgiAc1NUWMTHfh8tHgRs3MZzlCSlKusZcByOBKnqHJ07JP1sZ2lDVquo1RjPLO9JBBw==",
+      "requires": {
+        "@wasm-audio-decoders/common": "6.0.2"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "mse-audio-wrapper": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/mse-audio-wrapper/-/mse-audio-wrapper-1.4.7.tgz",
+      "integrity": "sha512-wRO8wWUMQAQsiRtR1MDE6mVnbnI8cpxLf7/drpPm5YuImAvYG4GSyNQlatYuLgERUEqRj9f6Rj5GfwhzFXW80A==",
+      "requires": {
+        "codec-parser": "2.2.0"
+      }
     },
     "multicast-dns": {
       "version": "7.2.5",
@@ -31658,6 +31837,14 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
+      }
+    },
+    "opus-decoder": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/opus-decoder/-/opus-decoder-0.6.2.tgz",
+      "integrity": "sha512-jqq9Jr1WrNJkD5yP2+BSUeJhkCSldOtDQrjzyOt2SkMc1oEB8Phv6zx/Wngxc+UQeftvLlAHL//BgXU4qbjc9Q==",
+      "requires": {
+        "@wasm-audio-decoders/common": "6.0.2"
       }
     },
     "ora": {
@@ -34429,6 +34616,11 @@
       "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
       "dev": true
     },
+    "simple-yenc": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-0.2.3.tgz",
+      "integrity": "sha512-LGufdReGRgj0dXpqpF7j/MQ8SKu4pXAzpkHxQSDI0/GMOlmGY6oivl2hhsyMfAaOGYC6iqcxiDtBy+1MmM4JSA=="
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -34900,6 +35092,15 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "synaudio": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/synaudio/-/synaudio-0.3.2.tgz",
+      "integrity": "sha512-Vciq/I2LilGSmPVQmRSOod4HW0/d2dUFb5u3xdIrEoRFXNmEOF0bNF76X9Sn9pkpaQDR0yYU487tijVPYhCDsw==",
+      "requires": {
+        "@eshaz/web-worker": "1.2.0",
+        "simple-yenc": "^0.2.3"
+      }
     },
     "tailwindcss": {
       "version": "3.1.8",

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "connected-react-router": "^6.9.1",
     "deepmerge": "^4.2.2",
     "history": "^4.10.1",
+    "icecast-metadata-player": "^1.14.2",
     "inflection": "^1.13.1",
     "jwt-decode": "^3.1.2",
     "lodash.pick": "^4.4.0",

--- a/ui/src/actions/player.js
+++ b/ui/src/actions/player.js
@@ -6,6 +6,7 @@ export const PLAYER_CLEAR_QUEUE = 'PLAYER_CLEAR_QUEUE'
 export const PLAYER_PLAY_TRACKS = 'PLAYER_PLAY_TRACKS'
 export const PLAYER_CURRENT = 'PLAYER_CURRENT'
 export const PLAYER_SET_VOLUME = 'PLAYER_SET_VOLUME'
+export const PLAYER_SET_RADIO = 'PLAYER_SET_RADIO'
 
 export const setTrack = (data) => ({
   type: PLAYER_SET_TRACK,
@@ -88,4 +89,9 @@ export const currentPlaying = (audioInfo) => ({
 export const setVolume = (volume) => ({
   type: PLAYER_SET_VOLUME,
   data: { volume },
+})
+
+export const playRadio = (radio) => ({
+  type: PLAYER_SET_RADIO,
+  data: { radio }
 })

--- a/ui/src/actions/player.js
+++ b/ui/src/actions/player.js
@@ -93,5 +93,5 @@ export const setVolume = (volume) => ({
 
 export const playRadio = (radio) => ({
   type: PLAYER_SET_RADIO,
-  data: { radio }
+  data: { radio },
 })

--- a/ui/src/audioplayer/AudioTitle.js
+++ b/ui/src/audioplayer/AudioTitle.js
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import { QualityInfo } from '../common'
 import useStyle from './styles'
 
-const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile, radioInfo }) => {
+const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile }) => {
   const classes = useStyle()
   const className = classes.audioTitle
   const isDesktop = useMediaQuery('(min-width:810px)')
@@ -22,33 +22,11 @@ const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile, radioInfo }) => 
     trackGain: song.rgTrackGain,
   }
 
-  let album;
-  let artist;
-  let title;
-
-  if (radioInfo) {
-    const split = radioInfo.StreamTitle.split(" - ")
-    artist = split[0]
-    title = split.slice(1).join(" - ")
-    album = song.title
-  } else {
-    artist = song.artist
-    title = song.title
-    album = song.album
-  }
-
   return (
-    <Link
-      to={
-        radioInfo
-          ? `/radio/${audioInfo.trackId}/show`
-          : `/album/${song.albumId}/show`
-      }
-      className={className}
-    >
+    <Link to={`/album/${song.albumId}/show`} className={className}>
       <span>
         <span className={clsx(classes.songTitle, 'songTitle')}>
-          {title}
+          {song.title}
         </span>
         {isDesktop && (
           <QualityInfo
@@ -61,17 +39,17 @@ const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile, radioInfo }) => 
       {isMobile ? (
         <>
           <span className={classes.songInfo}>
-            <span className={'songArtist'}>{artist}</span>
+            <span className={'songArtist'}>{song.artist}</span>
           </span>
           <span className={clsx(classes.songInfo, classes.songAlbum)}>
-            <span className={'songAlbum'}>{album}</span>
+            <span className={'songAlbum'}>{song.album}</span>
             {song.year ? ` - ${song.year}` : ''}
           </span>
         </>
       ) : (
         <span className={classes.songInfo}>
-          <span className={'songArtist'}>{artist}</span> -{' '}
-          <span className={'songAlbum'}>{album}</span>
+          <span className={'songArtist'}>{song.artist}</span> -{' '}
+          <span className={'songAlbum'}>{song.album}</span>
           {song.year ? ` - ${song.year}` : ''}
         </span>
       )}

--- a/ui/src/audioplayer/AudioTitle.js
+++ b/ui/src/audioplayer/AudioTitle.js
@@ -5,7 +5,7 @@ import clsx from 'clsx'
 import { QualityInfo } from '../common'
 import useStyle from './styles'
 
-const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile }) => {
+const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile, radioInfo }) => {
   const classes = useStyle()
   const className = classes.audioTitle
   const isDesktop = useMediaQuery('(min-width:810px)')
@@ -22,10 +22,25 @@ const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile }) => {
     trackGain: song.rgTrackGain,
   }
 
+  let album;
+  let artist;
+  let title;
+
+  if (radioInfo) {
+    const split = radioInfo.StreamTitle.split(" - ")
+    artist = split[0]
+    title = split.slice(1).join(" - ")
+    album = song.title
+  } else {
+    artist = song.artist
+    title = song.title
+    album = song.album
+  }
+
   return (
     <Link
       to={
-        audioInfo.isRadio
+        radioInfo
           ? `/radio/${audioInfo.trackId}/show`
           : `/album/${song.albumId}/show`
       }
@@ -33,7 +48,7 @@ const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile }) => {
     >
       <span>
         <span className={clsx(classes.songTitle, 'songTitle')}>
-          {song.title}
+          {title}
         </span>
         {isDesktop && (
           <QualityInfo
@@ -46,17 +61,17 @@ const AudioTitle = React.memo(({ audioInfo, gainInfo, isMobile }) => {
       {isMobile ? (
         <>
           <span className={classes.songInfo}>
-            <span className={'songArtist'}>{song.artist}</span>
+            <span className={'songArtist'}>{artist}</span>
           </span>
           <span className={clsx(classes.songInfo, classes.songAlbum)}>
-            <span className={'songAlbum'}>{song.album}</span>
+            <span className={'songAlbum'}>{album}</span>
             {song.year ? ` - ${song.year}` : ''}
           </span>
         </>
       ) : (
         <span className={classes.songInfo}>
-          <span className={'songArtist'}>{song.artist}</span> -{' '}
-          <span className={'songAlbum'}>{song.album}</span>
+          <span className={'songArtist'}>{artist}</span> -{' '}
+          <span className={'songAlbum'}>{album}</span>
           {song.year ? ` - ${song.year}` : ''}
         </span>
       )}

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMediaQuery } from '@material-ui/core'
 import { ThemeProvider } from '@material-ui/core/styles'
+import IcecastMetadataPlayer from 'icecast-metadata-player'
 import {
   createMuiTheme,
   useAuthState,
@@ -63,6 +64,7 @@ const Player = () => {
   const gainInfo = useSelector((state) => state.replayGain)
   const [context, setContext] = useState(null)
   const [gainNode, setGainNode] = useState(null)
+  const [radioCast, setRadioCast] = useState(null)
 
   useEffect(() => {
     if (
@@ -124,6 +126,40 @@ const Player = () => {
     gainInfo.preAmp,
     playerState,
   ])
+
+  useEffect(() => {
+    if (isRadio) {
+      const newUrl = playerState.current.musicSrc
+      if (radioCast !== null) {
+        // radioCast.switchEndpoint(newUrl)
+      } else {
+        const player = new IcecastMetadataPlayer(newUrl, {
+          onMetadata: (meta) => {
+            console.log(meta)
+          },
+          onPlay: () => {
+            console.log('playing')
+          },
+          onStop: () => {},
+          onLoad: () => {},
+          onError: (error) => {},
+          onRetry: () => {},
+          onStreamStart: () => {},
+          onSwitch: () => {},
+          icyDetectionTimeout: 5000,
+          enableLogging: true,
+          audioElement: audioInstance,
+          retryTimeout: 120,
+          metadataTypes: ['icy', 'ogg'],
+        })
+
+        player.play()
+        setRadioCast(player)
+      }
+    } else if (radioCast !== null) {
+      setRadioCast(null)
+    }
+  }, [audioInstance, isRadio, playerState, radioCast])
 
   const defaultOptions = useMemo(
     () => ({

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -10,7 +10,6 @@ import { useMediaQuery } from '@material-ui/core'
 import { ThemeProvider } from '@material-ui/core/styles'
 import {
   createMuiTheme,
-  Loading,
   useAuthState,
   useDataProvider,
   useTranslate,

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -1,4 +1,10 @@
-import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
+import React, {
+  Suspense,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMediaQuery } from '@material-ui/core'
 import { ThemeProvider } from '@material-ui/core/styles'

--- a/ui/src/audioplayer/Player.js
+++ b/ui/src/audioplayer/Player.js
@@ -1,9 +1,10 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react'
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMediaQuery } from '@material-ui/core'
 import { ThemeProvider } from '@material-ui/core/styles'
 import {
   createMuiTheme,
+  Loading,
   useAuthState,
   useDataProvider,
   useTranslate,
@@ -23,7 +24,8 @@ import subsonic from '../subsonic'
 import locale from './locale'
 import { keyMap } from '../hotkeys'
 import keyHandlers from './keyHandlers'
-import RadioPlayer from '../radio/RadioPlayer'
+
+const RadioPlayer = React.lazy(() => import('../radio/RadioPlayer'))
 
 function calculateReplayGain(preAmp, gain, peak) {
   if (gain === undefined || peak === undefined) {
@@ -332,12 +334,16 @@ const Player = () => {
         onBeforeDestroy={onBeforeDestroy}
         getAudioInstance={setAudioInstance}
       />
-      <RadioPlayer
-        className={radioClasses.player}
-        locale={playerLocale}
-        theme={playerTheme}
-        {...(playerState.radio || {})}
-      />
+      {isRadio && (
+        <Suspense fallback={<Loading />}>
+          <RadioPlayer
+            className={radioClasses.player}
+            locale={playerLocale}
+            theme={playerTheme}
+            {...(playerState.radio || {})}
+          />
+        </Suspense>
+      )}
       <GlobalHotKeys handlers={handlers} keyMap={keyMap} allowChanges />
     </ThemeProvider>
   )

--- a/ui/src/audioplayer/PlayerToolbar.js
+++ b/ui/src/audioplayer/PlayerToolbar.js
@@ -35,7 +35,6 @@ const Toolbar = ({ id }) => {
   )
 }
 
-const PlayerToolbar = ({ id, isRadio }) =>
-  id && !isRadio ? <Toolbar id={id} /> : <Placeholder />
+const PlayerToolbar = ({ id }) => (id ? <Toolbar id={id} /> : <Placeholder />)
 
 export default PlayerToolbar

--- a/ui/src/audioplayer/styles.js
+++ b/ui/src/audioplayer/styles.js
@@ -78,13 +78,6 @@ const useStyle = makeStyles(
         {
           display: 'none',
         },
-      '& .music-player-panel .panel-content .progress-bar-content section.audio-main':
-        {
-          display: (props) => (props.isRadio ? 'none' : 'inline-flex'),
-        },
-      '& .react-jinke-music-player-mobile-progress': {
-        display: (props) => (props.isRadio ? 'none' : 'flex'),
-      },
     },
   }),
   { name: 'NDAudioPlayer' }

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -32,6 +32,7 @@ const defaultConfig = {
   enableReplayGain: true,
   defaultDownsamplingFormat: 'opus',
   publicBaseUrl: '/share',
+  enableProxy: true,
 }
 
 let config

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -175,13 +175,16 @@
                 "createdAt": "Created at",
                 "isPlaylist": "Playlist?",
                 "url": "Stream URL",
-                "links": "Radio links. Click one to play"
+                "links": "Radio links. Click one to play",
+                "title": "Track title",
+                "artist": "Track artist"
             },
             "actions": {
                 "playNow": "Play Now"
             },
             "message": {
-                "noArtist": "Could not detect artist. Click to update"
+                "noArtist": "Could not detect artist. Click to update",
+                "noArtistNotif": "Could not detect artist. Please manually fix"
             }
         },
         "share": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -172,10 +172,16 @@
                 "streamUrl": "Stream URL",
                 "homePageUrl": "Home Page URL",
                 "updatedAt": "Updated at",
-                "createdAt": "Created at"
+                "createdAt": "Created at",
+                "isPlaylist": "Playlist?",
+                "url": "Stream URL",
+                "links": "Radio links. Click one to play"
             },
             "actions": {
                 "playNow": "Play Now"
+            },
+            "message": {
+                "noArtist": "Could not detect artist. Click to update"
             }
         },
         "share": {

--- a/ui/src/radio/FixMetadataButton.js
+++ b/ui/src/radio/FixMetadataButton.js
@@ -1,0 +1,32 @@
+import { Button, makeStyles } from '@material-ui/core'
+import ErrorOutline from '@material-ui/icons/ErrorOutline'
+import { useTranslate } from 'react-admin'
+
+const useStyles = makeStyles(() => ({
+  button: {
+    textTransform: 'none',
+  },
+}))
+
+const FixMetadataButton = ({ onFix }) => {
+  const styles = useStyles()
+  const translate = useTranslate()
+
+  return (
+    <Button
+      variant="outlined"
+      startIcon={<ErrorOutline />}
+      size="small"
+      className={styles.button}
+      onClick={(evt) => {
+        evt.stopPropagation()
+        evt.preventDefault()
+        onFix()
+      }}
+    >
+      {translate('resources.radio.message.noArtist')}
+    </Button>
+  )
+}
+
+export default FixMetadataButton

--- a/ui/src/radio/RadioCreate.js
+++ b/ui/src/radio/RadioCreate.js
@@ -1,27 +1,10 @@
-import {
-  Create,
-  required,
-  SimpleForm,
-  TextInput,
-  useTranslate,
-} from 'react-admin'
-import { Title } from '../common'
+import { Create, required, SimpleForm, TextInput } from 'react-admin'
 import { urlValidate } from '../utils/validations'
-
-const RadioTitle = () => {
-  const translate = useTranslate()
-  const resourceName = translate('resources.radio.name', {
-    smart_count: 1,
-  })
-  const title = translate('ra.page.create', {
-    name: `${resourceName}`,
-  })
-  return <Title subTitle={title} />
-}
+import RadioPageTitle from './RadioPageTitle'
 
 const RadioCreate = (props) => {
   return (
-    <Create title={<RadioTitle />} {...props}>
+    <Create title={<RadioPageTitle />} {...props}>
       <SimpleForm redirect="list" variant={'outlined'}>
         <TextInput source="name" validate={[required()]} />
         <TextInput

--- a/ui/src/radio/RadioDialog.js
+++ b/ui/src/radio/RadioDialog.js
@@ -1,0 +1,79 @@
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  TextField,
+} from '@material-ui/core'
+import { useCallback, useEffect, useState } from 'react'
+import { useTranslate } from 'react-admin'
+
+const RadioDialog = ({ open, onClose, setMetadata, title }) => {
+  const translate = useTranslate()
+
+  const [fixedTitle, setFixedTitle] = useState(title)
+  const [fixedArtist, setFixedArtist] = useState('')
+
+  useEffect(() => {
+    setFixedTitle(title)
+    setFixedArtist('')
+  }, [title])
+
+  const onSave = useCallback(() => {
+    if (fixedArtist && fixedTitle) {
+      setMetadata({ artist: fixedArtist, title: fixedTitle, fix: true })
+    }
+
+    setFixedArtist('')
+    onClose()
+  }, [fixedArtist, fixedTitle, onClose, setMetadata])
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      onBackdropClick={onClose}
+      fullWidth
+      maxWidth="md"
+      aria-labelledby="form-dialog-radio-metadata"
+    >
+      <DialogTitle id="form-dialog-radio-metadata">
+        {translate('resources.radio.message.noArtistNotif')}
+      </DialogTitle>
+      <DialogContent>
+        <DialogContentText></DialogContentText>
+        <TextField
+          value={fixedTitle}
+          fullWidth
+          onChange={(evt) => setFixedTitle(evt.target.value)}
+          required
+          label={translate('resources.radio.fields.title')}
+        />
+        <TextField
+          value={fixedArtist}
+          fullWidth
+          onChange={(evt) => setFixedArtist(evt.target.value)}
+          required
+          label={translate('resources.radio.fields.artist')}
+        />
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} color="primary">
+          {translate('ra.action.cancel')}
+        </Button>
+        <Button
+          color="primary"
+          data-testid="dialog-radio-save"
+          disabled={!fixedArtist || !fixedTitle}
+          onClick={onSave}
+        >
+          {translate('ra.action.save')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+export default RadioDialog

--- a/ui/src/radio/RadioEdit.js
+++ b/ui/src/radio/RadioEdit.js
@@ -1,25 +1,11 @@
-import {
-  DateField,
-  Edit,
-  required,
-  SimpleForm,
-  TextInput,
-  useTranslate,
-} from 'react-admin'
+import { DateField, Edit, required, SimpleForm, TextInput } from 'react-admin'
 import { urlValidate } from '../utils/validations'
-import { Title } from '../common'
+import RadioLinkList from './RadioLinkList'
+import RadioPageTitle from './RadioPageTitle'
 
-const RadioTitle = ({ record }) => {
-  const translate = useTranslate()
-  const resourceName = translate('resources.radio.name', {
-    smart_count: 1,
-  })
-  return <Title subTitle={`${resourceName} ${record ? record.name : ''}`} />
-}
-
-const RadioEdit = (props) => {
+const RadioEdit = ({ hasCreate, hasEdit, hasList, hasShow, ...props }) => {
   return (
-    <Edit title={<RadioTitle />} {...props}>
+    <Edit title={<RadioPageTitle />} {...props}>
       <SimpleForm variant="outlined" {...props}>
         <TextInput source="name" validate={[required()]} />
         <TextInput
@@ -34,6 +20,7 @@ const RadioEdit = (props) => {
           fullWidth
           validate={[urlValidate]}
         />
+        <RadioLinkList />
         <DateField variant="body1" source="updatedAt" showTime />
         <DateField variant="body1" source="createdAt" showTime />
       </SimpleForm>

--- a/ui/src/radio/RadioLinkList.js
+++ b/ui/src/radio/RadioLinkList.js
@@ -1,0 +1,39 @@
+import PropTypes from 'prop-types'
+import {
+  ArrayField,
+  Datagrid,
+  Labeled,
+  TextField,
+  useRecordContext,
+  useTranslate,
+} from 'react-admin'
+import { useDispatch } from 'react-redux'
+import { playRadio } from '../actions'
+import { songFromRadio } from './helper'
+
+const RadioLinkList = (props) => {
+  const record = useRecordContext(props)
+  const dispatch = useDispatch()
+  const translate = useTranslate()
+
+  const handleRowClick = async (id, basePath, row) => {
+    dispatch(playRadio(await songFromRadio(record, row)))
+  }
+
+  return record.links ? (
+    <Labeled label={translate('resources.radio.fields.links')} fullWidth>
+      <ArrayField source="links">
+        <Datagrid rowClick={handleRowClick}>
+          <TextField source="name" />
+          <TextField source="url" />
+        </Datagrid>
+      </ArrayField>
+    </Labeled>
+  ) : null
+}
+
+RadioLinkList.propTypes = {
+  record: PropTypes.object,
+}
+
+export default RadioLinkList

--- a/ui/src/radio/RadioList.js
+++ b/ui/src/radio/RadioList.js
@@ -1,6 +1,7 @@
 import { makeStyles, useMediaQuery } from '@material-ui/core'
 import React, { cloneElement } from 'react'
 import {
+  BooleanField,
   CreateButton,
   Datagrid,
   DateField,
@@ -31,6 +32,9 @@ const useStyles = makeStyles({
   },
   contextMenu: {
     visibility: 'hidden',
+  },
+  streamUrl: {
+    overflowWrap: 'anywhere',
   },
 })
 
@@ -89,7 +93,8 @@ const RadioList = ({ permissions, ...props }) => {
         rel="noopener noreferrer"
       />
     ),
-    streamUrl: <TextField source="streamUrl" />,
+    streamUrl: <TextField className={classes.streamUrl} source="streamUrl" />,
+    isPlaylist: <BooleanField source="isPlaylist" />,
     updatedAt: <DateField source="updatedAt" showTime />,
     createdAt: <DateField source="createdAt" showTime />,
   }
@@ -97,11 +102,15 @@ const RadioList = ({ permissions, ...props }) => {
   const columns = useSelectedFields({
     resource: 'radio',
     columns: toggleableFields,
-    defaultOff: ['createdAt'],
+    defaultOff: ['createdAt', 'streamUrl'],
   })
 
   const handleRowClick = async (id, basePath, record) => {
-    dispatch(playRadio(await songFromRadio(record)))
+    if (!record.isPlaylist) {
+      dispatch(playRadio(await songFromRadio(record)))
+    } else {
+      window.location.href = `#/radio/${id}/show`
+    }
   }
 
   return (

--- a/ui/src/radio/RadioList.js
+++ b/ui/src/radio/RadioList.js
@@ -17,7 +17,7 @@ import {
 } from 'react-admin'
 import { ToggleFieldsMenu, useSelectedFields } from '../common'
 import { StreamField } from './StreamField'
-import { setTrack } from '../actions'
+import { playRadio } from '../actions'
 import { songFromRadio } from './helper'
 import { useDispatch } from 'react-redux'
 
@@ -101,7 +101,7 @@ const RadioList = ({ permissions, ...props }) => {
   })
 
   const handleRowClick = async (id, basePath, record) => {
-    dispatch(setTrack(await songFromRadio(record)))
+    dispatch(playRadio(await songFromRadio(record)))
   }
 
   return (

--- a/ui/src/radio/RadioPageTitle.js
+++ b/ui/src/radio/RadioPageTitle.js
@@ -1,0 +1,14 @@
+import { Title, useTranslate } from 'react-admin'
+
+const RadioPageTitle = () => {
+  const translate = useTranslate()
+  const resourceName = translate('resources.radio.name', {
+    smart_count: 1,
+  })
+  const title = translate('ra.page.create', {
+    name: `${resourceName}`,
+  })
+  return <Title subTitle={title} />
+}
+
+export default RadioPageTitle

--- a/ui/src/radio/RadioPlayer.js
+++ b/ui/src/radio/RadioPlayer.js
@@ -116,7 +116,7 @@ const RadioPlayer = ({
           setPlaying(false)
         },
         icyDetectionTimeout: 10000,
-        enableLogging: true,
+        enableLogging: false, // set this to true for dev
         audioElement: audioRef.current,
         playbackMethod: 'mediasource',
       })

--- a/ui/src/radio/RadioPlayer.js
+++ b/ui/src/radio/RadioPlayer.js
@@ -94,7 +94,7 @@ const RadioPlayer = ({
 
         return () => {
           node.src = ''
-        } 
+        }
       } else {
         return
       }

--- a/ui/src/radio/RadioPlayer.js
+++ b/ui/src/radio/RadioPlayer.js
@@ -1,0 +1,356 @@
+import clsx from 'clsx'
+import IcecastMetadataPlayer from 'icecast-metadata-player'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+import Slider from 'rc-slider/lib/Slider'
+
+import {
+  AnimatePauseIcon,
+  AnimatePlayIcon,
+  CloseIcon,
+  DeleteIcon,
+  VolumeMuteIcon,
+  VolumeUnmuteIcon,
+} from 'navidrome-music-player/es/components/Icon'
+import RadioTitle from './RadioTitle'
+import { useDispatch } from 'react-redux'
+
+import { clearQueue } from '../actions'
+import { useMediaQuery } from '@material-ui/core'
+import RadioPlayerMobile from './RadioPlayerMobile'
+import subsonic from '../subsonic'
+
+const DEFAULT_ICON = {
+  pause: <AnimatePauseIcon />,
+  play: <AnimatePlayIcon />,
+  destroy: <CloseIcon />,
+  close: <CloseIcon />,
+  delete: <DeleteIcon size={24} />,
+  volume: <VolumeUnmuteIcon size={26} />,
+  mute: <VolumeMuteIcon size={26} />,
+}
+
+const MIN_TIME_BETWEEN_SCROBBLE_MS = 30 * 1000
+const SCROBBLE_DELAY_MS = 4 * 60 * 1000
+
+function parseMetadata(metadata) {
+  const split = metadata.StreamTitle.split(' - ')
+  const artist = split[0]
+  const title = split.slice(1).join(' - ')
+
+  return [artist, title]
+}
+
+// light, darg, ligera
+const RadioPlayer = ({
+  className,
+  cover,
+  icon = {},
+  locale,
+  homePageUrl,
+  id,
+  name,
+  streamUrl,
+  theme,
+}) => {
+  const dispatch = useDispatch()
+  const audioRef = useRef()
+
+  const [cast, setCast] = useState(null)
+  const [currentStream, setCurrentStream] = useState(null)
+  const [lastUpdate, setLastUpdate] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [metadata, setMetadata] = useState({})
+  const [playing, setPlaying] = useState(false)
+  const [savedVolume, setSavedVolume] = useState(0)
+  const [timeoutId, setTimeoutId] = useState(null)
+  const [volume, setVolume] = useState(1)
+
+  // Yes. We have a lock. This is here to prevent attempts to create multiple
+  // players. Necessary because they are created in an async function
+  const [lock, setLock] = useState(false)
+
+  const isMobile = useMediaQuery(
+    '(max-width: 768px) and (orientation : portrait)'
+  )
+
+  const Spin = () => <span className="loading group">{icon.loading}</span>
+
+  const iconMap = { ...DEFAULT_ICON, ...icon, loading: <Spin /> }
+
+  const mapListenToBar = (vol) => Math.sqrt(vol)
+  const mapBarToListen = (vol) => vol ** 2
+
+  const metadataUpdate = useCallback(
+    (newMetadata) => {
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+      }
+
+      const [artist, title] = parseMetadata(newMetadata)
+
+      if ('mediaSession' in navigator) {
+        navigator.mediaSession.metadata = new MediaMetadata({
+          album: name,
+          artist,
+          title,
+        })
+      }
+
+      subsonic.scrobbleRadio(artist, title, false)
+
+      const updateTime = new Date()
+
+      if (lastUpdate !== null && metadata.StreamTitle) {
+        const diffMillis = updateTime - lastUpdate
+
+        if (diffMillis > MIN_TIME_BETWEEN_SCROBBLE_MS) {
+          const [priorArtist, priorTitle] = parseMetadata(metadata)
+
+          subsonic.scrobbleRadio(priorArtist, priorTitle, true)
+        }
+      }
+
+      const newTimer = setTimeout(() => {
+        subsonic.scrobbleRadio(artist, title, true)
+      }, SCROBBLE_DELAY_MS)
+
+      setLastUpdate(updateTime)
+      setMetadata(newMetadata)
+      setTimeoutId(newTimer)
+    },
+    [lastUpdate, metadata, name, timeoutId]
+  )
+
+  useEffect(() => {
+    async function handleChange() {
+      if (
+        lock ||
+        (cast && currentStream === streamUrl && cast.state !== 'stopped')
+      ) {
+        return
+      }
+
+      if (cast) {
+        setLock(true)
+
+        if (timeoutId !== null) {
+          clearTimeout(timeoutId)
+          setTimeoutId(null)
+        }
+
+        await cast.stop()
+        await cast.detachAudioElement()
+      }
+
+      if (streamUrl) {
+        const player = new IcecastMetadataPlayer(streamUrl, {
+          onMetadata: metadataUpdate,
+          onPlay: () => {
+            setLoading(false)
+            setPlaying(true)
+          },
+          onStop: () => {
+            setPlaying(false)
+          },
+          onLoad: () => {
+            console.log('loading')
+          },
+          icyDetectionTimeout: 10000,
+          enableLogging: true,
+          audioElement: audioRef.current,
+          playbackMethod: 'mediasource',
+        })
+
+        player.id = Math.random()
+        player.play()
+
+        setCast(player)
+        setLoading(true)
+        setMetadata({})
+      } else {
+        setCast(null)
+      }
+
+      setCurrentStream(streamUrl)
+      setLock(false)
+    }
+
+    handleChange()
+  }, [
+    audioRef,
+    cast,
+    currentStream,
+    lock,
+    metadataUpdate,
+    streamUrl,
+    timeoutId,
+  ])
+
+  useEffect(() => {
+    const audio = audioRef.current
+
+    if (audio) {
+      audio.onvolumechange = () => {
+        const { volume } = audio
+        setVolume(mapListenToBar(volume))
+      }
+    }
+  }, [audioRef])
+
+  const setAudioVolume = useCallback(
+    (volumeBarVal) => {
+      if (cast) {
+        cast.audioElement.volume = mapBarToListen(volumeBarVal)
+
+        setSavedVolume(volumeBarVal)
+        setVolume(volumeBarVal)
+      }
+    },
+    [cast]
+  )
+
+  const mute = useCallback(() => {
+    if (cast) {
+      setVolume(0)
+      setSavedVolume(cast.audioElement.volume)
+
+      cast.audioElement.volume = 0
+    }
+  }, [cast])
+
+  const resetVolume = useCallback(() => {
+    setAudioVolume(mapListenToBar(savedVolume || 0.1))
+  }, [savedVolume, setAudioVolume])
+
+  const togglePlay = useCallback(() => {
+    if (cast) {
+      const elem = cast.audioElement
+
+      if (elem.paused) {
+        elem.play()
+        setPlaying(true)
+      } else {
+        elem.pause()
+        setPlaying(false)
+      }
+    }
+  }, [cast])
+
+  const coverClick = useCallback(() => {
+    window.location.href = `#/radio?displayedFilters={}&filter={"name":"${name}"}`
+  }, [name])
+
+  const stopPlaying = useCallback(() => {
+    audioRef.current.src = ''
+    dispatch(clearQueue())
+  }, [dispatch])
+
+  return (
+    <div
+      className={clsx(
+        'react-jinke-music-player-main',
+        {
+          'light-theme': theme === 'light',
+          'dark-theme': theme === 'dark',
+        },
+        className
+      )}
+    >
+      {isMobile && (
+        <RadioPlayerMobile
+          cover={cover}
+          homePageUrl={homePageUrl}
+          icon={iconMap}
+          loading={loading}
+          locale={locale}
+          metadata={metadata}
+          name={name}
+          onClose={stopPlaying}
+          onCoverClick={coverClick}
+          onPlay={togglePlay}
+          playing={playing}
+        />
+      )}
+      {!isMobile && (
+        <div className={clsx('music-player-panel', 'translate')}>
+          <section className="panel-content">
+            {cover && (
+              <div
+                className={clsx('img-content', 'img-rotate', {
+                  'img-rotate-pause': !playing || !cover,
+                })}
+                style={{ backgroundImage: `url(${cover})` }}
+                onClick={() => coverClick()}
+              />
+            )}
+            <div className="progress-bar-content">
+              <span className="audio-title" title={metadata.StreamTitle || ''}>
+                <RadioTitle
+                  homePageUrl={homePageUrl}
+                  isMobile={false}
+                  metadata={metadata}
+                  name={name}
+                />
+              </span>
+              <section className="audio-main"></section>
+            </div>
+            <div className="player-content">
+              <span className="group">
+                {loading ? (
+                  <span
+                    className="group loading-icon"
+                    title={locale.loadingText}
+                  >
+                    {iconMap.loading}
+                  </span>
+                ) : (
+                  <span
+                    className="group play-btn"
+                    onClick={togglePlay}
+                    title={
+                      playing ? locale.clickToPauseText : locale.clickToPlayText
+                    }
+                  >
+                    {playing ? iconMap.pause : iconMap.play}
+                  </span>
+                )}
+              </span>
+
+              <span className="group play-sounds" title={locale.volumeText}>
+                {volume === 0 ? (
+                  <span className="sounds-icon" onClick={resetVolume}>
+                    {iconMap.mute}
+                  </span>
+                ) : (
+                  <span className="sounds-icon" onClick={mute}>
+                    {iconMap.volume}
+                  </span>
+                )}
+                <Slider
+                  value={volume}
+                  onChange={setAudioVolume}
+                  className="sound-operation"
+                  min={0}
+                  max={1}
+                  step={0.01}
+                />
+              </span>
+              <span
+                title={locale.destroyText}
+                className="group destroy-btn"
+                onClick={stopPlaying}
+              >
+                {iconMap.destroy}
+              </span>
+            </div>
+          </section>
+        </div>
+      )}
+
+      {streamUrl && <audio ref={audioRef} />}
+    </div>
+  )
+}
+
+export default RadioPlayer

--- a/ui/src/radio/RadioPlayerMobile.js
+++ b/ui/src/radio/RadioPlayerMobile.js
@@ -6,14 +6,15 @@ const prefix = 'react-jinke-music-player-mobile'
 
 const RadioPlayerMobile = ({
   cover,
-  homePageUrl,
   icon,
+  id,
   loading,
   locale,
   metadata,
   name,
   onClose,
   onCoverClick,
+  onFix,
   onPlay,
   playing,
 }) => (
@@ -21,10 +22,11 @@ const RadioPlayerMobile = ({
     <div className={`${prefix}-header group`}>
       <div className={`${prefix}-header-title`} title={name}>
         <RadioTitle
-          homePageUrl={homePageUrl}
+          id={id}
           isMobile={true}
           metadata={metadata}
           name={name}
+          onFix={onFix}
         />
       </div>
 

--- a/ui/src/radio/RadioPlayerMobile.js
+++ b/ui/src/radio/RadioPlayerMobile.js
@@ -1,0 +1,72 @@
+import clsx from 'clsx'
+import React, { memo } from 'react'
+import RadioTitle from './RadioTitle'
+
+const prefix = 'react-jinke-music-player-mobile'
+
+const RadioPlayerMobile = ({
+  cover,
+  homePageUrl,
+  icon,
+  loading,
+  locale,
+  metadata,
+  name,
+  onClose,
+  onCoverClick,
+  onPlay,
+  playing,
+}) => (
+  <div className={clsx(prefix, 'default-bg')}>
+    <div className={`${prefix}-header group`}>
+      <div className={`${prefix}-header-title`} title={name}>
+        <RadioTitle
+          homePageUrl={homePageUrl}
+          isMobile={true}
+          metadata={metadata}
+          name={name}
+        />
+      </div>
+
+      <div className={`${prefix}-header-right`} onClick={onClose}>
+        {icon.close}
+      </div>
+    </div>
+
+    {cover && (
+      <div
+        className={`${prefix}-cover text-center`}
+        onClick={() => onCoverClick()}
+      >
+        <img
+          src={cover}
+          alt="cover"
+          className={clsx('cover', {
+            'img-rotate-pause': !playing || !cover,
+          })}
+        />
+      </div>
+    )}
+
+    <div className={`${prefix}-toggle text-center group`}>
+      {loading ? (
+        <span className="group loading-icon">{icon.loading}</span>
+      ) : (
+        <span
+          className="group play-btn"
+          title={playing ? locale.clickToPauseText : locale.clickToPlayText}
+          onClick={onPlay}
+        >
+          {playing ? icon.pause : icon.play}
+        </span>
+      )}
+    </div>
+  </div>
+)
+
+RadioPlayerMobile.defaultProps = {
+  icon: {},
+  renderAudioTitle: () => {},
+}
+
+export default memo(RadioPlayerMobile)

--- a/ui/src/radio/RadioShow.js
+++ b/ui/src/radio/RadioShow.js
@@ -1,0 +1,41 @@
+import {
+  DateField,
+  Show,
+  SimpleShowLayout,
+  TextField,
+  UrlField,
+  useTranslate,
+} from 'react-admin'
+import RadioLinkList from './RadioLinkList'
+
+const RadioTitle = ({ record }) => {
+  const translate = useTranslate()
+
+  return (
+    <span>
+      {translate('resources.radio.name', { smart_count: 1 })} {record.name}
+    </span>
+  )
+}
+
+const RadioShow = (props) => {
+  return (
+    <Show title={<RadioTitle />} {...props}>
+      <SimpleShowLayout>
+        <TextField source="name" />
+        <TextField source="streamUrl" />
+        <UrlField
+          source="homePageUrl"
+          onClick={(e) => e.stopPropagation()}
+          target="_blank"
+          rel="noopener noreferrer"
+        />{' '}
+        <RadioLinkList />
+        <DateField variant="body1" source="updatedAt" showTime />
+        <DateField variant="body1" source="createdAt" showTime />
+      </SimpleShowLayout>
+    </Show>
+  )
+}
+
+export default RadioShow

--- a/ui/src/radio/RadioTitle.js
+++ b/ui/src/radio/RadioTitle.js
@@ -2,49 +2,63 @@ import React from 'react'
 import clsx from 'clsx'
 
 import useStyle from '../audioplayer/styles'
-import { Link } from 'react-admin'
+import { Link, useTranslate } from 'react-admin'
+import ErrorOutline from '@material-ui/icons/ErrorOutline'
+import { Button, makeStyles } from '@material-ui/core'
 
-const RadioTitle = React.memo(({ homePageUrl, isMobile, name, metadata }) => {
-  const classes = useStyle()
-  const className = classes.audioTitle
+const useStyles = makeStyles(() => ({
+  button: {
+    textTransform: 'none',
+  },
+}))
 
-  let artist
-  let title
+const RadioTitle = React.memo(
+  ({ homePageUrl, id, isMobile, name, metadata }) => {
+    const classes = useStyle()
+    const styles = useStyles()
+    const translate = useTranslate()
+    const className = classes.audioTitle
 
-  if (metadata.StreamTitle) {
-    const split = metadata.StreamTitle.split(' - ')
-    artist = split[0]
-    title = split.slice(1).join(' - ')
-  } else {
-    title = homePageUrl
-    artist = ''
-  }
-
-  return (
-    <Link
-      to={`/radio?displayedFilters={}&filter={"name":"${name}"}`}
-      className={className}
-    >
-      <span>
-        <span className={clsx(classes.songTitle, 'songTitle')}>{title}</span>
-      </span>
-      {isMobile ? (
-        <>
-          <span className={classes.songInfo}>
-            <span className="songArtist">{artist}</span>
+    return (
+      <Link to={`/radio/${id}/show`} className={className}>
+        <span>
+          <span className={clsx(classes.songTitle, 'songTitle')}>
+            {metadata.title}
           </span>
-          <span className={clsx(classes.songInfo, classes.songAlbum)}>
-            <span className="songAlbum">{name}</span>
-          </span>
-        </>
-      ) : (
-        <span className={classes.songInfo}>
-          <span className="songArtist">{artist}</span> -{' '}
-          <span className="songAlbum">{name}</span>
         </span>
-      )}
-    </Link>
-  )
-})
+        {isMobile ? (
+          <>
+            <span className={classes.songInfo}>
+              <span className="songArtist">{metadata.artist}</span>
+            </span>
+            <span className={clsx(classes.songInfo, classes.songAlbum)}>
+              <span className="songAlbum">{name}</span>
+            </span>
+          </>
+        ) : (
+          <span className={classes.songInfo}>
+            {metadata.title && !metadata.artist ? (
+              <span className="songArtist">
+                <Button
+                  variant="outlined"
+                  startIcon={<ErrorOutline />}
+                  size="small"
+                  className={styles.button}
+                >
+                  {translate('resources.radio.message.noArtist')}
+                </Button>
+              </span>
+            ) : (
+              <>
+                <span className="songArtist">{metadata.artist}</span> -{' '}
+                <span className="songAlbum">{name}</span>
+              </>
+            )}
+          </span>
+        )}
+      </Link>
+    )
+  }
+)
 
 export default RadioTitle

--- a/ui/src/radio/RadioTitle.js
+++ b/ui/src/radio/RadioTitle.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import clsx from 'clsx'
+
+import useStyle from '../audioplayer/styles'
+import { Link } from 'react-admin'
+
+const RadioTitle = React.memo(({ homePageUrl, isMobile, name, metadata }) => {
+  const classes = useStyle()
+  const className = classes.audioTitle
+
+  let artist
+  let title
+
+  if (metadata.StreamTitle) {
+    const split = metadata.StreamTitle.split(' - ')
+    artist = split[0]
+    title = split.slice(1).join(' - ')
+  } else {
+    title = homePageUrl
+    artist = ''
+  }
+
+  return (
+    <Link
+      to={`/radio?displayedFilters={}&filter={"name":"${name}"}`}
+      className={className}
+    >
+      <span>
+        <span className={clsx(classes.songTitle, 'songTitle')}>{title}</span>
+      </span>
+      {isMobile ? (
+        <>
+          <span className={classes.songInfo}>
+            <span className="songArtist">{artist}</span>
+          </span>
+          <span className={clsx(classes.songInfo, classes.songAlbum)}>
+            <span className="songAlbum">{name}</span>
+          </span>
+        </>
+      ) : (
+        <span className={classes.songInfo}>
+          <span className="songArtist">{artist}</span> -{' '}
+          <span className="songAlbum">{name}</span>
+        </span>
+      )}
+    </Link>
+  )
+})
+
+export default RadioTitle

--- a/ui/src/radio/RadioTitle.js
+++ b/ui/src/radio/RadioTitle.js
@@ -2,63 +2,49 @@ import React from 'react'
 import clsx from 'clsx'
 
 import useStyle from '../audioplayer/styles'
-import { Link, useTranslate } from 'react-admin'
-import ErrorOutline from '@material-ui/icons/ErrorOutline'
-import { Button, makeStyles } from '@material-ui/core'
+import { Link } from 'react-admin'
+import FixMetadataButton from './FixMetadataButton'
 
-const useStyles = makeStyles(() => ({
-  button: {
-    textTransform: 'none',
-  },
-}))
+const RadioTitle = React.memo(({ id, isMobile, name, metadata, onFix }) => {
+  const classes = useStyle()
+  const className = classes.audioTitle
 
-const RadioTitle = React.memo(
-  ({ homePageUrl, id, isMobile, name, metadata }) => {
-    const classes = useStyle()
-    const styles = useStyles()
-    const translate = useTranslate()
-    const className = classes.audioTitle
+  const isMissingArtist = metadata.title && !metadata.artist
 
-    return (
-      <Link to={`/radio/${id}/show`} className={className}>
-        <span>
-          <span className={clsx(classes.songTitle, 'songTitle')}>
-            {metadata.title}
-          </span>
+  return (
+    <Link to={`/radio/${id}/show`} className={className}>
+      <span>
+        <span className={clsx(classes.songTitle, 'songTitle')}>
+          {metadata.title}
         </span>
-        {isMobile ? (
-          <>
-            <span className={classes.songInfo}>
-              <span className="songArtist">{metadata.artist}</span>
-            </span>
-            <span className={clsx(classes.songInfo, classes.songAlbum)}>
-              <span className="songAlbum">{name}</span>
-            </span>
-          </>
-        ) : (
+      </span>
+      {isMobile ? (
+        <>
           <span className={classes.songInfo}>
-            {metadata.title && !metadata.artist ? (
-              <span className="songArtist">
-                <Button
-                  variant="outlined"
-                  startIcon={<ErrorOutline />}
-                  size="small"
-                  className={styles.button}
-                >
-                  {translate('resources.radio.message.noArtist')}
-                </Button>
-              </span>
-            ) : (
-              <>
-                <span className="songArtist">{metadata.artist}</span> -{' '}
-                <span className="songAlbum">{name}</span>
-              </>
-            )}
+            <span className="songArtist">
+              {isMissingArtist ? <FixMetadataButton /> : metadata.artist}
+            </span>
           </span>
-        )}
-      </Link>
-    )
-  }
-)
+          <span className={clsx(classes.songInfo, classes.songAlbum)}>
+            <span className="songAlbum">{name}</span>
+          </span>
+        </>
+      ) : (
+        <span className={classes.songInfo}>
+          {isMissingArtist ? (
+            <span className="songArtist">
+              {<FixMetadataButton onFix={onFix} />}
+            </span>
+          ) : (
+            <>
+              <span className="songArtist">{metadata.artist}</span> -{' '}
+              <span className="songAlbum">{name}</span>
+            </>
+          )}
+        </span>
+      )}
+    </Link>
+  )
+})
 
 export default RadioTitle

--- a/ui/src/radio/StreamField.js
+++ b/ui/src/radio/StreamField.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React, { useCallback } from 'react'
 import { useRecordContext } from 'react-admin'
 import { useDispatch } from 'react-redux'
-import { setTrack } from '../actions'
+import { playRadio } from '../actions'
 import { songFromRadio } from './helper'
 import PlayArrowIcon from '@material-ui/icons/PlayArrow'
 
@@ -24,7 +24,7 @@ export const StreamField = (props) => {
     async (evt) => {
       evt.stopPropagation()
       evt.preventDefault()
-      dispatch(setTrack(await songFromRadio(record)))
+      dispatch(playRadio(await songFromRadio(record)))
     },
     [dispatch, record]
   )

--- a/ui/src/radio/helper.js
+++ b/ui/src/radio/helper.js
@@ -1,3 +1,5 @@
+import subsonic from '../subsonic'
+
 export async function songFromRadio(radio) {
   if (!radio) {
     return undefined
@@ -13,11 +15,10 @@ export async function songFromRadio(radio) {
 
   return {
     ...radio,
-    title: radio.name,
-    album: radio.homePageUrl || radio.name,
-    artist: radio.name,
     cover,
-    isRadio: true,
+    streamUrl: subsonic.url('proxy', '', {
+      url: radio.streamUrl,
+    }),
   }
 }
 

--- a/ui/src/radio/helper.js
+++ b/ui/src/radio/helper.js
@@ -1,7 +1,7 @@
 import config from '../config'
 import subsonic from '../subsonic'
 
-export async function songFromRadio(radio) {
+export async function songFromRadio(radio, subStream) {
   if (!radio) {
     return undefined
   }
@@ -25,17 +25,27 @@ export async function songFromRadio(radio) {
     cover = urlString
   } catch {}
 
+  let radioName, targetUrl
+
+  if (subStream) {
+    radioName = `${subStream.name} (${radio.name})`
+    targetUrl = subStream.url
+  } else {
+    radioName = radio.name
+    targetUrl = radio.streamUrl
+  }
+
   let streamUrl
 
   if (config.enableProxy) {
     streamUrl = subsonic.url('proxy/stream', '', {
-      url: radio.streamUrl,
+      url: targetUrl,
     })
   } else {
-    streamUrl = radio.streamUrl
+    streamUrl = targetUrl
   }
 
-  return { ...radio, cover, streamUrl }
+  return { ...radio, cover, name: radioName, streamUrl }
 }
 
 const resourceExists = (url) => {

--- a/ui/src/radio/helper.js
+++ b/ui/src/radio/helper.js
@@ -1,3 +1,4 @@
+import config from '../config'
 import subsonic from '../subsonic'
 
 export async function songFromRadio(radio) {
@@ -9,17 +10,32 @@ export async function songFromRadio(radio) {
   try {
     const url = new URL(radio.homePageUrl ?? radio.streamUrl)
     url.pathname = '/favicon.ico'
-    await resourceExists(url)
-    cover = url.toString()
+
+    let urlString;
+
+    if (config.enableProxy) {
+      urlString = subsonic.url('proxy/icon', '', {
+        url: url.toString()
+      })
+    } else {
+      urlString = url.toString()
+    }
+
+    await resourceExists(urlString)
+    cover = urlString
   } catch {}
 
-  return {
-    ...radio,
-    cover,
-    streamUrl: subsonic.url('proxy', '', {
+  let streamUrl;
+
+  if (config.enableProxy) {
+    streamUrl = subsonic.url('proxy/stream', '', {
       url: radio.streamUrl,
-    }),
+    })
+  } else {
+    streamUrl = radio.streamUrl
   }
+
+  return { ...radio, cover, streamUrl }
 }
 
 const resourceExists = (url) => {

--- a/ui/src/radio/helper.js
+++ b/ui/src/radio/helper.js
@@ -11,11 +11,11 @@ export async function songFromRadio(radio) {
     const url = new URL(radio.homePageUrl ?? radio.streamUrl)
     url.pathname = '/favicon.ico'
 
-    let urlString;
+    let urlString
 
     if (config.enableProxy) {
       urlString = subsonic.url('proxy/icon', '', {
-        url: url.toString()
+        url: url.toString(),
       })
     } else {
       urlString = url.toString()
@@ -25,7 +25,7 @@ export async function songFromRadio(radio) {
     cover = urlString
   } catch {}
 
-  let streamUrl;
+  let streamUrl
 
   if (config.enableProxy) {
     streamUrl = subsonic.url('proxy/stream', '', {

--- a/ui/src/radio/index.js
+++ b/ui/src/radio/index.js
@@ -5,9 +5,11 @@ import DynamicMenuIcon from '../layout/DynamicMenuIcon'
 import RadioIcon from '@material-ui/icons/Radio'
 import RadioOutlinedIcon from '@material-ui/icons/RadioOutlined'
 import React from 'react'
+import RadioShow from './RadioShow'
 
 const all = {
   list: RadioList,
+  show: RadioShow,
   icon: (
     <DynamicMenuIcon
       path={'radio'}

--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -33,7 +33,9 @@ const mapToAudioLists = (item) => {
       uuid: uuidv4(),
       name: item.name,
       song: item,
-      musicSrc: item.streamUrl,
+      musicSrc: subsonic.url('proxy', '', {
+        url: item.streamUrl,
+      }),
       cover: item.cover,
       isRadio: true,
     }

--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -6,6 +6,7 @@ import {
   PLAYER_CURRENT,
   PLAYER_PLAY_NEXT,
   PLAYER_PLAY_TRACKS,
+  PLAYER_SET_RADIO,
   PLAYER_SET_TRACK,
   PLAYER_SET_VOLUME,
   PLAYER_SYNC_QUEUE,
@@ -15,6 +16,7 @@ import config from '../config'
 const initialState = {
   queue: [],
   current: {},
+  radio: {},
   clear: false,
   volume: config.defaultUIVolume / 100,
   savedPlayIndex: 0,
@@ -26,20 +28,6 @@ const timestampRegex =
 const mapToAudioLists = (item) => {
   // If item comes from a playlist, trackId is mediaFileId
   const trackId = item.mediaFileId || item.id
-
-  if (item.isRadio) {
-    return {
-      trackId,
-      uuid: uuidv4(),
-      name: item.name,
-      song: item,
-      musicSrc: subsonic.url('proxy', '', {
-        url: item.streamUrl,
-      }),
-      cover: item.cover,
-      isRadio: true,
-    }
-  }
 
   const { lyrics } = item
   return {
@@ -77,6 +65,7 @@ const reducePlayTracks = (state, { data, id }) => {
     queue,
     playIndex,
     clear: true,
+    radio: {},
   }
 }
 
@@ -86,6 +75,7 @@ const reduceSetTrack = (state, { data }) => {
     queue: [mapToAudioLists(data)],
     playIndex: 0,
     clear: true,
+    radio: {},
   }
 }
 
@@ -120,6 +110,7 @@ const reducePlayNext = (state, { data }) => {
     ...state,
     queue: newQueue,
     clear: true,
+    radio: {},
   }
 }
 
@@ -153,6 +144,14 @@ const reduceCurrent = (state, { data }) => {
   }
 }
 
+const reduceRadio = (state, { data: { radio } }) => {
+  return {
+    ...initialState,
+    volume: state.volume,
+    radio,
+  }
+}
+
 export const playerReducer = (previousState = initialState, payload) => {
   const { type } = payload
   switch (type) {
@@ -172,6 +171,8 @@ export const playerReducer = (previousState = initialState, payload) => {
       return reduceSyncQueue(previousState, payload)
     case PLAYER_CURRENT:
       return reduceCurrent(previousState, payload)
+    case PLAYER_SET_RADIO:
+      return reduceRadio(previousState, payload)
     default:
       return previousState
   }

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -32,6 +32,15 @@ const scrobble = (id, time, submission = true) =>
 
 const nowPlaying = (id) => scrobble(id, null, false)
 
+const scrobbleRadio = (artist, title, submission = true) =>
+  httpClient(
+    url('scrobbleRadio', '', {
+      artist,
+      title,
+      submission,
+    })
+  )
+
 const star = (id) => httpClient(url('star', id))
 
 const unstar = (id) => httpClient(url('unstar', id))
@@ -92,4 +101,5 @@ export default {
   streamUrl,
   getAlbumInfo,
   getArtistInfo,
+  scrobbleRadio,
 }


### PR DESCRIPTION
This PR seeks to add real support for internet radios in Navidrome. Because most servers block requests due to CORS limitations, I added the ability to proxy radio streams (and icons) through Navidrome. The ability to do so (and how many streams) are both configurable. If disabled, fall back to trying to play the stream.

Major changes:
- `/rest/proxy/{icon,stream}`: endpoints to proxy favicons and streams, respectively, through navidrome.
- `ui/src/radio/RadioPlayer.js`: replicate the existing player UI, but for radios
- `icecast-metadata-player`: node module that supports parsing metadata from ice/shoutcast streams. Since this is large, the radio player is loaded lazily
- Scrobbling support for radios! Adds another table which stores radio scrobbles. As far as I can tell, the only guaranteed metadata is the artist and title.

TODO:

- [x] Tests
- [x] Handle .pls streams properly?

The big one :tm: