### PR TITLE
fix disappearing LastFM links

### DIFF
--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -61,7 +61,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"enableSharing":             conf.Server.EnableSharing,
 			"defaultDownloadableShare":  conf.Server.DefaultDownloadableShare,
 			"devSidebarPlaylists":       conf.Server.DevSidebarPlaylists,
-			"lastFMEnabled":             conf.Server.LastFM.Enabled && conf.Server.LastFM.ApiKey != "" && conf.Server.LastFM.Secret != "",
+			"lastFMEnabled":             conf.Server.LastFM.Enabled,
 			"devShowArtistPage":         conf.Server.DevShowArtistPage,
 			"listenBrainzEnabled":       conf.Server.ListenBrainz.Enabled,
 			"enableExternalServices":    conf.Server.EnableExternalServices,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -283,8 +283,6 @@ var _ = Describe("serveIndex", func() {
 
 	It("sets the lastFMEnabled", func() {
 		conf.Server.LastFM.Enabled = true
-		conf.Server.LastFM.ApiKey = "123"
-		conf.Server.LastFM.Secret = "456"
 
 		r := httptest.NewRequest("GET", "/index.html", nil)
 		w := httptest.NewRecorder()

--- a/ui/src/personal/Personal.js
+++ b/ui/src/personal/Personal.js
@@ -27,7 +27,9 @@ const Personal = () => {
         <SelectDefaultView />
         {config.enableReplayGain && <ReplayGainToggle />}
         <NotificationsToggle />
-        {config.lastFMEnabled && <LastfmScrobbleToggle />}
+        {config.lastFMEnabled && localStorage.getItem('lastfm-apikey') && (
+          <LastfmScrobbleToggle />
+        )}
         {config.listenBrainzEnabled && <ListenBrainzScrobbleToggle />}
       </SimpleForm>
     </Card>


### PR DESCRIPTION
Regardless of if `LastFM.Enabled` was true in the configuration, navidrome would set it to false based on if LastFM API and secret were set. This was done so that navidrome coulkd determine if it should display the "Scrobble to Last.fm" toggle switch in the personal settings screen. 

This pr removes that logic, and checks if `lastfm-apikey` is set in the local storage instead.

Fixes #3076