### PR TITLE
fix(ui): Fix playlist track id, handle missing tracks better

### DIFF
--- a/core/inspect.go
+++ b/core/inspect.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 
 	"github.com/navidrome/navidrome/core/storage"
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/metadata"
 	. "github.com/navidrome/navidrome/utils/gg"
@@ -33,7 +34,13 @@ func Inspect(filePath string, libraryId int, folderId string) (*InspectOutput, e
 		return nil, err
 	}
 
-	md := metadata.New(path, tags[file])
+	tag, ok := tags[file]
+	if !ok {
+		log.Error("Could not get tags for path", "path", filePath)
+		return nil, model.ErrNotFound
+	}
+
+	md := metadata.New(path, tag)
 	result := &InspectOutput{
 		File:       filePath,
 		RawTags:    tags[file].Tags,

--- a/server/nativeapi/inspect.go
+++ b/server/nativeapi/inspect.go
@@ -19,6 +19,10 @@ func doInspect(ctx context.Context, ds model.DataStore, id string) (*core.Inspec
 		return nil, err
 	}
 
+	if file.Missing {
+		return nil, model.ErrNotFound
+	}
+
 	return core.Inspect(file.AbsolutePath(), file.LibraryID, file.FolderID)
 }
 

--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -110,9 +110,10 @@ export const SongContextMenu = ({
       label: translate('resources.song.actions.info'),
       action: async (record) => {
         let fullRecord = record
-        if (permissions === 'admin') {
+        if (permissions === 'admin' && !record.missing) {
           try {
-            const data = await httpClient(`/api/inspect?id=${record.id}`)
+            let id = record.mediaFileId ?? record.id
+            const data = await httpClient(`/api/inspect?id=${id}`)
             fullRecord = { ...record, rawTags: data.json.rawTags }
           } catch (error) {
             notify(


### PR DESCRIPTION
- Use `mediaFileId` instead of `id` for playlist tracks
- Only fetch if the file is not missing
- If extractor fails to get the file, also error (rather than panic)