### PR TITLE
Add R128_{TRACK,ALBUM}_GAIN support to the scanner

### DIFF
--- a/scanner/metadata/metadata.go
+++ b/scanner/metadata/metadata.go
@@ -173,17 +173,14 @@ func (t Tags) MbzAlbumComment() string {
 }
 
 // Gain Properties
-type GainType int
 
-// Used by getGainValue to determine which gain tags to looks for
-const (
-	AlbumGain GainType = iota
-	TrackGain
-)
-
-func (t Tags) RGAlbumGain() float64 { return t.getGainValue(AlbumGain) }
+func (t Tags) RGAlbumGain() float64 {
+	return t.getGainValue("replaygain_album_gain", "r128_album_gain")
+}
 func (t Tags) RGAlbumPeak() float64 { return t.getPeakValue("replaygain_album_peak") }
-func (t Tags) RGTrackGain() float64 { return t.getGainValue(TrackGain) }
+func (t Tags) RGTrackGain() float64 {
+	return t.getGainValue("replaygain_track_gain", "r128_track_gain")
+}
 func (t Tags) RGTrackPeak() float64 { return t.getPeakValue("replaygain_track_peak") }
 
 // File properties
@@ -245,18 +242,7 @@ func (t Tags) Lyrics() string {
 	return string(res)
 }
 
-func (t Tags) getGainValue(gainType GainType) float64 {
-	// Gain is in the form [-]a.bb dB
-	var rgTagName string
-	var r128TagName string
-	if gainType == AlbumGain {
-		rgTagName = "replaygain_album_gain"
-		r128TagName = "r128_album_gain"
-	} else {
-		rgTagName = "replaygain_track_gain"
-		r128TagName = "r128_track_gain"
-	}
-
+func (t Tags) getGainValue(rgTagName, r128TagName string) float64 {
 	// Check for ReplayGain first
 	// ReplayGain is in the form [-]a.bb dB and normalized to -18dB
 	var tag = t.getFirstTagValue(rgTagName)

--- a/scanner/metadata/metadata_internal_test.go
+++ b/scanner/metadata/metadata_internal_test.go
@@ -128,5 +128,17 @@ var _ = Describe("Tags", func() {
 			Entry("Infinity", "Infinity", 1.0),
 			Entry("Invalid value", "INVALID VALUE", 1.0),
 		)
+		DescribeTable("getR128GainValue",
+			func(tag string, expected float64) {
+				md := &Tags{}
+				md.Tags = map[string][]string{"r128_track_gain": {tag}}
+				Expect(md.RGTrackGain()).To(Equal(expected))
+
+			},
+			Entry("0", "0", 5.0),
+			Entry("-3776", "-3776", -9.75),
+			Entry("Infinity", "Infinity", 0.0),
+			Entry("Invalid value", "INVALID VALUE", 0.0),
+		)
 	})
 })


### PR DESCRIPTION
OPUS files are supposed to have R128 gain tags instead of the regular ReplayGain ones: https://datatracker.ietf.org/doc/html/rfc7845#section-5.2.1

This spec targets a loudness of -23dB as opposed to ReplayGain's -18dB.

So what I do is this, if a file does not have a ReplayGain tag, I proceed to check the existence the corresponding R128 track. Then I calculate the dB adjustment and add 5dB to it so that the target loudness ends up being the same as that ReplayGain. This seems like the simplest approach.