### PR TITLE
[bugfix]: allow reverse proxy auth for unix socket

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -193,7 +193,7 @@ func UsernameFromToken(r *http.Request) string {
 }
 
 func UsernameFromReverseProxyHeader(r *http.Request) string {
-	if conf.Server.ReverseProxyWhitelist == "" {
+	if conf.Server.ReverseProxyWhitelist == "" && !strings.HasPrefix(conf.Server.Address, "unix:") {
 		return ""
 	}
 	if !validateIPAgainstList(r.RemoteAddr, conf.Server.ReverseProxyWhitelist) {
@@ -316,6 +316,12 @@ func handleLoginFromHeaders(ds model.DataStore, r *http.Request) map[string]inte
 }
 
 func validateIPAgainstList(ip string, comaSeparatedList string) bool {
+	// Per https://github.com/golang/go/issues/49825, the remote address
+	// on a unix socket is '@'
+	if ip == "@" && strings.HasPrefix(conf.Server.Address, "unix:") {
+		return true
+	}
+
 	if comaSeparatedList == "" || ip == "" {
 		return false
 	}


### PR DESCRIPTION
`remoteAddr` returns `@` when listening on a UNIX socket, which breaks reverse proxy auth. This PR allows `@` on `unix:` path to go through