### PR TITLE
fix(server): try to find proper embedded front cover - only for vorbis comments for now

### DIFF
--- a/core/artwork/reader_album.go
+++ b/core/artwork/reader_album.go
@@ -63,7 +63,7 @@ func (a *albumArtworkReader) fromCoverArtPriority(ctx context.Context, ffmpeg ff
 		pattern = strings.TrimSpace(pattern)
 		switch {
 		case pattern == "embedded":
-			ff = append(ff, fromTag(a.album.EmbedArtPath), fromFFmpegTag(ctx, ffmpeg, a.album.EmbedArtPath))
+			ff = append(ff, fromTag(ctx, a.album.EmbedArtPath), fromFFmpegTag(ctx, ffmpeg, a.album.EmbedArtPath))
 		case pattern == "external":
 			ff = append(ff, fromAlbumExternalSource(ctx, a.album, a.em))
 		case a.album.ImageFiles != "":

--- a/core/artwork/reader_mediafile.go
+++ b/core/artwork/reader_mediafile.go
@@ -55,7 +55,7 @@ func (a *mediafileArtworkReader) Reader(ctx context.Context) (io.ReadCloser, str
 	var ff []sourceFunc
 	if a.mediafile.CoverArtID().Kind == model.KindMediaFileArtwork {
 		ff = []sourceFunc{
-			fromTag(a.mediafile.Path),
+			fromTag(ctx, a.mediafile.Path),
 			fromFFmpegTag(ctx, a.a.ffmpeg, a.mediafile.Path),
 		}
 	}

--- a/core/artwork/sources.go
+++ b/core/artwork/sources.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"regexp"
 	"runtime"
 	"strings"
 	"time"
@@ -79,7 +80,14 @@ func fromExternalFile(ctx context.Context, files string, pattern string) sourceF
 	}
 }
 
-func fromTag(path string) sourceFunc {
+func fromTag(ctx context.Context, path string) sourceFunc {
+	// These regexes are used to match the picture type in the file, in the order they are listed.
+	picTypeRegexes := []*regexp.Regexp{
+		regexp.MustCompile(`(?i).*cover.*front.*|.*front.*cover.*`),
+		regexp.MustCompile(`(?i).*front.*`),
+		regexp.MustCompile(`(?i).*cover.*`),
+	}
+
 	return func() (io.ReadCloser, string, error) {
 		if path == "" {
 			return nil, "", nil
@@ -95,14 +103,34 @@ func fromTag(path string) sourceFunc {
 			return nil, "", err
 		}
 
-		picture := m.Picture()
-		if picture == nil {
+		types := m.PictureTypes()
+		if len(types) == 0 {
 			return nil, "", fmt.Errorf("no embedded image found in %s", path)
+		}
+
+		var picture *tag.Picture
+		for _, regex := range picTypeRegexes {
+			for _, t := range types {
+				if regex.MatchString(t) {
+					log.Trace(ctx, "Found embedded image", "type", t, "path", path)
+					picture = m.Pictures(t)
+					break
+				}
+			}
+			if picture != nil {
+				break
+			}
+		}
+		if picture == nil {
+			log.Trace(ctx, "Could not find a front image. Getting the first one", "type", types[0], "path", path)
+			picture = m.Picture()
+		}
+		if picture == nil {
+			return nil, "", fmt.Errorf("could not load embedded image from %s", path)
 		}
 		return io.NopCloser(bytes.NewReader(picture.Data)), path, nil
 	}
 }
-
 func fromFFmpegTag(ctx context.Context, ffmpeg ffmpeg.FFmpeg, path string) sourceFunc {
 	return func() (io.ReadCloser, string, error) {
 		if path == "" {

--- a/core/artwork/sources.go
+++ b/core/artwork/sources.go
@@ -80,14 +80,14 @@ func fromExternalFile(ctx context.Context, files string, pattern string) sourceF
 	}
 }
 
-func fromTag(ctx context.Context, path string) sourceFunc {
-	// These regexes are used to match the picture type in the file, in the order they are listed.
-	picTypeRegexes := []*regexp.Regexp{
-		regexp.MustCompile(`(?i).*cover.*front.*|.*front.*cover.*`),
-		regexp.MustCompile(`(?i).*front.*`),
-		regexp.MustCompile(`(?i).*cover.*`),
-	}
+// These regexes are used to match the picture type in the file, in the order they are listed.
+var picTypeRegexes = []*regexp.Regexp{
+	regexp.MustCompile(`(?i).*cover.*front.*|.*front.*cover.*`),
+	regexp.MustCompile(`(?i).*front.*`),
+	regexp.MustCompile(`(?i).*cover.*`),
+}
 
+func fromTag(ctx context.Context, path string) sourceFunc {
 	return func() (io.ReadCloser, string, error) {
 		if path == "" {
 			return nil, "", nil
@@ -131,6 +131,7 @@ func fromTag(ctx context.Context, path string) sourceFunc {
 		return io.NopCloser(bytes.NewReader(picture.Data)), path, nil
 	}
 }
+
 func fromFFmpegTag(ctx context.Context, ffmpeg ffmpeg.FFmpeg, path string) sourceFunc {
 	return func() (io.ReadCloser, string, error) {
 		if path == "" {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/navidrome/navidrome
 
 go 1.23.2
 
+// Fork to fix https://github.com/navidrome/navidrome/pull/3254
 replace github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 => github.com/deluan/tag v0.0.0-20241002021117-dfe5e6ea396d
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/navidrome/navidrome
 
 go 1.23.2
 
+replace github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 => github.com/deluan/tag v0.0.0-20241002021117-dfe5e6ea396d
+
 require (
 	github.com/Masterminds/squirrel v1.5.4
 	github.com/RaveNoX/go-jsoncommentstrip v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -24,10 +24,10 @@ github.com/deluan/rest v0.0.0-20211102003136-6260bc399cbf h1:tb246l2Zmpt/GpF9EcH
 github.com/deluan/rest v0.0.0-20211102003136-6260bc399cbf/go.mod h1:tSgDythFsl0QgS/PFWfIZqcJKnkADWneY80jaVRlqK8=
 github.com/deluan/sanitize v0.0.0-20230310221930-6e18967d9fc1 h1:mGvOb3zxl4vCLv+dbf7JA6CAaM2UH/AGP1KX4DsJmTI=
 github.com/deluan/sanitize v0.0.0-20230310221930-6e18967d9fc1/go.mod h1:ZNCLJfehvEf34B7BbLKjgpsL9lyW7q938w/GY1XgV4E=
+github.com/deluan/tag v0.0.0-20241002021117-dfe5e6ea396d h1:x/R3+oPEjnisl1zBx2f2v7Gf6f11l0N0JoD6BkwcJyA=
+github.com/deluan/tag v0.0.0-20241002021117-dfe5e6ea396d/go.mod h1:apkPC/CR3s48O2D7Y++n1XWEpgPNNCjXYga3PPbJe2E=
 github.com/dexterlb/mpvipc v0.0.0-20241005113212-7cdefca0e933 h1:r4hxcT6GBIA/j8Ox4OXI5MNgMKfR+9plcAWYi1OnmOg=
 github.com/dexterlb/mpvipc v0.0.0-20241005113212-7cdefca0e933/go.mod h1:RkQWLNITKkXHLP7LXxZSgEq+uFWU25M5qW7qfEhL9Wc=
-github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8 h1:OtSeLS5y0Uy01jaKK4mA/WVIYtpzVm63vLVAPzJXigg=
-github.com/dhowden/tag v0.0.0-20240417053706-3d75831295e8/go.mod h1:apkPC/CR3s48O2D7Y++n1XWEpgPNNCjXYga3PPbJe2E=
 github.com/disintegration/imaging v1.6.2 h1:w1LecBlG2Lnp8B3jk5zSuNqd7b4DXhcjwek1ei82L+c=
 github.com/disintegration/imaging v1.6.2/go.mod h1:44/5580QXChDfwIclfc/PCwrr44amcmDAg8hxG0Ewe4=
 github.com/djherbis/atime v1.1.0 h1:rgwVbP/5by8BvvjBNrbh64Qz33idKT3pSnMSJsxhi0g=


### PR DESCRIPTION
Tries these images in order to find the proper embedded cover:

- Search for images with description matching "cover" AND "front"
- Search for images with description matching "front"
- Search for images with description matching "cover"
- Fallback to first image if none of the above is found

Fix #3254


This uses a `dhowden/tag` fork for now. See https://github.com/dhowden/tag/issues/109