### PR TITLE
fix(server): use cancellable context instead of Sleep for initial insights delay

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -208,11 +208,10 @@ func startInsightsCollector(ctx context.Context) func() error {
 			return nil
 		}
 		log.Info(ctx, "Starting Insight Collector")
-		t := time.After(consts.InsightsUpdateInterval)
 		select {
+		case <-time.After(conf.Server.DevInsightsInitialDelay):
 		case <-ctx.Done():
 			return nil
-		case <-t:
 		}
 		ic := CreateInsights()
 		ic.Run(ctx)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -208,7 +208,12 @@ func startInsightsCollector(ctx context.Context) func() error {
 			return nil
 		}
 		log.Info(ctx, "Starting Insight Collector")
-		time.Sleep(conf.Server.DevInsightsInitialDelay)
+		t := time.After(consts.InsightsUpdateInterval)
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-t:
+		}
 		ic := CreateInsights()
 		ic.Run(ctx)
 		return nil


### PR DESCRIPTION
Fixes Navidrome not exiting cleanly on stop.