### PR TITLE
fix(artwork): always select the coverArt of the first disc in multi-disc albums

### DIFF
--- a/core/artwork/reader_album.go
+++ b/core/artwork/reader_album.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -113,5 +114,10 @@ func loadAlbumFoldersPaths(ctx context.Context, ds model.DataStore, albums ...mo
 			imgFiles = append(imgFiles, filepath.Join(path, img))
 		}
 	}
+
+	// Sort image files to ensure consistent selection of cover art
+	// This prioritizes files from lower-numbered disc folders by sorting the paths
+	slices.Sort(imgFiles)
+
 	return paths, imgFiles, &updatedAt, nil
 }

--- a/core/artwork/reader_album_test.go
+++ b/core/artwork/reader_album_test.go
@@ -1,0 +1,76 @@
+package artwork
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/navidrome/navidrome/model"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Album Artwork Reader", func() {
+	Describe("loadAlbumFoldersPaths", func() {
+		var (
+			ctx        context.Context
+			ds         *fakeDataStore
+			repo       *fakeFolderRepo
+			album      model.Album
+			now        time.Time
+			expectedAt time.Time
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			now = time.Now().Truncate(time.Second)
+			expectedAt = now.Add(5 * time.Minute)
+
+			// Set up the test folders with image files
+			repo = &fakeFolderRepo{
+				result: []model.Folder{
+					{
+						Path:            "Artist/Album/Disc1",
+						ImagesUpdatedAt: expectedAt,
+						ImageFiles:      []string{"cover.jpg", "back.jpg"},
+					},
+					{
+						Path:            "Artist/Album/Disc2",
+						ImagesUpdatedAt: now,
+						ImageFiles:      []string{"cover.jpg"},
+					},
+					{
+						Path:            "Artist/Album/Disc10",
+						ImagesUpdatedAt: now,
+						ImageFiles:      []string{"cover.jpg"},
+					},
+				},
+				err: nil,
+			}
+			ds = &fakeDataStore{
+				folderRepo: repo,
+			}
+			album = model.Album{
+				ID:        "album1",
+				Name:      "Album",
+				FolderIDs: []string{"folder1", "folder2", "folder3"},
+			}
+		})
+
+		It("returns sorted image files", func() {
+			_, imgFiles, imagesUpdatedAt, err := loadAlbumFoldersPaths(ctx, ds, album)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(*imagesUpdatedAt).To(Equal(expectedAt))
+
+			// Check that image files are sorted alphabetically
+			Expect(imgFiles).To(HaveLen(4))
+
+			// The files should be sorted by full path
+			Expect(imgFiles[0]).To(Equal(filepath.FromSlash("Artist/Album/Disc1/back.jpg")))
+			Expect(imgFiles[1]).To(Equal(filepath.FromSlash("Artist/Album/Disc1/cover.jpg")))
+			Expect(imgFiles[2]).To(Equal(filepath.FromSlash("Artist/Album/Disc10/cover.jpg")))
+			Expect(imgFiles[3]).To(Equal(filepath.FromSlash("Artist/Album/Disc2/cover.jpg")))
+		})
+	})
+})

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -305,6 +305,75 @@ var _ = Describe("MediaFiles", func() {
 					})
 				})
 			})
