### PR TITLE
fix(scanner): Always refresh folder image time when adding first image

### DIFF
--- a/scanner/walk_dir_tree.go
+++ b/scanner/walk_dir_tree.go
@@ -214,7 +214,9 @@ func loadDir(ctx context.Context, job *scanJob, dirPath string, ignorePatterns [
 				folder.numPlaylists++
 			case model.IsImageFile(entry.Name()):
 				folder.imageFiles[entry.Name()] = entry
-				if fileInfo.ModTime().After(folder.imagesUpdatedAt) {
+				if folder.imagesUpdatedAt.IsZero() {
+					folder.imagesUpdatedAt = folder.modTime
+				} else if fileInfo.ModTime().After(folder.imagesUpdatedAt) {
 					folder.imagesUpdatedAt = fileInfo.ModTime()
 				}
 			}

--- a/scanner/walk_dir_tree.go
+++ b/scanner/walk_dir_tree.go
@@ -161,6 +161,7 @@ func loadDir(ctx context.Context, job *scanJob, dirPath string, ignorePatterns [
 		return nil, nil, err
 	}
 	folder.modTime = dirInfo.ModTime()
+	folder.imagesUpdatedAt = folder.modTime
 
 	dir, err := job.fs.Open(dirPath)
 	if err != nil {
@@ -214,9 +215,7 @@ func loadDir(ctx context.Context, job *scanJob, dirPath string, ignorePatterns [
 				folder.numPlaylists++
 			case model.IsImageFile(entry.Name()):
 				folder.imageFiles[entry.Name()] = entry
-				if folder.imagesUpdatedAt.IsZero() {
-					folder.imagesUpdatedAt = folder.modTime
-				} else if fileInfo.ModTime().After(folder.imagesUpdatedAt) {
+				if fileInfo.ModTime().After(folder.imagesUpdatedAt) {
 					folder.imagesUpdatedAt = fileInfo.ModTime()
 				}
 			}

--- a/scanner/walk_dir_tree.go
+++ b/scanner/walk_dir_tree.go
@@ -15,6 +15,7 @@ import (
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/chrono"
 	ignore "github.com/sabhiram/go-gitignore"
 )
@@ -161,7 +162,6 @@ func loadDir(ctx context.Context, job *scanJob, dirPath string, ignorePatterns [
 		return nil, nil, err
 	}
 	folder.modTime = dirInfo.ModTime()
-	folder.imagesUpdatedAt = folder.modTime
 
 	dir, err := job.fs.Open(dirPath)
 	if err != nil {
@@ -215,9 +215,7 @@ func loadDir(ctx context.Context, job *scanJob, dirPath string, ignorePatterns [
 				folder.numPlaylists++
 			case model.IsImageFile(entry.Name()):
 				folder.imageFiles[entry.Name()] = entry
-				if fileInfo.ModTime().After(folder.imagesUpdatedAt) {
-					folder.imagesUpdatedAt = fileInfo.ModTime()
-				}
+				folder.imagesUpdatedAt = utils.TimeNewest(folder.imagesUpdatedAt, fileInfo.ModTime(), folder.modTime)
 			}
 		}
 	}

--- a/utils/time.go
+++ b/utils/time.go
@@ -1,0 +1,13 @@
+package utils
+
+import "time"
+
+func TimeNewest(times ...time.Time) time.Time {
+	newest := time.Time{}
+	for _, t := range times {
+		if t.After(newest) {
+			newest = t
+		}
+	}
+	return newest
+}

--- a/utils/time_test.go
+++ b/utils/time_test.go
@@ -1,0 +1,28 @@
+package utils_test
+
+import (
+	"time"
+
+	"github.com/navidrome/navidrome/utils"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TimeNewest", func() {
+	It("returns zero time when no times are provided", func() {
+		Expect(utils.TimeNewest()).To(Equal(time.Time{}))
+	})
+
+	It("returns the time when only one time is provided", func() {
+		t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		Expect(utils.TimeNewest(t1)).To(Equal(t1))
+	})
+
+	It("returns the newest time when multiple times are provided", func() {
+		t1 := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+		t2 := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+		t3 := time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC)
+
+		Expect(utils.TimeNewest(t1, t2, t3)).To(Equal(t2))
+	})
+})


### PR DESCRIPTION
Currently, the `images_updated_at` field is only set to the image modification time. However, in cases where a new image is added _and_ said image is older than the folder mod time, the field is not updated properly.

In this the case where `images_updated_at` is null (no images were ever added) and a new images is found, use the folder modification time instead of image modification time.

**Note**, this doesn't handle cases such as replacing a newer image with an older one.