### PR TITLE
chore: remove DevEnableBufferedScrobble and always enable buffered scrobbling

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -109,7 +109,6 @@ type configOptions struct {
 	DevActivityPanel                 bool
 	DevActivityPanelUpdateRate       time.Duration
 	DevSidebarPlaylists              bool
-	DevEnableBufferedScrobble        bool
 	DevShowArtistPage                bool
 	DevOffsetOptimize                int
 	DevArtworkMaxRequests            int
@@ -312,6 +311,7 @@ func Load(noConfigDump bool) {
 	}
 	logDeprecatedOptions("Scanner.GenreSeparators")
 	logDeprecatedOptions("Scanner.GroupAlbumReleases")
+	logDeprecatedOptions("DevEnableBufferedScrobble") // Deprecated: Buffered scrobbling is now always enabled and this option is ignored
 
 	// Call init hooks
 	for _, hook := range hooks {
@@ -535,7 +535,6 @@ func init() {
 	viper.SetDefault("devautologinusername", "")
 	viper.SetDefault("devactivitypanel", true)
 	viper.SetDefault("devactivitypanelupdaterate", 300*time.Millisecond)
-	viper.SetDefault("devenablebufferedscrobble", true)
 	viper.SetDefault("devsidebarplaylists", true)
 	viper.SetDefault("devshowartistpage", true)
 	viper.SetDefault("devoffsetoptimize", 50000)

--- a/core/scrobbler/play_tracker.go
+++ b/core/scrobbler/play_tracker.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -61,9 +60,7 @@ func newPlayTracker(ds model.DataStore, broker events.Broker) *playTracker {
 			continue
 		}
 		enabled = append(enabled, name)
-		if conf.Server.DevEnableBufferedScrobble {
-			s = newBufferedScrobbler(ds, s, name)
-		}
+		s = newBufferedScrobbler(ds, s, name)
 		p.scrobblers[name] = s
 	}
 	log.Debug("List of scrobblers enabled", "names", enabled)
@@ -183,11 +180,7 @@ func (p *playTracker) dispatchScrobble(ctx context.Context, t *model.MediaFile, 
 		if !s.IsAuthorized(ctx, u.ID) {
 			continue
 		}
-		if conf.Server.DevEnableBufferedScrobble {
-			log.Debug(ctx, "Buffering Scrobble", "scrobbler", name, "track", t.Title, "artist", t.Artist)
-		} else {
-			log.Debug(ctx, "Sending Scrobble", "scrobbler", name, "track", t.Title, "artist", t.Artist)
-		}
+		log.Debug(ctx, "Buffering Scrobble", "scrobbler", name, "track", t.Title, "artist", t.Artist)
 		err := s.Scrobble(ctx, u.ID, scrobble)
 		if err != nil {
 			log.Error(ctx, "Error sending Scrobble", "scrobbler", name, "track", t.Title, "artist", t.Artist, err)

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 
 	"github.com/navidrome/navidrome/model"
@@ -27,9 +26,6 @@ var _ = Describe("PlayTracker", func() {
 	var fake fakeScrobbler
 
 	BeforeEach(func() {
-		// Remove buffering to simplify tests
-		conf.Server.DevEnableBufferedScrobble = false
-
 		ctx = context.Background()
 		ctx = request.WithUser(ctx, model.User{ID: "u-1"})
 		ctx = request.WithPlayer(ctx, model.Player{ScrobbleEnabled: true})
@@ -42,6 +38,7 @@ var _ = Describe("PlayTracker", func() {
 			return nil
 		})
 		tracker = newPlayTracker(ds, events.GetBroker())
+		tracker.(*playTracker).scrobblers["fake"] = &fake // Bypass buffering for tests
 
 		track = model.MediaFile{
 			ID:             "123",


### PR DESCRIPTION
Removed all code, config, and test references to DevEnableBufferedScrobble. 

- Buffered scrobbling is now always enabled. 
- Added this option to the list of deprecated config options with a warning.
- Updated all logic and tests to reflect this.