### PR TITLE
fix(theme): Fix certain text being unreadable with Libera

### DIFF
--- a/ui/src/themes/ligera.js
+++ b/ui/src/themes/ligera.js
@@ -115,7 +115,7 @@ export default {
     },
     MuiFormGroup: {
       root: {
-        color: bLight['500'],
+        color: '#464646',
       },
     },
     MuiMenuItem: {


### PR DESCRIPTION
Description: Certain bits of text were unreadable when using the Libera theme, due to them being the same color as the background.

Changes: This changes those text sections to be their correct color.

**Before:**
<img width="423" alt="Screenshot 2023-09-10 at 11 24 03" src="https://github.com/navidrome/navidrome/assets/77685111/72faafca-b77c-4d74-9d4d-5416467ac7a4">

**After:**
<img width="423" alt="Screenshot 2023-09-10 at 11 23 48" src="https://github.com/navidrome/navidrome/assets/77685111/5aa39f99-aca5-4786-9974-1f964f32a7db">


