### PR TITLE
[enhancement]: Support fetching lyrics from filesystem

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -529,7 +529,7 @@ func init() {
 	viper.SetDefault("inspect.backloglimit", consts.RequestThrottleBacklogLimit)
 	viper.SetDefault("inspect.backlogtimeout", consts.RequestThrottleBacklogTimeout)
 
-	viper.SetDefault("lyricspriority", "embedded,.lrc,.txt")
+	viper.SetDefault("lyricspriority", ".lrc,.txt,embedded")
 
 	// DevFlags. These are used to enable/disable debugging and incomplete features
 	viper.SetDefault("devlogsourceline", false)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -93,6 +93,7 @@ type configOptions struct {
 	PID                             pidOptions
 	Inspect                         inspectOptions
 	Subsonic                        subsonicOptions
+	LyricsPriority                  string
 
 	Agents       string
 	LastFM       lastfmOptions
@@ -527,6 +528,8 @@ func init() {
 	viper.SetDefault("inspect.maxrequests", 1)
 	viper.SetDefault("inspect.backloglimit", consts.RequestThrottleBacklogLimit)
 	viper.SetDefault("inspect.backlogtimeout", consts.RequestThrottleBacklogTimeout)
+
+	viper.SetDefault("lyricspriority", "embedded,.lrc,.txt")
 
 	// DevFlags. These are used to enable/disable debugging and incomplete features
 	viper.SetDefault("devlogsourceline", false)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -55,7 +55,6 @@ const (
 
 	ArtistInfoTimeToLive      = 24 * time.Hour
 	AlbumInfoTimeToLive       = 7 * 24 * time.Hour
-	LyricsInfoTimeToLive      = 24 * time.Hour
 	UpdateLastAccessFrequency = time.Minute
 	UpdatePlayerFrequency     = time.Minute
 

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -55,6 +55,7 @@ const (
 
 	ArtistInfoTimeToLive      = 24 * time.Hour
 	AlbumInfoTimeToLive       = 7 * 24 * time.Hour
+	LyricsInfoTimeToLive      = 24 * time.Hour
 	UpdateLastAccessFrequency = time.Minute
 	UpdatePlayerFrequency     = time.Minute
 

--- a/core/lyrics/lyrics.go
+++ b/core/lyrics/lyrics.go
@@ -1,0 +1,35 @@
+package lyrics
+
+import (
+	"context"
+	"strings"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+)
+
+func GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error) {
+	var lyricsList model.LyricList
+	var err error
+
+	for pattern := range strings.SplitSeq(strings.ToLower(conf.Server.LyricsPriority), ",") {
+		pattern = strings.TrimSpace(pattern)
+		switch {
+		case pattern == "embedded":
+			lyricsList, err = fromEmbedded(mf)
+		case strings.HasPrefix(pattern, "."):
+			lyricsList, err = fromExternalFile(mf, pattern)
+		default:
+			log.Error(ctx, "Invalid lyric pattern", "pattern", pattern)
+		}
+
+		if err != nil {
+			return nil, err
+		} else if len(lyricsList) > 0 {
+			return lyricsList, nil
+		}
+	}
+
+	return nil, nil
+}

--- a/core/lyrics/lyrics.go
+++ b/core/lyrics/lyrics.go
@@ -17,14 +17,15 @@ func GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error
 		pattern = strings.TrimSpace(pattern)
 		switch {
 		case pattern == "embedded":
-			lyricsList, err = fromEmbedded(mf)
+			lyricsList, err = fromEmbedded(ctx, mf)
 		case strings.HasPrefix(pattern, "."):
-			lyricsList, err = fromExternalFile(mf, pattern)
+			lyricsList, err = fromExternalFile(ctx, mf, pattern)
 		default:
 			log.Error(ctx, "Invalid lyric pattern", "pattern", pattern)
 		}
 
 		if err != nil {
+			log.Error(ctx, "error parsing lyrics", "source", pattern, err)
 			return nil, err
 		}
 

--- a/core/lyrics/lyrics.go
+++ b/core/lyrics/lyrics.go
@@ -26,7 +26,6 @@ func GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error
 
 		if err != nil {
 			log.Error(ctx, "error parsing lyrics", "source", pattern, err)
-			return nil, err
 		}
 
 		if len(lyricsList) > 0 {

--- a/core/lyrics/lyrics.go
+++ b/core/lyrics/lyrics.go
@@ -26,7 +26,9 @@ func GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error
 
 		if err != nil {
 			return nil, err
-		} else if len(lyricsList) > 0 {
+		}
+
+		if len(lyricsList) > 0 {
 			return lyricsList, nil
 		}
 	}

--- a/core/lyrics/lyrics_suite_test.go
+++ b/core/lyrics/lyrics_suite_test.go
@@ -1,0 +1,17 @@
+package lyrics_test
+
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLyrics(t *testing.T) {
+	tests.Init(t, false)
+	log.SetLevel(log.LevelFatal)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Lyrics Suite")
+}

--- a/core/lyrics/lyrics_test.go
+++ b/core/lyrics/lyrics_test.go
@@ -1,0 +1,80 @@
+package lyrics_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/core/lyrics"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/gg"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sources", func() {
+	var mf model.MediaFile
+	var ctx context.Context
+
+	const badLyrics = "This is a set of lyrics\nThat is not good"
+	unsynced, _ := model.ToLyrics("xxx", badLyrics)
+	embeddedLyrics := model.LyricList{*unsynced}
+
+	syncedLyrics := model.LyricList{
+		model.Lyrics{
+			DisplayArtist: "Rick Astley",
+			DisplayTitle:  "That one song",
+			Lang:          "eng",
+			Line: []model.Line{
+				{
+					Start: gg.P(int64(18800)),
+					Value: "We're no strangers to love",
+				},
+				{
+					Start: gg.P(int64(22801)),
+					Value: "You know the rules and so do I",
+				},
+			},
+			Offset: gg.P(int64(-100)),
+			Synced: true,
+		},
+	}
+
+	unsyncedLyrics := model.LyricList{
+		model.Lyrics{
+			Lang: "xxx",
+			Line: []model.Line{
+				{
+					Value: "We're no strangers to love",
+				},
+				{
+					Value: "You know the rules and so do I",
+				},
+			},
+			Synced: false,
+		},
+	}
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+
+		lyricsJson, _ := json.Marshal(embeddedLyrics)
+
+		mf = model.MediaFile{
+			Lyrics: string(lyricsJson),
+			Path:   "tests/fixtures/test.mp3",
+		}
+		ctx = context.Background()
+	})
+
+	DescribeTable("Lyrics Priority", func(priority string, expected model.LyricList) {
+		conf.Server.LyricsPriority = priority
+		list, err := lyrics.GetLyrics(ctx, &mf)
+		Expect(err).To(BeNil())
+		Expect(list).To(Equal(expected))
+	},
+		Entry("embedded > lrc > txt", "embedded,.lrc,.txt", embeddedLyrics),
+		Entry("lrc > embedded > txt", ".lrc,embedded,.txt", syncedLyrics),
+		Entry("txt > lrc > embedded", ".txt,.lrc,embedded", unsyncedLyrics))
+})

