### PR TITLE
feat(ui): Allow filtering on multiple genres

### DIFF
--- a/ui/src/album/AlbumList.jsx
+++ b/ui/src/album/AlbumList.jsx
@@ -2,11 +2,13 @@ import { useSelector } from 'react-redux'
 import { Redirect, useLocation } from 'react-router-dom'
 import {
   AutocompleteInput,
+  AutocompleteArrayInput,
   Filter,
   NullableBooleanInput,
   NumberInput,
   Pagination,
   ReferenceInput,
+  ReferenceArrayInput,
   SearchInput,
   useRefresh,
   useTranslate,
@@ -29,9 +31,19 @@ import albumLists, { defaultAlbumList } from './albumLists'
 import config from '../config'
 import AlbumInfo from './AlbumInfo'
 import ExpandInfoDialog from '../dialogs/ExpandInfoDialog'
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+
+const inputStyle = makeStyles({
+  chip: {
+    margin: 0,
+    height: '24px',
+  },
+})
 
 const AlbumFilter = (props) => {
   const translate = useTranslate()
+  const classes = inputStyle()
   return (
     <Filter {...props} variant={'outlined'}>
       <SearchInput id="search" source="name" alwaysOn />
@@ -44,7 +56,7 @@ const AlbumFilter = (props) => {
       >
         <AutocompleteInput emptyText="-- None --" />
       </ReferenceInput>
-      <ReferenceInput
+      <ReferenceArrayInput
         label={translate('resources.album.fields.genre')}
         source="genre_id"
         reference="genre"
@@ -52,8 +64,8 @@ const AlbumFilter = (props) => {
         sort={{ field: 'name', order: 'ASC' }}
         filterToQuery={(searchText) => ({ name: [searchText] })}
       >
-        <AutocompleteInput emptyText="-- None --" />
-      </ReferenceInput>
+        <AutocompleteArrayInput emptyText="-- None --" classes={classes} />
+      </ReferenceArrayInput>
       <NullableBooleanInput source="compilation" />
       <NumberInput source="year" />
       {config.enableFavourites && (

--- a/ui/src/artist/ArtistList.jsx
+++ b/ui/src/artist/ArtistList.jsx
@@ -1,13 +1,13 @@
 import React, { useMemo } from 'react'
 import { useHistory } from 'react-router-dom'
 import {
-  AutocompleteInput,
+  AutocompleteArrayInput,
   Datagrid,
   DatagridBody,
   DatagridRow,
   Filter,
   NumberField,
-  ReferenceInput,
+  ReferenceArrayInput,
   SearchInput,
   TextField,
   useTranslate,
@@ -56,12 +56,21 @@ const useStyles = makeStyles({
   },
 })
 
+const inputStyle = makeStyles({
+  chip: {
+    margin: 0,
+    height: '24px',
+  },
+})
+
 const ArtistFilter = (props) => {
   const translate = useTranslate()
+  const classes = inputStyle()
+
   return (
     <Filter {...props} variant={'outlined'}>
       <SearchInput id="search" source="name" alwaysOn />
-      <ReferenceInput
+      <ReferenceArrayInput
         label={translate('resources.artist.fields.genre')}
         source="genre_id"
         reference="genre"
@@ -69,8 +78,8 @@ const ArtistFilter = (props) => {
         sort={{ field: 'name', order: 'ASC' }}
         filterToQuery={(searchText) => ({ name: [searchText] })}
       >
-        <AutocompleteInput emptyText="-- None --" />
-      </ReferenceInput>
+        <AutocompleteArrayInput emptyText="-- None --" classes={classes} />
+      </ReferenceArrayInput>
       {config.enableFavourites && (
         <QuickFilter
           source="starred"

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import {
-  AutocompleteInput,
+  AutocompleteArrayInput,
   Filter,
   FunctionField,
   NumberField,
-  ReferenceInput,
+  ReferenceArrayInput,
   SearchInput,
   TextField,
   useTranslate,
@@ -59,12 +59,20 @@ const useStyles = makeStyles({
   },
 })
 
+const inputStyle = makeStyles({
+  chip: {
+    margin: 0,
+    height: '24px',
+  },
+})
+
 const SongFilter = (props) => {
   const translate = useTranslate()
+  const classes = inputStyle()
   return (
     <Filter {...props} variant={'outlined'}>
       <SearchInput source="title" alwaysOn />
-      <ReferenceInput
+      <ReferenceArrayInput
         label={translate('resources.song.fields.genre')}
         source="genre_id"
         reference="genre"
@@ -72,8 +80,8 @@ const SongFilter = (props) => {
         sort={{ field: 'name', order: 'ASC' }}
         filterToQuery={(searchText) => ({ name: [searchText] })}
       >
-        <AutocompleteInput emptyText="-- None --" />
-      </ReferenceInput>
+        <AutocompleteArrayInput emptyText="-- None --" classes={classes} />
+      </ReferenceArrayInput>
       {config.enableFavourites && (
         <QuickFilter
           source="starred"


### PR DESCRIPTION
Hi. I found myself wanting to filter on multiple genres at once. For instance I have some songs labeled with `Drum & Bass`, and some with `Drum And Bass`. Or I simply want to use Shuffle All on multiple genres.
I thought it would need backend changes, but I found `ReferenceArrayInput` and it looks like it works.

![image](https://github.com/user-attachments/assets/73fbb4df-308c-441d-ad3a-a59073f88cfa)