### PR TITLE
feat(persistence): Better handling of punctuation in searches - #1641

### DIFF
--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -37,6 +37,7 @@ var _ = Describe("AlbumRepository", func() {
 		It("returns all records sorted", func() {
 			Expect(repo.GetAll(model.QueryOptions{Sort: "name"})).To(Equal(model.Albums{
 				albumAbbeyRoad,
+				albumMonster,
 				albumRadioactivity,
 				albumSgtPeppers,
 			}))
@@ -46,6 +47,7 @@ var _ = Describe("AlbumRepository", func() {
 			Expect(repo.GetAll(model.QueryOptions{Sort: "name", Order: "desc"})).To(Equal(model.Albums{
 				albumSgtPeppers,
 				albumRadioactivity,
+				albumMonster,
 				albumAbbeyRoad,
 			}))
 		})
@@ -53,6 +55,20 @@ var _ = Describe("AlbumRepository", func() {
 		It("paginates the result", func() {
 			Expect(repo.GetAll(model.QueryOptions{Offset: 1, Max: 1})).To(Equal(model.Albums{
 				albumAbbeyRoad,
+			}))
+		})
+	})
+
+	Describe("Search", func() {
+		It("returns exact match", func() {
+			Expect(repo.Search("R.E.M.", 0, 1)).To(Equal(model.Albums{
+				albumMonster,
+			}))
+		})
+
+		It("returns match regardless of punctuation", func() {
+			Expect(repo.Search("REM", 0, 1)).To(Equal(model.Albums{
+				albumMonster,
 			}))
 		})
 	})

--- a/persistence/persistence_suite_test.go
+++ b/persistence/persistence_suite_test.go
@@ -49,10 +49,12 @@ var (
 	albumSgtPeppers    = model.Album{ID: "101", Name: "Sgt Peppers", Artist: "The Beatles", OrderAlbumName: "sgt peppers", AlbumArtistID: "3", Genre: "Rock", Genres: model.Genres{genreRock}, EmbedArtPath: P("/beatles/1/sgt/a day.mp3"), SongCount: 1, MaxYear: 1967, FullText: " beatles peppers sgt the"}
 	albumAbbeyRoad     = model.Album{ID: "102", Name: "Abbey Road", Artist: "The Beatles", OrderAlbumName: "abbey road", AlbumArtistID: "3", Genre: "Rock", Genres: model.Genres{genreRock}, EmbedArtPath: P("/beatles/1/come together.mp3"), SongCount: 1, MaxYear: 1969, FullText: " abbey beatles road the"}
 	albumRadioactivity = model.Album{ID: "103", Name: "Radioactivity", Artist: "Kraftwerk", OrderAlbumName: "radioactivity", AlbumArtistID: "2", Genre: "Electronic", Genres: model.Genres{genreElectronic, genreRock}, EmbedArtPath: P("/kraft/radio/radio.mp3"), SongCount: 2, FullText: " kraftwerk radioactivity"}
+	albumMonster       = model.Album{ID: "104", Name: "Monster", Artist: "R.E.M.", OrderAlbumName: "monster", AlbumArtistID: "1", Genre: "Rock", EmbedArtPath: P("/kraft/radio/radio.mp3"), SongCount: 2, FullText: " R.E.M monster"}
 	testAlbums         = model.Albums{
 		albumSgtPeppers,
 		albumAbbeyRoad,
 		albumRadioactivity,
+		albumMonster,
 	}
 )
 

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -39,7 +39,7 @@ func fullTextExpr(value string) Sqlizer {
 	parts := strings.Split(q, " ")
 	filters := And{}
 	for _, part := range parts {
-		filters = append(filters, Like{"full_text": "%" + sep + part + "%"})
+		filters = append(filters, Like{"REPLACE(REPLACE(REPLACE(REPLACE(full_text, '.', ''), ',', ''), ':', ''), '-', '')": "%" + sep + part + "%"})
 	}
 	return filters
 }

--- a/utils/sanitize_strings.go
+++ b/utils/sanitize_strings.go
@@ -10,7 +10,7 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 )
 
-var quotesRegex = regexp.MustCompile("[“”‘’'\"\\[\\(\\{\\]\\)\\}]")
+var quotesRegex = regexp.MustCompile("[.,:\\-“”‘’'\"\\[\\(\\{\\]\\)\\}]")
 
 func SanitizeStrings(text ...string) string {
 	sanitizedText := strings.Builder{}

--- a/utils/sanitize_strings_test.go
+++ b/utils/sanitize_strings_test.go
@@ -18,6 +18,22 @@ var _ = Describe("SanitizeStrings", func() {
 		Expect(SanitizeStrings(" some  text  ")).To(Equal("some text"))
 	})
 
+	It("remove full stop", func() {
+		Expect(SanitizeStrings("some. text")).To(Equal("some text"))
+	})
+
+	It("remove comma", func() {
+		Expect(SanitizeStrings("some, text")).To(Equal("some text"))
+	})
+
+	It("remove colon", func() {
+		Expect(SanitizeStrings("some :text")).To(Equal("some text"))
+	})
+
+	It("remove dash", func() {
+		Expect(SanitizeStrings("some- text")).To(Equal("some text"))
+	})
+
 	It("remove duplicated words", func() {
 		Expect(SanitizeStrings("legião urbana urbana legiÃo")).To(Equal("legiao urbana"))
 	})


### PR DESCRIPTION
Closes #1641

Description: 
Ignores punctuation when searching for albums. More specifically, the search won't be affected at all, if an album name contains any of the following:
* full stop: `.`
* comma: `,`
* colon (the letter :wink: ): `:`
* dash: `-`

Technically, the solution is not the most delicate one (the query needs to contain lots of nested REPLACE calls), but it works like a charm! And most importantly I did not have to touch the database to achieve this!

Changes:
* modified the rexeg that sanitizes the input string
* modified the query that does the search in the full_text and it removes any of the punctuation listed above

![navidrome-1641](https://user-images.githubusercontent.com/16381881/227643703-0402dded-d645-4147-a2d2-98a18251c795.gif)
