### PR TITLE
feat(os): support clearing play queue

### DIFF
--- a/persistence/playqueue_repository.go
+++ b/persistence/playqueue_repository.go
@@ -42,6 +42,9 @@ func (r *playQueueRepository) Store(q *model.PlayQueue) error {
 		log.Error(r.ctx, "Error deleting previous playqueue", "user", u.UserName, err)
 		return err
 	}
+	if len(q.Items) == 0 {
+		return nil
+	}
 	pq := r.fromModel(q)
 	if pq.ID == "" {
 		pq.CreatedAt = time.Now()


### PR DESCRIPTION
To clear the users' Play Queue, call `savePlayQueue` without any `id`.

See: https://github.com/opensubsonic/open-subsonic-api/pull/106#event-14682075631