### PR TITLE
Feat/lastfm use album artist

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -112,10 +112,11 @@ type scannerOptions struct {
 }
 
 type lastfmOptions struct {
-	Enabled  bool
-	ApiKey   string
-	Secret   string
-	Language string
+	Enabled        bool
+	ApiKey         string
+	Secret         string
+	Language       string
+	UseAlbumArtist bool
 }
 
 type spotifyOptions struct {
@@ -340,6 +341,7 @@ func init() {
 	viper.SetDefault("lastfm.language", "en")
 	viper.SetDefault("lastfm.apikey", "")
 	viper.SetDefault("lastfm.secret", "")
+	viper.SetDefault("lastfm.usealbumartist", false)
 	viper.SetDefault("spotify.id", "")
 	viper.SetDefault("spotify.secret", "")
 	viper.SetDefault("listenbrainz.enabled", true)

--- a/core/agents/lastfm/agent.go
+++ b/core/agents/lastfm/agent.go
@@ -28,27 +28,29 @@ var ignoredBiographies = []string{
 }
 
 type lastfmAgent struct {
-	ds          model.DataStore
-	sessionKeys *agents.SessionKeys
-	apiKey      string
-	secret      string
-	lang        string
-	client      *client
+	ds             model.DataStore
+	sessionKeys    *agents.SessionKeys
+	apiKey         string
+	secret         string
+	lang           string
+	useAlbumArtist bool
+	client         *client
 }
 
 func lastFMConstructor(ds model.DataStore) *lastfmAgent {
 	l := &lastfmAgent{
-		ds:          ds,
-		lang:        conf.Server.LastFM.Language,
-		apiKey:      conf.Server.LastFM.ApiKey,
-		secret:      conf.Server.LastFM.Secret,
-		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
+		ds:             ds,
+		lang:           conf.Server.LastFM.Language,
+		apiKey:         conf.Server.LastFM.ApiKey,
+		secret:         conf.Server.LastFM.Secret,
+		useAlbumArtist: conf.Server.LastFM.UseAlbumArtist,
+		sessionKeys:    &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 	}
 	hc := &http.Client{
 		Timeout: consts.DefaultHttpClientTimeOut,
 	}
 	chc := utils.NewCachedHTTPClient(hc, consts.DefaultHttpClientTimeOut)
-	l.client = newClient(l.apiKey, l.secret, l.lang, chc)
+	l.client = newClient(l.apiKey, l.secret, l.lang, l.useAlbumArtist, chc)
 	return l
 }
 

--- a/core/agents/lastfm/auth_router.go
+++ b/core/agents/lastfm/auth_router.go
@@ -44,7 +44,7 @@ func NewRouter(ds model.DataStore) *Router {
 	hc := &http.Client{
 		Timeout: consts.DefaultHttpClientTimeOut,
 	}
-	r.client = newClient(r.apiKey, r.secret, "en", hc)
+	r.client = newClient(r.apiKey, r.secret, "en", false, hc)
 	return r
 }
 

--- a/core/agents/lastfm/client_test.go
+++ b/core/agents/lastfm/client_test.go
@@ -22,7 +22,7 @@ var _ = Describe("client", func() {
 
 	BeforeEach(func() {
 		httpClient = &tests.FakeHttpClient{}
-		client = newClient("API_KEY", "SECRET", "pt", httpClient)
+		client = newClient("API_KEY", "SECRET", "pt", false, httpClient)
 	})
 
 	Describe("albumGetInfo", func() {


### PR DESCRIPTION
Adding a config to allow scrobble the `albumArtist` instead of `artist`. This is because some songs with various artists are being scrobbled wrongly.

Now (`artist` tag):
![Screenshot from 2024-03-14 08-54-20](https://github.com/navidrome/navidrome/assets/20695061/b8f0a4c9-852f-4fd2-ad33-297462083586)

With the `albumArtist`:
![Screenshot from 2024-03-14 08-53-34](https://github.com/navidrome/navidrome/assets/20695061/daa952fa-e6a5-4044-9756-98e56e4b24f1)

This change do not break anything. The default value for `UseAlbumArtist` is `false`.

Also, I dind't find where I can update these docs (https://www.navidrome.org/docs/usage/configuration-options/).
