### PR TITLE
allow the data mount to be used with users other than root

### DIFF
--- a/.github/workflows/pipeline.dockerfile
+++ b/.github/workflows/pipeline.dockerfile
@@ -25,6 +25,7 @@ RUN ffmpeg -buildconf
 
 COPY --from=copy-binary /navidrome /app/
 
+RUN mkdir /data && chmod 777 /data
 VOLUME ["/data", "/music"]
 ENV ND_MUSICFOLDER /music
 ENV ND_DATAFOLDER /data


### PR DESCRIPTION
I would like to be able to run navidrome as a non-root user.
The data mount needs to allow for that.

Tested it like this:

```
FROM deluan/navidrome:latest
RUN mkdir /data && chmod 777 /data
```