### PR TITLE
Fix album image_files being null.

### DIFF
--- a/db/migration/20240122223340_fix_null_image_files.go
+++ b/db/migration/20240122223340_fix_null_image_files.go
@@ -1,0 +1,28 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(Up20240122223340, Down20240122223340)
+}
+
+func Up20240122223340(ctx context.Context, tx *sql.Tx) error {
+	// This code is executed when the migration is applied.
+	_, err := tx.Exec(`
+	alter table album add image_files_new varchar not null default '';
+	update album set image_files_new = image_files where image_files is not null;
+	alter table album drop image_files;
+	alter table album rename image_files_new to image_files;
+`)
+	return err
+}
+
+func Down20240122223340(ctx context.Context, tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+	return nil
+}

--- a/db/migration/20240122223340_fix_null_image_files.go
+++ b/db/migration/20240122223340_fix_null_image_files.go
@@ -12,7 +12,6 @@ func init() {
 }
 
 func Up20240122223340(ctx context.Context, tx *sql.Tx) error {
-	// This code is executed when the migration is applied.
 	_, err := tx.Exec(`
 	alter table album add image_files_new varchar not null default '';
 	update album set image_files_new = image_files where image_files is not null;
@@ -23,6 +22,5 @@ func Up20240122223340(ctx context.Context, tx *sql.Tx) error {
 }
 
 func Down20240122223340(ctx context.Context, tx *sql.Tx) error {
-	// This code is executed when the migration is rolled back.
 	return nil
 }

--- a/db/migration/20240122223340_fix_null_image_files.go
+++ b/db/migration/20240122223340_fix_null_image_files.go
@@ -12,7 +12,7 @@ func init() {
 }
 
 func Up20240122223340(ctx context.Context, tx *sql.Tx) error {
-	_, err := tx.Exec(`
+	_, err := tx.ExecContext(ctx, `
 	alter table album add image_files_new varchar not null default '';
 	update album set image_files_new = image_files where image_files is not null;
 	alter table album drop image_files;
@@ -21,6 +21,6 @@ func Up20240122223340(ctx context.Context, tx *sql.Tx) error {
 	return err
 }
 
-func Down20240122223340(ctx context.Context, tx *sql.Tx) error {
+func Down20240122223340(context.Context, *sql.Tx) error {
 	return nil
 }


### PR DESCRIPTION
Fix #2806 

This makes image_files be an empty string by default, which stops the `converting NULL to string is unsupported` from occurring. 