### PR TITLE
Fixing Memory Leak in CachedGenreRepository

### DIFF
--- a/scanner/cached_genre_repository.go
+++ b/scanner/cached_genre_repository.go
@@ -8,25 +8,27 @@ import (
 	"github.com/jellydator/ttlcache/v2"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/singleton"
 )
 
 func newCachedGenreRepository(ctx context.Context, repo model.GenreRepository) model.GenreRepository {
-	r := &cachedGenreRepo{
-		GenreRepository: repo,
-		ctx:             ctx,
-	}
-	genres, err := repo.GetAll()
-	if err != nil {
-		log.Error(ctx, "Could not load genres from DB", err)
-		return repo
-	}
+	return singleton.GetInstance(func() *cachedGenreRepo {
+		r := &cachedGenreRepo{
+			GenreRepository: repo,
+			ctx:             ctx,
+		}
+		genres, err := repo.GetAll()
 
-	r.cache = ttlcache.NewCache()
-	for _, g := range genres {
-		_ = r.cache.Set(strings.ToLower(g.Name), g.ID)
-	}
-
-	return r
+		if err != nil {
+			log.Error(ctx, "Could not load genres from DB", err)
+			panic(err)
+		}
+		r.cache = ttlcache.NewCache()
+		for _, g := range genres {
+			_ = r.cache.Set(strings.ToLower(g.Name), g.ID)
+		}
+		return r
+	})
 }
 
 type cachedGenreRepo struct {


### PR DESCRIPTION
I think this fixes https://github.com/navidrome/navidrome/issues/2003

In the testing I've done, the obvious growth in memory (with scanning every minute) is instances of the cache within the Cached Genre Repository. I'm not 100% if this is the only leak contributing to that issue, but it was definitely the largest contributor for me. 

I've not dug into the ttlcache code, but it appears that it is never GC'd and I'm assuming that the library is not built to be used with many dynamically created instances of the cache, previously every time that the scanner was run, the ttlcache was also created each time. This caused (under testing with 166 genres in the database) the memory consumed by navidrome to 101.18MB over approx 3 days; 96% of which is in instances of this cache. Swapping to a singleton has reduced this to down to ~ 2.6MB

Before:
```
Type: inuse_space 
Entering interactive mode (type "help" for commands, "o" for options) 
(pprof) top 
Showing nodes accounting for 34844.30kB, 91.90% of 37916.74kB total 
Showing top 10 nodes out of 101 
     flat  flat%   sum%        cum   cum% 
11264.86kB 29.71% 29.71% 11264.86kB 29.71%  github.com/jellydator/ttlcache/v2.newItem 
8704.40kB 22.96% 52.67%  8704.40kB 22.96%  github.com/mattn/go-sqlite3._Cfunc_GoStringN 
6708.13kB 17.69% 70.36% 20538.62kB 54.17%  github.com/jellydator/ttlcache/v2.(*Cache).SetWithTTL 
2565.63kB  6.77% 77.12%  2565.63kB  6.77%  github.com/jellydator/ttlcache/v2.(*priorityQueue).Push 
1536.02kB  4.05% 81.18% 32827.18kB 86.58%  github.com/navidrome/navidrome/scanner.newCachedGenreRepository 
1024.12kB  2.70% 83.88%  1024.12kB  2.70%  github.com/jellydator/ttlcache/v2.NewCache 
1024.02kB  2.70% 86.58%  1024.02kB  2.70%  strings.(*Builder).grow 
 902.59kB  2.38% 88.96%   902.59kB  2.38%  compress/flate.NewWriter 
 561.50kB  1.48% 90.44%   561.50kB  1.48%  golang.org/x/net/html.map.init.1 
 553.04kB  1.46% 91.90%   553.04kB  1.46%  github.com/navidrome/navidrome/scanner.(*TagScanner).getDBDirTree 
```

After
```
Type: inuse_space 
Entering interactive mode (type "help" for commands, "o" for options) 
(pprof) top 
Showing nodes accounting for 3896.41kB, 100% of 3896.41kB total 
Showing top 10 nodes out of 72 
     flat  flat%   sum%        cum   cum% 
1052.61kB 27.01% 27.01%  1052.61kB 27.01%  sync.(*Map).Swap 
 794.19kB 20.38% 47.40%  1306.21kB 33.52%  github.com/navidrome/navidrome/scanner.(*TagScanner).Scan 
 513.50kB 13.18% 60.58%   513.50kB 13.18%  regexp/syntax.(*compiler).inst 
 512.05kB 13.14% 73.72%   512.05kB 13.14%  crypto/x509.(*CertPool).addCertFunc 
 512.03kB 13.14% 86.86%   512.03kB 13.14%  github.com/prometheus/client_golang/prometheus.MakeLabelPairs 
 512.02kB 13.14%   100%   512.02kB 13.14%  github.com/mattn/go-sqlite3._Cfunc_GoStringN if 
        0     0%   100%   512.05kB 13.14%  crypto/tls.(*Conn).HandshakeContext 
        0     0%   100%   512.05kB 13.14%  crypto/tls.(*Conn).clientHandshake 
        0     0%   100%   512.05kB 13.14%  crypto/tls.(*Conn).handshakeContext 
        0     0%   100%   512.05kB 13.14%  crypto/tls.(*Conn).verifyServerCertificate
```

I've implemented this as a singleton as this seemed the quickest way to achieve this, however we could also remove the ttlcache from this use and replace it with a map and instantiate it each time and that will probably get gc'd correctly. From what I can see, there doesn't seem to be any major problems with the ttl cache (excluding memory) but how the cache is maintained long-term isn't particularly clear to me, it doesn't seem to ever have a mechanism to remove genres (this might be fine, they might never be removed from the DB).