### PR TITLE
[bugfix]: coalesce genre to null for smart playlist

### DIFF
--- a/model/criteria/criteria_test.go
+++ b/model/criteria/criteria_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Criteria", func() {
 				All{
 					StartsWith{"comment": "this"},
 					InTheRange{"year": []int{1980, 1990}},
+					IsNot{"genre": "test"},
 				},
 			},
 			Sort:   "title",
@@ -43,7 +44,8 @@ var _ = Describe("Criteria", func() {
 		},
 		{ "all": [
 				{ "startsWith": {"comment": "this"} },
-				{ "inTheRange": {"year":[1980,1990]} }
+				{ "inTheRange": {"year":[1980,1990]} },
+				{ "isNot": { "genre": "test" }}
 			]
 		}
 	],
@@ -62,8 +64,8 @@ var _ = Describe("Criteria", func() {
 	It("generates valid SQL", func() {
 		sql, args, err := goObj.ToSql()
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		gomega.Expect(sql).To(gomega.Equal("(media_file.title LIKE ? AND media_file.title NOT LIKE ? AND (media_file.artist <> ? OR media_file.album = ?) AND (media_file.comment LIKE ? AND (media_file.year >= ? AND media_file.year <= ?)))"))
-		gomega.Expect(args).To(gomega.ConsistOf("%love%", "%hate%", "u2", "best of", "this%", 1980, 1990))
+		gomega.Expect(sql).To(gomega.Equal("(media_file.title LIKE ? AND media_file.title NOT LIKE ? AND (media_file.artist <> ? OR media_file.album = ?) AND (media_file.comment LIKE ? AND (media_file.year >= ? AND media_file.year <= ?) AND COALESCE(genre.name, '') <> ?))"))
+		gomega.Expect(args).To(gomega.ConsistOf("%love%", "%hate%", "u2", "best of", "this%", 1980, 1990, "test"))
 	})
 
 	It("marshals to JSON", func() {

--- a/model/criteria/fields.go
+++ b/model/criteria/fields.go
@@ -40,7 +40,7 @@ var fieldMap = map[string]*mappedField{
 	"bitrate":         {field: "media_file.bit_rate"},
 	"bpm":             {field: "media_file.bpm"},
 	"channels":        {field: "media_file.channels"},
-	"genre":           {field: "genre.name"},
+	"genre":           {field: "COALESCE(genre.name, '')"},
 	"loved":           {field: "COALESCE(annotation.starred, false)"},
 	"dateloved":       {field: "annotation.starred_at"},
 	"lastplayed":      {field: "annotation.play_date"},


### PR DESCRIPTION
Currently, if a track does not have a genre, adding a genre filter will cause the track to be ignored (null comparison). This PR converts null to empty string.