### PR TITLE
[bugfix]: fix album/media file random sort

### DIFF
--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -141,7 +141,7 @@ func (r sqlRepository) applyFilters(sq SelectBuilder, options ...model.QueryOpti
 
 func (r sqlRepository) seededRandomSort() string {
 	u, _ := request.UserFrom(r.ctx)
-	return fmt.Sprintf("SEEDEDRAND('%s', id)", r.tableName+u.ID)
+	return fmt.Sprintf("SEEDEDRAND('%s', %s.id)", r.tableName+u.ID, r.tableName)
 }
 
 func (r sqlRepository) resetSeededRandom(options []model.QueryOptions) {


### PR DESCRIPTION
Currently, if you have random sort and genre filter, you get an error

```
`SELECT coalesce(starred, 0) as starred, coalesce(rating, 0) as rating, starred_at, play_date, coalesce(play_count, 0) as play_count, album.* FROM album LEFT JOIN annotation on (annotation.item_id = album.id AND annotation.item_type = 'album' AND annotation.user_id = 'user-id') LEFT JOIN album_genres ag on album.id = ag.album_id LEFT JOIN genre on ag.genre_id = genre.id WHERE (genre_id = {:p0}) ORDER BY SEEDEDRAND('album-id', id) asc LIMIT 18`  args="map[p0:genre-id]" elapsedTime="...µs" error="ambiguous column name: id" requestId= rowsAffected=0 username=...
```

This is because the `id` field in `SEEDRAND` is ambiguous. This PR adds the table name to the id field to make this id unambiguous.