### PR TITLE
(bugfix): Fix service worker crashing on precacheAndRoute

### DIFF
--- a/ui/bin/update-workbox.sh
+++ b/ui/bin/update-workbox.sh
@@ -13,4 +13,5 @@ mv build/3rdparty/workbox-*/workbox-core.prod.js ${WORKBOX_DIR}
 mv build/3rdparty/workbox-*/workbox-strategies.prod.js ${WORKBOX_DIR}
 mv build/3rdparty/workbox-*/workbox-routing.prod.js ${WORKBOX_DIR}
 mv build/3rdparty/workbox-*/workbox-navigation-preload.prod.js ${WORKBOX_DIR}
+mv build/3rdparty/workbox-*/workbox-precaching.prod.js ${WORKBOX_DIR}
 rm -rf build/3rdparty/workbox-*

--- a/ui/src/sw.js
+++ b/ui/src/sw.js
@@ -12,6 +12,7 @@ workbox.loadModule('workbox-core')
 workbox.loadModule('workbox-strategies')
 workbox.loadModule('workbox-routing')
 workbox.loadModule('workbox-navigation-preload')
+workbox.loadModule('workbox-precaching')
 
 workbox.core.clientsClaim()
 self.skipWaiting()
@@ -48,7 +49,7 @@ const navigationHandler = async (params) => {
 }
 
 // self.__WB_MANIFEST is default injection point
-precacheAndRoute(self.__WB_MANIFEST)
+workbox.precaching.precacheAndRoute(self.__WB_MANIFEST)
 
 // Register this strategy to handle all navigations.
 workbox.routing.registerRoute(


### PR DESCRIPTION
`precacheAndRoute` is not a global. Add the proper import to prevent service worker from crashing.