--- a/core/lyrics/lyrics_test.go
+++ b/core/lyrics/lyrics_test.go
@@ -3,11 +3,13 @@ package lyrics_test
 import (
 	"context"
 	"encoding/json"
+	"os"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core/lyrics"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/gg"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -77,4 +79,46 @@ var _ = Describe("sources", func() {
 		Entry("embedded > lrc > txt", "embedded,.lrc,.txt", embeddedLyrics),
 		Entry("lrc > embedded > txt", ".lrc,embedded,.txt", syncedLyrics),
 		Entry("txt > lrc > embedded", ".txt,.lrc,embedded", unsyncedLyrics))
+
+	Context("Errors", func() {
+		var RegularUserContext = XContext
+		var isRegularUser = os.Getuid() != 0
+		if isRegularUser {
+			RegularUserContext = Context
+		}
+
+		RegularUserContext("run without root permissions", func() {
+			var accessForbiddenFile string
+
+			BeforeEach(func() {
+				accessForbiddenFile = utils.TempFileName("access_forbidden-", ".mp3")
+
+				f, err := os.OpenFile(accessForbiddenFile, os.O_WRONLY|os.O_CREATE, 0222)
+				Expect(err).ToNot(HaveOccurred())
+
+				mf.Path = accessForbiddenFile
+
+				DeferCleanup(func() {
+					Expect(f.Close()).To(Succeed())
+					Expect(os.Remove(accessForbiddenFile)).To(Succeed())
+				})
+			})
+
+			It("should fallback to embedded if an error happens when parsing file", func() {
+				conf.Server.LyricsPriority = ".mp3,embedded"
+
+				list, err := lyrics.GetLyrics(ctx, &mf)
+				Expect(err).To(BeNil())
+				Expect(list).To(Equal(embeddedLyrics))
+			})
+
+			It("should return nothing if error happens when trying to parse file", func() {
+				conf.Server.LyricsPriority = ".mp3"
+
+				list, err := lyrics.GetLyrics(ctx, &mf)
+				Expect(err).To(BeNil())
+				Expect(list).To(BeEmpty())
+			})
+		})
+	})
 })

