### PR TITLE
make scanner.albumID() a generic function

### DIFF
--- a/scanner/mapping.go
+++ b/scanner/mapping.go
@@ -134,7 +134,7 @@ func (s mediaFileMapper) albumID(values ...string) string {
 	var albumPath = strings.Builder{}
 	for _, value := range values {
 		if value != "" {
-			fmt.Fprintf(&albumPath, "//%s", value)
+			fmt.Fprintf(&albumPath, "\\%s", value)
 		}
 	}
 	return fmt.Sprintf("%x", md5.Sum([]byte(albumPath.String())))


### PR DESCRIPTION
- make albumID() a generic function
- in toMediaFile(), generate mf.AlbumID last so it can use any metadata field populated earlier

Makes it clearer what fields are used to disambiguate albums