### PR TITLE
improve TopSongs findMatchingTrack by de-prioritizing compilations

### DIFF
--- a/core/external_metadata.go
+++ b/core/external_metadata.go
@@ -414,7 +414,7 @@ func (e *externalMetadata) findMatchingTrack(ctx context.Context, mbid string, a
 			},
 			squirrel.Like{"order_title": strings.TrimSpace(sanitize.Accents(title))},
 		},
-		Sort: "starred desc, rating desc, year asc",
+		Sort: "starred desc, rating desc, year asc, compilation asc ",
 		Max:  1,
 	})
 	if err != nil || len(mfs) == 0 {


### PR DESCRIPTION
In reference to https://github.com/navidrome/navidrome/issues/1701

The gist is: Navidromes "findMatchingTrack" function should try to match from albumartist direct releases *first*, *then* from compilation albums.