### PR TITLE
fix(insights): improving reports

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,4 @@ dist
 binaries
 cache
 music
+!Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -25,11 +25,11 @@ setup: check_env download-deps setup-git ##@1_Run_First Install dependencies and
 .PHONY: setup
 
 dev: check_env   ##@Development Start Navidrome in development mode, with hot-reload for both frontend and backend
-	npx foreman -j Procfile.dev -p 4533 start
+	ND_ENABLEINSIGHTSCOLLECTOR="false" npx foreman -j Procfile.dev -p 4533 start
 .PHONY: dev
 
 server: check_go_env buildjs ##@Development Start the backend in development mode
-	@go run github.com/cespare/reflex@latest -d none -c reflex.conf
+	@ND_ENABLEINSIGHTSCOLLECTOR="false" go run github.com/cespare/reflex@latest -d none -c reflex.conf
 .PHONY: server
 
 watch: ##@Development Start Go tests in watch mode (re-run when code changes)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -208,8 +208,7 @@ func startInsightsCollector(ctx context.Context) func() error {
 			return nil
 		}
 		log.Info(ctx, "Starting Insight Collector")
-		// Wait 30 minutes before starting the first run, to avoid 429 errors from the Insights server
-		time.Sleep(30 * time.Minute)
+		time.Sleep(conf.Server.DevInsightsInitialDelay)
 		ic := CreateInsights()
 		ic.Run(ctx)
 		return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -208,6 +208,8 @@ func startInsightsCollector(ctx context.Context) func() error {
 			return nil
 		}
 		log.Info(ctx, "Starting Insight Collector")
