### PR TITLE
Add option to make shares downloadable

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -54,13 +54,13 @@ func CreateSubsonicAPIRouter() *subsonic.Router {
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, externalMetadata)
 	transcodingCache := core.GetTranscodingCache()
 	mediaStreamer := core.NewMediaStreamer(dataStore, fFmpeg, transcodingCache)
-	archiver := core.NewArchiver(mediaStreamer, dataStore)
+	share := core.NewShare(dataStore)
+	archiver := core.NewArchiver(mediaStreamer, dataStore, share)
 	players := core.NewPlayers(dataStore)
 	scanner := GetScanner()
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
 	playTracker := scrobbler.GetPlayTracker(dataStore, broker)
-	share := core.NewShare(dataStore)
 	router := subsonic.New(dataStore, artworkArtwork, mediaStreamer, archiver, players, externalMetadata, scanner, broker, playlists, playTracker, share)
 	return router
 }
@@ -76,7 +76,8 @@ func CreatePublicRouter() *public.Router {
 	transcodingCache := core.GetTranscodingCache()
 	mediaStreamer := core.NewMediaStreamer(dataStore, fFmpeg, transcodingCache)
 	share := core.NewShare(dataStore)
-	router := public.New(dataStore, artworkArtwork, mediaStreamer, share)
+	archiver := core.NewArchiver(mediaStreamer, dataStore, share)
+	router := public.New(dataStore, artworkArtwork, mediaStreamer, share, archiver)
 	return router
 }
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -59,6 +59,7 @@ type configOptions struct {
 	EnableStarRating             bool
 	EnableUserEditing            bool
 	EnableSharing                bool
+	DefaultDownloadableShare     bool
 	DefaultTheme                 string
 	DefaultLanguage              string
 	DefaultUIVolume              int
@@ -306,6 +307,7 @@ func init() {
 	viper.SetDefault("devautologinusername", "")
 	viper.SetDefault("devactivitypanel", true)
 	viper.SetDefault("enablesharing", false)
+	viper.SetDefault("defaultdownloadableshare", false)
 	viper.SetDefault("devenablebufferedscrobble", true)
 	viper.SetDefault("devsidebarplaylists", true)
 	viper.SetDefault("devshowartistpage", true)

--- a/core/archiver.go
+++ b/core/archiver.go
@@ -91,8 +91,10 @@ func (a *archiver) albumFilename(mf model.MediaFile, format string, isMultDisc b
 
 func (a *archiver) ZipShare(ctx context.Context, id string, out io.Writer) error {
 	s, err := a.shares.Load(ctx, id)
+	if !s.Downloadable {
+		return model.ErrNotAuthorized
+	}
 	if err != nil {
-		log.Error(ctx, "Error loading mediafiles from share", "id", id, err)
 		return err
 	}
 	log.Debug(ctx, "Zipping share", "name", s.ID, "format", s.Format, "bitrate", s.MaxBitRate, "numTracks", len(s.Tracks))

--- a/core/archiver.go
+++ b/core/archiver.go
@@ -18,16 +18,18 @@ import (
 type Archiver interface {
 	ZipAlbum(ctx context.Context, id string, format string, bitrate int, w io.Writer) error
 	ZipArtist(ctx context.Context, id string, format string, bitrate int, w io.Writer) error
+	ZipShare(ctx context.Context, id string, w io.Writer) error
 	ZipPlaylist(ctx context.Context, id string, format string, bitrate int, w io.Writer) error
 }
 
-func NewArchiver(ms MediaStreamer, ds model.DataStore) Archiver {
-	return &archiver{ds: ds, ms: ms}
+func NewArchiver(ms MediaStreamer, ds model.DataStore, shares Share) Archiver {
+	return &archiver{ds: ds, ms: ms, shares: shares}
 }
 
 type archiver struct {
-	ds model.DataStore
-	ms MediaStreamer
+	ds     model.DataStore
+	ms     MediaStreamer
+	shares Share
 }
 
 func (a *archiver) ZipAlbum(ctx context.Context, id string, format string, bitrate int, out io.Writer) error {
@@ -87,19 +89,29 @@ func (a *archiver) albumFilename(mf model.MediaFile, format string, isMultDisc b
 	return fmt.Sprintf("%s/%s", mf.Album, file)
 }
 
+func (a *archiver) ZipShare(ctx context.Context, id string, out io.Writer) error {
+	s, err := a.shares.Load(ctx, id)
+	if err != nil {
+		log.Error(ctx, "Error loading mediafiles from share", "id", id, err)
+		return err
+	}
+	log.Debug(ctx, "Zipping share", "name", s.ID, "format", s.Format, "bitrate", s.MaxBitRate, "numTracks", len(s.Tracks))
+	return a.zipMediaFiles(ctx, id, s.Format, s.MaxBitRate, out, s.Tracks)
+}
+
 func (a *archiver) ZipPlaylist(ctx context.Context, id string, format string, bitrate int, out io.Writer) error {
 	pls, err := a.ds.Playlist(ctx).GetWithTracks(id, true)
 	if err != nil {
 		log.Error(ctx, "Error loading mediafiles from playlist", "id", id, err)
 		return err
 	}
-	return a.zipPlaylist(ctx, id, format, bitrate, out, pls)
-}
-
-func (a *archiver) zipPlaylist(ctx context.Context, id string, format string, bitrate int, out io.Writer, pls *model.Playlist) error {
-	z := createZipWriter(out, format, bitrate)
 	mfs := pls.MediaFiles()
 	log.Debug(ctx, "Zipping playlist", "name", pls.Name, "format", format, "bitrate", bitrate, "numTracks", len(mfs))
+	return a.zipMediaFiles(ctx, id, format, bitrate, out, mfs)
+}
+
+func (a *archiver) zipMediaFiles(ctx context.Context, id string, format string, bitrate int, out io.Writer, mfs model.MediaFiles) error {
+	z := createZipWriter(out, format, bitrate)
 	for idx, mf := range mfs {
 		file := a.playlistFilename(mf, format, idx)
 		_ = a.addFileToZip(ctx, z, mf, format, bitrate, file)
@@ -132,7 +144,7 @@ func (a *archiver) addFileToZip(ctx context.Context, z *zip.Writer, mf model.Med
 	}
 
 	var r io.ReadCloser
-	if format != "raw" {
+	if format != "raw" && format != "" {
 		r, err = a.ms.DoStream(ctx, &mf, format, bitrate)
 	} else {
 		r, err = os.Open(mf.Path)

--- a/core/share.go
+++ b/core/share.go
@@ -35,7 +35,7 @@ func (s *shareService) Load(ctx context.Context, id string) (*model.Share, error
 		return nil, err
 	}
 	if !share.ExpiresAt.IsZero() && share.ExpiresAt.Before(time.Now()) {
-		return nil, model.ErrNotAvailable
+		return nil, model.ErrExpired
 	}
 	share.LastVisitedAt = time.Now()
 	share.VisitCount++

--- a/core/share.go
+++ b/core/share.go
@@ -125,7 +125,7 @@ func (r *shareRepositoryWrapper) Save(entity interface{}) (string, error) {
 }
 
 func (r *shareRepositoryWrapper) Update(id string, entity interface{}, _ ...string) error {
-	cols := []string{"description"}
+	cols := []string{"description", "downloadable"}
 
 	// TODO Better handling of Share expiration
 	if !entity.(*model.Share).ExpiresAt.IsZero() {

--- a/core/share_test.go
+++ b/core/share_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Share", func() {
 				entity := &model.Share{}
 				err := repo.Update("id", entity)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(mockedRepo.(*tests.MockShareRepo).Cols).To(ConsistOf("description"))
+				Expect(mockedRepo.(*tests.MockShareRepo).Cols).To(ConsistOf("description", "downloadable"))
 			})
 		})
 	})

--- a/db/migration/20230310222612_add_download_to_share.go
+++ b/db/migration/20230310222612_add_download_to_share.go
@@ -1,0 +1,23 @@
+package migrations
+
+import (
+	"database/sql"
+
+	"github.com/pressly/goose"
+)
+
+func init() {
+	goose.AddMigration(upAddDownloadToShare, downAddDownloadToShare)
+}
+
+func upAddDownloadToShare(tx *sql.Tx) error {
+	_, err := tx.Exec(`
+alter table share
+	add downloadable bool not null default false;
+`)
+	return err
+}
+
+func downAddDownloadToShare(tx *sql.Tx) error {
+	return nil
+}

--- a/model/errors.go
+++ b/model/errors.go
@@ -6,5 +6,6 @@ var (
 	ErrNotFound      = errors.New("data not found")
 	ErrInvalidAuth   = errors.New("invalid authentication")
 	ErrNotAuthorized = errors.New("not authorized")
+	ErrExpired       = errors.New("access expired")
 	ErrNotAvailable  = errors.New("functionality not available")
 )

--- a/model/share.go
+++ b/model/share.go
@@ -12,6 +12,7 @@ type Share struct {
 	UserID        string     `structs:"user_id" json:"userId,omitempty"  orm:"column(user_id)"`
 	Username      string     `structs:"-" json:"username,omitempty"      orm:"-"`
 	Description   string     `structs:"description" json:"description,omitempty"`
+	Downloadable  bool       `structs:"downloadable" json:"downloadable"`
 	ExpiresAt     time.Time  `structs:"expires_at" json:"expiresAt,omitempty"`
 	LastVisitedAt time.Time  `structs:"last_visited_at" json:"lastVisitedAt,omitempty"`
 	ResourceIDs   string     `structs:"resource_ids" json:"resourceIds,omitempty"   orm:"column(resource_ids)"`

--- a/resources/i18n/pt.json
+++ b/resources/i18n/pt.json
@@ -183,6 +183,7 @@
                 "username": "Compartilhado por",
                 "url": "Link",
                 "description": "Descrição",
+                "downloadable": "Permitir Baixar?",
                 "contents": "Conteúdo",
                 "expiresAt": "Dt. Expiração",
                 "lastVisitedAt": "Última visita",

--- a/server/public/handle_downloads.go
+++ b/server/public/handle_downloads.go
@@ -1,0 +1,16 @@
+package public
+
+import (
+	"net/http"
+)
+
+func (p *Router) handleDownloads(w http.ResponseWriter, r *http.Request) {
+	id := r.URL.Query().Get(":id")
+	if id == "" {
+		http.Error(w, "invalid id", http.StatusBadRequest)
+		return
+	}
+
+	err := p.archiver.ZipShare(r.Context(), id, w)
+	checkShareError(r.Context(), w, err, id)
+}

--- a/server/public/handle_shares.go
+++ b/server/public/handle_shares.go
@@ -1,6 +1,7 @@
 package public
 
 import (
+	"context"
 	"errors"
 	"net/http"
 
@@ -27,23 +28,27 @@ func (p *Router) handleShares(w http.ResponseWriter, r *http.Request) {
 
 	// If it is not, consider it a share ID
 	s, err := p.share.Load(r.Context(), id)
-	switch {
-	case errors.Is(err, model.ErrNotAvailable):
-		log.Error(r, "Share expired", "id", id, err)
-		http.Error(w, "Share not available anymore", http.StatusGone)
-	case errors.Is(err, model.ErrNotFound):
-		log.Error(r, "Share not found", "id", id, err)
-		http.Error(w, "Share not found", http.StatusNotFound)
-	case err != nil:
-		log.Error(r, "Error retrieving share", "id", id, err)
-		http.Error(w, "Error retrieving share", http.StatusInternalServerError)
-	}
 	if err != nil {
+		checkShareError(r.Context(), w, err, id)
 		return
 	}
 
 	s = p.mapShareInfo(r, *s)
 	server.IndexWithShare(p.ds, ui.BuildAssets(), s)(w, r)
+}
+
+func checkShareError(ctx context.Context, w http.ResponseWriter, err error, id string) {
+	switch {
+	case errors.Is(err, model.ErrExpired):
+		log.Error(ctx, "Share expired", "id", id, err)
+		http.Error(w, "Share not available anymore", http.StatusGone)
+	case errors.Is(err, model.ErrNotFound):
+		log.Error(ctx, "Share not found", "id", id, err)
+		http.Error(w, "Share not found", http.StatusNotFound)
+	case err != nil:
+		log.Error(ctx, "Error retrieving share", "id", id, err)
+		http.Error(w, "Error retrieving share", http.StatusInternalServerError)
+	}
 }
 
 func (p *Router) mapShareInfo(r *http.Request, s model.Share) *model.Share {

--- a/server/public/handle_shares.go
+++ b/server/public/handle_shares.go
@@ -45,6 +45,9 @@ func checkShareError(ctx context.Context, w http.ResponseWriter, err error, id s
 	case errors.Is(err, model.ErrNotFound):
 		log.Error(ctx, "Share not found", "id", id, err)
 		http.Error(w, "Share not found", http.StatusNotFound)
+	case errors.Is(err, model.ErrNotAuthorized):
+		log.Error(ctx, "Share is not downloadable", "id", id, err)
+		http.Error(w, "This share is not downloadable", http.StatusForbidden)
 	case err != nil:
 		log.Error(ctx, "Error retrieving share", "id", id, err)
 		http.Error(w, "Error retrieving share", http.StatusInternalServerError)

--- a/server/public/public.go
+++ b/server/public/public.go
@@ -20,13 +20,14 @@ type Router struct {
 	http.Handler
 	artwork       artwork.Artwork
 	streamer      core.MediaStreamer
+	archiver      core.Archiver
 	share         core.Share
 	assetsHandler http.Handler
 	ds            model.DataStore
 }
 
-func New(ds model.DataStore, artwork artwork.Artwork, streamer core.MediaStreamer, share core.Share) *Router {
-	p := &Router{ds: ds, artwork: artwork, streamer: streamer, share: share}
+func New(ds model.DataStore, artwork artwork.Artwork, streamer core.MediaStreamer, share core.Share, archiver core.Archiver) *Router {
+	p := &Router{ds: ds, artwork: artwork, streamer: streamer, share: share, archiver: archiver}
 	shareRoot := path.Join(conf.Server.BasePath, consts.URLPathPublic)
 	p.assetsHandler = http.StripPrefix(shareRoot, http.FileServer(http.FS(ui.BuildAssets())))
 	p.Handler = p.routes()
@@ -51,6 +52,7 @@ func (p *Router) routes() http.Handler {
 		})
 		if conf.Server.EnableSharing {
 			r.HandleFunc("/s/{id}", p.handleStream)
+			r.HandleFunc("/d/{id}", p.handleDownloads)
 			r.HandleFunc("/{id}", p.handleShares)
 			r.HandleFunc("/", p.handleShares)
 			r.Handle("/*", p.assetsHandler)

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -122,8 +122,10 @@ func getIndexTemplate(r *http.Request, fs fs.FS) (*template.Template, error) {
 }
 
 type shareData struct {
-	Description string       `json:"description"`
-	Tracks      []shareTrack `json:"tracks"`
+	ID           string       `json:"id"`
+	Description  string       `json:"description"`
+	Downloadable bool         `json:"downloadable"`
+	Tracks       []shareTrack `json:"tracks"`
 }
 
 type shareTrack struct {
@@ -141,7 +143,9 @@ func addShareData(r *http.Request, data map[string]interface{}, shareInfo *model
 		return
 	}
 	sd := shareData{
-		Description: shareInfo.Description,
+		ID:           shareInfo.ID,
+		Description:  shareInfo.Description,
+		Downloadable: shareInfo.Downloadable,
 	}
 	sd.Tracks = slice.Map(shareInfo.Tracks, func(mf model.MediaFile) shareTrack {
 		return shareTrack{

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -58,6 +58,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"devActivityPanel":          conf.Server.DevActivityPanel,
 			"enableUserEditing":         conf.Server.EnableUserEditing,
 			"enableSharing":             conf.Server.EnableSharing,
+			"defaultDownloadableShare":  conf.Server.DefaultDownloadableShare,
 			"devSidebarPlaylists":       conf.Server.DevSidebarPlaylists,
 			"lastFMEnabled":             conf.Server.LastFM.Enabled,
 			"lastFMApiKey":              conf.Server.LastFM.ApiKey,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -245,6 +245,17 @@ var _ = Describe("serveIndex", func() {
 		Expect(config).To(HaveKeyWithValue("enableSharing", false))
 	})
 
+	It("sets the defaultDownloadableShare", func() {
+		conf.Server.DefaultDownloadableShare = true
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		serveIndex(ds, fs, nil)(w, r)
+
+		config := extractAppConfig(w.Body.String())
+		Expect(config).To(HaveKeyWithValue("defaultDownloadableShare", true))
+	})
+
 	It("sets the defaultDownsamplingFormat", func() {
 		r := httptest.NewRequest("GET", "/index.html", nil)
 		w := httptest.NewRecorder()

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -37,7 +37,7 @@ import config, { shareInfo } from './config'
 import { setDispatch, startEventStream, stopEventStream } from './eventStream'
 import { keyMap } from './hotkeys'
 import useChangeThemeColor from './useChangeThemeColor'
-import SharePlayer from './SharePlayer'
+import SharePlayer from './share/SharePlayer'
 
 const history = createHashHistory()
 

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -22,6 +22,7 @@ const defaultConfig = {
   defaultUIVolume: 100,
   enableUserEditing: true,
   enableSharing: true,
+  defaultDownloadableShare: true,
   devSidebarPlaylists: true,
   lastFMEnabled: true,
   lastFMApiKey: '9b94a5515ea66b2da3ec03c12300327e',

--- a/ui/src/dialogs/ShareDialog.js
+++ b/ui/src/dialogs/ShareDialog.js
@@ -8,6 +8,7 @@ import {
 import {
   SimpleForm,
   TextInput,
+  BooleanInput,
   useCreate,
   useNotify,
   useTranslate,
@@ -17,6 +18,7 @@ import { shareUrl } from '../utils'
 import { useTranscodingOptions } from './useTranscodingOptions'
 import { useDispatch, useSelector } from 'react-redux'
 import { closeShareMenu } from '../actions'
+import config from '../config'
 
 export const ShareDialog = () => {
   const {
@@ -30,6 +32,9 @@ export const ShareDialog = () => {
   const notify = useNotify()
   const translate = useTranslate()
   const [description, setDescription] = useState('')
+  const [downloadable, setDownloadable] = useState(
+    config.defaultDownloadableShare
+  )
   useEffect(() => {
     setDescription('')
   }, [ids])
@@ -41,6 +46,7 @@ export const ShareDialog = () => {
       resourceType: resource,
       resourceIds: ids?.join(','),
       description,
+      downloadable,
       ...(!originalFormat && { format }),
       ...(!originalFormat && { maxBitRate }),
     },
@@ -105,10 +111,19 @@ export const ShareDialog = () => {
       <DialogContent>
         <SimpleForm toolbar={null} variant={'outlined'}>
           <TextInput
-            source="description"
+            resource={'share'}
+            source={'description'}
             fullWidth
             onChange={(event) => {
               setDescription(event.target.value)
+            }}
+          />
+          <BooleanInput
+            resource={'share'}
+            source={'downloadable'}
+            defaultValue={downloadable}
+            onChange={(value) => {
+              setDownloadable(value)
             }}
           />
           <TranscodingOptionsInput

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -184,6 +184,7 @@
                 "username": "Shared By",
                 "url": "URL",
                 "description": "Description",
+                "downloadable": "Allow Downloads?",
                 "contents": "Contents",
                 "expiresAt": "Expires",
                 "lastVisitedAt": "Last Visited",

--- a/ui/src/share/ShareEdit.js
+++ b/ui/src/share/ShareEdit.js
@@ -1,5 +1,6 @@
 import {
   DateTimeInput,
+  BooleanInput,
   Edit,
   NumberField,
   SimpleForm,
@@ -19,6 +20,7 @@ export const ShareEdit = (props) => {
           {url}
         </Link>
         <TextInput source="description" />
+        <BooleanInput source="downloadable" />
         <DateTimeInput source="expiresAt" />
         <TextInput source="contents" disabled />
         <TextInput source="format" disabled />

--- a/ui/src/share/ShareList.js
+++ b/ui/src/share/ShareList.js
@@ -1,6 +1,7 @@
 import {
   Datagrid,
   FunctionField,
+  BooleanField,
   List,
   NumberField,
   SimpleList,
@@ -24,6 +25,7 @@ export const FormatInfo = ({ record, size }) => {
 
 const ShareList = (props) => {
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
+  const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('lg'))
   const translate = useTranslate()
   const notify = useNotify()
 
@@ -101,10 +103,13 @@ const ShareList = (props) => {
           />
           <TextField source="username" />
           <TextField source="description" />
-          <TextField source="contents" />
-          <FormatInfo source="format" />
+          {isDesktop && <TextField source="contents" />}
+          {isDesktop && <FormatInfo source="format" />}
+          <BooleanField source="downloadable" />
           <NumberField source="visitCount" />
-          <DateField source="lastVisitedAt" showTime sortByOrder={'DESC'} />
+          {isDesktop && (
+            <DateField source="lastVisitedAt" showTime sortByOrder={'DESC'} />
+          )}
           <DateField source="expiresAt" showTime />
         </Datagrid>
       )}

--- a/ui/src/share/SharePlayer.js
+++ b/ui/src/share/SharePlayer.js
@@ -1,6 +1,6 @@
 import ReactJkMusicPlayer from 'navidrome-music-player'
-import { shareInfo } from './config'
-import { shareCoverUrl, shareStreamUrl } from './utils'
+import { shareInfo } from '../config'
+import { shareCoverUrl, shareDownloadUrl, shareStreamUrl } from '../utils'
 
 import { makeStyles } from '@material-ui/core/styles'
 
@@ -34,12 +34,17 @@ const SharePlayer = () => {
       duration: s.duration,
     }
   })
+  const onBeforeAudioDownload = () => {
+    return Promise.resolve({
+      src: shareDownloadUrl(shareInfo?.id),
+    })
+  }
   const options = {
     audioLists: list,
     mode: 'full',
     toggleMode: false,
     mobileMediaQuery: '',
-    showDownload: false,
+    showDownload: shareInfo?.downloadable,
     showReload: false,
     showMediaSession: true,
     theme: 'auto',
@@ -49,7 +54,13 @@ const SharePlayer = () => {
     spaceBar: true,
     volumeFade: { fadeIn: 200, fadeOut: 200 },
   }
-  return <ReactJkMusicPlayer {...options} className={classes.player} />
+  return (
+    <ReactJkMusicPlayer
+      {...options}
+      className={classes.player}
+      onBeforeAudioDownload={onBeforeAudioDownload}
+    />
+  )
 }
 
 export default SharePlayer

--- a/ui/src/utils/urls.js
+++ b/ui/src/utils/urls.js
@@ -19,6 +19,10 @@ export const shareStreamUrl = (id) => {
   return baseUrl(config.publicBaseUrl + '/s/' + id)
 }
 
+export const shareDownloadUrl = (id) => {
+  return baseUrl(config.publicBaseUrl + '/d/' + id)
+}
+
 export const shareCoverUrl = (id) => {
   return baseUrl(config.publicBaseUrl + '/img/' + id + '?size=300')
 }


### PR DESCRIPTION
This PR introduces an new config option, `DefaultDownloadableShare`, to set what is the default to use when sharing.

Each share can be set as "downloadable" individually, and this can be changed after the share is created.

Fix #2125 