### PR TITLE
Fix ld warnings on taglib_wrapper.

### DIFF
--- a/scanner/metadata/taglib/taglib_wrapper.go
+++ b/scanner/metadata/taglib/taglib_wrapper.go
@@ -2,7 +2,6 @@ package taglib
 
 /*
 #cgo pkg-config: taglib
-#cgo !illumos LDFLAGS: -lstdc++
 #cgo illumos LDFLAGS: -lstdc++ -lsendfile
 #cgo linux darwin CXXFLAGS: -std=c++11
 #include <stdio.h>


### PR DESCRIPTION
Fix the `ld: warning: ignoring duplicate libraries` warning message when building and testing.