### PR TITLE
fix(ui): fix play queue for play button and context menus

### DIFF
--- a/ui/src/common/ContextMenus.jsx
+++ b/ui/src/common/ContextMenus.jsx
@@ -203,7 +203,7 @@ export const AlbumContextMenu = (props) =>
       resource={'album'}
       songQueryParams={{
         pagination: { page: 1, perPage: -1 },
-        sort: { field: 'trackNumber', order: 'ASC' },
+        sort: { field: 'album', order: 'ASC' },
         filter: {
           album_id: props.record.id,
           release_date: props.releaseDate,
@@ -234,7 +234,7 @@ export const ArtistContextMenu = (props) =>
       songQueryParams={{
         pagination: { page: 1, perPage: 200 },
         sort: {
-          field: 'trackNumber',
+          field: 'album',
           order: 'ASC',
         },
         filter: { album_artist_id: props.record.id },

--- a/ui/src/common/PlayButton.jsx
+++ b/ui/src/common/PlayButton.jsx
@@ -21,7 +21,7 @@ export const PlayButton = ({ record, size, className }) => {
     dataProvider
       .getList('song', {
         pagination: { page: 1, perPage: -1 },
-        sort: { field: 'trackNumber', order: 'ASC' },
+        sort: { field: 'album', order: 'ASC' },
         filter: {
           album_id: record.id,
           release_date: record.releaseDate,


### PR DESCRIPTION
Closes: #3557

Change the AlbumListView and context menu's play buttons so that they sort by `album` instead of `trackNumber`