### PR TITLE
Add new PreferSortTags option

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -51,6 +51,7 @@ type configOptions struct {
 	DefaultDownsamplingFormat    string
 	SearchFullString             bool
 	RecentlyAddedByModTime       bool
+	PreferSortTags               bool
 	IgnoredArticles              string
 	IndexGroups                  string
 	SubsonicArtistParticipations bool
@@ -296,6 +297,7 @@ func init() {
 	viper.SetDefault("defaultdownsamplingformat", consts.DefaultDownsamplingFormat)
 	viper.SetDefault("searchfullstring", false)
 	viper.SetDefault("recentlyaddedbymodtime", false)
+	viper.SetDefault("prefersorttags", false)
 	viper.SetDefault("ignoredarticles", "The El La Los Las Le Les Os As O A")
 	viper.SetDefault("indexgroups", "A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ) [Unknown]([)")
 	viper.SetDefault("subsonicartistparticipations", false)

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -50,13 +50,6 @@ func NewAlbumRepository(ctx context.Context, db dbx.Builder) model.AlbumReposito
 	r.ctx = ctx
 	r.db = db
 	r.tableName = "album"
-	r.sortMappings = map[string]string{
-		"name":           "order_album_name asc, order_album_artist_name asc",
-		"artist":         "compilation asc, order_album_artist_name asc, order_album_name asc",
-		"random":         "RANDOM()",
-		"max_year":       "coalesce(nullif(original_date,''), cast(max_year as text)), release_date, name, order_album_name asc",
-		"recently_added": recentlyAddedSort(),
-	}
 	r.filterMappings = map[string]filterFunc{
 		"id":              idFilter(r.tableName),
 		"name":            fullTextFilter,
@@ -66,6 +59,21 @@ func NewAlbumRepository(ctx context.Context, db dbx.Builder) model.AlbumReposito
 		"recently_played": recentlyPlayedFilter,
 		"starred":         booleanFilter,
 		"has_rating":      hasRatingFilter,
+	}
+	r.sortMappings = map[string]string{
+		"name":           "order_album_name asc, order_album_artist_name asc",
+		"artist":         "compilation asc, order_album_artist_name asc, order_album_name asc",
+		"random":         "RANDOM()",
+		"max_year":       "coalesce(nullif(original_date,''), cast(max_year as text)), release_date, name, order_album_name asc",
+		"recently_added": recentlyAddedSort(),
+	}
+	if conf.Server.PreferSortTags {
+		r.sortMappings = map[string]string{
+			"name":        "COALESCE(NULLIF(sort_album_name,''),order_album_name)",
+			"artist":      "compilation asc, COALESCE(NULLIF(sort_album_artist_name,''),order_album_artist_name) asc, COALESCE(NULLIF(sort_album_name,''),order_album_name) asc",
+			"albumArtist": "compilation asc, COALESCE(NULLIF(sort_album_artist_name,''),order_album_artist_name) asc, COALESCE(NULLIF(sort_album_name,''),order_album_name) asc",
+			"max_year":    "coalesce(nullif(original_date,''), cast(max_year as text)), release_date, name, COALESCE(NULLIF(sort_album_name,''),order_album_name) asc",
+		}
 	}
 
 	return r

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -60,13 +60,19 @@ func NewArtistRepository(ctx context.Context, db dbx.Builder) model.ArtistReposi
 	r.db = db
 	r.indexGroups = utils.ParseIndexGroups(conf.Server.IndexGroups)
 	r.tableName = "artist"
-	r.sortMappings = map[string]string{
-		"name": "order_artist_name",
-	}
 	r.filterMappings = map[string]filterFunc{
 		"id":      idFilter(r.tableName),
 		"name":    fullTextFilter,
 		"starred": booleanFilter,
+	}
+	if conf.Server.PreferSortTags {
+		r.sortMappings = map[string]string{
+			"name": "COALESCE(NULLIF(sort_artist_name,''),order_artist_name)",
+		}
+	} else {
+		r.sortMappings = map[string]string{
+			"name": "order_artist_name",
+		}
 	}
 	return r
 }

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/pocketbase/dbx"
@@ -25,15 +26,22 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) *mediaFileRepos
 	r.ctx = ctx
 	r.db = db
 	r.tableName = "media_file"
+	r.filterMappings = map[string]filterFunc{
+		"id":      idFilter(r.tableName),
+		"title":   fullTextFilter,
+		"starred": booleanFilter,
+	}
 	r.sortMappings = map[string]string{
 		"artist": "order_artist_name asc, order_album_name asc, release_date asc, disc_number asc, track_number asc",
 		"album":  "order_album_name asc, release_date asc, disc_number asc, track_number asc, order_artist_name asc, title asc",
 		"random": "RANDOM()",
 	}
-	r.filterMappings = map[string]filterFunc{
-		"id":      idFilter(r.tableName),
-		"title":   fullTextFilter,
-		"starred": booleanFilter,
+	if conf.Server.PreferSortTags {
+		r.sortMappings = map[string]string{
+			"title":  "COALESCE(NULLIF(sort_title,''),title)",
+			"artist": "COALESCE(NULLIF(sort_artist_name,''),order_artist_name) asc, COALESCE(NULLIF(sort_album_name,''),order_album_name) asc, release_date asc, disc_number asc, track_number asc",
+			"album":  "COALESCE(NULLIF(sort_album_name,''),order_album_name) asc, release_date asc, disc_number asc, track_number asc, COALESCE(NULLIF(sort_artist_name,''),order_artist_name) asc, COALESCE(NULLIF(sort_title,''),title) asc",
+		}
 	}
 	return r
 }


### PR DESCRIPTION
Fixes #643

Navidrome traditionally sort albums, artists and songs by using the name/title tag and removing the articles from the prefix (Ex: "The Beatles" => "Beatles"). See the [IgnoredArticles](https://www.navidrome.org/docs/usage/configuration-options/#:~:text=Empty%20(disabled)-,IgnoredArticles,-ND_IGNOREDARTICLES) config option.

This PR introduces a new `PreferSortTags` (`ND_PREFERSORTTAGS`), `false` by default. If set to true, Navidrome will try to use any sort tag (sorttitle, sortalbumname, sortartistname) if found, if not it falls back to the previous behaviour. 

This flag does not require a full scan.

@certuna, I'd like your opinion on this. Please let me know what you think.