--- a/core/lyrics/sources.go
+++ b/core/lyrics/sources.go
@@ -1,0 +1,41 @@
+package lyrics
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+func fromEmbedded(mf *model.MediaFile) (model.LyricList, error) {
+	if mf.Lyrics != "" {
+		return mf.StructuredLyrics()
+	}
+
+	return nil, nil
+}
+
+func fromExternalFile(mf *model.MediaFile, suffix string) (model.LyricList, error) {
+	basePath := mf.AbsolutePath()
+	ext := filepath.Ext(basePath)
+
+	externalLyric := basePath[0:len(basePath)-len(ext)] + suffix
+
+	contents, err := os.ReadFile(externalLyric)
+
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	lyrics, err := model.ToLyrics("xxx", string(contents))
+	if err != nil {
+		return nil, err
+	} else if lyrics == nil {
+		return nil, nil
+	}
+
+	return model.LyricList{*lyrics}, nil
+}

--- a/core/lyrics/sources.go
+++ b/core/lyrics/sources.go
@@ -1,22 +1,27 @@
 package lyrics
 
 import (
+	"context"
 	"errors"
 	"os"
 	"path"
 
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 )
 
-func fromEmbedded(mf *model.MediaFile) (model.LyricList, error) {
+func fromEmbedded(ctx context.Context, mf *model.MediaFile) (model.LyricList, error) {
 	if mf.Lyrics != "" {
+		log.Trace(ctx, "embedded lyrics found in file", "title", mf.Title)
 		return mf.StructuredLyrics()
 	}
+
+	log.Trace(ctx, "no embedded lyrics for file", "path", mf.Title)
 
 	return nil, nil
 }
 
-func fromExternalFile(mf *model.MediaFile, suffix string) (model.LyricList, error) {
+func fromExternalFile(ctx context.Context, mf *model.MediaFile, suffix string) (model.LyricList, error) {
 	basePath := mf.AbsolutePath()
 	ext := path.Ext(basePath)
 
@@ -25,6 +30,7 @@ func fromExternalFile(mf *model.MediaFile, suffix string) (model.LyricList, erro
 	contents, err := os.ReadFile(externalLyric)
 
 	if errors.Is(err, os.ErrNotExist) {
+		log.Trace(ctx, "no lyrics found at path", "path", externalLyric)
 		return nil, nil
 	} else if err != nil {
 		return nil, err
@@ -32,10 +38,14 @@ func fromExternalFile(mf *model.MediaFile, suffix string) (model.LyricList, erro
 
 	lyrics, err := model.ToLyrics("xxx", string(contents))
 	if err != nil {
+		log.Error(ctx, "error parsing lyric external file", "path", externalLyric, err)
 		return nil, err
 	} else if lyrics == nil {
+		log.Trace(ctx, "empty lyrics from external file", "path", externalLyric)
 		return nil, nil
 	}
+
+	log.Trace(ctx, "retrieved lyrics from external file", "path", externalLyric)
 
 	return model.LyricList{*lyrics}, nil
 }

--- a/core/lyrics/sources.go
+++ b/core/lyrics/sources.go
@@ -3,7 +3,7 @@ package lyrics
 import (
 	"errors"
 	"os"
-	"path/filepath"
+	"path"
 
 	"github.com/navidrome/navidrome/model"
 )
@@ -18,7 +18,7 @@ func fromEmbedded(mf *model.MediaFile) (model.LyricList, error) {
 
 func fromExternalFile(mf *model.MediaFile, suffix string) (model.LyricList, error) {
 	basePath := mf.AbsolutePath()
-	ext := filepath.Ext(basePath)
+	ext := path.Ext(basePath)
 
 	externalLyric := basePath[0:len(basePath)-len(ext)] + suffix
 

--- a/core/lyrics/sources_test.go
+++ b/core/lyrics/sources_test.go
@@ -1,6 +1,7 @@
 package lyrics
 
 import (
+	"context"
 	"encoding/json"
 
 	"github.com/navidrome/navidrome/model"
@@ -10,10 +11,12 @@ import (
 )
 
 var _ = Describe("sources", func() {
+	ctx := context.Background()
+
 	Describe("fromEmbedded", func() {
 		It("should return nothing for a media file with no lyrics", func() {
 			mf := model.MediaFile{}
-			lyrics, err := fromEmbedded(&mf)
+			lyrics, err := fromEmbedded(ctx, &mf)
 
 			Expect(err).To(BeNil())
 			Expect(lyrics).To(HaveLen(0))
@@ -35,7 +38,7 @@ var _ = Describe("sources", func() {
 				Lyrics: string(lyricsJson),
 			}
 
-			lyrics, err := fromEmbedded(&mf)
+			lyrics, err := fromEmbedded(ctx, &mf)
 			Expect(err).To(BeNil())
 			Expect(lyrics).ToNot(BeNil())
 			Expect(lyrics).To(Equal(expectedList))
@@ -43,7 +46,7 @@ var _ = Describe("sources", func() {
 
 		It("should return an error if somehow the JSON is bad", func() {
 			mf := model.MediaFile{Lyrics: "["}
-			lyrics, err := fromEmbedded(&mf)
+			lyrics, err := fromEmbedded(ctx, &mf)
 
 			Expect(lyrics).To(HaveLen(0))
 			Expect(err).ToNot(BeNil())
@@ -53,7 +56,7 @@ var _ = Describe("sources", func() {
 	Describe("fromExternalFile", func() {
 		It("should return nil for lyrics that don't exist", func() {
 			mf := model.MediaFile{Path: "tests/fixtures/01 Invisible (RED) Edit Version.mp3"}
-			lyrics, err := fromExternalFile(&mf, ".lrc")
+			lyrics, err := fromExternalFile(ctx, &mf, ".lrc")
 
 			Expect(err).To(BeNil())
 			Expect(lyrics).To(HaveLen(0))
@@ -61,7 +64,7 @@ var _ = Describe("sources", func() {
 
 		It("should return synchronized lyrics from a file", func() {
 			mf := model.MediaFile{Path: "tests/fixtures/test.mp3"}
-			lyrics, err := fromExternalFile(&mf, ".lrc")
+			lyrics, err := fromExternalFile(ctx, &mf, ".lrc")
 
 			Expect(err).To(BeNil())
 			Expect(lyrics).To(Equal(model.LyricList{
@@ -87,7 +90,7 @@ var _ = Describe("sources", func() {
 
 		It("should return unsynchronized lyrics from a file", func() {
 			mf := model.MediaFile{Path: "tests/fixtures/test.mp3"}
-			lyrics, err := fromExternalFile(&mf, ".txt")
+			lyrics, err := fromExternalFile(ctx, &mf, ".txt")
 
 			Expect(err).To(BeNil())
 			Expect(lyrics).To(Equal(model.LyricList{

--- a/core/lyrics/sources_test.go
+++ b/core/lyrics/sources_test.go
@@ -1,0 +1,109 @@
+package lyrics
+
+import (
+	"encoding/json"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/gg"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("sources", func() {
+	Describe("fromEmbedded", func() {
+		It("should return nothing for a media file with no lyrics", func() {
+			mf := model.MediaFile{}
+			lyrics, err := fromEmbedded(&mf)
+
+			Expect(err).To(BeNil())
+			Expect(lyrics).To(HaveLen(0))
+		})
+
+		It("should return lyrics for a media file with well-formatted lyrics", func() {
+			const syncedLyrics = "[00:18.80]We're no strangers to love\n[00:22.801]You know the rules and so do I"
+			const unsyncedLyrics = "We're no strangers to love\nYou know the rules and so do I"
+
+			synced, _ := model.ToLyrics("eng", syncedLyrics)
+			unsynced, _ := model.ToLyrics("xxx", unsyncedLyrics)
+
+			expectedList := model.LyricList{*synced, *unsynced}
+			lyricsJson, err := json.Marshal(expectedList)
+
+			Expect(err).ToNot(HaveOccurred())
+
+			mf := model.MediaFile{
+				Lyrics: string(lyricsJson),
+			}
+
+			lyrics, err := fromEmbedded(&mf)
+			Expect(err).To(BeNil())
+			Expect(lyrics).ToNot(BeNil())
+			Expect(lyrics).To(Equal(expectedList))
+		})
+
+		It("should return an error if somehow the JSON is bad", func() {
+			mf := model.MediaFile{Lyrics: "["}
+			lyrics, err := fromEmbedded(&mf)
+
+			Expect(lyrics).To(HaveLen(0))
+			Expect(err).ToNot(BeNil())
+		})
+	})
+
+	Describe("fromExternalFile", func() {
+		It("should return nil for lyrics that don't exist", func() {
+			mf := model.MediaFile{Path: "tests/fixtures/01 Invisible (RED) Edit Version.mp3"}
+			lyrics, err := fromExternalFile(&mf, ".lrc")
+
+			Expect(err).To(BeNil())
+			Expect(lyrics).To(HaveLen(0))
+		})
+
+		It("should return synchronized lyrics from a file", func() {
+			mf := model.MediaFile{Path: "tests/fixtures/test.mp3"}
+			lyrics, err := fromExternalFile(&mf, ".lrc")
+
+			Expect(err).To(BeNil())
+			Expect(lyrics).To(Equal(model.LyricList{
+				model.Lyrics{
+					DisplayArtist: "Rick Astley",
+					DisplayTitle:  "That one song",
+					Lang:          "eng",
+					Line: []model.Line{
+						{
+							Start: gg.P(int64(18800)),
+							Value: "We're no strangers to love",
+						},
+						{
+							Start: gg.P(int64(22801)),
+							Value: "You know the rules and so do I",
+						},
+					},
+					Offset: gg.P(int64(-100)),
+					Synced: true,
+				},
+			}))
+		})
+
+		It("should return unsynchronized lyrics from a file", func() {
+			mf := model.MediaFile{Path: "tests/fixtures/test.mp3"}
+			lyrics, err := fromExternalFile(&mf, ".txt")
+
+			Expect(err).To(BeNil())
+			Expect(lyrics).To(Equal(model.LyricList{
+				model.Lyrics{
+					Lang: "xxx",
+					Line: []model.Line{
+						{
+							Value: "We're no strangers to love",
+						},
+						{
+							Value: "You know the rules and so do I",
+						},
+					},
+					Synced: false,
+				},
+			}))
+		})
+	})
+})

--- a/model/lyrics.go
+++ b/model/lyrics.go
@@ -32,7 +32,7 @@ var (
 	// Should either be at the beginning of file, or beginning of line
 	syncRegex  = regexp.MustCompile(`(^|\n)\s*` + timeRegexString)
 	timeRegex  = regexp.MustCompile(timeRegexString)
-	lrcIdRegex = regexp.MustCompile(`\[(ar|ti|offset):([^]]+)]`)
+	lrcIdRegex = regexp.MustCompile(`\[(ar|ti|offset|lang):([^]]+)]`)
 )
 
 func (l Lyrics) IsEmpty() bool {
@@ -72,6 +72,8 @@ func ToLyrics(language, text string) (*Lyrics, error) {
 				switch idTag[1] {
 				case "ar":
 					artist = str.SanitizeText(strings.TrimSpace(idTag[2]))
+				case "lang":
+					language = str.SanitizeText(strings.TrimSpace(idTag[2]))
 				case "offset":
 					{
 						off, err := strconv.ParseInt(strings.TrimSpace(idTag[2]), 10, 64)

--- a/model/lyrics_test.go
+++ b/model/lyrics_test.go
@@ -9,8 +9,9 @@ import (
 var _ = Describe("ToLyrics", func() {
 	It("should parse tags with spaces", func() {
 		num := int64(1551)
-		lyrics, err := ToLyrics("xxx", "[offset: 1551 ]\n[ti: A title ]\n[ar: An artist ]\n[00:00.00]Hi there")
+		lyrics, err := ToLyrics("xxx", "[lang:  eng  ]\n[offset: 1551 ]\n[ti: A title ]\n[ar: An artist ]\n[00:00.00]Hi there")
 		Expect(err).ToNot(HaveOccurred())
+		Expect(lyrics.Lang).To(Equal("eng"))
 		Expect(lyrics.Synced).To(BeTrue())
 		Expect(lyrics.DisplayArtist).To(Equal("An artist"))
 		Expect(lyrics.DisplayTitle).To(Equal("A title"))

--- a/server/subsonic/api_suite_test.go
+++ b/server/subsonic/api_suite_test.go
@@ -4,11 +4,13 @@ import (
 	"testing"
 
 	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 func TestSubsonicApi(t *testing.T) {
+	tests.Init(t, false)
 	log.SetLevel(log.LevelFatal)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Subsonic API Suite")

--- a/server/subsonic/filter/filters.go
+++ b/server/subsonic/filter/filters.go
@@ -108,12 +108,12 @@ func SongsByRandom(genre string, fromYear, toYear int) Options {
 	return addDefaultFilters(options)
 }
 
-func SongWithLyrics(artist, title string) Options {
+func SongWithArtistTitle(artist, title string) Options {
 	return addDefaultFilters(Options{
 		Sort:    "updated_at",
 		Order:   "desc",
 		Max:     1,
-		Filters: And{Eq{"artist": artist, "title": title}, NotEq{"lyrics": ""}},
+		Filters: And{Eq{"artist": artist, "title": title}},
 	})
 }
 

--- a/server/subsonic/media_retrieval.go
+++ b/server/subsonic/media_retrieval.go
@@ -110,7 +110,9 @@ func (api *Router) GetLyrics(r *http.Request) (*responses.Subsonic, error) {
 	structuredLyrics, err := lyrics.GetLyrics(r.Context(), &mediaFiles[0])
 	if err != nil {
 		return nil, err
-	} else if len(structuredLyrics) == 0 {
+	}
+
+	if len(structuredLyrics) == 0 {
 		return response, nil
 	}
 

--- a/server/subsonic/media_retrieval.go
+++ b/server/subsonic/media_retrieval.go
@@ -13,6 +13,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/resources"
+	"github.com/navidrome/navidrome/server/subsonic/filter"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
 	"github.com/navidrome/navidrome/utils/gravatar"
 	"github.com/navidrome/navidrome/utils/req"
@@ -97,7 +98,7 @@ func (api *Router) GetLyrics(r *http.Request) (*responses.Subsonic, error) {
 	response := newResponse()
 	lyricsResponse := responses.Lyrics{}
 	response.Lyrics = &lyricsResponse
-	mediaFiles, err := api.ds.MediaFile(r.Context()).GetAll()
+	mediaFiles, err := api.ds.MediaFile(r.Context()).GetAll(filter.SongWithArtistTitle(artist, title))
 
 	if err != nil {
 		return nil, err

--- a/server/subsonic/media_retrieval_test.go
+++ b/server/subsonic/media_retrieval_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http/httptest"
 	"time"
 
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -32,6 +34,8 @@ var _ = Describe("MediaRetrievalController", func() {
 		artwork = &fakeArtwork{}
 		router = New(ds, artwork, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w = httptest.NewRecorder()
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.LyricsPriority = "embedded"
 	})
 
 	Describe("GetCoverArt", func() {

--- a/server/subsonic/media_retrieval_test.go
+++ b/server/subsonic/media_retrieval_test.go
@@ -35,7 +35,7 @@ var _ = Describe("MediaRetrievalController", func() {
 		router = New(ds, artwork, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w = httptest.NewRecorder()
 		DeferCleanup(configtest.SetupConfig())
-		conf.Server.LyricsPriority = "embedded"
+		conf.Server.LyricsPriority = "embedded,.lrc"
 	})
 
 	Describe("GetCoverArt", func() {
@@ -112,6 +112,22 @@ var _ = Describe("MediaRetrievalController", func() {
 			Expect(response.Lyrics.Artist).To(Equal(""))
 			Expect(response.Lyrics.Title).To(Equal(""))
 			Expect(response.Lyrics.Value).To(Equal(""))
+		})
+		It("should return lyric file when finding mediafile with no embedded lyrics but present on filesystem", func() {
+			r := newGetRequest("artist=Rick+Astley", "title=Never+Gonna+Give+You+Up")
+			mockRepo.SetData(model.MediaFiles{
+				{
+					Path:   "tests/fixtures/test.mp3",
+					ID:     "1",
+					Artist: "Rick Astley",
+					Title:  "Never Gonna Give You Up",
+				},
+			})
+			response, err := router.GetLyrics(r)
+			Expect(err).To(BeNil())
+			Expect(response.Lyrics.Artist).To(Equal("Rick Astley"))
+			Expect(response.Lyrics.Title).To(Equal("Never Gonna Give You Up"))
+			Expect(response.Lyrics.Value).To(Equal("We're no strangers to love\nYou know the rules and so do I\n"))
 		})
 	})
 

--- a/tests/fixtures/test.lrc
+++ b/tests/fixtures/test.lrc
@@ -1,0 +1,6 @@
+[ar:Rick Astley]
+[ti:That one song]
+[offset:-100]
+[lang:eng]
+[00:18.80]We're no strangers to love
+[00:22.801]You know the rules and so do I

--- a/tests/fixtures/test.txt
+++ b/tests/fixtures/test.txt
@@ -1,0 +1,2 @@
+We're no strangers to love
+You know the rules and so do I


### PR DESCRIPTION
~~- Adds LyricsRetriever interface to fetch lyircs from external source~~
~~- Adds external lyrics/updated at MediaFile (default caching of 1 month)~~
~~- Adds lrclib agent, which fetches from lrclib.net~~
~~- Updates local agent to read lyrics from track.txt/track.lrc~~

Support reading lyrics from filesystem using arbitrary file extensions (, e.g., `.lrc`, `.txt`) and `embedded` and configuring priority.
Other lyric fetchers to come from plugin
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for fetching lyrics from filesystem with configurable priority in `core/lyrics` and updates configuration and tests accordingly.
> 
>   - **Behavior**:
>     - Adds `GetLyrics()` in `core/lyrics/lyrics.go` to fetch lyrics based on priority from `embedded`, `.lrc`, and `.txt` files.
>     - Configurable priority for lyric sources via `LyricsPriority` in `conf/configuration.go`.
>     - Default priority set to `embedded,.lrc,.txt`.
>   - **Configuration**:
>     - Adds `LyricsPriority` to `configOptions` in `conf/configuration.go`.
>     - Sets default `lyricspriority` to `embedded,.lrc,.txt` in `init()`.
>   - **Tests**:
>     - Adds `lyrics_test.go` and `sources_test.go` in `core/lyrics` to test fetching lyrics from different sources.
>     - Updates `media_retrieval_test.go` to test lyrics retrieval via Subsonic API.
>   - **Misc**:
>     - Adds `.lrc` and `.txt` test files in `tests/fixtures/` for testing purposes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=navidrome%2Fnavidrome&utm_source=github&utm_medium=referral)<sup> for a25e18364cbb4852308412cfc7c83de8fb8824fc. You can [customize](https://app.ellipsis.dev/navidrome/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->