### PR TITLE
add docker compose examples, with traefik or caddy and without, fixes #476

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ navidrome.db-shm
 navidrome.db-wal
 tags
 .gitinfo
+docker-compose.yml
+!contrib/docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ cache/*
 embedded_gen.go
 dist
 music
-docker-compose.yml
 navidrome.db-shm
 navidrome.db-wal
 tags

--- a/contrib/docker-compose/Caddyfile
+++ b/contrib/docker-compose/Caddyfile
@@ -1,0 +1,7 @@
+https://your.website {
+  reverse_proxy * navidrome:4533 {
+    header_up Host {http.reverse_proxy.upstream.hostport}
+    header_up X-Forwarded-For {http.request.remote}
+    header_up X-Real-IP {http.reverse_proxy.upstream.port}
+  }
+}

--- a/contrib/docker-compose/docker-compose-caddy.yml
+++ b/contrib/docker-compose/docker-compose-caddy.yml
@@ -1,0 +1,31 @@
+version: '3.6'
+
+volumes:
+  caddy_data:
+  navidrome_data:
+
+services:
+
+  caddy:
+    container_name: "caddy"
+    image: caddy:2.6-alpine
+    restart: unless-stopped
+    read_only: true
+    volumes:
+      - "caddy_data:/data:rw"
+      - "./Caddyfile:/etc/caddy/Caddyfile:ro"
+    ports:
+      - "80:80"
+      - "443:443"
+
+  navidrome:
+    container_name: "navidrome"
+    image: deluan/navidrome:latest
+    restart: unless-stopped
+    read_only: true
+    # user: 1000:1000
+    ports:
+      - "4533:4533"
+    volumes:
+      - "navidrome_data:/data"
+      #- "/mnt/music:/music:ro"

--- a/contrib/docker-compose/docker-compose-traefik.yml
+++ b/contrib/docker-compose/docker-compose-traefik.yml
@@ -1,0 +1,51 @@
+version: "3.6"
+
+volumes:
+  traefik_data:
+  navidrome_data:
+
+services:
+
+  traefik:
+    container_name: "traefik"
+    image: traefik:2.9
+    restart: unless-stopped
+    read_only: true
+    command:
+      - "--log.level=ERROR"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.tc.acme.tlschallenge=true"
+      #- "--certificatesresolvers.tc.acme.caserver=https://acme-staging-v02.api.letsencrypt.org/directory"
+      - "--certificatesresolvers.tc.acme.email=foo@foo.com"
+      - "--certificatesresolvers.tc.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "443:443"
+    volumes:
+      - "traefik_data:/letsencrypt"
+      #- "/var/run/docker.sock:/var/run/docker.sock:ro"
+
+  navidrome:
+    container_name: "navidrome"
+    image: deluan/navidrome:latest
+    restart: unless-stopped
+    read_only: true
+    # user: 1000:1000
+    ports:
+      - "4533:4533"
+    environment:
+      ND_SCANINTERVAL: 6h
+      ND_LOGLEVEL: info
+      ND_SESSIONTIMEOUT: 168h
+      ND_BASEURL: ""
+    volumes:
+      - "navidrome_data:/data"
+      #- "/mnt/music:/music:ro"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.navidrome.rule=Host(`foo.com`)"
+      - "traefik.http.routers.navidrome.entrypoints=websecure"
+      - "traefik.http.routers.navidrome.tls=true"
+      - "traefik.http.routers.navidrome.tls.certresolver=tc"
+      - "traefik.http.services.navidrome.loadbalancer.server.port=4533"

--- a/contrib/docker-compose/docker-compose.yml
+++ b/contrib/docker-compose/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.6'
+
+volumes:
+  navidrome_data:
+
+services:
+
+  navidrome:
+    container_name: "navidrome"
+    image: deluan/navidrome:latest
+    restart: unless-stopped
+    read_only: true
+    # user: 1000:1000
+    ports:
+      - "4533:4533"
+    volumes:
+      - "navidrome_data:/data"
+      #- "/mnt/music:/music:ro"


### PR DESCRIPTION
as discussed in https://github.com/navidrome/navidrome/issues/476
