### PR TITLE
Recursively refresh playlist tracks within smart playlist rules

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -49,6 +49,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
+	SmartPlaylistRefreshTimeout     time.Duration
 	AutoTranscodeDownload           bool
 	DefaultDownsamplingFormat       string
 	SearchFullString                bool
@@ -302,6 +303,7 @@ func init() {
 	viper.SetDefault("autoimportplaylists", true)
 	viper.SetDefault("defaultplaylistpublicvisibility", false)
 	viper.SetDefault("playlistspath", consts.DefaultPlaylistsPath)
+	viper.SetDefault("smartplaylistrefreshtimeout", 5*time.Second)
 	viper.SetDefault("enabledownloads", true)
 	viper.SetDefault("enableexternalservices", true)
 	viper.SetDefault("enablemediafilecoverart", true)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -303,7 +303,7 @@ func init() {
 	viper.SetDefault("autoimportplaylists", true)
 	viper.SetDefault("defaultplaylistpublicvisibility", false)
 	viper.SetDefault("playlistspath", consts.DefaultPlaylistsPath)
-	viper.SetDefault("smartPlaylistRefreshDelay", 1*time.Minute)
+	viper.SetDefault("smartPlaylistRefreshDelay", 5*time.Second)
 	viper.SetDefault("enabledownloads", true)
 	viper.SetDefault("enableexternalservices", true)
 	viper.SetDefault("enablemediafilecoverart", true)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -49,7 +49,7 @@ type configOptions struct {
 	AutoImportPlaylists             bool
 	DefaultPlaylistPublicVisibility bool
 	PlaylistsPath                   string
-	SmartPlaylistRefreshTimeout     time.Duration
+	SmartPlaylistRefreshDelay       time.Duration
 	AutoTranscodeDownload           bool
 	DefaultDownsamplingFormat       string
 	SearchFullString                bool
@@ -303,7 +303,7 @@ func init() {
 	viper.SetDefault("autoimportplaylists", true)
 	viper.SetDefault("defaultplaylistpublicvisibility", false)
 	viper.SetDefault("playlistspath", consts.DefaultPlaylistsPath)
-	viper.SetDefault("smartplaylistrefreshtimeout", 5*time.Second)
+	viper.SetDefault("smartPlaylistRefreshDelay", 1*time.Minute)
 	viper.SetDefault("enabledownloads", true)
 	viper.SetDefault("enableexternalservices", true)
 	viper.SetDefault("enablemediafilecoverart", true)

--- a/model/criteria/criteria.go
+++ b/model/criteria/criteria.go
@@ -50,6 +50,21 @@ func (c Criteria) ToSql() (sql string, args []interface{}, err error) {
 	return c.Expression.ToSql()
 }
 
+func (c Criteria) ChildPlaylistIds() (ids []string) {
+	if c.Expression == nil {
+		return ids
+	}
+
+	switch rules := c.Expression.(type) {
+	case Any:
+		ids = rules.ChildPlaylistIds()
+	case All:
+		ids = rules.ChildPlaylistIds()
+	}
+
+	return ids
+}
+
 func (c Criteria) MarshalJSON() ([]byte, error) {
 	aux := struct {
 		All    []Expression `json:"all,omitempty"`

--- a/model/criteria/criteria_test.go
+++ b/model/criteria/criteria_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 )
@@ -89,4 +90,94 @@ var _ = Describe("Criteria", func() {
 		gomega.Expect(newObj.OrderBy()).To(gomega.Equal("random() asc"))
 	})
 
+	It("extracts all child smart playlist IDs from All expression criteria", func() {
+		topLevelInPlaylistID := uuid.NewString()
+		topLevelNotInPlaylistID := uuid.NewString()
+
+		nestedAnyInPlaylistID := uuid.NewString()
+		nestedAnyNotInPlaylistID := uuid.NewString()
+
+		nestedAllInPlaylistID := uuid.NewString()
+		nestedAllNotInPlaylistID := uuid.NewString()
+
+		goObj := Criteria{
+			Expression: All{
+				InPlaylist{"id": topLevelInPlaylistID},
+				NotInPlaylist{"id": topLevelNotInPlaylistID},
+				Any{
+					InPlaylist{"id": nestedAnyInPlaylistID},
+					NotInPlaylist{"id": nestedAnyNotInPlaylistID},
+				},
+				All{
+					InPlaylist{"id": nestedAllInPlaylistID},
+					NotInPlaylist{"id": nestedAllNotInPlaylistID},
+				},
+			},
+		}
+
+		ids := goObj.ChildPlaylistIds()
+
+		gomega.Expect(ids).To(gomega.ConsistOf(topLevelInPlaylistID, topLevelNotInPlaylistID, nestedAnyInPlaylistID, nestedAnyNotInPlaylistID, nestedAllInPlaylistID, nestedAllNotInPlaylistID))
+	})
+
+	It("extracts all child smart playlist IDs from Any expression criteria", func() {
+		topLevelInPlaylistID := uuid.NewString()
+		topLevelNotInPlaylistID := uuid.NewString()
+
+		nestedAnyInPlaylistID := uuid.NewString()
+		nestedAnyNotInPlaylistID := uuid.NewString()
+
+		nestedAllInPlaylistID := uuid.NewString()
+		nestedAllNotInPlaylistID := uuid.NewString()
+
+		goObj := Criteria{
+			Expression: Any{
+				InPlaylist{"id": topLevelInPlaylistID},
+				NotInPlaylist{"id": topLevelNotInPlaylistID},
+				Any{
+					InPlaylist{"id": nestedAnyInPlaylistID},
+					NotInPlaylist{"id": nestedAnyNotInPlaylistID},
+				},
+				All{
+					InPlaylist{"id": nestedAllInPlaylistID},
+					NotInPlaylist{"id": nestedAllNotInPlaylistID},
+				},
+			},
+		}
+
+		ids := goObj.ChildPlaylistIds()
+
+		gomega.Expect(ids).To(gomega.ConsistOf(topLevelInPlaylistID, topLevelNotInPlaylistID, nestedAnyInPlaylistID, nestedAnyNotInPlaylistID, nestedAllInPlaylistID, nestedAllNotInPlaylistID))
+	})
+
+	It("extracts child smart playlist IDs from deeply nested expression", func() {
+		nestedAnyInPlaylistID := uuid.NewString()
+		nestedAnyNotInPlaylistID := uuid.NewString()
+
+		nestedAllInPlaylistID := uuid.NewString()
+		nestedAllNotInPlaylistID := uuid.NewString()
+
+		goObj := Criteria{
+			Expression: Any{
+				Any{
+					All{
+						Any{
+							InPlaylist{"id": nestedAnyInPlaylistID},
+							NotInPlaylist{"id": nestedAnyNotInPlaylistID},
+							Any{
+								All{
+									InPlaylist{"id": nestedAllInPlaylistID},
+									NotInPlaylist{"id": nestedAllNotInPlaylistID},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		ids := goObj.ChildPlaylistIds()
+
+		gomega.Expect(ids).To(gomega.ConsistOf(nestedAnyInPlaylistID, nestedAnyNotInPlaylistID, nestedAllInPlaylistID, nestedAllNotInPlaylistID))
+	})
 })

--- a/model/criteria/operators.go
+++ b/model/criteria/operators.go
@@ -23,6 +23,10 @@ func (all All) MarshalJSON() ([]byte, error) {
 	return marshalConjunction("all", all)
 }
 
+func (all All) ChildPlaylistIds() (ids []string) {
+	return extractPlaylistIds(all, ids)
+}
+
 type (
 	Any squirrel.Or
 	Or  = Any
@@ -34,6 +38,10 @@ func (any Any) ToSql() (sql string, args []interface{}, err error) {
 
 func (any Any) MarshalJSON() ([]byte, error) {
 	return marshalConjunction("any", any)
+}
+
+func (any Any) ChildPlaylistIds() (ids []string) {
+	return extractPlaylistIds(any, ids)
 }
 
 type Is squirrel.Eq
@@ -274,4 +282,30 @@ func inList(m map[string]interface{}, negate bool) (sql string, args []interface
 	} else {
 		return "media_file.id IN (" + subQText + ")", subQArgs, nil
 	}
+}
+
+func extractPlaylistIds(inputRule interface{}, ids []string) []string {
+	var id string
+	var ok bool
+
+	switch rule := inputRule.(type) {
+	case Any:
+		for _, rules := range rule {
+			ids = extractPlaylistIds(rules, ids)
+		}
+	case All:
+		for _, rules := range rule {
+			ids = extractPlaylistIds(rules, ids)
+		}
+	case InPlaylist:
+		if id, ok = rule["id"].(string); ok {
+			ids = append(ids, id)
+		}
+	case NotInPlaylist:
+		if id, ok = rule["id"].(string); ok {
+			ids = append(ids, id)
+		}
+	}
+
+	return ids
 }

--- a/model/criteria/operators.go
+++ b/model/criteria/operators.go
@@ -24,7 +24,7 @@ func (all All) MarshalJSON() ([]byte, error) {
 }
 
 func (all All) ChildPlaylistIds() (ids []string) {
-	return extractPlaylistIds(all, ids)
+	return extractPlaylistIds(all)
 }
 
 type (
@@ -41,7 +41,7 @@ func (any Any) MarshalJSON() ([]byte, error) {
 }
 
 func (any Any) ChildPlaylistIds() (ids []string) {
-	return extractPlaylistIds(any, ids)
+	return extractPlaylistIds(any)
 }
 
 type Is squirrel.Eq
@@ -284,18 +284,18 @@ func inList(m map[string]interface{}, negate bool) (sql string, args []interface
 	}
 }
 
-func extractPlaylistIds(inputRule interface{}, ids []string) []string {
+func extractPlaylistIds(inputRule interface{}) (ids []string) {
 	var id string
 	var ok bool
 
 	switch rule := inputRule.(type) {
 	case Any:
 		for _, rules := range rule {
-			ids = extractPlaylistIds(rules, ids)
+			ids = append(ids, extractPlaylistIds(rules)...)
 		}
 	case All:
 		for _, rules := range rule {
-			ids = extractPlaylistIds(rules, ids)
+			ids = append(ids, extractPlaylistIds(rules)...)
 		}
 	case InPlaylist:
 		if id, ok = rule["id"].(string); ok {
@@ -307,5 +307,5 @@ func extractPlaylistIds(inputRule interface{}, ids []string) []string {
 		}
 	}
 
-	return ids
+	return
 }

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
@@ -198,8 +199,8 @@ func (r *playlistRepository) selectPlaylist(options ...model.QueryOptions) Selec
 }
 
 func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
-	// Only refresh if it is a smart playlist and was not refreshed in the last 5 seconds
-	if !pls.IsSmartPlaylist() || (pls.EvaluatedAt != nil && time.Since(*pls.EvaluatedAt) < 5*time.Second) {
+	// Only refresh if it is a smart playlist and was not refreshed within the interval provided by the refresh timeout config
+	if !pls.IsSmartPlaylist() || (pls.EvaluatedAt != nil && time.Since(*pls.EvaluatedAt) < conf.Server.SmartPlaylistRefreshTimeout) {
 		return false
 	}
 

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -199,8 +199,8 @@ func (r *playlistRepository) selectPlaylist(options ...model.QueryOptions) Selec
 }
 
 func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
-	// Only refresh if it is a smart playlist and was not refreshed within the interval provided by the refresh timeout config
-	if !pls.IsSmartPlaylist() || (pls.EvaluatedAt != nil && time.Since(*pls.EvaluatedAt) < conf.Server.SmartPlaylistRefreshTimeout) {
+	// Only refresh if it is a smart playlist and was not refreshed within the interval provided by the refresh delay config
+	if !pls.IsSmartPlaylist() || (pls.EvaluatedAt != nil && time.Since(*pls.EvaluatedAt) < conf.Server.SmartPlaylistRefreshDelay) {
 		return false
 	}
 


### PR DESCRIPTION
Fixes #3017 

This PR ensure that when a smart playlist is refreshed, the playlists used in its rules also have their tracks refreshed first.

This is my first time diving into the Navidrome codebase and using the Go language, so if there is anything I need to do to improve the code here please let me know and I'll be happy to fix it up!