### PR TITLE
fix(bfr): force upgrade to read all folders.

### DIFF
--- a/db/migrations/20241026183640_support_new_scanner.go
+++ b/db/migrations/20241026183640_support_new_scanner.go
@@ -164,7 +164,9 @@ join library on media_file.library_id = library.id`, string(os.PathSeparator)))
 			return nil
 		}
 
-		stmt, err := tx.PrepareContext(ctx, "insert into folder (id, library_id, path, name, parent_id) values (?, ?, ?, ?, ?)")
+		stmt, err := tx.PrepareContext(ctx,
+			"insert into folder (id, library_id, path, name, parent_id, updated_at) values (?, ?, ?, ?, ?, '0000-00-00 00:00:00')",
+		)
 		if err != nil {
 			return err
 		}

--- a/scanner/phase_1_folders.go
+++ b/scanner/phase_1_folders.go
@@ -150,6 +150,14 @@ func (p *phaseFolders) producer() ppl.Producer[*folderEntry] {
 					Path:      folder.path,
 					Phase:     "1",
 				})
+
+				// Log folder info
+				log.Trace(p.ctx, "Scanner: Checking folder state", " folder", folder.path, "_updTime", folder.updTime,
+					"_modTime", folder.modTime, "_lastScanStartedAt", folder.job.lib.LastScanStartedAt,
+					"numAudioFiles", len(folder.audioFiles), "numImageFiles", len(folder.imageFiles),
+					"numPlaylists", folder.numPlaylists, "numSubfolders", folder.numSubFolders)
+
+				// Check if folder is outdated
 				if folder.isOutdated() {
 					if !p.state.fullScan {
 						if folder.hasNoFiles() && folder.isNew() {
@@ -161,6 +169,8 @@ func (p *phaseFolders) producer() ppl.Producer[*folderEntry] {
 					totalChanged++
 					folder.elapsed.Stop()
 					put(folder)
+				} else {
+					log.Trace(p.ctx, "Scanner: Skipping up-to-date folder", "folder", folder.path, "lastUpdate", folder.modTime, "lib", job.lib.Name)
 				}
 			}
 			total += job.numFolders.Load()


### PR DESCRIPTION
It was skipping folders for certain timezones.

This bug would manifest as all your artists have 0 albums/songs after you finish upgrading to 0.55.X.

If you already upgraded to 0.55.0 or 0.55.1, and don't have the old backup to try upgrading again, just wait the number of hours your timezone is ahead of UTC (ex: CEST = 1hour), and manually trigger a full scan.
