### PR TITLE
fix: languageName for Persian

### DIFF
--- a/resources/i18n/fa.json
+++ b/resources/i18n/fa.json
@@ -1,5 +1,5 @@
 {
-    "languageName": "انگلیسی",
+    "languageName": "فارسی",
     "resources": {
         "song": {
             "name": "ترانه |||| ترانه ها",


### PR DESCRIPTION
The original "انگلیسی" is "English"