### PR TITLE
fix(server): db migration does not work for MusicFolders ending with a trailing slash.

### DIFF
--- a/db/migrations/20241026183640_support_new_scanner.go
+++ b/db/migrations/20241026183640_support_new_scanner.go
@@ -178,7 +178,7 @@ join library on media_file.library_id = library.id`, string(os.PathSeparator)))
 				f := model.NewFolder(lib, path)
 				_, err = stmt.ExecContext(ctx, f.ID, lib.ID, f.Path, f.Name, f.ParentID)
 				if err != nil {
-					log.Error("Error writing folder to DB", "path", path, err)
+					log.Error("error writing folder to DB", "path", path, err)
 				}
 			}
 			return err
@@ -187,7 +187,13 @@ join library on media_file.library_id = library.id`, string(os.PathSeparator)))
 			return fmt.Errorf("error populating folder table: %w", err)
 		}
 
-		libPathLen := utf8.RuneCountInString(lib.Path)
+		// Remove library path prefix from media_file paths
+		// Make sure the library path has no trailing slash
+		libPath := strings.TrimSuffix(lib.Path, string(os.PathSeparator))
+		libPathLen := utf8.RuneCountInString(libPath)
+
+		// In one go, update all paths in the media_file table, removing the library path prefix
+		// and replacing any backslashes with slashes (the path separator used by the io/fs package)
 		_, err = tx.ExecContext(ctx, fmt.Sprintf(`
 update media_file set path = replace(substr(path, %d), '\', '/');`, libPathLen+2))
 		if err != nil {

--- a/db/migrations/20241026183640_support_new_scanner.go
+++ b/db/migrations/20241026183640_support_new_scanner.go
@@ -187,9 +187,8 @@ join library on media_file.library_id = library.id`, string(os.PathSeparator)))
 			return fmt.Errorf("error populating folder table: %w", err)
 		}
 
-		// Remove library path prefix from media_file paths
-		// Make sure the library path has no trailing slash
-		libPath := strings.TrimSuffix(lib.Path, string(os.PathSeparator))
+		// Count the number of characters in the library path
+		libPath := filepath.Clean(lib.Path)
 		libPathLen := utf8.RuneCountInString(libPath)
 
 		// In one go, update all paths in the media_file table, removing the library path prefix


### PR DESCRIPTION
Fixes #3788 