### PR TITLE
Add playback position to scrobble NowPlaying

### DIFF
--- a/core/agents/lastfm/agent.go
+++ b/core/agents/lastfm/agent.go
@@ -283,7 +283,7 @@ func (l *lastfmAgent) callArtistGetTopTracks(ctx context.Context, artistName str
 	return t.Track, nil
 }
 
-func (l *lastfmAgent) NowPlaying(ctx context.Context, userId string, track *model.MediaFile) error {
+func (l *lastfmAgent) NowPlaying(ctx context.Context, userId string, track *model.MediaFile, position int) error {
 	sk, err := l.sessionKeys.Get(ctx, userId)
 	if err != nil || sk == "" {
 		return scrobbler.ErrNotAuthorized

--- a/core/agents/lastfm/agent_test.go
+++ b/core/agents/lastfm/agent_test.go
@@ -203,7 +203,7 @@ var _ = Describe("lastfmAgent", func() {
 			It("calls Last.fm with correct params", func() {
 				httpClient.Res = http.Response{Body: io.NopCloser(bytes.NewBufferString("{}")), StatusCode: 200}
 
-				err := agent.NowPlaying(ctx, "user-1", track)
+				err := agent.NowPlaying(ctx, "user-1", track, 0)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(httpClient.SavedRequest.Method).To(Equal(http.MethodPost))
@@ -220,7 +220,7 @@ var _ = Describe("lastfmAgent", func() {
 			})
 
 			It("returns ErrNotAuthorized if user is not linked", func() {
-				err := agent.NowPlaying(ctx, "user-2", track)
+				err := agent.NowPlaying(ctx, "user-2", track, 0)
 				Expect(err).To(MatchError(scrobbler.ErrNotAuthorized))
 			})
 		})

--- a/core/agents/listenbrainz/agent.go
+++ b/core/agents/listenbrainz/agent.go
@@ -73,7 +73,7 @@ func (l *listenBrainzAgent) formatListen(track *model.MediaFile) listenInfo {
 	return li
 }
 
-func (l *listenBrainzAgent) NowPlaying(ctx context.Context, userId string, track *model.MediaFile) error {
+func (l *listenBrainzAgent) NowPlaying(ctx context.Context, userId string, track *model.MediaFile, position int) error {
 	sk, err := l.sessionKeys.Get(ctx, userId)
 	if err != nil || sk == "" {
 		return errors.Join(err, scrobbler.ErrNotAuthorized)

--- a/core/agents/listenbrainz/agent_test.go
+++ b/core/agents/listenbrainz/agent_test.go
@@ -79,12 +79,12 @@ var _ = Describe("listenBrainzAgent", func() {
 		It("updates NowPlaying successfully", func() {
 			httpClient.Res = http.Response{Body: io.NopCloser(bytes.NewBufferString(`{"status": "ok"}`)), StatusCode: 200}
 
-			err := agent.NowPlaying(ctx, "user-1", track)
+			err := agent.NowPlaying(ctx, "user-1", track, 0)
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("returns ErrNotAuthorized if user is not linked", func() {
-			err := agent.NowPlaying(ctx, "user-2", track)
+			err := agent.NowPlaying(ctx, "user-2", track, 0)
 			Expect(err).To(MatchError(scrobbler.ErrNotAuthorized))
 		})
 	})

--- a/core/scrobbler/buffered_scrobbler.go
+++ b/core/scrobbler/buffered_scrobbler.go
@@ -42,8 +42,8 @@ func (b *bufferedScrobbler) IsAuthorized(ctx context.Context, userId string) boo
 	return b.wrapped.IsAuthorized(ctx, userId)
 }
 
-func (b *bufferedScrobbler) NowPlaying(ctx context.Context, userId string, track *model.MediaFile) error {
-	return b.wrapped.NowPlaying(ctx, userId, track)
+func (b *bufferedScrobbler) NowPlaying(ctx context.Context, userId string, track *model.MediaFile, position int) error {
+	return b.wrapped.NowPlaying(ctx, userId, track, position)
 }
 
 func (b *bufferedScrobbler) Scrobble(ctx context.Context, userId string, s Scrobble) error {

--- a/core/scrobbler/buffered_scrobbler_test.go
+++ b/core/scrobbler/buffered_scrobbler_test.go
@@ -37,7 +37,7 @@ var _ = Describe("BufferedScrobbler", func() {
 
 	It("forwards NowPlaying calls", func() {
 		track := &model.MediaFile{ID: "123", Title: "Test Track"}
-		Expect(bs.NowPlaying(ctx, "user1", track)).To(Succeed())
+		Expect(bs.NowPlaying(ctx, "user1", track, 0)).To(Succeed())
 		Expect(scr.NowPlayingCalled).To(BeTrue())
 		Expect(scr.UserID).To(Equal("user1"))
 		Expect(scr.Track).To(Equal(track))

--- a/core/scrobbler/interfaces.go
+++ b/core/scrobbler/interfaces.go
@@ -21,7 +21,7 @@ var (
 
 type Scrobbler interface {
 	IsAuthorized(ctx context.Context, userId string) bool
-	NowPlaying(ctx context.Context, userId string, track *model.MediaFile) error
+	NowPlaying(ctx context.Context, userId string, track *model.MediaFile, position int) error
 	Scrobble(ctx context.Context, userId string, s Scrobble) error
 }
 

--- a/plugins/adapter_scrobbler.go
+++ b/plugins/adapter_scrobbler.go
@@ -60,7 +60,7 @@ func (w *wasmScrobblerPlugin) IsAuthorized(ctx context.Context, userId string) b
 	return err == nil && result
 }
 
-func (w *wasmScrobblerPlugin) NowPlaying(ctx context.Context, userId string, track *model.MediaFile) error {
+func (w *wasmScrobblerPlugin) NowPlaying(ctx context.Context, userId string, track *model.MediaFile, position int) error {
 	username, _ := request.UsernameFrom(ctx)
 	if username == "" {
 		u, ok := request.UserFrom(ctx)
@@ -86,6 +86,7 @@ func (w *wasmScrobblerPlugin) NowPlaying(ctx context.Context, userId string, tra
 		Artists:      artists,
 		AlbumArtists: albumArtists,
 		Length:       int32(track.Duration),
+		Position:     int32(position),
 	}
 	_, err := callMethod(ctx, w, "NowPlaying", func(inst api.Scrobbler) (struct{}, error) {
 		resp, err := inst.NowPlaying(ctx, &api.ScrobblerNowPlayingRequest{

--- a/plugins/api/api.pb.go
+++ b/plugins/api/api.pb.go
@@ -8,6 +8,7 @@ package api
 
 import (
 	context "context"
+
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
@@ -650,6 +651,7 @@ type TrackInfo struct {
 	Artists      []*Artist `protobuf:"bytes,6,rep,name=artists,proto3" json:"artists,omitempty"`
 	AlbumArtists []*Artist `protobuf:"bytes,7,rep,name=album_artists,json=albumArtists,proto3" json:"album_artists,omitempty"`
 	Length       int32     `protobuf:"varint,8,opt,name=length,proto3" json:"length,omitempty"` // seconds
+	Position     int32     `protobuf:"varint,9,opt,name=position,proto3" json:"position,omitempty"`
 }
 
 func (x *TrackInfo) ProtoReflect() protoreflect.Message {
@@ -708,6 +710,13 @@ func (x *TrackInfo) GetAlbumArtists() []*Artist {
 func (x *TrackInfo) GetLength() int32 {
 	if x != nil {
 		return x.Length
+	}
+	return 0
+}
+
+func (x *TrackInfo) GetPosition() int32 {
+	if x != nil {
+		return x.Position
 	}
 	return 0
 }

--- a/plugins/api/api.proto
+++ b/plugins/api/api.proto
@@ -148,6 +148,7 @@ message TrackInfo {
   repeated Artist artists = 6;
   repeated Artist album_artists = 7;
   int32 length = 8; // seconds
+  int32 position = 9; // seconds
 }
 
 message ScrobblerNowPlayingRequest {

--- a/plugins/api/api_vtproto.pb.go
+++ b/plugins/api/api_vtproto.pb.go
@@ -8,9 +8,10 @@ package api
 
 import (
 	fmt "fmt"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	io "io"
 	bits "math/bits"
+
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -1129,6 +1130,11 @@ func (m *TrackInfo) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i = encodeVarint(dAtA, i, uint64(m.Length))
 		i--
 		dAtA[i] = 0x40
+	}
+	if m.Position != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.Position))
+		i--
+		dAtA[i] = 0x48
 	}
 	if len(m.AlbumArtists) > 0 {
 		for iNdEx := len(m.AlbumArtists) - 1; iNdEx >= 0; iNdEx-- {
@@ -2373,6 +2379,9 @@ func (m *TrackInfo) SizeVT() (n int) {
 	}
 	if m.Length != 0 {
 		n += 1 + sov(uint64(m.Length))
+	}
+	if m.Position != 0 {
+		n += 1 + sov(uint64(m.Position))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -5503,6 +5512,25 @@ func (m *TrackInfo) UnmarshalVT(dAtA []byte) error {
 				b := dAtA[iNdEx]
 				iNdEx++
 				m.Length |= int32(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+		case 9:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Position", wireType)
+			}
+			m.Position = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.Position |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}

--- a/plugins/examples/discord-rich-presence/plugin.go
+++ b/plugins/examples/discord-rich-presence/plugin.go
@@ -71,8 +71,8 @@ func (d *DiscordRPPlugin) NowPlaying(ctx context.Context, request *api.Scrobbler
 		Details:     request.Track.Name,
 		State:       d.getArtistList(request.Track),
 		Timestamps: activityTimestamps{
-			Start: request.Timestamp * 1000,
-			End:   (request.Timestamp + int64(request.Track.Length)) * 1000,
+			Start: (request.Timestamp - int64(request.Track.Position)) * 1000,
+			End:   (request.Timestamp - int64(request.Track.Position) + int64(request.Track.Length)) * 1000,
 		},
 		Assets: activityAssets{
 			LargeImage: d.imageURL(ctx, request),

--- a/server/subsonic/media_annotation_test.go
+++ b/server/subsonic/media_annotation_test.go
@@ -104,7 +104,7 @@ type fakePlayTracker struct {
 	Error       error
 }
 
-func (f *fakePlayTracker) NowPlaying(_ context.Context, playerId string, _ string, trackId string) error {
+func (f *fakePlayTracker) NowPlaying(_ context.Context, playerId string, _ string, trackId string, position int) error {
 	if f.Error != nil {
 		return f.Error
 	}

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -214,7 +214,8 @@ const Player = () => {
         const song = info.song
         document.title = `${song.title} - ${song.artist} - Navidrome`
         if (!info.isRadio) {
-          subsonic.nowPlaying(info.trackId)
+          const pos = startTime === null ? null : Math.floor(info.currentTime)
+          subsonic.nowPlaying(info.trackId, pos)
         }
         setPreload(false)
         if (config.gaTrackingId) {

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -31,15 +31,16 @@ const url = (command, id, options) => {
 
 const ping = () => httpClient(url('ping'))
 
-const scrobble = (id, time, submission = true) =>
+const scrobble = (id, time, submission = true, position = null) =>
   httpClient(
     url('scrobble', id, {
       ...(submission && time && { time }),
       submission,
+      ...(!submission && position !== null && { position }),
     }),
   )
 
-const nowPlaying = (id) => scrobble(id, null, false)
+const nowPlaying = (id, position = null) => scrobble(id, null, false, position)
 
 const star = (id) => httpClient(url('star', id))
 


### PR DESCRIPTION
## Summary
- extend `scrobble` endpoint with `position` parameter
- store playback position in PlayTracker
- propagate position through scrobbler interfaces and plugin adapter
- expose position in plugin API `TrackInfo`
- update Discord rich presence plugin to use position
- update UI to send current position when resuming playback

## Testing
- `go test -tags netgo ./...`
- `npm test --silent`