### PR TITLE
fix(server): better embedded artwork extraction with ffmpeg

### DIFF
--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -29,7 +29,7 @@ func New() FFmpeg {
 }
 
 const (
-	extractImageCmd = "ffmpeg -i %s -an -vcodec copy -f image2pipe -"
+	extractImageCmd = "ffmpeg -i %s -map 0:v -map -0:V -vcodec copy -f image2pipe -"
 	probeCmd        = "ffmpeg %s -f ffmetadata"
 )
 


### PR DESCRIPTION
This pull request includes a change to the `core/ffmpeg/ffmpeg.go` file to improve the command used for extracting images with FFmpeg.

* [`core/ffmpeg/ffmpeg.go`](diffhunk://#diff-a9b3e13d6a71ca846882c8ea135dc820571c5f7f895da5ce0d8e78fce2e43c2aL32-R32): Modified the `extractImageCmd` to use `-map 0:v -map -0:V` instead of `-an` for better video stream selection.

   - `-map 0:v` selects all video streams from the input
   - `-map -0:V` excludes all "main" video streams (capital V)

This combination effectively selects only the attached pictures.

Fixes #3859