### PR TITLE
fix(ui): show composer and other roles' albums in the artist page

### DIFF
--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -119,11 +119,17 @@ var albumFilters = sync.OnceValue(func() map[string]filterFunc {
 		"has_rating":      hasRatingFilter,
 		"missing":         booleanFilter,
 		"genre_id":        tagIDFilter,
+		"total_id":        allRolesFilter,
 	}
 	// Add all album tags as filters
 	for tag := range model.AlbumLevelTags() {
 		filters[string(tag)] = tagIDFilter
 	}
+
+	for role := range model.AllRoles {
+		filters[role+"_id"] = artistFilter
+	}
+
 	return filters
 })
 
@@ -154,13 +160,13 @@ func yearFilter(_ string, value interface{}) Sqlizer {
 }
 
 // BFR: Support other roles
-func artistFilter(_ string, value interface{}) Sqlizer {
-	return Or{
-		Exists("json_tree(Participants, '$.albumartist')", Eq{"value": value}),
-		Exists("json_tree(Participants, '$.artist')", Eq{"value": value}),
-	}
-	// For any role:
-	//return Like{"Participants": fmt.Sprintf(`%%"%s"%%`, value)}
+func artistFilter(name string, value interface{}) Sqlizer {
+	key := name[:len(name)-3]
+	return Exists(fmt.Sprintf("json_tree(Participants, '$.%s')", key), Eq{"value": value})
+}
+
+func allRolesFilter(_ string, value interface{}) Sqlizer {
+	return Like{"Participants": fmt.Sprintf(`%%"%s"%%`, value)}
 }
 
 func (r *albumRepository) CountAll(options ...model.QueryOptions) (int64, error) {

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -270,30 +270,42 @@ func (api *Router) GetGenres(r *http.Request) (*responses.Subsonic, error) {
 	return response, nil
 }
 
-func (api *Router) GetArtistInfo(r *http.Request) (*responses.Subsonic, error) {
+func (api *Router) getArtistInfo(r *http.Request) (*responses.ArtistInfoBase, *model.Artists, error) {
 	ctx := r.Context()
 	p := req.Params(r)
 	id, err := p.String("id")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	count := p.IntOr("count", 20)
 	includeNotPresent := p.BoolOr("includeNotPresent", false)
 
 	artist, err := api.externalMetadata.UpdateArtistInfo(ctx, id, count, includeNotPresent)
 	if err != nil {
+		return nil, nil, err
+	}
+
+	base := responses.ArtistInfoBase{}
+	base.Biography = artist.Biography
+	base.SmallImageUrl = public.ImageURL(r, artist.CoverArtID(), 300)
+	base.MediumImageUrl = public.ImageURL(r, artist.CoverArtID(), 600)
+	base.LargeImageUrl = public.ImageURL(r, artist.CoverArtID(), 1200)
+	base.LastFmUrl = artist.ExternalUrl
+	base.MusicBrainzID = artist.MbzArtistID
+
+	return &base, &artist.SimilarArtists, nil
+}
+
+func (api *Router) GetArtistInfo(r *http.Request) (*responses.Subsonic, error) {
+	base, similarArtists, err := api.getArtistInfo(r)
+	if err != nil {
 		return nil, err
 	}
 
 	response := newResponse()
-	response.ArtistInfo = &responses.ArtistInfo{}
-	response.ArtistInfo.Biography = artist.Biography
-	response.ArtistInfo.SmallImageUrl = public.ImageURL(r, artist.CoverArtID(), 300)
-	response.ArtistInfo.MediumImageUrl = public.ImageURL(r, artist.CoverArtID(), 600)
-	response.ArtistInfo.LargeImageUrl = public.ImageURL(r, artist.CoverArtID(), 1200)
-	response.ArtistInfo.LastFmUrl = artist.ExternalUrl
-	response.ArtistInfo.MusicBrainzID = artist.MbzArtistID
-	for _, s := range artist.SimilarArtists {
+	response.ArtistInfo.ArtistInfoBase = *base
+
+	for _, s := range *similarArtists {
 		similar := toArtist(r, s)
 		if s.ID == "" {
 			similar.Id = "-1"
@@ -304,23 +316,19 @@ func (api *Router) GetArtistInfo(r *http.Request) (*responses.Subsonic, error) {
 }
 
 func (api *Router) GetArtistInfo2(r *http.Request) (*responses.Subsonic, error) {
-	info, err := api.GetArtistInfo(r)
+	base, similarArtists, err := api.getArtistInfo(r)
 	if err != nil {
 		return nil, err
 	}
 
 	response := newResponse()
-	response.ArtistInfo2 = &responses.ArtistInfo2{}
-	response.ArtistInfo2.ArtistInfoBase = info.ArtistInfo.ArtistInfoBase
-	for _, s := range info.ArtistInfo.SimilarArtist {
-		similar := responses.ArtistID3{}
-		similar.Id = s.Id
-		similar.Name = s.Name
-		similar.AlbumCount = s.AlbumCount
-		similar.Starred = s.Starred
-		similar.UserRating = s.UserRating
-		similar.CoverArt = s.CoverArt
-		similar.ArtistImageUrl = s.ArtistImageUrl
+	response.ArtistInfo2.ArtistInfoBase = *base
+
+	for _, s := range *similarArtists {
+		similar := toArtistID3(r, s)
+		if s.ID == "" {
+			similar.Id = "-1"
+		}
 		response.ArtistInfo2.SimilarArtist = append(response.ArtistInfo2.SimilarArtist, similar)
 	}
 	return response, nil

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -303,6 +303,7 @@ func (api *Router) GetArtistInfo(r *http.Request) (*responses.Subsonic, error) {
 	}
 
 	response := newResponse()
+	response.ArtistInfo = &responses.ArtistInfo{}
 	response.ArtistInfo.ArtistInfoBase = *base
 
 	for _, s := range *similarArtists {
@@ -322,6 +323,7 @@ func (api *Router) GetArtistInfo2(r *http.Request) (*responses.Subsonic, error) 
 	}
 
 	response := newResponse()
+	response.ArtistInfo2 = &responses.ArtistInfo2{}
 	response.ArtistInfo2.ArtistInfoBase = *base
 
 	for _, s := range *similarArtists {

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -10,6 +10,10 @@ import (
 )
 
 var _ = Describe("helpers", func() {
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+	})
+
 	Describe("fakePath", func() {
 		var mf model.MediaFile
 		BeforeEach(func() {
@@ -134,4 +138,29 @@ var _ = Describe("helpers", func() {
 		Entry("returns \"explicit\" when the db value is \"e\"", "e", "explicit"),
 		Entry("returns an empty string when the db value is \"\"", "", ""),
 		Entry("returns an empty string when there are unexpected values on the db", "abc", ""))
+
+	Describe("getArtistAlbumCount", func() {
+		artist := model.Artist{
+			Stats: map[model.Role]model.ArtistStats{
+				model.RoleAlbumArtist: {
+					AlbumCount: 3,
+				},
+				model.RoleArtist: {
+					AlbumCount: 4,
+				},
+			},
+		}
+
+		It("Handles album count without artist participations", func() {
+			conf.Server.Subsonic.ArtistParticipations = false
+			result := getArtistAlbumCount(artist)
+			Expect(result).To(Equal(int32(3)))
+		})
+
+		It("Handles album count without with participations", func() {
+			conf.Server.Subsonic.ArtistParticipations = true
+			result := getArtistAlbumCount(artist)
+			Expect(result).To(Equal(int32(4)))
+		})
+	})
 })

--- a/server/subsonic/responses/.snapshots/Responses Indexes with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses Indexes with data should match .JSON
@@ -12,7 +12,6 @@
           {
             "id": "111",
             "name": "aaa",
-            "albumCount": 2,
             "starred": "2016-03-02T20:30:00Z",
             "userRating": 3,
             "artistImageUrl": "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"

--- a/server/subsonic/responses/.snapshots/Responses Indexes with data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses Indexes with data should match .XML
@@ -1,7 +1,7 @@
 <subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.8.0" type="navidrome" serverVersion="v0.0.0" openSubsonic="true">
   <indexes lastModified="1" ignoredArticles="A">
     <index name="A">
-      <artist id="111" name="aaa" albumCount="2" starred="2016-03-02T20:30:00Z" userRating="3" artistImageUrl="https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"></artist>
+      <artist id="111" name="aaa" starred="2016-03-02T20:30:00Z" userRating="3" artistImageUrl="https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png"></artist>
     </index>
   </indexes>
 </subsonic-response>

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -92,7 +92,6 @@ type MusicFolders struct {
 type Artist struct {
 	Id             string     `xml:"id,attr"                           json:"id"`
 	Name           string     `xml:"name,attr"                         json:"name"`
-	AlbumCount     int32      `xml:"albumCount,attr,omitempty"         json:"albumCount,omitempty"`
 	Starred        *time.Time `xml:"starred,attr,omitempty"            json:"starred,omitempty"`
 	UserRating     int32      `xml:"userRating,attr,omitempty"         json:"userRating,omitempty"`
 	CoverArt       string     `xml:"coverArt,attr,omitempty"           json:"coverArt,omitempty"`
@@ -233,7 +232,7 @@ type ArtistID3 struct {
 	Id                     string     `xml:"id,attr"                            json:"id"`
 	Name                   string     `xml:"name,attr"                          json:"name"`
 	CoverArt               string     `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
-	AlbumCount             int32      `xml:"albumCount,attr,omitempty"          json:"albumCount,omitempty"`
+	AlbumCount             int32      `xml:"albumCount,attr"                    json:"albumCount"`
 	Starred                *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
 	UserRating             int32      `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
 	ArtistImageUrl         string     `xml:"artistImageUrl,attr,omitempty"      json:"artistImageUrl,omitempty"`

--- a/server/subsonic/responses/responses_test.go
+++ b/server/subsonic/responses/responses_test.go
@@ -103,7 +103,6 @@ var _ = Describe("Responses", func() {
 					Name:           "aaa",
 					Starred:        &t,
 					UserRating:     3,
-					AlbumCount:     2,
 					ArtistImageUrl: "https://lastfm.freetls.fastly.net/i/u/300x300/2a96cbd8b46e442fc41c2b86b821562f.png",
 				}
 				index := make([]Index, 1)

--- a/server/subsonic/searching.go
+++ b/server/subsonic/searching.go
@@ -94,7 +94,6 @@ func (api *Router) Search2(r *http.Request) (*responses.Subsonic, error) {
 		a := responses.Artist{
 			Id:             artist.ID,
 			Name:           artist.Name,
-			AlbumCount:     int32(artist.AlbumCount),
 			UserRating:     int32(artist.Rating),
 			CoverArt:       artist.CoverArtID().String(),
 			ArtistImageUrl: public.ImageURL(r, artist.CoverArtID(), 600),

--- a/ui/src/artist/ArtistList.jsx
+++ b/ui/src/artist/ArtistList.jsx
@@ -10,7 +10,6 @@ import {
   SearchInput,
   SelectInput,
   TextField,
-  useTranslate,
 } from 'react-admin'
 import { useMediaQuery, withWidth } from '@material-ui/core'
 import FavoriteIcon from '@material-ui/icons/Favorite'
@@ -32,6 +31,7 @@ import ArtistSimpleList from './ArtistSimpleList'
 import { DraggableTypes } from '../consts'
 import en from '../i18n/en.json'
 import { formatBytes } from '../utils/index.js'
+import { useArtistRoles } from '../common/useArtistRoles.jsx'
 
 const useStyles = makeStyles({
   contextHeader: {
@@ -58,18 +58,7 @@ const useStyles = makeStyles({
 })
 
 const ArtistFilter = (props) => {
-  const translate = useTranslate()
-  const rolesObj = en?.resources?.artist?.roles
-  const roles = Object.keys(rolesObj).reduce((acc, role) => {
-    acc.push({
-      id: role,
-      name: translate(`resources.artist.roles.${role}`, {
-        smart_count: 2,
-      }),
-    })
-    return acc
-  }, [])
-  roles?.sort((a, b) => a.name.localeCompare(b.name))
+  const roles = useArtistRoles(true)
   return (
     <Filter {...props} variant={'outlined'}>
       <SearchInput id="search" source="name" alwaysOn />

--- a/ui/src/artist/ArtistList.jsx
+++ b/ui/src/artist/ArtistList.jsx
@@ -29,7 +29,6 @@ import config from '../config'
 import ArtistListActions from './ArtistListActions'
 import ArtistSimpleList from './ArtistSimpleList'
 import { DraggableTypes } from '../consts'
-import en from '../i18n/en.json'
 import { formatBytes } from '../utils/index.js'
 import { useArtistRoles } from '../common/useArtistRoles.jsx'
 
@@ -98,7 +97,10 @@ const ArtistDatagrid = (props) => (
 const ArtistListView = ({ hasShow, hasEdit, hasList, width, ...rest }) => {
   const { filterValues } = rest
   const classes = useStyles()
-  const handleArtistLink = useGetHandleArtistClick(width)
+  const handleArtistLink = useGetHandleArtistClick(
+    width,
+    rest.filterValues?.role,
+  )
   const history = useHistory()
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   useResourceRefresh('artist')

--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -78,7 +78,7 @@ const AlbumShowLayout = (props) => {
   const roles = useArtistRoles(false)
   const classes = useStyles()
 
-  const maxPerPage = 72
+  const maxPerPage = 36
   let perPage = 0
   let pagination = null
 
@@ -90,7 +90,7 @@ const AlbumShowLayout = (props) => {
   if (count > maxPerPage) {
     perPage = Math.trunc(maxPerPage / perPageOptions[0]) * perPageOptions[0]
     const rowsPerPageOptions = [1, 2, 3].map((option) =>
-      Math.trunc(option * (perPage / 3)),
+      Math.trunc(option * perPage),
     )
     pagination = <Pagination rowsPerPageOptions={rowsPerPageOptions} />
   }

--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -1,5 +1,12 @@
 import React, { useState, createElement, useEffect } from 'react'
-import { useMediaQuery, withWidth } from '@material-ui/core'
+import {
+  InputLabel,
+  makeStyles,
+  MenuItem,
+  Select,
+  useMediaQuery,
+  withWidth,
+} from '@material-ui/core'
 import {
   useShowController,
   ShowContextProvider,
@@ -7,12 +14,21 @@ import {
   useShowContext,
   ReferenceManyField,
   Pagination,
+  useTranslate,
 } from 'react-admin'
+import en from '../i18n/en.json'
 import subsonic from '../subsonic'
 import AlbumGridView from '../album/AlbumGridView'
 import MobileArtistDetails from './MobileArtistDetails'
 import DesktopArtistDetails from './DesktopArtistDetails'
 import { useAlbumsPerPage } from '../common/index.js'
+import { useArtistRoles } from '../common/useArtistRoles.jsx'
+
+const useStyles = makeStyles({
+  root: {
+    padding: '1em',
+  },
+})
 
 const ArtistDetails = (props) => {
   const record = useRecordContext(props)
@@ -51,19 +67,23 @@ const ArtistDetails = (props) => {
 }
 
 const AlbumShowLayout = (props) => {
+  const translate = useTranslate()
   const showContext = useShowContext(props)
   const record = useRecordContext()
   const { width } = props
   const [, perPageOptions] = useAlbumsPerPage(width)
+  const [role, setRole] = useState('albumartist')
+  const roles = useArtistRoles(false)
+  const classes = useStyles()
 
-  const maxPerPage = 90
+  const maxPerPage = 72
   let perPage = 0
   let pagination = null
 
-  const count = Math.max(
-    record?.stats?.['albumartist']?.albumCount || 0,
-    record?.stats?.['artist']?.albumCount ?? 0,
-  )
+  const count =
+    role === 'total'
+      ? record?.albumCount
+      : record?.stats?.[role]?.albumCount || 0
 
   if (count > maxPerPage) {
     perPage = Math.trunc(maxPerPage / perPageOptions[0]) * perPageOptions[0]
@@ -73,17 +93,39 @@ const AlbumShowLayout = (props) => {
     pagination = <Pagination rowsPerPageOptions={rowsPerPageOptions} />
   }
 
+  const id = `${role}_id`
+
   return (
     <>
       {record && <ArtistDetails />}
+      <div className={classes.root}>
+        <InputLabel>{translate('resources.artist.fields.role')}</InputLabel>
+        <Select
+          value={role}
+          onChange={(event) => setRole(event.target.value)}
+          fullWidth
+        >
+          <MenuItem key="total" value="total">
+            {translate('resources.artist.fields.allRoles')} (
+            {record?.albumCount || 0})
+          </MenuItem>
+          {roles
+            .filter((role) => record?.stats?.[role.id]?.albumCount)
+            .map((role) => (
+              <MenuItem key={role.id} value={role.id}>
+                {role.name} ({record.stats[role.id].albumCount})
+              </MenuItem>
+            ))}
+        </Select>
+      </div>
       {record && (
         <ReferenceManyField
           {...showContext}
           addLabel={false}
           reference="album"
-          target="artist_id"
+          target={id}
           sort={{ field: 'max_year', order: 'ASC' }}
-          filter={{ artist_id: record?.id }}
+          filter={{ [id]: record?.id }}
           perPage={perPage}
           pagination={pagination}
         >

--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -95,7 +95,7 @@ const AlbumShowLayout = (props) => {
     pagination = <Pagination rowsPerPageOptions={rowsPerPageOptions} />
   }
 
-  const id = `${role}_id`
+  const id = `role_${role}_id`
 
   return (
     <>

--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -1,6 +1,5 @@
 import React, { useState, createElement, useEffect } from 'react'
 import {
-  InputLabel,
   makeStyles,
   MenuItem,
   Select,
@@ -16,13 +15,13 @@ import {
   Pagination,
   useTranslate,
 } from 'react-admin'
-import en from '../i18n/en.json'
 import subsonic from '../subsonic'
 import AlbumGridView from '../album/AlbumGridView'
 import MobileArtistDetails from './MobileArtistDetails'
 import DesktopArtistDetails from './DesktopArtistDetails'
 import { useAlbumsPerPage } from '../common/index.js'
 import { useArtistRoles } from '../common/useArtistRoles.jsx'
+import { useLocation } from 'react-router-dom/cjs/react-router-dom.min.js'
 
 const useStyles = makeStyles({
   root: {
@@ -72,7 +71,10 @@ const AlbumShowLayout = (props) => {
   const record = useRecordContext()
   const { width } = props
   const [, perPageOptions] = useAlbumsPerPage(width)
-  const [role, setRole] = useState('albumartist')
+  const { search } = useLocation()
+  const [role, setRole] = useState(
+    new URLSearchParams(search).get('role') ?? 'total',
+  )
   const roles = useArtistRoles(false)
   const classes = useStyles()
 
@@ -99,7 +101,6 @@ const AlbumShowLayout = (props) => {
     <>
       {record && <ArtistDetails />}
       <div className={classes.root}>
-        <InputLabel>{translate('resources.artist.fields.role')}</InputLabel>
         <Select
           value={role}
           onChange={(event) => setRole(event.target.value)}

--- a/ui/src/common/useArtistRoles.jsx
+++ b/ui/src/common/useArtistRoles.jsx
@@ -1,0 +1,27 @@
+import { useMemo } from 'react'
+import en from '../i18n/en.json'
+import { useTranslate } from 'react-admin'
+
+export const useArtistRoles = (plural) => {
+  const translate = useTranslate()
+  const count = plural ? 2 : 1
+
+  const roles = useMemo(() => {
+    const rolesObj = en?.resources?.artist?.roles
+
+    const roles = Object.keys(rolesObj).reduce((acc, role) => {
+      acc.push({
+        id: role,
+        name: translate(`resources.artist.roles.${role}`, {
+          smart_count: count,
+        }),
+      })
+      return acc
+    }, [])
+    roles?.sort((a, b) => a.name.localeCompare(b.name))
+
+    return roles
+  }, [count, translate])
+
+  return roles
+}

--- a/ui/src/common/useGetHandleArtistClick.jsx
+++ b/ui/src/common/useGetHandleArtistClick.jsx
@@ -1,11 +1,11 @@
 import { useAlbumsPerPage } from './useAlbumsPerPage'
 import config from '../config.js'
 
-export const useGetHandleArtistClick = (width) => {
+export const useGetHandleArtistClick = (width, role = undefined) => {
   const [perPage] = useAlbumsPerPage(width)
   return (id) => {
     return config.devShowArtistPage && id !== config.variousArtistsId
-      ? `/artist/${id}/show`
+      ? `/artist/${id}/show` + (role ? `?role=${role}` : '')
       : `/album?filter={"artist_id":"${id}"}&order=ASC&sort=max_year&displayedFilters={"compilation":true}&perPage=${perPage}`
   }
 }

--- a/ui/src/common/useGetHandleArtistClick.jsx
+++ b/ui/src/common/useGetHandleArtistClick.jsx
@@ -6,6 +6,6 @@ export const useGetHandleArtistClick = (width, role = undefined) => {
   return (id) => {
     return config.devShowArtistPage && id !== config.variousArtistsId
       ? `/artist/${id}/show` + (role ? `?role=${role}` : '')
-      : `/album?filter={"artist_id":"${id}"}&order=ASC&sort=max_year&displayedFilters={"compilation":true}&perPage=${perPage}`
+      : `/album?filter={"albumartist_id":"${id}"}&order=ASC&sort=max_year&displayedFilters={"compilation":true}&perPage=${perPage}`
   }
 }

--- a/ui/src/common/useGetHandleArtistClick.jsx
+++ b/ui/src/common/useGetHandleArtistClick.jsx
@@ -6,6 +6,6 @@ export const useGetHandleArtistClick = (width, role = undefined) => {
   return (id) => {
     return config.devShowArtistPage && id !== config.variousArtistsId
       ? `/artist/${id}/show` + (role ? `?role=${role}` : '')
-      : `/album?filter={"albumartist_id":"${id}"}&order=ASC&sort=max_year&displayedFilters={"compilation":true}&perPage=${perPage}`
+      : `/album?filter={"artist_id":"${id}"}&order=ASC&sort=max_year&displayedFilters={"compilation":true}&perPage=${perPage}`
   }
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -102,7 +102,8 @@
         "playCount": "Plays",
         "rating": "Rating",
         "genre": "Genre",
-        "role": "Role"
+        "role": "Role",
+        "allRoles": "All Roles"
       },
       "roles": {
         "albumartist": "Album Artist |||| Album Artists",


### PR DESCRIPTION
Currently, Navidrome returns albums (/songs) for artists where the artist is credited as album artist/artist. However, the album count, song count, and size are based off of total credits, leading to potentially severe inconsistency. This PR seeks to limit the inconsistency such that `artist.AlbumCount <= len(returned albums)`.

Changes:
1. In `artist_repository`, make size/song count/album count based off of max(albumartist, artist)
2. Do the same for sort mapping. When role is not specified, default to the same sort as well
3. Make subsonic more consistent: `albumCount` is album only when `ArtistParticipations` is false (this results in an exact match), and the count otherwise
4. Some fixes for Subsonic typing. Specifically, `albumCount` is not set for `artist`, and is required for `artistid3`