### PR TITLE
Fix fields not being sent on getPlaylist responses.

### DIFF
--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -345,11 +345,11 @@ func (r *playlistRepository) refreshCounters(pls *model.Playlist) error {
 func (r *playlistRepository) loadTracks(sel SelectBuilder, id string) (model.PlaylistTracks, error) {
 	tracksQuery := sel.
 		Columns(
-			"coalesce(starred, 0)",
+			"coalesce(starred, 0) as starred",
 			"starred_at",
-			"coalesce(play_count, 0)",
+			"coalesce(play_count, 0) as play_count",
 			"play_date",
-			"coalesce(rating, 0)",
+			"coalesce(rating, 0) as rating",
 			"f.*",
 			"playlist_tracks.*",
 		).

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -51,9 +51,9 @@ func (r *playlistTrackRepository) Read(id string) (interface{}, error) {
 			" AND annotation.item_type = 'media_file'"+
 			" AND annotation.user_id = '"+userId(r.ctx)+"')").
 		Columns(
-			"coalesce(starred, 0)",
-			"coalesce(play_count, 0)",
-			"coalesce(rating, 0)",
+			"coalesce(starred, 0) as starred",
+			"coalesce(play_count, 0) as play_count",
+			"coalesce(rating, 0) as rating",
 			"starred_at",
 			"play_date",
 			"f.*",


### PR DESCRIPTION
Resolves #2816 

As @flyingOwl reported in his issue, some information was no longer being displayed on subsonic clients. This is due to the switch from orm to dbx that was made in 0ca0d5da228a5c2810c6103185891272ade1cdbf.

This fix makes sure that the rows affected have the correct names.