### PR TITLE
fix(playlist): Ignore playlists starting with a dot - #2367

### DIFF
--- a/scanner/playlist_importer.go
+++ b/scanner/playlist_importer.go
@@ -36,6 +36,9 @@ func (s *playlistImporter) processPlaylists(ctx context.Context, dir string) int
 		return count
 	}
 	for _, f := range files {
+		if strings.HasPrefix(f.Name(), ".") {
+			continue
+		}
 		if !model.IsValidPlaylist(f.Name()) {
 			continue
 		}

--- a/tests/fixtures/playlists/subfolder1/.hidden_playlist1.m3u
+++ b/tests/fixtures/playlists/subfolder1/.hidden_playlist1.m3u
@@ -1,0 +1,2 @@
+test.mp3
+test.ogg

--- a/tests/fixtures/playlists/subfolder2/.hidden_playlist2.m3u
+++ b/tests/fixtures/playlists/subfolder2/.hidden_playlist2.m3u
@@ -1,0 +1,2 @@
+test.mp3
+test.ogg


### PR DESCRIPTION
Closes #2367 

I added the same code from tag scanner to ignore files starting with a dot "." and a couple of hidden playlist for the tests.