### PR TITLE
[bugfix]: Fix background color for nord theme

### DIFF
--- a/ui/src/themes/nord.js
+++ b/ui/src/themes/nord.js
@@ -338,6 +338,7 @@ export default {
       content: {
         padding: '0 !important',
         background: '#3B4252',
+        backgroundColor: 'rgb(59, 66, 82)',
       },
       root: {
         backgroundColor: '#2E3440',


### PR DESCRIPTION
Resolves #2667. _Something_ changed that resulted in the background of the Nord theme being different. This PR restores the original background (the value below would be `#303030`)
![nord-update](https://github.com/navidrome/navidrome/assets/17521368/e6620298-c3e3-4ff9-8914-16c70b385bcc)
