### PR TITLE
ignore data folder and cache folder for scanner

### DIFF
--- a/scanner/watcher.go
+++ b/scanner/watcher.go
@@ -133,6 +133,12 @@ func isIgnoredPath(_ context.Context, _ fs.FS, path string) bool {
 		return false
 	case name == ".DS_Store":
 		return true
+	case baseDir == conf.Server.DataFolder:
+		return true
+	case name == "navidrome.db", name == "navidrome.db-shm", name == "navidrome.db-wal":
+		return true
+	case baseDir == conf.Server.CacheFolder:
+		return true
 	}
 	// As it can be a deletion and not a change, we cannot reliably know if the path is a file or directory.
 	// But at this point, we can assume it's a directory. If it's a file, it would be ignored anyway


### PR DESCRIPTION
When music lib contains data folder, the scanner will run in an infinite loop.
<img width="1238" alt="スクリーンショット 2025-03-10 16 38 31" src="https://github.com/user-attachments/assets/407078c7-39a6-466c-b116-74ce3b66ef7b" />
