### PR TITLE
feat(server): custom ArtistJoiner config

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -129,6 +129,7 @@ type scannerOptions struct {
 	WatcherWait        time.Duration
 	ScanOnStartup      bool
 	Extractor          string
+	ArtistJoiner       string
 	GenreSeparators    string // Deprecated: Use Tags.genre.Split instead
 	GroupAlbumReleases bool   // Deprecated: Use PID.Album instead
 }
@@ -495,6 +496,7 @@ func init() {
 	viper.SetDefault("scanner.extractor", consts.DefaultScannerExtractor)
 	viper.SetDefault("scanner.watcherwait", consts.DefaultWatcherWait)
 	viper.SetDefault("scanner.scanonstartup", true)
+	viper.SetDefault("scanner.artistjoiner", consts.ArtistJoiner)
 	viper.SetDefault("scanner.genreseparators", "")
 	viper.SetDefault("scanner.groupalbumreleases", false)
 

--- a/model/metadata/map_participants.go
+++ b/model/metadata/map_participants.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"strings"
 
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/str"
@@ -210,8 +211,8 @@ func (md Metadata) getArtistValues(single, multi model.TagName) []string {
 
 func (md Metadata) mapDisplayName(singularTagName, pluralTagName model.TagName) string {
 	return cmp.Or(
-		strings.Join(md.tags[singularTagName], consts.ArtistJoiner),
-		strings.Join(md.tags[pluralTagName], consts.ArtistJoiner),
+		strings.Join(md.tags[singularTagName], conf.Server.Scanner.ArtistJoiner),
+		strings.Join(md.tags[pluralTagName], conf.Server.Scanner.ArtistJoiner),
 	)
 }
 

--- a/ui/src/common/ArtistLinkField.test.jsx
+++ b/ui/src/common/ArtistLinkField.test.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { render, screen } from '@testing-library/react'
-import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ArtistLinkField } from './ArtistLinkField'
 import { intersperse } from '../utils/index.js'
 
@@ -18,9 +18,11 @@ vi.mock('../utils/index.js', () => ({
 }))
 
 vi.mock('@material-ui/core', () => ({
-  withWidth: () => (Component) => (props) => (
-    <Component {...props} width="md" />
-  ),
+  withWidth: () => (Component) => {
+    const WithWidthComponent = (props) => <Component {...props} width="md" />
+    WithWidthComponent.displayName = `WithWidth(${Component.displayName || Component.name || 'Component'})`
+    return WithWidthComponent
+  },
 }))
 
 vi.mock('react-admin', () => ({
@@ -36,125 +38,201 @@ describe('ArtistLinkField', () => {
     vi.clearAllMocks()
   })
 
-  test('renders artists from participants when available', () => {
-    const record = {
-      participants: {
-        artist: [
-          { id: '1', name: 'Artist 1' },
-          { id: '2', name: 'Artist 2' },
-        ],
-      },
-    }
+  describe('when rendering artists', () => {
+    it('renders artists from participants when available', () => {
+      const record = {
+        participants: {
+          artist: [
+            { id: '1', name: 'Artist 1' },
+            { id: '2', name: 'Artist 2' },
+          ],
+        },
+      }
 
-    render(<ArtistLinkField record={record} source="artist" />)
+      render(<ArtistLinkField record={record} source="artist" />)
 
-    expect(screen.getByText('Artist 1')).toBeInTheDocument()
-    expect(screen.getByText('Artist 2')).toBeInTheDocument()
+      expect(screen.getByText('Artist 1')).toBeInTheDocument()
+      expect(screen.getByText('Artist 2')).toBeInTheDocument()
+    })
+
+    it('falls back to record[source] when participants not available', () => {
+      const record = {
+        artist: 'Fallback Artist',
+        artistId: '123',
+      }
+
+      render(<ArtistLinkField record={record} source="artist" />)
+
+      expect(screen.getByText('Fallback Artist')).toBeInTheDocument()
+    })
+
+    it('handles empty artists array', () => {
+      const record = {
+        participants: {
+          artist: [],
+        },
+      }
+
+      render(<ArtistLinkField record={record} source="artist" />)
+
+      expect(intersperse).toHaveBeenCalledWith([], ' • ')
+    })
   })
 
-  test('falls back to record[source] when participants not available', () => {
-    const record = {
-      artist: 'Fallback Artist',
-      artistId: '123',
-    }
+  describe('when handling remixers', () => {
+    it('adds remixers when showing artist role', () => {
+      const record = {
+        participants: {
+          artist: [{ id: '1', name: 'Artist 1' }],
+          remixer: [{ id: '2', name: 'Remixer 1' }],
+        },
+      }
 
-    render(<ArtistLinkField record={record} source="artist" />)
+      render(<ArtistLinkField record={record} source="artist" />)
 
-    expect(screen.getByText('Fallback Artist')).toBeInTheDocument()
+      expect(screen.getByText('Artist 1')).toBeInTheDocument()
+      expect(screen.getByText('Remixer 1')).toBeInTheDocument()
+    })
+
+    it('limits remixers to maximum of 2', () => {
+      const record = {
+        participants: {
+          artist: [{ id: '1', name: 'Artist 1' }],
+          remixer: [
+            { id: '2', name: 'Remixer 1' },
+            { id: '3', name: 'Remixer 2' },
+            { id: '4', name: 'Remixer 3' },
+          ],
+        },
+      }
+
+      render(<ArtistLinkField record={record} source="artist" />)
+
+      expect(screen.getByText('Artist 1')).toBeInTheDocument()
+      expect(screen.getByText('Remixer 1')).toBeInTheDocument()
+      expect(screen.getByText('Remixer 2')).toBeInTheDocument()
+      expect(screen.queryByText('Remixer 3')).not.toBeInTheDocument()
+    })
+
+    it('deduplicates artists and remixers', () => {
+      const record = {
+        participants: {
+          artist: [{ id: '1', name: 'Duplicate Person' }],
+          remixer: [{ id: '1', name: 'Duplicate Person' }],
+        },
+      }
+
+      render(<ArtistLinkField record={record} source="artist" />)
+
+      const links = screen.getAllByRole('link')
+      expect(links).toHaveLength(1)
+      expect(links[0]).toHaveTextContent('Duplicate Person')
+    })
   })
 
-  test('adds remixers when showing artist role', () => {
-    const record = {
-      participants: {
-        artist: [{ id: '1', name: 'Artist 1' }],
-        remixer: [{ id: '2', name: 'Remixer 1' }],
-      },
-    }
+  describe('when using parseAndReplaceArtists', () => {
+    it('uses parseAndReplaceArtists when role is albumartist', () => {
+      const record = {
+        albumArtist: 'Group Artist',
+        participants: {
+          albumartist: [{ id: '1', name: 'Group Artist' }],
+        },
+      }
 
-    render(<ArtistLinkField record={record} source="artist" />)
+      render(<ArtistLinkField record={record} source="albumArtist" />)
 
-    expect(screen.getByText('Artist 1')).toBeInTheDocument()
-    expect(screen.getByText('Remixer 1')).toBeInTheDocument()
+      expect(screen.getByText('Group Artist')).toBeInTheDocument()
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/artist/1')
+    })
+
+    it('uses parseAndReplaceArtists when role is artist', () => {
+      const record = {
+        artist: 'Main Artist',
+        participants: {
+          artist: [{ id: '1', name: 'Main Artist' }],
+        },
+      }
+
+      render(<ArtistLinkField record={record} source="artist" />)
+
+      expect(screen.getByText('Main Artist')).toBeInTheDocument()
+      expect(screen.getByRole('link')).toHaveAttribute('href', '/artist/1')
+    })
+
+    it('adds remixers after parseAndReplaceArtists for artist role', () => {
+      const record = {
+        artist: 'Main Artist',
+        participants: {
+          artist: [{ id: '1', name: 'Main Artist' }],
+          remixer: [{ id: '2', name: 'Remixer 1' }],
+        },
+      }
+
+      render(<ArtistLinkField record={record} source="artist" />)
+
+      const links = screen.getAllByRole('link')
+      expect(links).toHaveLength(2)
+      expect(links[0]).toHaveAttribute('href', '/artist/1')
+      expect(links[1]).toHaveAttribute('href', '/artist/2')
+    })
   })
 
-  test('uses parseAndReplaceArtists when role is albumartist', () => {
-    const record = {
-      albumArtist: 'Group Artist',
-      participants: {
-        albumartist: [{ id: '1', name: 'Group Artist' }],
-      },
-    }
+  describe('when handling artist deduplication', () => {
+    it('deduplicates artists with the same id', () => {
+      const record = {
+        participants: {
+          artist: [
+            { id: '1', name: 'Duplicate Artist' },
+            { id: '1', name: 'Duplicate Artist', subRole: 'Vocals' },
+          ],
+        },
+      }
 
-    render(<ArtistLinkField record={record} source="albumArtist" />)
+      render(<ArtistLinkField record={record} source="artist" />)
 
-    expect(screen.getByText('Group Artist')).toBeInTheDocument()
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/artist/1')
+      const links = screen.getAllByRole('link')
+      expect(links).toHaveLength(1)
+      expect(links[0]).toHaveTextContent('Duplicate Artist (Vocals)')
+    })
+
+    it('aggregates subroles for the same artist', () => {
+      const record = {
+        participants: {
+          artist: [
+            { id: '1', name: 'Multi-Role Artist', subRole: 'Vocals' },
+            { id: '1', name: 'Multi-Role Artist', subRole: 'Guitar' },
+          ],
+        },
+      }
+
+      render(<ArtistLinkField record={record} source="artist" />)
+
+      expect(
+        screen.getByText('Multi-Role Artist (Vocals, Guitar)'),
+      ).toBeInTheDocument()
+    })
   })
 
-  test('deduplicates artists with the same id', () => {
-    const record = {
-      participants: {
-        artist: [
-          { id: '1', name: 'Duplicate Artist' },
-          { id: '1', name: 'Duplicate Artist', subRole: 'Vocals' },
-        ],
-      },
-    }
+  describe('when limiting displayed artists', () => {
+    it('limits the number of artists displayed', () => {
+      const record = {
+        participants: {
+          artist: [
+            { id: '1', name: 'Artist 1' },
+            { id: '2', name: 'Artist 2' },
+            { id: '3', name: 'Artist 3' },
+            { id: '4', name: 'Artist 4' },
+          ],
+        },
+      }
 
-    render(<ArtistLinkField record={record} source="artist" />)
+      render(<ArtistLinkField record={record} source="artist" limit={3} />)
 
-    const links = screen.getAllByRole('link')
-    expect(links).toHaveLength(1)
-    expect(links[0]).toHaveTextContent('Duplicate Artist (Vocals)')
-  })
-
-  test('limits the number of artists displayed', () => {
-    const record = {
-      participants: {
-        artist: [
-          { id: '1', name: 'Artist 1' },
-          { id: '2', name: 'Artist 2' },
-          { id: '3', name: 'Artist 3' },
-          { id: '4', name: 'Artist 4' },
-        ],
-      },
-    }
-
-    render(<ArtistLinkField record={record} source="artist" limit={3} />)
-
-    expect(screen.getByText('Artist 1')).toBeInTheDocument()
-    expect(screen.getByText('Artist 2')).toBeInTheDocument()
-    expect(screen.getByText('Artist 3')).toBeInTheDocument()
-    expect(screen.queryByText('Artist 4')).not.toBeInTheDocument()
-    expect(screen.getByText('...')).toBeInTheDocument()
-  })
-
-  test('aggregates subroles for the same artist', () => {
-    const record = {
-      participants: {
-        artist: [
-          { id: '1', name: 'Multi-Role Artist', subRole: 'Vocals' },
-          { id: '1', name: 'Multi-Role Artist', subRole: 'Guitar' },
-        ],
-      },
-    }
-
-    render(<ArtistLinkField record={record} source="artist" />)
-
-    expect(
-      screen.getByText('Multi-Role Artist (Vocals, Guitar)'),
-    ).toBeInTheDocument()
-  })
-
-  test('handles empty artists array', () => {
-    const record = {
-      participants: {
-        artist: [],
-      },
-    }
-
-    render(<ArtistLinkField record={record} source="artist" />)
-
-    expect(intersperse).toHaveBeenCalledWith([], ' • ')
+      expect(screen.getByText('Artist 1')).toBeInTheDocument()
+      expect(screen.getByText('Artist 2')).toBeInTheDocument()
+      expect(screen.getByText('Artist 3')).toBeInTheDocument()
+      expect(screen.queryByText('Artist 4')).not.toBeInTheDocument()
+      expect(screen.getByText('...')).toBeInTheDocument()
+    })
   })
 })

--- a/ui/src/common/ArtistLinkField.test.jsx
+++ b/ui/src/common/ArtistLinkField.test.jsx
@@ -1,0 +1,160 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+import { ArtistLinkField } from './ArtistLinkField'
+import { intersperse } from '../utils/index.js'
+
+// Mock dependencies
+vi.mock('react-redux', () => ({
+  useDispatch: vi.fn(() => vi.fn()),
+}))
+
+vi.mock('./useGetHandleArtistClick', () => ({
+  useGetHandleArtistClick: vi.fn(() => (id) => `/artist/${id}`),
+}))
+
+vi.mock('../utils/index.js', () => ({
+  intersperse: vi.fn((arr) => arr),
+}))
+
+vi.mock('@material-ui/core', () => ({
+  withWidth: () => (Component) => (props) => (
+    <Component {...props} width="md" />
+  ),
+}))
+
+vi.mock('react-admin', () => ({
+  Link: ({ children, to, ...props }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+describe('ArtistLinkField', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('renders artists from participants when available', () => {
+    const record = {
+      participants: {
+        artist: [
+          { id: '1', name: 'Artist 1' },
+          { id: '2', name: 'Artist 2' },
+        ],
+      },
+    }
+
+    render(<ArtistLinkField record={record} source="artist" />)
+
+    expect(screen.getByText('Artist 1')).toBeInTheDocument()
+    expect(screen.getByText('Artist 2')).toBeInTheDocument()
+  })
+
+  test('falls back to record[source] when participants not available', () => {
+    const record = {
+      artist: 'Fallback Artist',
+      artistId: '123',
+    }
+
+    render(<ArtistLinkField record={record} source="artist" />)
+
+    expect(screen.getByText('Fallback Artist')).toBeInTheDocument()
+  })
+
+  test('adds remixers when showing artist role', () => {
+    const record = {
+      participants: {
+        artist: [{ id: '1', name: 'Artist 1' }],
+        remixer: [{ id: '2', name: 'Remixer 1' }],
+      },
+    }
+
+    render(<ArtistLinkField record={record} source="artist" />)
+
+    expect(screen.getByText('Artist 1')).toBeInTheDocument()
+    expect(screen.getByText('Remixer 1')).toBeInTheDocument()
+  })
+
+  test('uses parseAndReplaceArtists when role is albumartist', () => {
+    const record = {
+      albumArtist: 'Group Artist',
+      participants: {
+        albumartist: [{ id: '1', name: 'Group Artist' }],
+      },
+    }
+
+    render(<ArtistLinkField record={record} source="albumArtist" />)
+
+    expect(screen.getByText('Group Artist')).toBeInTheDocument()
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/artist/1')
+  })
+
+  test('deduplicates artists with the same id', () => {
+    const record = {
+      participants: {
+        artist: [
+          { id: '1', name: 'Duplicate Artist' },
+          { id: '1', name: 'Duplicate Artist', subRole: 'Vocals' },
+        ],
+      },
+    }
+
+    render(<ArtistLinkField record={record} source="artist" />)
+
+    const links = screen.getAllByRole('link')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveTextContent('Duplicate Artist (Vocals)')
+  })
+
+  test('limits the number of artists displayed', () => {
+    const record = {
+      participants: {
+        artist: [
+          { id: '1', name: 'Artist 1' },
+          { id: '2', name: 'Artist 2' },
+          { id: '3', name: 'Artist 3' },
+          { id: '4', name: 'Artist 4' },
+        ],
+      },
+    }
+
+    render(<ArtistLinkField record={record} source="artist" limit={3} />)
+
+    expect(screen.getByText('Artist 1')).toBeInTheDocument()
+    expect(screen.getByText('Artist 2')).toBeInTheDocument()
+    expect(screen.getByText('Artist 3')).toBeInTheDocument()
+    expect(screen.queryByText('Artist 4')).not.toBeInTheDocument()
+    expect(screen.getByText('...')).toBeInTheDocument()
+  })
+
+  test('aggregates subroles for the same artist', () => {
+    const record = {
+      participants: {
+        artist: [
+          { id: '1', name: 'Multi-Role Artist', subRole: 'Vocals' },
+          { id: '1', name: 'Multi-Role Artist', subRole: 'Guitar' },
+        ],
+      },
+    }
+
+    render(<ArtistLinkField record={record} source="artist" />)
+
+    expect(
+      screen.getByText('Multi-Role Artist (Vocals, Guitar)'),
+    ).toBeInTheDocument()
+  })
+
+  test('handles empty artists array', () => {
+    const record = {
+      participants: {
+        artist: [],
+      },
+    }
+
+    render(<ArtistLinkField record={record} source="artist" />)
+
+    expect(intersperse).toHaveBeenCalledWith([], ' • ')
+  })
+})


### PR DESCRIPTION
This pull request introduces changes to enhance the handling of artist and remixer metadata, improve the configuration options, and add comprehensive testing for the `ArtistLinkField` component. The most important changes include adding a new configuration option for the artist joiner, updating the metadata mapping to use this new configuration, and refactoring the `ArtistLinkField` component to handle artists and remixers more effectively.

### Configuration Enhancements:
* [`conf/configuration.go`](diffhunk://#diff-5b7f9f2790a5795a69654b2ba8c72112da865800efa1110b181c6c70de96c9dbR132): Added a new configuration option `Scanner.ArtistJoiner`, default value is `" • "`. 

### Metadata Mapping Updates:
* [`model/metadata/map_participants.go`](diffhunk://#diff-75c16e7d655baae2b572f2b738a59420bd568f2f45672360e4644b3a678060d2L213-R215): Updated the `mapDisplayName` function to use the new `ArtistJoiner` configuration from `conf.Server.Scanner`.

### UI Component Refactoring:
* [`ui/src/common/ArtistLinkField.jsx`](diffhunk://#diff-7274f878ec3a1b7ae1464ef4cf3d6f9aecdadf31f58bbb66bcdaeea98426893eL66-R129): Refactored the `ArtistLinkField` component to improve handling of artists and remixers, including deduplication and limiting the number of remixers displayed. [[1]](diffhunk://#diff-7274f878ec3a1b7ae1464ef4cf3d6f9aecdadf31f58bbb66bcdaeea98426893eL66-R129) [[2]](diffhunk://#diff-7274f878ec3a1b7ae1464ef4cf3d6f9aecdadf31f58bbb66bcdaeea98426893eL110-R155)

### Testing Enhancements:
* [`ui/src/common/ArtistLinkField.test.jsx`](diffhunk://#diff-f54290b065980b89d1483a423f2b947a80332f180aafb21d653b5ad8a4c752c1R1-R238): Added comprehensive tests for the `ArtistLinkField` component to cover various scenarios, including rendering artists, handling remixers, deduplication, and limiting displayed artists.