### PR TITLE
[enhancement]: OS expose release date for album, make original optional

### DIFF
--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -15,7 +15,6 @@ import (
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/public"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
-	"github.com/navidrome/navidrome/utils/gg"
 )
 
 func newResponse() *responses.Subsonic {
@@ -321,12 +320,8 @@ func buildAlbumID3(ctx context.Context, album model.Album) responses.AlbumID3 {
 	dir.MusicBrainzId = album.MbzAlbumID
 	dir.IsCompilation = album.Compilation
 	dir.SortName = album.SortAlbumName
-	if album.OriginalDate != "" {
-		dir.OriginalReleaseDate = gg.P(toItemDate(album.OriginalDate))
-	}
-	if album.ReleaseDate != "" {
-		dir.ReleaseDate = gg.P(toItemDate(album.ReleaseDate))
-	}
+	dir.OriginalReleaseDate = toItemDate(album.OriginalDate)
+	dir.ReleaseDate = toItemDate(album.ReleaseDate)
 	return dir
 }
 

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/public"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
+	"github.com/navidrome/navidrome/utils/gg"
 )
 
 func newResponse() *responses.Subsonic {
@@ -320,7 +321,12 @@ func buildAlbumID3(ctx context.Context, album model.Album) responses.AlbumID3 {
 	dir.MusicBrainzId = album.MbzAlbumID
 	dir.IsCompilation = album.Compilation
 	dir.SortName = album.SortAlbumName
-	dir.OriginalReleaseDate = toItemDate(album.OriginalDate)
+	if album.OriginalDate != "" {
+		dir.OriginalReleaseDate = gg.P(toItemDate(album.OriginalDate))
+	}
+	if album.ReleaseDate != "" {
+		dir.ReleaseDate = gg.P(toItemDate(album.ReleaseDate))
+	}
 	return dir
 }
 

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
@@ -36,6 +36,11 @@
       "month": 2,
       "day": 4
     },
+    "releaseDate": {
+      "year": 2000,
+      "month": 5,
+      "day": 10
+    },
     "song": [
       {
         "id": "1",

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .XML
@@ -5,6 +5,7 @@
     <discTitles disc="1" title="disc 1"></discTitles>
     <discTitles disc="2" title="disc 2"></discTitles>
     <originalReleaseDate year="1994" month="2" day="4"></originalReleaseDate>
+    <releaseDate year="2000" month="5" day="10"></releaseDate>
     <song id="1" isDir="true" title="title" album="album" artist="artist" track="1" year="1985" genre="Rock" coverArt="1" size="8421341" contentType="audio/flac" suffix="flac" starred="2016-03-02T20:30:00Z" transcodedContentType="audio/mpeg" transcodedSuffix="mp3" duration="146" bitRate="320" isVideo="false" bpm="127" comment="a comment" sortName="sorted song" mediaType="song" musicBrainzId="4321">
       <genres name="rock"></genres>
       <genres name="progressive"></genres>

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .JSON
@@ -12,6 +12,8 @@
     "musicBrainzId": "",
     "isCompilation": false,
     "sortName": "",
-    "discTitles": []
+    "discTitles": [],
+    "originalReleaseDate": {},
+    "releaseDate": {}
   }
 }

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .JSON
@@ -12,7 +12,6 @@
     "musicBrainzId": "",
     "isCompilation": false,
     "sortName": "",
-    "discTitles": [],
-    "originalReleaseDate": {}
+    "discTitles": []
   }
 }

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .XML
@@ -1,3 +1,6 @@
 <subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.8.0" type="navidrome" serverVersion="v0.0.0" openSubsonic="true">
-  <album id="" name="" userRating="0" musicBrainzId="" isCompilation="false" sortName=""></album>
+  <album id="" name="" userRating="0" musicBrainzId="" isCompilation="false" sortName="">
+    <originalReleaseDate></originalReleaseDate>
+    <releaseDate></releaseDate>
+  </album>
 </subsonic-response>

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .XML
@@ -1,5 +1,3 @@
 <subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.8.0" type="navidrome" serverVersion="v0.0.0" openSubsonic="true">
