### PR TITLE
Improves golangci-lint configuration and workflow

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -21,11 +21,11 @@ jobs:
         run: git config --global --add safe.directory $GITHUB_WORKSPACE;  git describe --dirty --always --tags
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v6
         with:
-          # TODO: revert to latest when this issue is resolved: https://github.com/golangci/golangci-lint/issues/4695
-          version: v1.57.2
+          version: latest
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          problem-matchers: true
           args: --timeout 2m
 
       - name: Install goimports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,3 @@
-run:
-  go: "1.20"
-
 linters:
   enable:
     - asasalint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,9 @@ linters:
     - unused
     - whitespace
 
-issues:
-  exclude-rules:
-    - linters:
-        - gosec
-      text: "(G501|G401|G505):"
+linters-settings:
+  gosec:
+    excludes:
+      - G501
+      - G401
+      - G505


### PR DESCRIPTION
- Update workflow
- use linter configuration instead of `exclude-rules`
- the default Go version is based on the `go.mod`
