### PR TITLE
Jukebox cleanup

### DIFF
--- a/core/playback/device.go
+++ b/core/playback/device.go
@@ -24,7 +24,6 @@ type PlaybackDevice struct {
 	Default              bool
 	User                 string
 	Name                 string
-	Method               string
 	DeviceName           string
 	PlaybackQueue        *Queue
 	Gain                 float32
@@ -60,12 +59,11 @@ func (pd *PlaybackDevice) getStatus() DeviceStatus {
 // NewPlaybackDevice creates a new playback device which implements all the basic Jukebox mode commands defined here:
 // http://www.subsonic.org/pages/api.jsp#jukeboxControl
 // Starts the trackSwitcher goroutine for the device.
-func NewPlaybackDevice(playbackServer PlaybackServer, name string, method string, deviceName string) *PlaybackDevice {
+func NewPlaybackDevice(playbackServer PlaybackServer, name string, deviceName string) *PlaybackDevice {
 	return &PlaybackDevice{
 		ParentPlaybackServer: playbackServer,
 		User:                 "",
 		Name:                 name,
-		Method:               method,
 		DeviceName:           deviceName,
 		Gain:                 DefaultGain,
 		PlaybackQueue:        NewQueue(),
@@ -278,7 +276,7 @@ func (pd *PlaybackDevice) switchActiveTrackByIndex(index int) error {
 		return fmt.Errorf("could not get current track")
 	}
 
-	track, err := mpv.NewTrack(pd.PlaybackDone, *currentTrack)
+	track, err := mpv.NewTrack(pd.PlaybackDone, pd.DeviceName, *currentTrack)
 	if err != nil {
 		return err
 	}

--- a/core/playback/device.go
+++ b/core/playback/device.go
@@ -146,12 +146,12 @@ func (pd *PlaybackDevice) Skip(ctx context.Context, index int, offset int) (Devi
 		pd.ActiveTrack.Pause()
 	}
 
-	if index != pd.PlaybackQueue.Index {
-		if pd.ActiveTrack != nil {
-			pd.ActiveTrack.Close()
-			pd.ActiveTrack = nil
-		}
+	if index != pd.PlaybackQueue.Index && pd.ActiveTrack != nil {
+		pd.ActiveTrack.Close()
+		pd.ActiveTrack = nil
+	}
 
+	if pd.ActiveTrack == nil {
 		err := pd.switchActiveTrackByIndex(index)
 		if err != nil {
 			return pd.getStatus(), err

--- a/core/playback/mpv/mpv.go
+++ b/core/playback/mpv/mpv.go
@@ -110,7 +110,7 @@ func fixCmd(cmd string) string {
 func mpvCommand() (string, error) {
 	mpvOnce.Do(func() {
 		if conf.Server.MPVPath != "" {
-			mpvPath = conf.Server.FFmpegPath
+			mpvPath = conf.Server.MPVPath
 			mpvPath, mpvErr = exec.LookPath(mpvPath)
 		} else {
 			mpvPath, mpvErr = exec.LookPath("mpv")

--- a/core/playback/mpv/mpv.go
+++ b/core/playback/mpv/mpv.go
@@ -19,7 +19,7 @@ import (
 
 // mpv --no-audio-display --pause 'Jack Johnson/On And On/01 Times Like These.m4a' --input-ipc-server=/tmp/gonzo.socket
 const (
-	mpvComdTemplate = "mpv --no-audio-display --pause %f --input-ipc-server=%s"
+	mpvComdTemplate = "mpv --audio-device=%d --no-audio-display --pause %f --input-ipc-server=%s"
 )
 
 func start(args []string) (Executor, error) {
@@ -81,9 +81,10 @@ func (j *Executor) wait() {
 }
 
 // Path will always be an absolute path
-func createMPVCommand(cmd, filename string, socketName string) []string {
+func createMPVCommand(cmd, deviceName string, filename string, socketName string) []string {
 	split := strings.Split(fixCmd(cmd), " ")
 	for i, s := range split {
+		s = strings.ReplaceAll(s, "%d", deviceName)
 		s = strings.ReplaceAll(s, "%f", filename)
 		s = strings.ReplaceAll(s, "%s", socketName)
 		split[i] = s

--- a/core/playback/mpv/track.go
+++ b/core/playback/mpv/track.go
@@ -24,7 +24,7 @@ type MpvTrack struct {
 	CloseCalled   bool
 }
 
-func NewTrack(playbackDoneChannel chan bool, mf model.MediaFile) (*MpvTrack, error) {
+func NewTrack(playbackDoneChannel chan bool, deviceName string, mf model.MediaFile) (*MpvTrack, error) {
 	log.Debug("loading track", "trackname", mf.Path, "mediatype", mf.ContentType())
 
 	if _, err := mpvCommand(); err != nil {
@@ -33,7 +33,7 @@ func NewTrack(playbackDoneChannel chan bool, mf model.MediaFile) (*MpvTrack, err
 
 	tmpSocketName := TempFileName("mpv-ctrl-", ".socket")
 
-	args := createMPVCommand(mpvComdTemplate, mf.Path, tmpSocketName)
+	args := createMPVCommand(mpvComdTemplate, deviceName, mf.Path, tmpSocketName)
 	exe, err := start(args)
 	if err != nil {
 		log.Error("error starting mpv process", "error", err)


### PR DESCRIPTION
This PR fixes a bug and a typo and aligns the configuration file syntax with mpv's audio device syntax.

Here's an example:

```
# Enable/Disable Jukebox mode
Jukebox.Enabled = true

# List of registered devices, syntax:
#  "symbolic name " - Symbolic name to be used in UI's
#  "device" - mpv audio device name, do mpv --audio-device=help to get a list

Jukebox.Devices = [
    # "symbolic name " "device"
    [ "internal",     "coreaudio/BuiltInSpeakerDevice" ],
    [ "dac",          "coreaudio/AppleUSBAudioEngine:Cambridge Audio :Cambridge Audio USB Audio 1.0:0000:1" ]
]

# Device to use for Jukebox mode, if there are multiple entries above.
# Using device "auto" if missing
Jukebox.Default = "dac"
```