### PR TITLE
[bugfix]: Only refresh smart playlist when fetching first track

### DIFF
--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -22,7 +22,7 @@ type restHandler = func(rest.RepositoryConstructor, ...rest.Logger) http.Handler
 func getPlaylist(ds model.DataStore) http.HandlerFunc {
 	// Add a middleware to capture the playlistId
 	wrapper := func(handler restHandler) http.HandlerFunc {
-		return func(res http.ResponseWriter, r *http.Request) {
+		return func(w http.ResponseWriter, r *http.Request) {
 			constructor := func(ctx context.Context) rest.Repository {
 				plsRepo := ds.Playlist(ctx)
 				plsId := chi.URLParam(r, "playlistId")
@@ -31,7 +31,7 @@ func getPlaylist(ds model.DataStore) http.HandlerFunc {
 				return plsRepo.Tracks(plsId, start == 0)
 			}
 
-			handler(constructor).ServeHTTP(res, r)
+			handler(constructor).ServeHTTP(w, r)
 		}
 	}
 

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -22,14 +22,16 @@ type restHandler = func(rest.RepositoryConstructor, ...rest.Logger) http.Handler
 func getPlaylist(ds model.DataStore) http.HandlerFunc {
 	// Add a middleware to capture the playlistId
 	wrapper := func(handler restHandler) http.HandlerFunc {
-		return func(res http.ResponseWriter, req *http.Request) {
+		return func(res http.ResponseWriter, r *http.Request) {
 			constructor := func(ctx context.Context) rest.Repository {
 				plsRepo := ds.Playlist(ctx)
-				plsId := chi.URLParam(req, "playlistId")
-				return plsRepo.Tracks(plsId, true)
+				plsId := chi.URLParam(r, "playlistId")
+				p := req.Params(r)
+				start := p.Int64Or("_start", 0)
+				return plsRepo.Tracks(plsId, start == 0)
 			}
 
-			handler(constructor).ServeHTTP(res, req)
+			handler(constructor).ServeHTTP(res, r)
 		}
 	}
 


### PR DESCRIPTION
If you have a smart playlist with sort `random`, when going through multiple pages the smart playlist will be constantly refreshed resulting in inconsistent behavior.
This PR fixes this behavior by only refreshing the playlist on the first page (`_start=0`).