### PR TITLE
chore(mappings): add unsynced lyrics to default mapping

### DIFF
--- a/resources/mappings.yaml
+++ b/resources/mappings.yaml
@@ -108,7 +108,7 @@ main:
   bpm:
     aliases: [ tbpm, bpm, tmpo, wm/beatsperminute ]
   lyrics:
-    aliases: [ uslt:description, lyrics, ©lyr, wm/lyrics ]
+    aliases: [ uslt:description, lyrics, ©lyr, wm/lyrics, unsyncedlyrics ]
     maxLength: 32768
     type: pair # ex: lyrics:eng, lyrics:xxx
   comment:


### PR DESCRIPTION
Something I just found out, but some taggers also add `unsyncedlyrics` (e.g., flac) for unsynced lyrics (instead of just `lyrics`). Add this to the default mapping (since I think it just makes sense).