### PR TITLE
fix(persistence): Update play_date on scrobble only when newer - #2262

### DIFF
--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -158,6 +158,31 @@ var _ = Describe("MediaRepository", func() {
 			Expect(mf.PlayCount).To(Equal(int64(1)))
 		})
 
+		It("preserves play date iff provided date is older", func() {
+			id := "incplay.playdate"
+			Expect(mr.Put(&model.MediaFile{ID: id})).To(BeNil())
+			playDate := time.Now()
+			Expect(mr.IncPlayCount(id, playDate)).To(BeNil())
+			mf, err := mr.Get(id)
+			Expect(err).To(BeNil())
+			Expect(mf.PlayDate.Unix()).To(Equal(playDate.Unix()))
+			Expect(mf.PlayCount).To(Equal(int64(1)))
+
+			playDateLate := playDate.AddDate(0, 0, 1)
+			Expect(mr.IncPlayCount(id, playDateLate)).To(BeNil())
+			mf, err = mr.Get(id)
+			Expect(err).To(BeNil())
+			Expect(mf.PlayDate.Unix()).To(Equal(playDateLate.Unix()))
+			Expect(mf.PlayCount).To(Equal(int64(2)))
+
+			playDateEarly := playDate.AddDate(0, 0, -1)
+			Expect(mr.IncPlayCount(id, playDateEarly)).To(BeNil())
+			mf, err = mr.Get(id)
+			Expect(err).To(BeNil())
+			Expect(mf.PlayDate.Unix()).To(Equal(playDateLate.Unix()))
+			Expect(mf.PlayCount).To(Equal(int64(3)))
+		})
+
 		It("increments play count on newly starred items", func() {
 			id := "star.incplay"
 			Expect(mr.Put(&model.MediaFile{ID: id})).To(BeNil())

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -158,7 +158,7 @@ var _ = Describe("MediaRepository", func() {
 			Expect(mf.PlayCount).To(Equal(int64(1)))
 		})
 
-		It("preserves play date iff provided date is older", func() {
+		It("preserves play date if and only if provided date is older", func() {
 			id := "incplay.playdate"
 			Expect(mr.Put(&model.MediaFile{ID: id})).To(BeNil())
 			playDate := time.Now()

--- a/persistence/sql_annotations.go
+++ b/persistence/sql_annotations.go
@@ -64,7 +64,7 @@ func (r sqlRepository) SetRating(rating int, itemID string) error {
 func (r sqlRepository) IncPlayCount(itemID string, ts time.Time) error {
 	upd := Update(annotationTable).Where(r.annId(itemID)).
 		Set("play_count", Expr("play_count+1")).
-		Set("play_date", ts)
+		Set("play_date", Expr("max(ifnull(play_date,''),?)", ts))
 	c, err := r.executeSQL(upd)
 
 	if c == 0 || errors.Is(err, orm.ErrNoRows) {


### PR DESCRIPTION
Closes #2262

## Description

Update play_date on scrobble only when newer

## Changes

Make `annotation.play_date` set to `max` of the existing value and the new value.

## Screenshots or Videos

(None)

## Related Issues and Pull Requests(if any)

(None)
