### PR TITLE
chore(tags): Restore setsubtitle as discsubtitle for non-WMA

### DIFF
--- a/resources/mappings.yaml
+++ b/resources/mappings.yaml
@@ -96,7 +96,7 @@ main:
     aliases: [ disctotal, totaldiscs ]
     album: true
   discsubtitle:
-    aliases: [ tsst, discsubtitle, ----:com.apple.itunes:discsubtitle, wm/setsubtitle ]
+    aliases: [ tsst, discsubtitle, ----:com.apple.itunes:discsubtitle, setsubtitle, wm/setsubtitle ]
   bpm:
     aliases: [ tbpm, bpm, tmpo, wm/beatsperminute ]
   lyrics:


### PR DESCRIPTION
With old metadata, Disc Subtitle was one of `tsst`, `discsubtitle`, or `setsubtitle`. With the updated, `setsubtitle` is only available for flac. Update `mappings.yaml` to maintain prior behavior.