### PR TITLE
Do not empty old artist metadata

### DIFF
--- a/model/artist.go
+++ b/model/artist.go
@@ -49,7 +49,7 @@ type ArtistIndexes []ArtistIndex
 type ArtistRepository interface {
 	CountAll(options ...QueryOptions) (int64, error)
 	Exists(id string) (bool, error)
-	Put(m *Artist) error
+	Put(m *Artist, colsToUpdate ...string) error
 	Get(id string) (*Artist, error)
 	GetAll(options ...QueryOptions) (Artists, error)
 	Search(q string, offset int, size int) (Artists, error)

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -60,10 +60,10 @@ func (r *artistRepository) Exists(id string) (bool, error) {
 	return r.exists(Select().Where(Eq{"artist.id": id}))
 }
 
-func (r *artistRepository) Put(a *model.Artist) error {
+func (r *artistRepository) Put(a *model.Artist, colsToUpdate ...string) error {
 	a.FullText = getFullText(a.Name, a.SortArtistName)
 	dba := r.fromModel(a)
-	_, err := r.put(dba.ID, dba)
+	_, err := r.put(dba.ID, dba, colsToUpdate...)
 	if err != nil {
 		return err
 	}

--- a/scanner/refresher.go
+++ b/scanner/refresher.go
@@ -142,7 +142,8 @@ func (r *refresher) refreshArtists(ctx context.Context, ids ...string) error {
 		// Force a external metadata lookup on next access
 		a.ExternalInfoUpdatedAt = time.Time{}
 
-		err := repo.Put(&a)
+		// Do not remove old metadata
+		err := repo.Put(&a, "album_count", "genres", "external_info_updated_at", "mbz_artist_id", "name", "order_artist_name", "size", "sort_artist_name", "song_count")
 		if err != nil {
 			return err
 		}

--- a/tests/mock_artist_repo.go
+++ b/tests/mock_artist_repo.go
@@ -50,7 +50,7 @@ func (m *MockArtistRepo) Get(id string) (*model.Artist, error) {
 	return nil, model.ErrNotFound
 }
 
-func (m *MockArtistRepo) Put(ar *model.Artist) error {
+func (m *MockArtistRepo) Put(ar *model.Artist, columsToUpdate ...string) error {
 	if m.err {
 		return errors.New("error")
 	}


### PR DESCRIPTION
Currently, on a full refresh, the artist metadata is cleared entirely and the updated timestamp is set to 0 (needs refresh). This PR changes this by only updating the necessary fields (but still marking metadata as old).