### PR TITLE
feat: support customizable album splitting (grouping) policy

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -114,9 +114,13 @@ type configOptions struct {
 }
 
 type scannerOptions struct {
-	Extractor          string
-	GenreSeparators    string
-	GroupAlbumReleases bool
+	Extractor       string
+	GenreSeparators string
+
+	// Split album policy
+	// For all possible factors, see `consts.SplitAlbumByXXX`
+	// The order of policy doesn't matter
+	SplitAlbumPolicy string
 }
 
 type lastfmOptions struct {
@@ -390,7 +394,7 @@ func init() {
 
 	viper.SetDefault("scanner.extractor", consts.DefaultScannerExtractor)
 	viper.SetDefault("scanner.genreseparators", ";/,")
-	viper.SetDefault("scanner.groupalbumreleases", false)
+	viper.SetDefault("scanner.splitalbumpolicy", consts.SplitAlbumDefaultPolicy)
 
 	viper.SetDefault("agents", "lastfm,spotify")
 	viper.SetDefault("lastfm.enabled", true)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -82,6 +82,16 @@ const (
 )
 
 const (
+	// possible splitting factor, it's possible to use multiple splitting factors
+
+	SplitAlbumByArtist  = "artist"  // split album by artist name
+	SplitAlbumByRelease = "release" // split album by release date
+
+	// default album splitting policy
+	SplitAlbumDefaultPolicy = SplitAlbumByArtist + "," + SplitAlbumByRelease
+)
+
+const (
 	AlbumPlayCountModeAbsolute   = "absolute"
 	AlbumPlayCountModeNormalized = "normalized"
 )

--- a/scanner/mapping.go
+++ b/scanner/mapping.go
@@ -123,8 +123,14 @@ func (s MediaFileMapper) trackID(md metadata.Tags) string {
 }
 
 func (s MediaFileMapper) albumID(md metadata.Tags, releaseDate string) string {
-	albumPath := strings.ToLower(fmt.Sprintf("%s\\%s", s.mapAlbumArtistName(md), s.mapAlbumName(md)))
-	if !conf.Server.Scanner.GroupAlbumReleases {
+	// include album name as part of album path first
+	albumPath := s.mapAlbumName(md)
+	if strings.Contains(conf.Server.Scanner.SplitAlbumPolicy, consts.SplitAlbumByArtist) {
+		albumPath = fmt.Sprintf("%s\\%s", albumPath, s.mapAlbumArtistName(md))
+	}
+	albumPath = strings.ToLower(albumPath)
+	if strings.Contains(conf.Server.Scanner.SplitAlbumPolicy, consts.SplitAlbumByRelease) {
+		// include release date as part of album path
 		if len(releaseDate) != 0 {
 			albumPath = fmt.Sprintf("%s\\%s", albumPath, releaseDate)
 		}


### PR DESCRIPTION
# Intro

This change makes the factors of splitting (or the other perspective: grouping) albums available to the user by setting up  `Scanner.SplitAlbumPolicy` config key.

The main intention of this change is to implement grouping of album with the same album name, determined by `albumID` function in `mapping`. The original configuration doesn't provide such option.

## Changes

- Add policy factor consts
- Replace `GroupAlbumReleases` to `SplitAlbumPolicy` in the config of `scannerOptions`
- Implement album ID splitting policy in `mapping.go`

## Compatibility

The behavior affter this change is identical to the origin since `SplitAlbumPolicy` is set to `SplitAlbumDefaultPolicy = "artist,release"`, which is equivalent to setting `GroupAlbumReleases` to  false.

After this change, to group albums only by its name, set `SplitAlbumPolicy` to `""` works.

## Other note

The [config option documentation](https://www.navidrome.org/docs/usage/configuration-options/) of navidrome should also be updated after this PR.

## Demo

Below is an example of applying this change.

* Before: the same album is splitted to pieces
  |albums|deeper look1|deeper look 2|
  |:-:|:-:|:-:|
  |<img width="818" alt="image" src="https://github.com/user-attachments/assets/87a378ad-3b5b-4969-9bbd-77757531137e">|<img width="557" alt="image" src="https://github.com/user-attachments/assets/a467a89b-f5b8-4346-8478-15f66058fcdb">|<img width="533" alt="image" src="https://github.com/user-attachments/assets/35664ba4-f18c-4a54-b89b-efdeb4b65344">|
* After: it is possible to group album by not splitting them by artist/release date
  |album|deeper look|
  |:-:|:-:|
  |<img width="600" alt="image" src="https://github.com/user-attachments/assets/7e6098f5-703b-4229-849f-a5d9e8160de2">|<img width="600" alt="image" src="https://github.com/user-attachments/assets/35261338-b900-4cdb-b3a2-968a1a680985">|

