### PR TITLE
Fix external link for artist page if LastFM is missinb but Musicbrainz is not

### DIFF
--- a/ui/src/artist/ArtistExternalLink.js
+++ b/ui/src/artist/ArtistExternalLink.js
@@ -9,18 +9,10 @@ import config from '../config'
 
 const ArtistExternalLinks = ({ artistInfo, record }) => {
   const translate = useTranslate()
-  let links = []
   let linkButtons = []
   const lastFMlink = artistInfo?.biography?.match(
     /<a\s+(?:[^>]*?\s+)?href=(["'])(.*?)\1/
   )
-
-  if (lastFMlink) {
-    links.push(lastFMlink[2])
-  }
-  if (artistInfo && artistInfo.musicBrainzId) {
-    links.push(`https://musicbrainz.org/artist/${artistInfo.musicBrainzId}`)
-  }
 
   const addLink = (url, title, icon) => {
     const translatedTitle = translate(title)
@@ -37,9 +29,9 @@ const ArtistExternalLinks = ({ artistInfo, record }) => {
     linkButtons.push(<span key={`link-${record.id}-${id}`}>{link}</span>)
   }
 
-  if (config.lastFMEnabled) {
+  if (config.lastFMEnabled && lastFMlink) {
     addLink(
-      links[0],
+      lastFMlink[2],
       'message.openIn.lastfm',
       <ImLastfm2 className="lastfm-icon" />
     )
@@ -47,7 +39,7 @@ const ArtistExternalLinks = ({ artistInfo, record }) => {
 
   artistInfo?.musicBrainzId &&
     addLink(
-      links[1],
+      `https://musicbrainz.org/artist/${artistInfo.musicBrainzId}`,
       'message.openIn.musicbrainz',
       <MusicBrainz className="musicbrainz-icon" />
     )

--- a/ui/src/artist/ArtistExternalLink.js
+++ b/ui/src/artist/ArtistExternalLink.js
@@ -36,9 +36,9 @@ const ArtistExternalLinks = ({ artistInfo, record }) => {
         'message.openIn.lastfm',
         <ImLastfm2 className="lastfm-icon" />
       )
-    } else if (artistInfo.lastFmUrl) {
+    } else if (artistInfo?.lastFmUrl) {
       addLink(
-        artistInfo.lastFmUrl,
+        artistInfo?.lastFmUrl,
         'message.openIn.lastfm',
         <ImLastfm2 className="lastfm-icon" />
       )

--- a/ui/src/artist/ArtistExternalLink.js
+++ b/ui/src/artist/ArtistExternalLink.js
@@ -29,12 +29,20 @@ const ArtistExternalLinks = ({ artistInfo, record }) => {
     linkButtons.push(<span key={`link-${record.id}-${id}`}>{link}</span>)
   }
 
-  if (config.lastFMEnabled && lastFMlink) {
-    addLink(
-      lastFMlink[2],
-      'message.openIn.lastfm',
-      <ImLastfm2 className="lastfm-icon" />
-    )
+  if (config.lastFMEnabled) {
+    if (lastFMlink) {
+      addLink(
+        lastFMlink[2],
+        'message.openIn.lastfm',
+        <ImLastfm2 className="lastfm-icon" />
+      )
+    } else if (artistInfo.lastFmUrl) {
+      addLink(
+        artistInfo.lastFmUrl,
+        'message.openIn.lastfm',
+        <ImLastfm2 className="lastfm-icon" />
+      )
+    }
   }
 
   artistInfo?.musicBrainzId &&


### PR DESCRIPTION
Currently, if you have an artist with no lastfm link but they have a musicbrainz id, the links are broken; this PR addresses that. Resolves #2370