### PR TITLE
Use file creation date for Date Added/CreatedAt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,10 @@ require (
 	github.com/deluan/sanitize v0.0.0-20230310221930-6e18967d9fc1
 	github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086
 	github.com/disintegration/imaging v1.6.2
+        github.com/djherbis/atime v1.1.0
 	github.com/djherbis/fscache v0.10.2-0.20220222230828-2909c950912d
 	github.com/djherbis/stream v1.4.0
-	github.com/djherbis/times v1.5.0
+	github.com/djherbis/times v1.6.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/faiface/beep v1.1.0
 	github.com/fatih/structs v1.1.0

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/deluan/sanitize v0.0.0-20230310221930-6e18967d9fc1
 	github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086
 	github.com/disintegration/imaging v1.6.2
-        github.com/djherbis/atime v1.1.0
+	github.com/djherbis/atime v1.1.0
 	github.com/djherbis/fscache v0.10.2-0.20220222230828-2909c950912d
 	github.com/djherbis/stream v1.4.0
 	github.com/djherbis/times v1.6.0

--- a/go.mod
+++ b/go.mod
@@ -13,9 +13,9 @@ require (
 	github.com/deluan/sanitize v0.0.0-20230310221930-6e18967d9fc1
 	github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086
 	github.com/disintegration/imaging v1.6.2
-	github.com/djherbis/atime v1.1.0
 	github.com/djherbis/fscache v0.10.2-0.20220222230828-2909c950912d
 	github.com/djherbis/stream v1.4.0
+	github.com/djherbis/times v1.5.0
 	github.com/dustin/go-humanize v1.0.1
 	github.com/faiface/beep v1.1.0
 	github.com/fatih/structs v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -82,12 +82,14 @@ github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086 h1:ORubSQoKnncsBnR4zD9
 github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086/go.mod h1:Z3Lomva4pyMWYezjMAU5QWRh0p1VvO4199OHlFnyKkM=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
+github.com/djherbis/atime v1.1.0 h1:rgwVbP/5by8BvvjBNrbh64Qz33idKT3pSnMSJsxhi0g=
+github.com/djherbis/atime v1.1.0/go.mod h1:28OF6Y8s3NQWwacXc5eZTsEsiMzp7LF8MbXE+XJPdBE=
 github.com/djherbis/fscache v0.10.2-0.20220222230828-2909c950912d h1:eAikRiT337jlFa/NSKGb7K0uoP8/cana3EXzIDyFI6E=
 github.com/djherbis/fscache v0.10.2-0.20220222230828-2909c950912d/go.mod h1:+uJNKpxCg52qVRGr+srICjiY8QvV0riatTzCGMUuSEY=
 github.com/djherbis/stream v1.4.0 h1:aVD46WZUiq5kJk55yxJAyw6Kuera6kmC3i2vEQyW/AE=
 github.com/djherbis/stream v1.4.0/go.mod h1:cqjC1ZRq3FFwkGmUtHwcldbnW8f0Q4YuVsGW1eAFtOk=
-github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
-github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
+github.com/djherbis/times v1.6.0 h1:w2ctJ92J8fBvWPxugmXIv7Nz7Q3iDMKNx9v5ocVH20c=
+github.com/djherbis/times v1.6.0/go.mod h1:gOHeRAz2h+VJNZ5Gmc/o7iD9k4wW7NMVqieYCY99oc0=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -82,12 +82,12 @@ github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086 h1:ORubSQoKnncsBnR4zD9
 github.com/dhowden/tag v0.0.0-20220618230019-adf36e896086/go.mod h1:Z3Lomva4pyMWYezjMAU5QWRh0p1VvO4199OHlFnyKkM=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
-github.com/djherbis/atime v1.1.0 h1:rgwVbP/5by8BvvjBNrbh64Qz33idKT3pSnMSJsxhi0g=
-github.com/djherbis/atime v1.1.0/go.mod h1:28OF6Y8s3NQWwacXc5eZTsEsiMzp7LF8MbXE+XJPdBE=
 github.com/djherbis/fscache v0.10.2-0.20220222230828-2909c950912d h1:eAikRiT337jlFa/NSKGb7K0uoP8/cana3EXzIDyFI6E=
 github.com/djherbis/fscache v0.10.2-0.20220222230828-2909c950912d/go.mod h1:+uJNKpxCg52qVRGr+srICjiY8QvV0riatTzCGMUuSEY=
 github.com/djherbis/stream v1.4.0 h1:aVD46WZUiq5kJk55yxJAyw6Kuera6kmC3i2vEQyW/AE=
 github.com/djherbis/stream v1.4.0/go.mod h1:cqjC1ZRq3FFwkGmUtHwcldbnW8f0Q4YuVsGW1eAFtOk=
+github.com/djherbis/times v1.5.0 h1:79myA211VwPhFTqUk8xehWrsEO+zcIZj0zT8mXPVARU=
+github.com/djherbis/times v1.5.0/go.mod h1:5q7FDLvbNg1L/KaBmPcWlVR9NmoKo3+ucqUA3ijQhA0=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/go.sum
+++ b/go.sum
@@ -556,6 +556,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220712014510-0a85c31ab51e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/scanner/mapping.go
+++ b/scanner/mapping.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/deluan/sanitize"
 	"github.com/navidrome/navidrome/conf"

--- a/scanner/mapping.go
+++ b/scanner/mapping.go
@@ -76,7 +76,7 @@ func (s mediaFileMapper) toMediaFile(md metadata.Tags) model.MediaFile {
 	mf.Comment = utils.SanitizeText(md.Comment())
 	mf.Lyrics = utils.SanitizeText(md.Lyrics())
 	mf.Bpm = md.Bpm()
-	mf.CreatedAt = time.Now()
+	mf.CreatedAt = md.BirthTime()
 	mf.UpdatedAt = md.ModificationTime()
 
 	return *mf

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -150,12 +150,12 @@ func (t Tags) Size() int64                 { return t.fileInfo.Size() }
 func (t Tags) FilePath() string            { return t.filePath }
 func (t Tags) Suffix() string              { return strings.ToLower(strings.TrimPrefix(path.Ext(t.filePath), ".")) }
 func (t Tags) BirthTime() time.Time {
-	times, _ := times.Stat(t.filePath)
-	if !times.HasBirthTime() {
+	fileProperties, err := times.Stat(t.filePath)
+	if !fileProperties.HasBirthTime() || err != nil {
 		return time.Now()
 	}
 
-	return times.BirthTime()
+	return fileProperties.BirthTime()
 }
 
 // Replaygain Properties

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/djherbis/times"
 	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
@@ -148,7 +149,14 @@ func (t Tags) ModificationTime() time.Time { return t.fileInfo.ModTime() }
 func (t Tags) Size() int64                 { return t.fileInfo.Size() }
 func (t Tags) FilePath() string            { return t.filePath }
 func (t Tags) Suffix() string              { return strings.ToLower(strings.TrimPrefix(path.Ext(t.filePath), ".")) }
-
+func (t Tags) BirthTime() time.Time {
+	times, _ := times.Stat(t.filePath)
+	if times.HasBirthTime() {
+		return times.BirthTime()
+	} else {
+		return time.Now()
+	}
+}
 // Replaygain Properties
 func (t Tags) RGAlbumGain() float64 { return t.getGainValue("replaygain_album_gain") }
 func (t Tags) RGAlbumPeak() float64 { return t.getPeakValue("replaygain_album_peak") }

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -151,7 +151,7 @@ func (t Tags) FilePath() string            { return t.filePath }
 func (t Tags) Suffix() string              { return strings.ToLower(strings.TrimPrefix(path.Ext(t.filePath), ".")) }
 func (t Tags) BirthTime() time.Time {
 	fileProperties, err := times.Stat(t.filePath)
-	if !fileProperties.HasBirthTime() || err != nil {
+	if err != nil || !fileProperties.HasBirthTime() != nil {
 		return time.Now()
 	}
 

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -150,12 +150,10 @@ func (t Tags) Size() int64                 { return t.fileInfo.Size() }
 func (t Tags) FilePath() string            { return t.filePath }
 func (t Tags) Suffix() string              { return strings.ToLower(strings.TrimPrefix(path.Ext(t.filePath), ".")) }
 func (t Tags) BirthTime() time.Time {
-	fileProperties, err := times.Stat(t.filePath)
-	if err != nil || !fileProperties.HasBirthTime() {
-		return time.Now()
+	if ts := times.Get(t.fileInfo); ts.HasBirthTime() {
+		return ts.BirthTime()
 	}
-
-	return fileProperties.BirthTime()
+	return time.Now()
 }
 
 // Replaygain Properties

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -151,7 +151,7 @@ func (t Tags) FilePath() string            { return t.filePath }
 func (t Tags) Suffix() string              { return strings.ToLower(strings.TrimPrefix(path.Ext(t.filePath), ".")) }
 func (t Tags) BirthTime() time.Time {
 	fileProperties, err := times.Stat(t.filePath)
-	if err != nil || !fileProperties.HasBirthTime() != nil {
+	if err != nil || !fileProperties.HasBirthTime() {
 		return time.Now()
 	}
 

--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -151,12 +151,13 @@ func (t Tags) FilePath() string            { return t.filePath }
 func (t Tags) Suffix() string              { return strings.ToLower(strings.TrimPrefix(path.Ext(t.filePath), ".")) }
 func (t Tags) BirthTime() time.Time {
 	times, _ := times.Stat(t.filePath)
-	if times.HasBirthTime() {
-		return times.BirthTime()
-	} else {
+	if !times.HasBirthTime() {
 		return time.Now()
 	}
+
+	return times.BirthTime()
 }
+
 // Replaygain Properties
 func (t Tags) RGAlbumGain() float64 { return t.getGainValue("replaygain_album_gain") }
 func (t Tags) RGAlbumPeak() float64 { return t.getPeakValue("replaygain_album_peak") }

--- a/utils/cache/spread_fs.go
+++ b/utils/cache/spread_fs.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/djherbis/atime"
 	"github.com/djherbis/fscache"
 	"github.com/djherbis/stream"
-	"github.com/djherbis/times"
 	"github.com/navidrome/navidrome/log"
 )
 
@@ -88,8 +88,7 @@ func (sfs *spreadFS) Stat(name string) (fscache.FileInfo, error) {
 	if err != nil {
 		return fscache.FileInfo{}, err
 	}
-	times, _ := times.Stat(name)
-	return fscache.FileInfo{FileInfo: stat, Atime: times.AccessTime()}, nil
+	return fscache.FileInfo{FileInfo: stat, Atime: atime.Get(stat)}, nil
 }
 
 func (sfs *spreadFS) RemoveAll() error {

--- a/utils/cache/spread_fs.go
+++ b/utils/cache/spread_fs.go
@@ -8,9 +8,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/djherbis/atime"
 	"github.com/djherbis/fscache"
 	"github.com/djherbis/stream"
+	"github.com/djherbis/times"
 	"github.com/navidrome/navidrome/log"
 )
 
@@ -88,7 +88,8 @@ func (sfs *spreadFS) Stat(name string) (fscache.FileInfo, error) {
 	if err != nil {
 		return fscache.FileInfo{}, err
 	}
-	return fscache.FileInfo{FileInfo: stat, Atime: atime.Get(stat)}, nil
+	times, _ := times.Stat(name)
+	return fscache.FileInfo{FileInfo: stat, Atime: times.AccessTime()}, nil
 }
 
 func (sfs *spreadFS) RemoveAll() error {


### PR DESCRIPTION
Linux support for btime in [djherbis/times](https://github.com/djherbis/times) has just been merged: https://github.com/djherbis/times/pull/13 . So we can now implement btime on all platforms, and finally close https://github.com/navidrome/navidrome/issues/1350

Behaviour is very simple: use `btime` for Date Added, if there is no `btime` (for example on ext2 volumes), then it falls back to `time.Now()`, like Navidrome currently does.

edit: 1.6.0 of the `times` package has now been released, tests work, so ready to go