### PR TITLE
feat(ui): Improve Artist Album pagination

### DIFF
--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -56,7 +56,7 @@ const AlbumShowLayout = (props) => {
   const { width } = props
   const [, perPageOptions] = useAlbumsPerPage(width)
 
-  const maxPerPage = 36
+  const maxPerPage = 90
   let perPage = 0
   let pagination = null
 
@@ -67,7 +67,9 @@ const AlbumShowLayout = (props) => {
 
   if (count > maxPerPage) {
     perPage = Math.trunc(maxPerPage / perPageOptions[0]) * perPageOptions[0]
-    const rowsPerPageOptions = [1, 2, 3].map((option) => option * perPage)
+    const rowsPerPageOptions = [1, 2, 3].map((option) =>
+      Math.trunc(option * (perPage / 3)),
+    )
     pagination = <Pagination rowsPerPageOptions={rowsPerPageOptions} />
   }
 

--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -56,11 +56,16 @@ const AlbumShowLayout = (props) => {
   const { width } = props
   const [, perPageOptions] = useAlbumsPerPage(width)
 
-  const maxPerPage = 90
+  const maxPerPage = 36
   let perPage = 0
   let pagination = null
 
-  if (record?.stats?.['artist']?.albumCount > maxPerPage) {
+  const count = Math.max(
+    record?.stats?.['albumartist']?.albumCount || 0,
+    record?.stats?.['artist']?.albumCount ?? 0,
+  )
+
+  if (count > maxPerPage) {
     perPage = Math.trunc(maxPerPage / perPageOptions[0]) * perPageOptions[0]
     const rowsPerPageOptions = [1, 2, 3].map((option) => option * perPage)
     pagination = <Pagination rowsPerPageOptions={rowsPerPageOptions} />


### PR DESCRIPTION
- use maximum of albumartist/artist credits for determining pagination
- reduce default maxPerPage considerably. This gives values of 36/72/108 at largest size