-  <album id="" name="" userRating="0" musicBrainzId="" isCompilation="false" sortName="">
-    <originalReleaseDate></originalReleaseDate>
-  </album>
+  <album id="" name="" userRating="0" musicBrainzId="" isCompilation="false" sortName=""></album>
 </subsonic-response>

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -231,8 +231,8 @@ type AlbumID3 struct {
 	IsCompilation       bool       `xml:"isCompilation,attr"    json:"isCompilation"`
 	SortName            string     `xml:"sortName,attr"         json:"sortName"`
 	DiscTitles          DiscTitles `xml:"discTitles"            json:"discTitles"`
-	OriginalReleaseDate ItemDate   `xml:"originalReleaseDate"   json:"originalReleaseDate,omitempty"`
-	ReleaseDate         ItemDate   `xml:"releaseDate" json:"releaseDate,omitempty"`
+	OriginalReleaseDate ItemDate   `xml:"originalReleaseDate"   json:"originalReleaseDate"`
+	ReleaseDate         ItemDate   `xml:"releaseDate"           json:"releaseDate"`
 }
 
 type ArtistWithAlbumsID3 struct {

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -231,7 +231,8 @@ type AlbumID3 struct {
 	IsCompilation       bool       `xml:"isCompilation,attr"    json:"isCompilation"`
 	SortName            string     `xml:"sortName,attr"         json:"sortName"`
 	DiscTitles          DiscTitles `xml:"discTitles"            json:"discTitles"`
-	OriginalReleaseDate ItemDate   `xml:"originalReleaseDate"   json:"originalReleaseDate"`
+	OriginalReleaseDate *ItemDate  `xml:"originalReleaseDate"   json:"originalReleaseDate,omitempty"`
+	ReleaseDate         *ItemDate  `xml:"releaseDate" json:"releaseDate,omitempty"`
 }
 
 type ArtistWithAlbumsID3 struct {

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -231,8 +231,8 @@ type AlbumID3 struct {
 	IsCompilation       bool       `xml:"isCompilation,attr"    json:"isCompilation"`
 	SortName            string     `xml:"sortName,attr"         json:"sortName"`
 	DiscTitles          DiscTitles `xml:"discTitles"            json:"discTitles"`
-	OriginalReleaseDate *ItemDate  `xml:"originalReleaseDate"   json:"originalReleaseDate,omitempty"`
-	ReleaseDate         *ItemDate  `xml:"releaseDate" json:"releaseDate,omitempty"`
+	OriginalReleaseDate ItemDate   `xml:"originalReleaseDate"   json:"originalReleaseDate,omitempty"`
+	ReleaseDate         ItemDate   `xml:"releaseDate" json:"releaseDate,omitempty"`
 }
 
 type ArtistWithAlbumsID3 struct {

--- a/server/subsonic/responses/responses_test.go
+++ b/server/subsonic/responses/responses_test.go
@@ -177,7 +177,8 @@ var _ = Describe("Responses", func() {
 					Genres:        []ItemGenre{{Name: "rock"}, {Name: "progressive"}},
 					MusicBrainzId: "1234", IsCompilation: true, SortName: "sorted album",
 					DiscTitles:          DiscTitles{{Disc: 1, Title: "disc 1"}, {Disc: 2, Title: "disc 2"}},
-					OriginalReleaseDate: ItemDate{Year: 1994, Month: 2, Day: 4},
+					OriginalReleaseDate: &ItemDate{Year: 1994, Month: 2, Day: 4},
+					ReleaseDate:         &ItemDate{Year: 2000, Month: 5, Day: 10},
 				}
 				t := time.Date(2016, 03, 2, 20, 30, 0, 0, time.UTC)
 				songs := []Child{{

--- a/server/subsonic/responses/responses_test.go
+++ b/server/subsonic/responses/responses_test.go
@@ -177,8 +177,8 @@ var _ = Describe("Responses", func() {
 					Genres:        []ItemGenre{{Name: "rock"}, {Name: "progressive"}},
 					MusicBrainzId: "1234", IsCompilation: true, SortName: "sorted album",
 					DiscTitles:          DiscTitles{{Disc: 1, Title: "disc 1"}, {Disc: 2, Title: "disc 2"}},
-					OriginalReleaseDate: &ItemDate{Year: 1994, Month: 2, Day: 4},
-					ReleaseDate:         &ItemDate{Year: 2000, Month: 5, Day: 10},
+					OriginalReleaseDate: ItemDate{Year: 1994, Month: 2, Day: 4},
+					ReleaseDate:         ItemDate{Year: 2000, Month: 5, Day: 10},
 				}
 				t := time.Date(2016, 03, 2, 20, 30, 0, 0, time.UTC)
 				songs := []Child{{


### PR DESCRIPTION
Formalizes support for https://github.com/opensubsonic/open-subsonic-api/pull/68. Also makes `originalReleaseDate` actually optional