+			Context("Album Art", func() {
+				When("we have media files with cover art from multiple discs", func() {
+					BeforeEach(func() {
+						mfs = MediaFiles{
+							{
+								Path:        "Artist/Album/Disc2/01.mp3",
+								HasCoverArt: true,
+								DiscNumber:  2,
+							},
+							{
+								Path:        "Artist/Album/Disc1/01.mp3",
+								HasCoverArt: true,
+								DiscNumber:  1,
+							},
+							{
+								Path:        "Artist/Album/Disc3/01.mp3",
+								HasCoverArt: true,
+								DiscNumber:  3,
+							},
+						}
+					})
+					It("selects the cover art from the lowest disc number", func() {
+						album := mfs.ToAlbum()
+						Expect(album.EmbedArtPath).To(Equal("Artist/Album/Disc1/01.mp3"))
+					})
+				})
+
+				When("we have media files with cover art from the same disc number", func() {
+					BeforeEach(func() {
+						mfs = MediaFiles{
+							{
+								Path:        "Artist/Album/Disc1/02.mp3",
+								HasCoverArt: true,
+								DiscNumber:  1,
+							},
+							{
+								Path:        "Artist/Album/Disc1/01.mp3",
+								HasCoverArt: true,
+								DiscNumber:  1,
+							},
+						}
+					})
+					It("selects the cover art with the lowest path alphabetically", func() {
+						album := mfs.ToAlbum()
+						Expect(album.EmbedArtPath).To(Equal("Artist/Album/Disc1/01.mp3"))
+					})
+				})
+
+				When("we have media files with some missing cover art", func() {
+					BeforeEach(func() {
+						mfs = MediaFiles{
+							{
+								Path:        "Artist/Album/Disc1/01.mp3",
+								HasCoverArt: false,
+								DiscNumber:  1,
+							},
+							{
+								Path:        "Artist/Album/Disc2/01.mp3",
+								HasCoverArt: true,
+								DiscNumber:  2,
+							},
+						}
+					})
+					It("selects the file with cover art even if from a higher disc number", func() {
+						album := mfs.ToAlbum()
+						Expect(album.EmbedArtPath).To(Equal("Artist/Album/Disc2/01.mp3"))
+					})
+				})
+			})
 		})
 	})
 })

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -373,6 +373,32 @@ var _ = Describe("MediaFiles", func() {
 						Expect(album.EmbedArtPath).To(Equal("Artist/Album/Disc2/01.mp3"))
 					})
 				})
+
+				When("we have media files with path names that don't correlate with disc numbers", func() {
+					BeforeEach(func() {
+						mfs = MediaFiles{
+							{
+								Path:        "Artist/Album/file-z.mp3", // Path would be sorted last alphabetically
+								HasCoverArt: true,
+								DiscNumber:  1, // But it has lowest disc number
+							},
+							{
+								Path:        "Artist/Album/file-a.mp3", // Path would be sorted first alphabetically
+								HasCoverArt: true,
+								DiscNumber:  2, // But it has higher disc number
+							},
+							{
+								Path:        "Artist/Album/file-m.mp3",
+								HasCoverArt: true,
+								DiscNumber:  3,
+							},
+						}
+					})
+					It("selects the cover art from the lowest disc number regardless of path", func() {
+						album := mfs.ToAlbum()
+						Expect(album.EmbedArtPath).To(Equal("Artist/Album/file-z.mp3"))
+					})
+				})
 			})
 		})
 	})


### PR DESCRIPTION
## Problem

Album cover art selection wasn't correctly prioritizing disc numbers over file paths, leading to inconsistent cover art selection in multi-disc albums. This affected both embedded artwork in media files and external cover art images in album folders.

Previously, with a folder structure like:
```
Artist/Album/Disc1/cover.jpg
Artist/Album/Disc2/cover.jpg
Artist/Album/Disc3/cover.jpg
```
Navidrome would always pull the cover from the lowest disc number, but after a recent update, multi-disc albums were pulling artwork from random discs.

## Solution

This PR includes two related fixes:

1. Fixed the `firstArtPath` function in `model/mediafile.go` to properly prioritize media files with the lowest disc number when selecting album artwork from embedded covers, regardless of the file path. If disc numbers are equal, then path ordering is used as a tiebreaker.

2. Added sorting to the `loadAlbumFoldersPaths` function in `core/artwork/reader_album.go` to ensure consistent selection of cover art from folder image files, properly sorting by path to prioritize files from lower-numbered disc folders.

These fixes ensure that tracks/folders from disc 1 will be preferred for album artwork over tracks/folders from higher disc numbers, matching the expected behavior before the big refactor.