### PR TITLE
fix(systemd): allow the setrlimit syscall - #1961

### DIFF
--- a/contrib/navidrome.service
+++ b/contrib/navidrome.service
@@ -38,6 +38,7 @@ RestrictNamespaces=yes
 RestrictRealtime=yes
 SystemCallFilter=@system-service
 SystemCallFilter=~@privileged @resources
+SystemCallFilter=setrlimit
 SystemCallArchitectures=native
 UMask=0066
 


### PR DESCRIPTION
This appears to be used by newer go versions and navidrome fails to start unless it's allowed.

Fixes #1961 