### PR TITLE
fix: crash on empty filters

### DIFF
--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -29,7 +29,9 @@ func (r *sqlRepository) parseRestFilters(ctx context.Context, options rest.Query
 		// Look for a custom filter function
 		f = strings.ToLower(f)
 		if ff, ok := r.filterMappings[f]; ok {
-			filters = append(filters, ff(f, v))
+			if filter := ff(f, v); filter != nil {
+				filters = append(filters, filter)
+			}
 			continue
 		}
 		// Ignore invalid filters (not based on a field or filter function)

--- a/persistence/sql_restful_test.go
+++ b/persistence/sql_restful_test.go
@@ -23,6 +23,24 @@ var _ = Describe("sqlRestful", func() {
 			Expect(r.parseRestFilters(context.Background(), options)).To(BeNil())
 		})
 
+		It(`returns nil if tries a filter with fullTextExpr("'")`, func() {
+			r.filterMappings = map[string]filterFunc{
+				"name": fullTextFilter,
+			}
+			options.Filters = map[string]interface{}{"name": "'"}
+			Expect(r.parseRestFilters(context.Background(), options)).To(BeEmpty())
+		})
+
+		It("does not add nill filters", func() {
+			r.filterMappings = map[string]filterFunc{
+				"name": func(string, any) squirrel.Sqlizer {
+					return nil
+				},
+			}
+			options.Filters = map[string]interface{}{"name": "joe"}
+			Expect(r.parseRestFilters(context.Background(), options)).To(BeEmpty())
+		})
+
 		It("returns a '=' condition for 'id' filter", func() {
 			options.Filters = map[string]interface{}{"id": "123"}
 			Expect(r.parseRestFilters(context.Background(), options)).To(Equal(squirrel.And{squirrel.Eq{"id": "123"}}))


### PR DESCRIPTION
If you type a ' (or other ignored symbols) in the search bar, it gives you an internal server error instead of the ' being treated as text on a search.

Some chars are removed from the search query, and when it was empty (after removing all ignored chars), if tried to create a null SQL clause, causing a panic.

Thanks @repomansez for reporting this.