### PR TITLE
Add mood column to Album and Song list views

### DIFF
--- a/ui/src/album/AlbumList.jsx
+++ b/ui/src/album/AlbumList.jsx
@@ -196,6 +196,7 @@ const AlbumList = (props) => {
       'songCount',
       'playCount',
       'year',
+      'mood',
       'duration',
       'rating',
       'size',

--- a/ui/src/album/AlbumTableView.jsx
+++ b/ui/src/album/AlbumTableView.jsx
@@ -6,6 +6,7 @@ import {
   DateField,
   NumberField,
   TextField,
+  FunctionField,
 } from 'react-admin'
 import { useMediaQuery } from '@material-ui/core'
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
@@ -107,6 +108,13 @@ const AlbumTableView = ({
       year: (
         <RangeField source={'year'} sortBy={'max_year'} sortByOrder={'DESC'} />
       ),
+      mood: isDesktop && (
+        <FunctionField
+          source="mood"
+          render={(r) => r.tags?.mood?.[0] || ''}
+          sortable={false}
+        />
+      ),
       duration: isDesktop && <DurationField source="duration" />,
       size: isDesktop && <SizeField source="size" />,
       rating: config.enableStarRating && (
@@ -124,7 +132,7 @@ const AlbumTableView = ({
   const columns = useSelectedFields({
     resource: 'album',
     columns: toggleableFields,
-    defaultOff: ['createdAt'],
+    defaultOff: ['createdAt', 'size', 'mood'],
   })
 
   return isXsmall ? (

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -168,6 +168,13 @@ const SongList = (props) => {
       ),
       bpm: isDesktop && <NumberField source="bpm" />,
       genre: <TextField source="genre" />,
+      mood: isDesktop && (
+        <FunctionField
+          source="mood"
+          render={(r) => r.tags?.mood?.[0] || ''}
+          sortable={false}
+        />
+      ),
       comment: <TextField source="comment" />,
       path: <PathField source="path" />,
       createdAt: <DateField source="createdAt" showTime />,
@@ -183,6 +190,7 @@ const SongList = (props) => {
       'playDate',
       'albumArtist',
       'genre',
+      'mood',
       'comment',
       'path',
       'createdAt',


### PR DESCRIPTION
## Description
This PR addresses issue #3924 by adding a toggleable mood column to both Album and Song list views.

## Changes
- Added a mood column to Album and Song list views
- Column displays only the first mood tag value from the tags
- Column is hidden by default (added to defaultOff)
- Column can be toggled via the column selector menu

This allows users to see mood tag values directly in the list views when they choose to enable the column.