### PR TITLE
Fix Lastfm api config missing

### DIFF
--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -61,6 +61,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"defaultDownloadableShare":  conf.Server.DefaultDownloadableShare,
 			"devSidebarPlaylists":       conf.Server.DevSidebarPlaylists,
 			"lastFMEnabled":             conf.Server.LastFM.Enabled && conf.Server.LastFM.ApiKey != "" && conf.Server.LastFM.Secret != "",
+			"lastFMApiKey":              conf.Server.LastFM.ApiKey,
 			"devShowArtistPage":         conf.Server.DevShowArtistPage,
 			"listenBrainzEnabled":       conf.Server.ListenBrainz.Enabled,
 			"enableExternalServices":    conf.Server.EnableExternalServices,


### PR DESCRIPTION
I haven't tested this, but looks like in commit https://github.com/navidrome/navidrome/commit/1f71e567411103486fbc24f9820323283742bc4b the config for Lastfm api was accidently removed, which causes this line below to fail https://github.com/navidrome/navidrome/blob/859cdda0bdaa67cc92e8312c2be13f12cb89fddb/ui/src/authProvider.js#L24

~~I will try to build and test this in a bit.~~

fixes #2896