+		// Wait 30 minutes before starting the first run, to avoid 429 errors from the Insights server
+		time.Sleep(30 * time.Minute)
 		ic := CreateInsights()
 		ic.Run(ctx)
 		return nil

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -113,6 +113,7 @@ type configOptions struct {
 	DevArtworkThrottleBacklogTimeout time.Duration
 	DevArtistInfoTimeToLive          time.Duration
 	DevAlbumInfoTimeToLive           time.Duration
+	DevInsightsInitialDelay          time.Duration
 }
 
 type scannerOptions struct {
@@ -470,6 +471,7 @@ func init() {
 	viper.SetDefault("devartworkthrottlebacklogtimeout", consts.RequestThrottleBacklogTimeout)
 	viper.SetDefault("devartistinfotimetolive", consts.ArtistInfoTimeToLive)
 	viper.SetDefault("devalbuminfotimetolive", consts.AlbumInfoTimeToLive)
+	viper.SetDefault("devinsightsinitialdelay", consts.InsightsInitialDelay)
 }
 
 func InitConfig(cfgFile string) {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -114,6 +114,7 @@ type configOptions struct {
 	DevArtistInfoTimeToLive          time.Duration
 	DevAlbumInfoTimeToLive           time.Duration
 	DevInsightsInitialDelay          time.Duration
+	DevEnablePlayerInsights          bool
 }
 
 type scannerOptions struct {
@@ -472,6 +473,7 @@ func init() {
 	viper.SetDefault("devartistinfotimetolive", consts.ArtistInfoTimeToLive)
 	viper.SetDefault("devalbuminfotimetolive", consts.AlbumInfoTimeToLive)
 	viper.SetDefault("devinsightsinitialdelay", consts.InsightsInitialDelay)
+	viper.SetDefault("devenableplayerinsights", true)
 }
 
 func InitConfig(cfgFile string) {

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -90,6 +90,7 @@ const (
 	InsightsIDKey          = "InsightsID"
 	InsightsEndpoint       = "https://insights.navidrome.org/collect"
 	InsightsUpdateInterval = 24 * time.Hour
+	InsightsInitialDelay   = 30 * time.Minute
 )
 
 var (

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -199,15 +199,37 @@ func (c *insightsCollector) collect(ctx context.Context) []byte {
 	data.Uptime = time.Since(consts.ServerStart).Milliseconds() / 1000
 
 	// Library info
-	data.Library.Tracks, _ = c.ds.MediaFile(ctx).CountAll()
-	data.Library.Albums, _ = c.ds.Album(ctx).CountAll()
-	data.Library.Artists, _ = c.ds.Artist(ctx).CountAll()
-	data.Library.Playlists, _ = c.ds.Playlist(ctx).Count()
-	data.Library.Shares, _ = c.ds.Share(ctx).CountAll()
-	data.Library.Radios, _ = c.ds.Radio(ctx).Count()
-	data.Library.ActiveUsers, _ = c.ds.User(ctx).CountAll(model.QueryOptions{
+	var err error
+	data.Library.Tracks, err = c.ds.MediaFile(ctx).CountAll()
+	if err != nil {
+		log.Trace(ctx, "Error reading tracks count", err)
+	}
+	data.Library.Albums, err = c.ds.Album(ctx).CountAll()
+	if err != nil {
+		log.Trace(ctx, "Error reading albums count", err)
+	}
+	data.Library.Artists, err = c.ds.Artist(ctx).CountAll()
+	if err != nil {
+		log.Trace(ctx, "Error reading artists count", err)
+	}
+	data.Library.Playlists, err = c.ds.Playlist(ctx).Count()
+	if err != nil {
+		log.Trace(ctx, "Error reading playlists count", err)
+	}
+	data.Library.Shares, err = c.ds.Share(ctx).CountAll()
+	if err != nil {
+		log.Trace(ctx, "Error reading shares count", err)
+	}
+	data.Library.Radios, err = c.ds.Radio(ctx).Count()
+	if err != nil {
+		log.Trace(ctx, "Error reading radios count", err)
+	}
+	data.Library.ActiveUsers, err = c.ds.User(ctx).CountAll(model.QueryOptions{
 		Filters: squirrel.Gt{"last_access_at": time.Now().Add(-7 * 24 * time.Hour)},
 	})
+	if err != nil {
+		log.Trace(ctx, "Error reading active users count", err)
+	}
 
 	// Memory info
 	var m runtime.MemStats

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -230,6 +230,12 @@ func (c *insightsCollector) collect(ctx context.Context) []byte {
 	if err != nil {
 		log.Trace(ctx, "Error reading active users count", err)
 	}
+	data.Library.ActivePlayers, err = c.ds.Player(ctx).CountByClient(model.QueryOptions{
+		Filters: squirrel.Gt{"last_seen": time.Now().Add(-7 * 24 * time.Hour)},
+	})
+	if err != nil {
+		log.Trace(ctx, "Error reading active players count", err)
+	}
 
 	// Memory info
 	var m runtime.MemStats

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -232,11 +232,13 @@ func (c *insightsCollector) collect(ctx context.Context) []byte {
 	if err != nil {
 		log.Trace(ctx, "Error reading active users count", err)
 	}
-	data.Library.ActivePlayers, err = c.ds.Player(ctx).CountByClient(model.QueryOptions{
-		Filters: squirrel.Gt{"last_seen": time.Now().Add(-7 * 24 * time.Hour)},
-	})
-	if err != nil {
-		log.Trace(ctx, "Error reading active players count", err)
+	if conf.Server.DevEnablePlayerInsights {
+		data.Library.ActivePlayers, err = c.ds.Player(ctx).CountByClient(model.QueryOptions{
+			Filters: squirrel.Gt{"last_seen": time.Now().Add(-7 * 24 * time.Hour)},
+		})
+		if err != nil {
+			log.Trace(ctx, "Error reading active players count", err)
+		}
 	}
 
 	// Memory info

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -16,6 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/core/auth"
 	"github.com/navidrome/navidrome/core/metrics/insights"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -54,6 +55,7 @@ func GetInstance(ds model.DataStore) Insights {
 }
 
 func (c *insightsCollector) Run(ctx context.Context) {
+	ctx = auth.WithAdminUser(ctx, c.ds)
 	for {
 		c.sendInsights(ctx)
 		select {
@@ -212,7 +214,7 @@ func (c *insightsCollector) collect(ctx context.Context) []byte {
 	if err != nil {
 		log.Trace(ctx, "Error reading artists count", err)
 	}
-	data.Library.Playlists, err = c.ds.Playlist(ctx).Count()
+	data.Library.Playlists, err = c.ds.Playlist(ctx).CountAll()
 	if err != nil {
 		log.Trace(ctx, "Error reading playlists count", err)
 	}

--- a/core/metrics/insights/data.go
+++ b/core/metrics/insights/data.go
@@ -29,13 +29,14 @@ type Data struct {
 		Backup *FSInfo `json:"backup,omitempty"`
 	} `json:"fs"`
 	Library struct {
-		Tracks      int64 `json:"tracks"`
-		Albums      int64 `json:"albums"`
-		Artists     int64 `json:"artists"`
-		Playlists   int64 `json:"playlists"`
-		Shares      int64 `json:"shares"`
-		Radios      int64 `json:"radios"`
-		ActiveUsers int64 `json:"activeUsers"`
+		Tracks        int64            `json:"tracks"`
+		Albums        int64            `json:"albums"`
+		Artists       int64            `json:"artists"`
+		Playlists     int64            `json:"playlists"`
+		Shares        int64            `json:"shares"`
+		Radios        int64            `json:"radios"`
+		ActiveUsers   int64            `json:"activeUsers"`
+		ActivePlayers map[string]int64 `json:"activePlayers"`
 	} `json:"library"`
 	Config struct {
 		LogLevel                string `json:"logLevel,omitempty"`

--- a/core/metrics/insights_linux.go
+++ b/core/metrics/insights_linux.go
@@ -41,22 +41,29 @@ type MountInfo struct {
 }
 
 var fsTypeMap = map[int64]string{
-	// Add filesystem type mappings
+	0x5346414f: "afs",
+	0x61756673: "aufs",
 	0x9123683E: "btrfs",
-	0x0000EF53: "ext2/ext3/ext4",
-	0x00006969: "nfs",
-	0x58465342: "xfs",
-	0x2FC12FC1: "zfs",
-	0x01021994: "tmpfs",
 	0x28cd3d45: "cramfs",
 	0x64626720: "debugfs",
+	0x0000EF53: "ext2/ext3/ext4",
+	0x6a656a63: "fakeowner", // FS inside a container
+	0x65735546: "fuse",
+	0x4244:     "hfs",
+	0x9660:     "iso9660",
+	0x3153464a: "jfs",
+	0x00006969: "nfs",
+	0x794c7630: "overlayfs",
+	0x9fa0:     "proc",
+	0x517b:     "smb",
+	0xfe534d42: "smb2",
 	0x73717368: "squashfs",
 	0x62656572: "sysfs",
-	0x9fa0:     "proc",
-	0x61756673: "aufs",
-	0x794c7630: "overlayfs",
-	0x6a656a63: "fakeowner", // FS inside a container
-	// Include other filesystem types as needed
+	0x01021994: "tmpfs",
+	0x01021997: "v9fs",
+	0x4d44:     "vfat",
+	0x58465342: "xfs",
+	0x2FC12FC1: "zfs",
 }
 
 func getFilesystemType(path string) (string, error) {

--- a/model/player.go
+++ b/model/player.go
@@ -26,5 +26,7 @@ type PlayerRepository interface {
 	Get(id string) (*Player, error)
 	FindMatch(userId, client, userAgent string) (*Player, error)
 	Put(p *Player) error
+	CountAll(...QueryOptions) (int64, error)
+	CountByClient(...QueryOptions) (map[string]int64, error)
 	// TODO: Add CountAll method. Useful at least for metrics.
 }


### PR DESCRIPTION
- [x] Add logs when there are errors getting library counters
- [x] Fix `vcs.modified=true` when there are no changes
- [x] Wait 30 minutes before first report, to avoid 429s from the insights server on restart
- [x] Disable reports when running in dev mode (`make server` or `make dev`)
- [x] Report clients counters (number of API clients, grouped by client type)
- [x] Add more FS types (ex: FUSE)