### PR TITLE
docs: Set org.opencontainers.image.source label in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,7 @@ COPY --from=build /out /
 ### Build Final Image
 FROM public.ecr.aws/docker/library/alpine:3.21 AS final
 LABEL maintainer="deluan@navidrome.org"
+LABEL org.opencontainers.image.source="https://github.com/navidrome/navidrome"
 
 # Install ffmpeg and mpv
 RUN apk add -U --no-cache ffmpeg mpv


### PR DESCRIPTION
As documented in the OCI Image Format, [org.opencontainers.image.source](https://github.com/opencontainers/image-spec/blob/5325ec48851022d6ded604199a3566254e72842a/annotations.md#L24) identifies an image's source repository. This is purely for documentation purposes. It does however help tools such as [Renovate](https://docs.renovatebot.com/modules/datasource/docker/#description) to find the changelogs when a new Navidrome version is released. The changelogs would then be included in the PR Renovate creates.

Just as an example, here's a screenshot of a Renovate PR which cannot find Navidrome's changelogs, so they are simply omitted.


<details>
  <summary>Example...</summary>
  
  ![renovate-pr-without-release-notes](https://github.com/user-attachments/assets/29520823-38a6-4808-97cd-5371a0b594be)
</details>
