### PR TITLE
fix(scanner): sort_artist_name to be used when  indexing performers if PreferSortTag is true

### DIFF
--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"net/url"
@@ -143,11 +144,7 @@ func (r *artistRepository) toModels(dba []dbArtist) model.Artists {
 func (r *artistRepository) getIndexKey(a *model.Artist) string {
 	source := a.Name
 	if conf.Server.PreferSortTags {
-		if len(a.SortArtistName) > 0 {
-			source = a.SortArtistName
-		} else if len(a.OrderArtistName) > 0 {
-			source = a.OrderArtistName
-		}
+		source = cmp.Or(a.SortArtistName, a.OrderArtistName, source)
 	}
 	name := strings.ToLower(str.RemoveArticle(source))
 	for k, v := range r.indexGroups {

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -141,7 +141,15 @@ func (r *artistRepository) toModels(dba []dbArtist) model.Artists {
 }
 
 func (r *artistRepository) getIndexKey(a *model.Artist) string {
-	name := strings.ToLower(str.RemoveArticle(a.Name))
+	source := a.Name
+	if conf.Server.PreferSortTags {
+		if len(a.SortArtistName) > 0 {
+			source = a.SortArtistName
+		} else if len(a.OrderArtistName) > 0 {
+			source = a.OrderArtistName
+		}
+	}
+	name := strings.ToLower(str.RemoveArticle(source))
 	for k, v := range r.indexGroups {
 		key := strings.ToLower(k)
 		if strings.HasPrefix(name, key) {
@@ -153,7 +161,11 @@ func (r *artistRepository) getIndexKey(a *model.Artist) string {
 
 // TODO Cache the index (recalculate when there are changes to the DB)
 func (r *artistRepository) GetIndex() (model.ArtistIndexes, error) {
-	all, err := r.GetAll(model.QueryOptions{Sort: "order_artist_name"})
+	sortColumn := "order_artist_name"
+	if conf.Server.PreferSortTags {
+		sortColumn = "sort_artist_name, order_artist_name"
+	}
+	all, err := r.GetAll(model.QueryOptions{Sort: sortColumn})
 	if err != nil {
 		return nil, err
 	}

--- a/persistence/export_test.go
+++ b/persistence/export_test.go
@@ -1,0 +1,5 @@
+package persistence
+
+// Definitions for testing private methods
+
+var GetIndexKey = (*artistRepository).getIndexKey

--- a/persistence/persistence_suite_test.go
+++ b/persistence/persistence_suite_test.go
@@ -35,8 +35,8 @@ var (
 )
 
 var (
-	artistKraftwerk = model.Artist{ID: "2", Name: "Kraftwerk", AlbumCount: 1, FullText: " kraftwerk"}
-	artistBeatles   = model.Artist{ID: "3", Name: "The Beatles", AlbumCount: 2, FullText: " beatles the"}
+	artistKraftwerk = model.Artist{ID: "2", Name: "Kraftwerk", OrderArtistName: "kraftwerk", AlbumCount: 1, FullText: " kraftwerk"}
+	artistBeatles   = model.Artist{ID: "3", Name: "The Beatles", OrderArtistName: "beatles", AlbumCount: 2, FullText: " beatles the"}
 	testArtists     = model.Artists{
 		artistKraftwerk,
 		artistBeatles,

--- a/scanner/metadata/taglib/taglib_test.go
+++ b/scanner/metadata/taglib/taglib_test.go
@@ -3,6 +3,7 @@ package taglib
 import (
 	"io/fs"
 	"os"
+	"path/filepath"
 
 	"github.com/navidrome/navidrome/scanner/metadata"
 	"github.com/navidrome/navidrome/utils"
@@ -89,6 +90,7 @@ var _ = Describe("Extractor", func() {
 		DescribeTable("Format-Specific tests",
 			func(file, duration, channels, samplerate, albumGain, albumPeak, trackGain, trackPeak string, id3Lyrics bool) {
 				file = "tests/fixtures/" + file
+				ext := filepath.Ext(file)
 				mds, err := e.Parse(file)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mds).To(HaveLen(1))
@@ -118,7 +120,7 @@ var _ = Describe("Extractor", func() {
 				// WMA does not have a "compilation" tag, but "wm/iscompilation"
 				if _, ok := m["compilation"]; ok {
 					Expect(m).To(HaveKeyWithValue("compilation", []string{"1"}))
-				} else {
+				} else if ext == ".wma" {
 					Expect(m).To(HaveKeyWithValue("wm/iscompilation", []string{"1"}))
 				}
 

--- a/scanner/metadata/taglib/taglib_test.go
+++ b/scanner/metadata/taglib/taglib_test.go
@@ -3,7 +3,6 @@ package taglib
 import (
 	"io/fs"
 	"os"
-	"path/filepath"
 
 	"github.com/navidrome/navidrome/scanner/metadata"
 	"github.com/navidrome/navidrome/utils"
@@ -90,7 +89,6 @@ var _ = Describe("Extractor", func() {
 		DescribeTable("Format-Specific tests",
 			func(file, duration, channels, samplerate, albumGain, albumPeak, trackGain, trackPeak string, id3Lyrics bool) {
 				file = "tests/fixtures/" + file
-				ext := filepath.Ext(file)
 				mds, err := e.Parse(file)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(mds).To(HaveLen(1))
@@ -120,7 +118,7 @@ var _ = Describe("Extractor", func() {
 				// WMA does not have a "compilation" tag, but "wm/iscompilation"
 				if _, ok := m["compilation"]; ok {
 					Expect(m).To(HaveKeyWithValue("compilation", []string{"1"}))
-				} else if ext == ".wma" {
+				} else {
 					Expect(m).To(HaveKeyWithValue("wm/iscompilation", []string{"1"}))
 				}
 


### PR DESCRIPTION
Closes #3285

Description

Navidrome is modified so that when the Subsonic getArtists API is executed, if the setting PreferSortTags is true, the value of index should be created using sort_artist_name.

Changes
- getIndexKey: Fixed the process of getting the original value of index.
- GetIndex: Fix sorting when retrieving records from table artist so that all artists with equal index values are included in the same index tag.
- Add test of getIndexKey. 
- Modify test of GetIndex.