### PR TITLE
Show rating field in player toolbar

### DIFF
--- a/ui/src/audioplayer/PlayerToolbar.js
+++ b/ui/src/audioplayer/PlayerToolbar.js
@@ -1,14 +1,15 @@
 import React, { useCallback } from 'react'
 import { useGetOne } from 'react-admin'
 import { GlobalHotKeys } from 'react-hotkeys'
-import { LoveButton, useToggleLove } from '../common'
+import { LoveButton, useToggleLove, RatingField, useRating } from '../common'
 import { keyMap } from '../hotkeys'
 
 const Placeholder = () => <LoveButton disabled={true} resource={'song'} />
 
 const Toolbar = ({ id }) => {
   const { data, loading } = useGetOne('song', id)
-  const [toggleLove, toggling] = useToggleLove('song', data)
+  const [toggleLove, togglingLove] = useToggleLove('song', data)
+  const [, , loadingRating] = useRating('song', data)
 
   const handlers = {
     TOGGLE_LOVE: useCallback(() => toggleLove(), [toggleLove]),
@@ -17,10 +18,15 @@ const Toolbar = ({ id }) => {
   return (
     <>
       <GlobalHotKeys keyMap={keyMap} handlers={handlers} allowChanges />
+      <RatingField
+        record={data}
+        resource={'song'}
+        disabled={loading || loadingRating}
+      />
       <LoveButton
         record={data}
         resource={'song'}
-        disabled={loading || toggling}
+        disabled={loading || togglingLove}
       />
     </>
   )

--- a/ui/src/common/RatingField.js
+++ b/ui/src/common/RatingField.js
@@ -6,6 +6,7 @@ import StarBorderIcon from '@material-ui/icons/StarBorder'
 import clsx from 'clsx'
 import { useRating } from './useRating'
 import { useRecordContext } from 'react-admin'
+import config from '../config'
 
 const useStyles = makeStyles({
   rating: {
@@ -43,6 +44,9 @@ export const RatingField = ({
     [rate],
   )
 
+  if (!config.enableStarRating) {
+    return <></>
+  }
   return (
     <span onClick={(e) => stopPropagation(e)}>
       <Rating


### PR DESCRIPTION
Closes #1494

## Description

The related issue is closed due to inactivity, but the reponses were positive.

It was mentioned that it should be 

> ... optionally switchable, since some of the users do not use the star rating function.

Here we respect the `EnableStarRating` config option, so the visibility of the stars are consistently shown or hidden.
This is already how the heart icons behave for favourite tracks (including throughout the UI with the `EnableFavourites` config option).

## Changes

- Show the star rating control on the 'Now Playing' toolbar
- Added a line in `RatingField` which hides it according to the `EnableFavourites` config option.
  - The ways which `RatingField` and `LoveButton` hide according to their config options doesn't seem to be consistent.
    I think this is the best way, to mirror the behaviour of `LoveButton`.
    Perhaps the visibility of `RatingField` can be refactored.

## Screenshots

![image](https://github.com/navidrome/navidrome/assets/3299161/b961bd2a-dc9c-4464-97c1-36dd486bb00d)

## Related Issues and Pull Requests

While writing this PR I realised this is related to PR #2510 (still open) and discussion #2488.
In that PR, there is a new UI option which chooses whether to show the star ratings or the favourite toggle.
Maybe having a per-user config option is a good idea, but it doesn't allow both controls to be shown together.

I have no problem if this PR is closed in favour of that one, but I would still like to address allowing both controls to be shown together.