### PR TITLE
Convert all Subsonic API ints to int32 as per specification

### DIFF
--- a/server/subsonic/album_lists.go
+++ b/server/subsonic/album_lists.go
@@ -155,8 +155,8 @@ func (api *Router) GetNowPlaying(r *http.Request) (*responses.Subsonic, error) {
 	for i, np := range npInfo {
 		response.NowPlaying.Entry[i].Child = childFromMediaFile(ctx, np.MediaFile)
 		response.NowPlaying.Entry[i].UserName = np.Username
-		response.NowPlaying.Entry[i].MinutesAgo = int(time.Since(np.Start).Minutes())
-		response.NowPlaying.Entry[i].PlayerId = i + 1 // Fake numeric playerId, it does not seem to be used for anything
+		response.NowPlaying.Entry[i].MinutesAgo = int32(time.Since(np.Start).Minutes())
+		response.NowPlaying.Entry[i].PlayerId = int32(i + 1) // Fake numeric playerId, it does not seem to be used for anything
 		response.NowPlaying.Entry[i].PlayerName = np.PlayerName
 	}
 	return response, nil

--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -262,7 +262,7 @@ func sendError(w http.ResponseWriter, r *http.Request, err error) {
 		code = subErr.code
 	}
 	response.Status = "failed"
-	response.Error = &responses.Error{Code: code, Message: err.Error()}
+	response.Error = &responses.Error{Code: int32(code), Message: err.Error()}
 
 	sendResponse(w, r, response)
 }

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -283,9 +283,9 @@ func (api *Router) GetArtistInfo2(r *http.Request) (*responses.Subsonic, error) 
 		similar := responses.ArtistID3{}
 		similar.Id = s.Id
 		similar.Name = s.Name
-		similar.AlbumCount = int32(s.AlbumCount)
+		similar.AlbumCount = s.AlbumCount
 		similar.Starred = s.Starred
-		similar.UserRating = s.UserRating
+		similar.UserRating = int(s.UserRating)
 		similar.CoverArt = s.CoverArt
 		similar.ArtistImageUrl = s.ArtistImageUrl
 		response.ArtistInfo2.SimilarArtist = append(response.ArtistInfo2.SimilarArtist, similar)

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -283,7 +283,7 @@ func (api *Router) GetArtistInfo2(r *http.Request) (*responses.Subsonic, error) 
 		similar := responses.ArtistID3{}
 		similar.Id = s.Id
 		similar.Name = s.Name
-		similar.AlbumCount = s.AlbumCount
+		similar.AlbumCount = int32(s.AlbumCount)
 		similar.Starred = s.Starred
 		similar.UserRating = s.UserRating
 		similar.CoverArt = s.CoverArt

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -285,7 +285,7 @@ func (api *Router) GetArtistInfo2(r *http.Request) (*responses.Subsonic, error) 
 		similar.Name = s.Name
 		similar.AlbumCount = s.AlbumCount
 		similar.Starred = s.Starred
-		similar.UserRating = int(s.UserRating)
+		similar.UserRating = s.UserRating
 		similar.CoverArt = s.CoverArt
 		similar.ArtistImageUrl = s.ArtistImageUrl
 		response.ArtistInfo2.SimilarArtist = append(response.ArtistInfo2.SimilarArtist, similar)
