### PR TITLE
feat(server): create M3Us from shares

### DIFF
--- a/model/share.go
+++ b/model/share.go
@@ -1,6 +1,8 @@
 package model
 
 import (
+	"cmp"
+	"fmt"
 	"strings"
 	"time"
 
@@ -47,6 +49,19 @@ func (s Share) CoverArtID() ArtworkID {
 }
 
 type Shares []Share
+
+// ToM3U8 exports the playlist to the Extended M3U8 format, as specified in
+// https://docs.fileformat.com/audio/m3u/#extended-m3u
+func (s Share) ToM3U8() string {
+	buf := strings.Builder{}
+	buf.WriteString("#EXTM3U\n")
+	buf.WriteString(fmt.Sprintf("#PLAYLIST:%s\n", cmp.Or(s.Description, s.ID)))
+	for _, t := range s.Tracks {
+		buf.WriteString(fmt.Sprintf("#EXTINF:%.f,%s - %s\n", t.Duration, t.Artist, t.Title))
+		buf.WriteString(t.Path + "\n")
+	}
+	return buf.String()
+}
 
 type ShareRepository interface {
 	Exists(id string) (bool, error)

--- a/server/public/public.go
+++ b/server/public/public.go
@@ -56,6 +56,7 @@ func (pub *Router) routes() http.Handler {
 			if conf.Server.EnableDownloads {
 				r.HandleFunc("/d/{id}", pub.handleDownloads)
 			}
+			r.HandleFunc("/{id}/m3u", pub.handleM3U)
 			r.HandleFunc("/{id}", pub.handleShares)
 			r.HandleFunc("/", pub.handleShares)
 			r.Handle("/*", pub.assetsHandler)


### PR DESCRIPTION
The URL for the m3u will be the same as the Share URL, just add a /m3u at the end. Example:
https://myserver/share/G3zqpMpHK8 => https://myserver/share/G3zqpMpHK8/m3u

See https://github.com/navidrome/navidrome/discussions/3651