### PR TITLE
[bugfix]: set rating to 0 when value is null

### DIFF
--- a/ui/src/common/RatingField.js
+++ b/ui/src/common/RatingField.js
@@ -38,7 +38,7 @@ export const RatingField = ({
 
   const handleRating = useCallback(
     (e, val) => {
-      rate(val, e.target.name)
+      rate(val ?? 0, e.target.name)
     },
     [rate],
   )


### PR DESCRIPTION
The value can either be a number or `null` (when selecting the same rating). Convert null to 0 because the backend doesn't accept null.