### PR TITLE
fix(configuration.go, mpv.go): Jukebox mode doesn't include MusicFold…

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -456,7 +456,7 @@ func init() {
 	viper.SetDefault("ignoredarticles", "The El La Los Las Le Les Os As O A")
 	viper.SetDefault("indexgroups", "A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ) [Unknown]([)")
 	viper.SetDefault("ffmpegpath", "")
-	viper.SetDefault("mpvcmdtemplate", "mpv --audio-device=%d --no-audio-display --pause %f --input-ipc-server=%s")
+	viper.SetDefault("mpvcmdtemplate", "mpv --audio-device=%d --no-audio-display %p/%f --input-ipc-server=%s")
 
 	viper.SetDefault("coverartpriority", "cover.*, folder.*, front.*, embedded, external")
 	viper.SetDefault("coverjpegquality", 75)

--- a/core/playback/mpv/mpv.go
+++ b/core/playback/mpv/mpv.go
@@ -74,6 +74,7 @@ func createMPVCommand(deviceName string, filename string, socketName string) []s
 	split := strings.Split(fixCmd(conf.Server.MPVCmdTemplate), " ")
 	for i, s := range split {
 		s = strings.ReplaceAll(s, "%d", deviceName)
+		s = strings.ReplaceAll(s, "%p", conf.Server.MusicFolder)
 		s = strings.ReplaceAll(s, "%f", filename)
 		s = strings.ReplaceAll(s, "%s", socketName)
 		split[i] = s


### PR DESCRIPTION
Jukebox mode doesn't include MusicFolder in mpv commander in mpv command - #4066

The call to createMPVCommand is not including the MusicFolder path in mpv command causing it to fail with file not found errors.

Updated default command template and createMPVCommand to use additional substitution with conf.server.MusicFolder
