### PR TITLE
fix bug in jukebox: property unavailable

### DIFF
--- a/core/playback/mpv/track.go
+++ b/core/playback/mpv/track.go
@@ -150,7 +150,8 @@ func (t *MpvTrack) Position() int {
 			if retryCount > 5 {
 				return 0
 			}
-			break
+			time.Sleep(time.Duration(retryCount) * time.Millisecond)
+			continue
 		}
 
 		if err != nil {

--- a/core/playback/mpv/track.go
+++ b/core/playback/mpv/track.go
@@ -167,7 +167,6 @@ func (t *MpvTrack) Position() int {
 			return int(pos)
 		}
 	}
-	return 0
 }
 
 func (t *MpvTrack) SetPosition(offset int) error {


### PR DESCRIPTION
in #2771 there are still some bugs with the jukebox mode

this PR solves one of the errors by fixing the get Position() function in case mpv errors out and needs multiple retries.
without this patch, the function directly returns