### PR TITLE
use doublestar to glob for artwork

### DIFF
--- a/core/artwork/reader_artist.go
+++ b/core/artwork/reader_artist.go
@@ -5,13 +5,13 @@ import (
 	"crypto/md5"
 	"fmt"
 	"io"
-	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core"
@@ -80,8 +80,8 @@ func (a *artistReader) LastUpdated() time.Time {
 
 func (a *artistReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {
 	return selectImageReader(ctx, a.artID,
-		fromArtistFolder(ctx, a.artistFolder, "artist.*"),
-		fromExternalFile(ctx, a.files, "artist.*"),
+		fromArtistFolder(ctx, a.artistFolder, "{artist,folder}.{jpg,jpeg,png}"),
+		fromExternalFile(ctx, a.files, "artist.{jpg,jpeg,png}"),
 		fromArtistExternalSource(ctx, a.artist, a.em),
 	)
 }
@@ -89,7 +89,7 @@ func (a *artistReader) Reader(ctx context.Context) (io.ReadCloser, string, error
 func fromArtistFolder(ctx context.Context, artistFolder string, pattern string) sourceFunc {
 	return func() (io.ReadCloser, string, error) {
 		fsys := os.DirFS(artistFolder)
-		matches, err := fs.Glob(fsys, pattern)
+		matches, err := doublestar.Glob(fsys, pattern)
 		if err != nil {
 			log.Warn(ctx, "Error matching artist image pattern", "pattern", pattern, "folder", artistFolder)
 			return nil, "", err

--- a/core/artwork/sources.go
+++ b/core/artwork/sources.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bmatcuk/doublestar/v4"
 	"github.com/dhowden/tag"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core"
@@ -60,7 +61,7 @@ func fromExternalFile(ctx context.Context, files string, pattern string) sourceF
 	return func() (io.ReadCloser, string, error) {
 		for _, file := range splitList(files) {
 			_, name := filepath.Split(file)
-			match, err := filepath.Match(pattern, strings.ToLower(name))
+			match, err := doublestar.Match(pattern, strings.ToLower(name))
 			if err != nil {
 				log.Warn(ctx, "Error matching cover art file to pattern", "pattern", pattern, "file", file)
 				continue

--- a/go.mod
+++ b/go.mod
@@ -227,6 +227,7 @@ require (
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.2.0 // indirect
 	github.com/ziutek/mymysql v1.5.4 // indirect
+	github.com/bmatcuk/doublestar/v4 v4.6.0 // indirect
 	gitlab.com/bosi/decorder v0.2.3 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/multierr v1.8.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/bkielbasa/cyclop v1.2.0 h1:7Jmnh0yL2DjKfw28p86YTd/B4lRGcNuu12sKE35sM7
 github.com/bkielbasa/cyclop v1.2.0/go.mod h1:qOI0yy6A7dYC4Zgsa72Ppm9kONl0RoIlPbzot9mhmeI=
 github.com/blizzy78/varnamelen v0.8.0 h1:oqSblyuQvFsW1hbBHh1zfwrKe3kcSj0rnXkKzsQ089M=
 github.com/blizzy78/varnamelen v0.8.0/go.mod h1:V9TzQZ4fLJ1DSrjVDfl89H7aMnTvKkApdHeyESmyR7k=
+github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
+github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bombsimon/wsl/v3 v3.4.0 h1:RkSxjT3tmlptwfgEgTgU+KYKLI35p/tviNXNXiL2aNU=
 github.com/bombsimon/wsl/v3 v3.4.0/go.mod h1:KkIB+TXkqy6MvK9BDZVbZxKNYsE1/oLRJbIFtf14qqo=
 github.com/bradleyjkemp/cupaloy/v2 v2.8.0 h1:any4BmKE+jGIaMpnU8YgH/I2LPiLBufr6oMMlVBbn9M=


### PR DESCRIPTION
Currently navidrome will accept artist.nfo files as album art because of the pattern `artist.*`. These files exist if the collection contains metadata for kodi. The artist directories contain the artist portraits in a file called `folder.jpg`. By using doublestar for globbing we can use a pattern `{artist,folder}.{jpg,jpeg,png}` to be more strict on the filetype and also consider these `folder.jpg` files.