@@ -354,8 +354,8 @@ func (api *Router) buildArtistDirectory(ctx context.Context, artist *model.Artis
 	if artist.PlayCount > 0 {
 		dir.Played = &artist.PlayDate
 	}
-	dir.AlbumCount = artist.AlbumCount
-	dir.UserRating = artist.Rating
+	dir.AlbumCount = int32(artist.AlbumCount)
+	dir.UserRating = int32(artist.Rating)
 	if artist.Starred {
 		dir.Starred = &artist.StarredAt
 	}
@@ -392,8 +392,8 @@ func (api *Router) buildAlbumDirectory(ctx context.Context, album *model.Album) 
 	if album.PlayCount > 0 {
 		dir.Played = &album.PlayDate
 	}
-	dir.UserRating = album.Rating
-	dir.SongCount = album.SongCount
+	dir.UserRating = int32(album.Rating)
+	dir.SongCount = int32(album.SongCount)
 	dir.CoverArt = album.CoverArtID().String()
 	if album.Starred {
 		dir.Starred = &album.StarredAt

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -415,15 +415,15 @@ func (api *Router) buildAlbum(ctx context.Context, album *model.Album, mfs model
 	dir.Artist = album.AlbumArtist
 	dir.ArtistId = album.AlbumArtistID
 	dir.CoverArt = album.CoverArtID().String()
-	dir.SongCount = album.SongCount
-	dir.Duration = int(album.Duration)
+	dir.SongCount = int32(album.SongCount)
+	dir.Duration = int32(album.Duration)
 	dir.PlayCount = album.PlayCount
 	if album.PlayCount > 0 {
 		dir.Played = &album.PlayDate
 	}
-	dir.Year = album.MaxYear
+	dir.Year = int32(album.MaxYear)
 	dir.Genre = album.Genre
-	dir.UserRating = album.Rating
+	dir.UserRating = int32(album.Rating)
 	if !album.CreatedAt.IsZero() {
 		dir.Created = &album.CreatedAt
 	}

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -142,14 +142,14 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 	child.IsDir = false
 	child.Parent = mf.AlbumID
 	child.Album = mf.Album
-	child.Year = mf.Year
+	child.Year = int32(mf.Year)
 	child.Artist = mf.Artist
 	child.Genre = mf.Genre
-	child.Track = mf.TrackNumber
-	child.Duration = int(mf.Duration)
+	child.Track = int32(mf.TrackNumber)
+	child.Duration = int32(mf.Duration)
 	child.Size = mf.Size
 	child.Suffix = mf.Suffix
-	child.BitRate = mf.BitRate
+	child.BitRate = int32(mf.BitRate)
 	child.CoverArt = mf.CoverArtID().String()
 	child.ContentType = mf.ContentType()
 	player, ok := request.PlayerFrom(ctx)
@@ -158,7 +158,7 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 	} else {
 		child.Path = fakePath(mf)
 	}
-	child.DiscNumber = mf.DiscNumber
+	child.DiscNumber = int32(mf.DiscNumber)
 	child.Created = &mf.CreatedAt
 	child.AlbumId = mf.AlbumID
 	child.ArtistId = mf.ArtistID
@@ -170,7 +170,7 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 	if mf.Starred {
 		child.Starred = &mf.StarredAt
 	}
-	child.UserRating = mf.Rating
+	child.UserRating = int32(mf.Rating)
 
 	format, _ := getTranscoding(ctx)
 	if mf.Suffix != "" && format != "" && mf.Suffix != format {
@@ -209,14 +209,14 @@ func childFromAlbum(_ context.Context, al model.Album) responses.Child {
 	child.Name = al.Name
 	child.Album = al.Name
 	child.Artist = al.AlbumArtist
-	child.Year = al.MaxYear
+	child.Year = int32(al.MaxYear)
 	child.Genre = al.Genre
 	child.CoverArt = al.CoverArtID().String()
 	child.Created = &al.CreatedAt
 	child.Parent = al.AlbumArtistID
 	child.ArtistId = al.AlbumArtistID
-	child.Duration = int(al.Duration)
-	child.SongCount = al.SongCount
+	child.Duration = int32(al.Duration)
+	child.SongCount = int32(al.SongCount)
 	if al.Starred {
 		child.Starred = &al.StarredAt
 	}
@@ -224,7 +224,7 @@ func childFromAlbum(_ context.Context, al model.Album) responses.Child {
 	if al.PlayCount > 0 {
 		child.Played = &al.PlayDate
 	}
-	child.UserRating = al.Rating
+	child.UserRating = int32(al.Rating)
 	return child
 }
 

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -103,7 +103,7 @@ func toArtistID3(r *http.Request, a model.Artist) responses.ArtistID3 {
 		AlbumCount:     int32(a.AlbumCount),
 		CoverArt:       a.CoverArtID().String(),
 		ArtistImageUrl: public.ImageURL(r, a.CoverArtID(), 600),
-		UserRating:     a.Rating,
+		UserRating:     int32(a.Rating),
 	}
 	if a.Starred {
 		artist.Starred = &a.StarredAt

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -100,7 +100,7 @@ func toArtistID3(r *http.Request, a model.Artist) responses.ArtistID3 {
 	artist := responses.ArtistID3{
 		Id:             a.ID,
 		Name:           a.Name,
-		AlbumCount:     a.AlbumCount,
+		AlbumCount:     int32(a.AlbumCount),
 		CoverArt:       a.CoverArtID().String(),
 		ArtistImageUrl: public.ImageURL(r, a.CoverArtID(), 600),
 		UserRating:     a.Rating,

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -85,8 +85,8 @@ func toArtist(r *http.Request, a model.Artist) responses.Artist {
 	artist := responses.Artist{
 		Id:             a.ID,
 		Name:           a.Name,
-		AlbumCount:     a.AlbumCount,
-		UserRating:     a.Rating,
+		AlbumCount:     int32(a.AlbumCount),
+		UserRating:     int32(a.Rating),
 		CoverArt:       a.CoverArtID().String(),
 		ArtistImageUrl: public.ImageURL(r, a.CoverArtID(), 600),
 	}

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -116,8 +116,8 @@ func toGenres(genres model.Genres) *responses.Genres {
 	for i, g := range genres {
 		response[i] = responses.Genre{
 			Name:       g.Name,
-			SongCount:  g.SongCount,
-			AlbumCount: g.AlbumCount,
+			SongCount:  int32(g.SongCount),
+			AlbumCount: int32(g.AlbumCount),
 		}
 	}
 	return &responses.Genres{Genre: response}

--- a/server/subsonic/playlists.go
+++ b/server/subsonic/playlists.go
@@ -165,9 +165,9 @@ func (api *Router) buildPlaylist(p model.Playlist) *responses.Playlist {
 	pls.Id = p.ID
 	pls.Name = p.Name
 	pls.Comment = p.Comment
-	pls.SongCount = p.SongCount
+	pls.SongCount = int32(p.SongCount)
 	pls.Owner = p.OwnerName
-	pls.Duration = int(p.Duration)
+	pls.Duration = int32(p.Duration)
 	pls.Public = p.Public
 	pls.Created = p.CreatedAt
 	pls.Changed = p.UpdatedAt

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -148,17 +148,17 @@ type Directory struct {
 	Starred    *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
 	PlayCount  int64      `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
 	Played     *time.Time `xml:"played,attr,omitempty"              json:"played,omitempty"`
-	UserRating int        `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	UserRating int32      `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
 
 	// ID3
 	Artist     string     `xml:"artist,attr,omitempty"              json:"artist,omitempty"`
 	ArtistId   string     `xml:"artistId,attr,omitempty"            json:"artistId,omitempty"`
 	CoverArt   string     `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
-	SongCount  int        `xml:"songCount,attr,omitempty"           json:"songCount,omitempty"`
-	AlbumCount int        `xml:"albumCount,attr,omitempty"          json:"albumCount,omitempty"`
-	Duration   int        `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
+	SongCount  int32      `xml:"songCount,attr,omitempty"           json:"songCount,omitempty"`
+	AlbumCount int32      `xml:"albumCount,attr,omitempty"          json:"albumCount,omitempty"`
+	Duration   int32      `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
 	Created    *time.Time `xml:"created,attr,omitempty"             json:"created,omitempty"`
-	Year       int        `xml:"year,attr,omitempty"                json:"year,omitempty"`
+	Year       int32      `xml:"year,attr,omitempty"                json:"year,omitempty"`
 	Genre      string     `xml:"genre,attr,omitempty"               json:"genre,omitempty"`
 
 	/*
@@ -172,7 +172,7 @@ type ArtistID3 struct {
 	CoverArt       string     `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
 	AlbumCount     int32      `xml:"albumCount,attr,omitempty"          json:"albumCount,omitempty"`
 	Starred        *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
-	UserRating     int        `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	UserRating     int32      `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
 	ArtistImageUrl string     `xml:"artistImageUrl,attr,omitempty"      json:"artistImageUrl,omitempty"`
 }
 

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -211,8 +211,8 @@ type Playlist struct {
 	Id        string    `xml:"id,attr"                       json:"id"`
 	Name      string    `xml:"name,attr"                     json:"name"`
 	Comment   string    `xml:"comment,attr,omitempty"        json:"comment,omitempty"`
-	SongCount int       `xml:"songCount,attr"                json:"songCount"`
-	Duration  int       `xml:"duration,attr"                 json:"duration"`
+	SongCount int32     `xml:"songCount,attr"                json:"songCount"`
+	Duration  int32     `xml:"duration,attr"                 json:"duration"`
 	Public    bool      `xml:"public,attr"                   json:"public"`
 	Owner     string    `xml:"owner,attr,omitempty"          json:"owner,omitempty"`
 	Created   time.Time `xml:"created,attr"                  json:"created"`

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -107,8 +107,8 @@ type Child struct {
 	Name                  string     `xml:"name,attr,omitempty"                     json:"name,omitempty"`
 	Album                 string     `xml:"album,attr,omitempty"                    json:"album,omitempty"`
 	Artist                string     `xml:"artist,attr,omitempty"                   json:"artist,omitempty"`
-	Track                 int        `xml:"track,attr,omitempty"                    json:"track,omitempty"`
-	Year                  int        `xml:"year,attr,omitempty"                     json:"year,omitempty"`
+	Track                 int32      `xml:"track,attr,omitempty"                    json:"track,omitempty"`
+	Year                  int32      `xml:"year,attr,omitempty"                     json:"year,omitempty"`
 	Genre                 string     `xml:"genre,attr,omitempty"                    json:"genre,omitempty"`
 	CoverArt              string     `xml:"coverArt,attr,omitempty"                 json:"coverArt,omitempty"`
 	Size                  int64      `xml:"size,attr,omitempty"                     json:"size,omitempty"`
@@ -117,18 +117,18 @@ type Child struct {
 	Starred               *time.Time `xml:"starred,attr,omitempty"                  json:"starred,omitempty"`
 	TranscodedContentType string     `xml:"transcodedContentType,attr,omitempty"    json:"transcodedContentType,omitempty"`
 	TranscodedSuffix      string     `xml:"transcodedSuffix,attr,omitempty"         json:"transcodedSuffix,omitempty"`
-	Duration              int        `xml:"duration,attr,omitempty"                 json:"duration,omitempty"`
-	BitRate               int        `xml:"bitRate,attr,omitempty"                  json:"bitRate,omitempty"`
+	Duration              int32      `xml:"duration,attr,omitempty"                 json:"duration,omitempty"`
+	BitRate               int32      `xml:"bitRate,attr,omitempty"                  json:"bitRate,omitempty"`
 	Path                  string     `xml:"path,attr,omitempty"                     json:"path,omitempty"`
 	PlayCount             int64      `xml:"playCount,attr,omitempty"                json:"playCount,omitempty"`
 	Played                *time.Time `xml:"played,attr,omitempty"                   json:"played,omitempty"`
-	DiscNumber            int        `xml:"discNumber,attr,omitempty"               json:"discNumber,omitempty"`
+	DiscNumber            int32      `xml:"discNumber,attr,omitempty"               json:"discNumber,omitempty"`
 	Created               *time.Time `xml:"created,attr,omitempty"                  json:"created,omitempty"`
 	AlbumId               string     `xml:"albumId,attr,omitempty"                  json:"albumId,omitempty"`
 	ArtistId              string     `xml:"artistId,attr,omitempty"                 json:"artistId,omitempty"`
 	Type                  string     `xml:"type,attr,omitempty"                     json:"type,omitempty"`
-	UserRating            int        `xml:"userRating,attr,omitempty"               json:"userRating,omitempty"`
-	SongCount             int        `xml:"songCount,attr,omitempty"                json:"songCount,omitempty"`
+	UserRating            int32      `xml:"userRating,attr,omitempty"               json:"userRating,omitempty"`
+	SongCount             int32      `xml:"songCount,attr,omitempty"                json:"songCount,omitempty"`
 	IsVideo               bool       `xml:"isVideo,attr"                            json:"isVideo"`
 	BookmarkPosition      int64      `xml:"bookmarkPosition,attr,omitempty"         json:"bookmarkPosition,omitempty"`
 	/*

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -58,7 +58,7 @@ type JsonWrapper struct {
 }
 
 type Error struct {
-	Code    int    `xml:"code,attr"                      json:"code"`
+	Code    int32  `xml:"code,attr"                      json:"code"`
 	Message string `xml:"message,attr"                   json:"message"`
 }
 

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -255,8 +255,8 @@ type Starred struct {
 type NowPlayingEntry struct {
 	Child
 	UserName   string `xml:"username,attr"                        json:"username"`
-	MinutesAgo int    `xml:"minutesAgo,attr"                      json:"minutesAgo"`
-	PlayerId   int    `xml:"playerId,attr"                        json:"playerId"`
+	MinutesAgo int32  `xml:"minutesAgo,attr"                      json:"minutesAgo"`
+	PlayerId   int32  `xml:"playerId,attr"                        json:"playerId"`
 	PlayerName string `xml:"playerName,attr"                      json:"playerName,omitempty"`
 }
 

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -170,7 +170,7 @@ type ArtistID3 struct {
 	Id             string     `xml:"id,attr"                            json:"id"`
 	Name           string     `xml:"name,attr"                          json:"name"`
 	CoverArt       string     `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
-	AlbumCount     int        `xml:"albumCount,attr,omitempty"          json:"albumCount,omitempty"`
+	AlbumCount     int32      `xml:"albumCount,attr,omitempty"          json:"albumCount,omitempty"`
 	Starred        *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
 	UserRating     int        `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
 	ArtistImageUrl string     `xml:"artistImageUrl,attr,omitempty"      json:"artistImageUrl,omitempty"`

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -369,7 +369,7 @@ type Share struct {
 	Created     time.Time  `xml:"created,attr"                json:"created"`
 	Expires     *time.Time `xml:"expires,omitempty,attr"      json:"expires,omitempty"`
 	LastVisited time.Time  `xml:"lastVisited,omitempty,attr"  json:"lastVisited"`
-	VisitCount  int        `xml:"visitCount,attr"             json:"visitCount"`
+	VisitCount  int32      `xml:"visitCount,attr"             json:"visitCount"`
 }
 
 type Shares struct {

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -290,8 +290,8 @@ type Users struct {
 
 type Genre struct {
 	Name       string `xml:",chardata"                      json:"value,omitempty"`
-	SongCount  int    `xml:"songCount,attr"             json:"songCount"`
-	AlbumCount int    `xml:"albumCount,attr"            json:"albumCount"`
+	SongCount  int32  `xml:"songCount,attr"             json:"songCount"`
+	AlbumCount int32  `xml:"albumCount,attr"            json:"albumCount"`
 }
 
 type Genres struct {

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -182,14 +182,14 @@ type AlbumID3 struct {
 	Artist     string     `xml:"artist,attr,omitempty"              json:"artist,omitempty"`
 	ArtistId   string     `xml:"artistId,attr,omitempty"            json:"artistId,omitempty"`
 	CoverArt   string     `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
-	SongCount  int        `xml:"songCount,attr,omitempty"           json:"songCount,omitempty"`
-	Duration   int        `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
+	SongCount  int32      `xml:"songCount,attr,omitempty"           json:"songCount,omitempty"`
+	Duration   int32      `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
 	PlayCount  int64      `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
 	Played     *time.Time `xml:"played,attr,omitempty"              json:"played,omitempty"`
 	Created    *time.Time `xml:"created,attr,omitempty"             json:"created,omitempty"`
 	Starred    *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
-	UserRating int        `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
-	Year       int        `xml:"year,attr,omitempty"                json:"year,omitempty"`
+	UserRating int32      `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	Year       int32      `xml:"year,attr,omitempty"                json:"year,omitempty"`
 	Genre      string     `xml:"genre,attr,omitempty"               json:"genre,omitempty"`
 }
 

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -265,23 +265,23 @@ type NowPlaying struct {
 }
 
 type User struct {
-	Username            string `xml:"username,attr"               json:"username"`
-	Email               string `xml:"email,attr,omitempty"        json:"email,omitempty"`
-	ScrobblingEnabled   bool   `xml:"scrobblingEnabled,attr"      json:"scrobblingEnabled"`
-	MaxBitRate          int    `xml:"maxBitRate,attr,omitempty"   json:"maxBitRate,omitempty"`
-	AdminRole           bool   `xml:"adminRole,attr"              json:"adminRole"`
-	SettingsRole        bool   `xml:"settingsRole,attr"           json:"settingsRole"`
-	DownloadRole        bool   `xml:"downloadRole,attr"           json:"downloadRole"`
-	UploadRole          bool   `xml:"uploadRole,attr"             json:"uploadRole"`
-	PlaylistRole        bool   `xml:"playlistRole,attr"           json:"playlistRole"`
-	CoverArtRole        bool   `xml:"coverArtRole,attr"           json:"coverArtRole"`
-	CommentRole         bool   `xml:"commentRole,attr"            json:"commentRole"`
-	PodcastRole         bool   `xml:"podcastRole,attr"            json:"podcastRole"`
-	StreamRole          bool   `xml:"streamRole,attr"             json:"streamRole"`
-	JukeboxRole         bool   `xml:"jukeboxRole,attr"            json:"jukeboxRole"`
-	ShareRole           bool   `xml:"shareRole,attr"              json:"shareRole"`
-	VideoConversionRole bool   `xml:"videoConversionRole,attr"    json:"videoConversionRole"`
-	Folder              []int  `xml:"folder,omitempty"            json:"folder,omitempty"`
+	Username            string  `xml:"username,attr"               json:"username"`
+	Email               string  `xml:"email,attr,omitempty"        json:"email,omitempty"`
+	ScrobblingEnabled   bool    `xml:"scrobblingEnabled,attr"      json:"scrobblingEnabled"`
+	MaxBitRate          int32   `xml:"maxBitRate,attr,omitempty"   json:"maxBitRate,omitempty"`
+	AdminRole           bool    `xml:"adminRole,attr"              json:"adminRole"`
+	SettingsRole        bool    `xml:"settingsRole,attr"           json:"settingsRole"`
+	DownloadRole        bool    `xml:"downloadRole,attr"           json:"downloadRole"`
+	UploadRole          bool    `xml:"uploadRole,attr"             json:"uploadRole"`
+	PlaylistRole        bool    `xml:"playlistRole,attr"           json:"playlistRole"`
+	CoverArtRole        bool    `xml:"coverArtRole,attr"           json:"coverArtRole"`
+	CommentRole         bool    `xml:"commentRole,attr"            json:"commentRole"`
+	PodcastRole         bool    `xml:"podcastRole,attr"            json:"podcastRole"`
+	StreamRole          bool    `xml:"streamRole,attr"             json:"streamRole"`
+	JukeboxRole         bool    `xml:"jukeboxRole,attr"            json:"jukeboxRole"`
+	ShareRole           bool    `xml:"shareRole,attr"              json:"shareRole"`
+	VideoConversionRole bool    `xml:"videoConversionRole,attr"    json:"videoConversionRole"`
+	Folder              []int32 `xml:"folder,omitempty"            json:"folder,omitempty"`
 }
 
 type Users struct {

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -78,9 +78,9 @@ type MusicFolders struct {
 type Artist struct {
 	Id             string     `xml:"id,attr"                           json:"id"`
 	Name           string     `xml:"name,attr"                         json:"name"`
-	AlbumCount     int        `xml:"albumCount,attr,omitempty"         json:"albumCount,omitempty"`
+	AlbumCount     int32      `xml:"albumCount,attr,omitempty"         json:"albumCount,omitempty"`
 	Starred        *time.Time `xml:"starred,attr,omitempty"            json:"starred,omitempty"`
-	UserRating     int        `xml:"userRating,attr,omitempty"         json:"userRating,omitempty"`
+	UserRating     int32      `xml:"userRating,attr,omitempty"         json:"userRating,omitempty"`
 	CoverArt       string     `xml:"coverArt,attr,omitempty"           json:"coverArt,omitempty"`
 	ArtistImageUrl string     `xml:"artistImageUrl,attr,omitempty"     json:"artistImageUrl,omitempty"`
 	/* TODO:

--- a/server/subsonic/responses/responses_test.go
+++ b/server/subsonic/responses/responses_test.go
@@ -215,7 +215,7 @@ var _ = Describe("Responses", func() {
 		Context("with data", func() {
 			BeforeEach(func() {
 				response.User.Email = "navidrome@deluan.com"
-				response.User.Folder = []int{1}
+				response.User.Folder = []int32{1}
 			})
 
 			It("should match .XML", func() {
@@ -247,7 +247,7 @@ var _ = Describe("Responses", func() {
 				u := User{Username: "deluan"}
 				u.Email = "navidrome@deluan.com"
 				u.AdminRole = true
-				u.Folder = []int{1}
+				u.Folder = []int32{1}
 				response.Users = &Users{User: []User{u}}
 			})
 

--- a/server/subsonic/searching.go
+++ b/server/subsonic/searching.go
@@ -104,8 +104,8 @@ func (api *Router) Search2(r *http.Request) (*responses.Subsonic, error) {
 		searchResult2.Artist[i] = responses.Artist{
 			Id:             artist.ID,
 			Name:           artist.Name,
-			AlbumCount:     artist.AlbumCount,
-			UserRating:     artist.Rating,
+			AlbumCount:     int32(artist.AlbumCount),
+			UserRating:     int32(artist.Rating),
 			CoverArt:       artist.CoverArtID().String(),
 			ArtistImageUrl: public.ImageURL(r, artist.CoverArtID(), 600),
 		}

--- a/server/subsonic/sharing.go
+++ b/server/subsonic/sharing.go
@@ -36,7 +36,7 @@ func (api *Router) buildShare(r *http.Request, share model.Share) responses.Shar
 		Created:     share.CreatedAt,
 		Expires:     &share.ExpiresAt,
 		LastVisited: share.LastVisitedAt,
-		VisitCount:  share.VisitCount,
+		VisitCount:  int32(share.VisitCount),
 	}
 	if resp.Description == "" {
 		resp.Description = share.Contents


### PR DESCRIPTION
Fixes issues with malformed tags breaking clients. Ex:
- http://support.symfonium.app/t/subsonic-source-navidrome-music-files-only-show-under-files-folder/1606/6
- http://support.symfonium.app/t/music-is-only-viewable-from-the-files-category-despite-working-yesterday-and-resyncing-with-my-server/1614/4