### PR TITLE
Update mappings.yaml

### DIFF
--- a/resources/mappings.yaml
+++ b/resources/mappings.yaml
@@ -88,7 +88,7 @@ main:
     split: [ ";", "/", "," ]
     album: true
   mood:
-    aliases: [ tmoo, mood, ----:com.apple.itunes:mood, wm/mood ]
+    aliases: [ tmoo, mood, ----:com.apple.itunes:mood, ab:mood, wm/mood ]
     split: [ ";", "/", "," ]
     album: true
   compilation:


### PR DESCRIPTION
Updated to add the default tagging for mood in Picard's AcousticBrainz tags plugin

![image](https://github.com/user-attachments/assets/93299f67-0e7d-4d0b-8a56-ea0c2041ed3c)
