### PR TITLE
subsonic-api: fallback to AlbumArtistId when child does not have ArtistId

### DIFF
--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -156,6 +156,9 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 	child.Created = &mf.CreatedAt
 	child.AlbumId = mf.AlbumID
 	child.ArtistId = mf.ArtistID
+	if child.ArtistId == "" {
+		child.ArtistId = mf.AlbumArtistID
+	}
 	child.Type = "music"
 	child.PlayCount = mf.PlayCount
 	if mf.PlayCount > 0 {


### PR DESCRIPTION
subsonic-api: fallback to AlbumArtistId when child does not have ArtistId

I noticed that ArtistId is sometimes blank in the Subsonic API, even when it does not need to be.

