### PR TITLE
fix(transcoding): restrict transcoding operations to admin users

### DIFF
--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -65,6 +65,11 @@ func loggedUser(ctx context.Context) *model.User {
 	}
 }
 
+func isAdmin(ctx context.Context) bool {
+	user := loggedUser(ctx)
+	return user.IsAdmin
+}
+
 func (r *sqlRepository) registerModel(instance any, filters map[string]filterFunc) {
 	if r.tableName == "" {
 		r.tableName = strings.TrimPrefix(reflect.TypeOf(instance).String(), "*model.")

--- a/persistence/transcoding_repository.go
+++ b/persistence/transcoding_repository.go
@@ -41,6 +41,9 @@ func (r *transcodingRepository) FindByFormat(format string) (*model.Transcoding,
 }
 
 func (r *transcodingRepository) Put(t *model.Transcoding) error {
+	if !isAdmin(r.ctx) {
+		return rest.ErrPermissionDenied
+	}
 	_, err := r.put(t.ID, t)
 	return err
 }
@@ -69,6 +72,9 @@ func (r *transcodingRepository) NewInstance() interface{} {
 }
 
 func (r *transcodingRepository) Save(entity interface{}) (string, error) {
+	if !isAdmin(r.ctx) {
+		return "", rest.ErrPermissionDenied
+	}
 	t := entity.(*model.Transcoding)
 	id, err := r.put(t.ID, t)
 	if errors.Is(err, model.ErrNotFound) {
@@ -78,6 +84,9 @@ func (r *transcodingRepository) Save(entity interface{}) (string, error) {
 }
 
 func (r *transcodingRepository) Update(id string, entity interface{}, cols ...string) error {
+	if !isAdmin(r.ctx) {
+		return rest.ErrPermissionDenied
+	}
 	t := entity.(*model.Transcoding)
 	t.ID = id
 	_, err := r.put(id, t)
@@ -88,6 +97,9 @@ func (r *transcodingRepository) Update(id string, entity interface{}, cols ...st
 }
 
 func (r *transcodingRepository) Delete(id string) error {
+	if !isAdmin(r.ctx) {
+		return rest.ErrPermissionDenied
+	}
 	err := r.delete(Eq{"id": id})
 	if errors.Is(err, model.ErrNotFound) {
 		return rest.ErrNotFound

--- a/persistence/transcoding_repository_test.go
+++ b/persistence/transcoding_repository_test.go
@@ -1,0 +1,96 @@
+package persistence
+
+import (
+	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("TranscodingRepository", func() {
+	var repo model.TranscodingRepository
+	var adminRepo model.TranscodingRepository
+
+	BeforeEach(func() {
+		ctx := log.NewContext(GinkgoT().Context())
+		ctx = request.WithUser(ctx, regularUser)
+		repo = NewTranscodingRepository(ctx, GetDBXBuilder())
+
+		adminCtx := log.NewContext(GinkgoT().Context())
+		adminCtx = request.WithUser(adminCtx, adminUser)
+		adminRepo = NewTranscodingRepository(adminCtx, GetDBXBuilder())
+	})
+
+	AfterEach(func() {
+		// Clean up any transcoding created during the tests
+		tc, err := adminRepo.FindByFormat("test_format")
+		if err == nil {
+			err = adminRepo.(*transcodingRepository).Delete(tc.ID)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	Describe("Admin User", func() {
+		It("creates a new transcoding", func() {
+			base, err := adminRepo.CountAll()
+			Expect(err).ToNot(HaveOccurred())
+
+			err = adminRepo.Put(&model.Transcoding{ID: "new", Name: "new", TargetFormat: "test_format", DefaultBitRate: 320, Command: "ffmpeg"})
+			Expect(err).ToNot(HaveOccurred())
+
+			count, err := adminRepo.CountAll()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(Equal(base + 1))
+		})
+
+		It("updates an existing transcoding", func() {
+			tr := &model.Transcoding{ID: "upd", Name: "old", TargetFormat: "test_format", DefaultBitRate: 100, Command: "ffmpeg"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+			tr.Name = "updated"
+			err := adminRepo.Put(tr)
+			Expect(err).ToNot(HaveOccurred())
+			res, err := adminRepo.FindByFormat("test_format")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.Name).To(Equal("updated"))
+		})
+
+		It("deletes a transcoding", func() {
+			err := adminRepo.Put(&model.Transcoding{ID: "to-delete", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 256, Command: "ffmpeg"})
+			Expect(err).ToNot(HaveOccurred())
+			err = adminRepo.(*transcodingRepository).Delete("to-delete")
+			Expect(err).ToNot(HaveOccurred())
+			_, err = adminRepo.Get("to-delete")
+			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+	})
+
+	Describe("Regular User", func() {
+		It("fails to create", func() {
+			err := repo.Put(&model.Transcoding{ID: "bad", Name: "bad", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"})
+			Expect(err).To(Equal(rest.ErrPermissionDenied))
+		})
+
+		It("fails to update", func() {
+			tr := &model.Transcoding{ID: "updreg", Name: "old", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+
+			tr.Name = "bad"
+			err := repo.Put(tr)
+			Expect(err).To(Equal(rest.ErrPermissionDenied))
+
+			//_ = adminRepo.(*transcodingRepository).Delete("updreg")
+		})
+
+		It("fails to delete", func() {
+			tr := &model.Transcoding{ID: "delreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+
+			err := repo.(*transcodingRepository).Delete("delreg")
+			Expect(err).To(Equal(rest.ErrPermissionDenied))
+
+			//_ = adminRepo.(*transcodingRepository).Delete("delreg")
+		})
+	})
+})


### PR DESCRIPTION
This pull request introduces role-based access control (RBAC) for the `transcodingRepository` by restricting certain operations to admin users only. It also adds comprehensive unit tests to validate the new behavior. The key changes include the addition of an `isAdmin` function, integration of permission checks across repository methods, and new test cases for admin and regular user scenarios.

### Role-Based Access Control (RBAC) Implementation:

* Added `isAdmin(ctx context.Context) bool` function to check if the current user has admin privileges. (`persistence/sql_base_repository.go`, [persistence/sql_base_repository.goR68-R72](diffhunk://#diff-6c854194ab908411d5d3b72b0121abdb9f2ac4caf24c8410139b35fdeaa87d47R68-R72))
* Integrated `isAdmin` checks into the following methods of `transcodingRepository` to restrict operations for non-admin users:
  - `Put` method now denies permission for non-admin users. (`persistence/transcoding_repository.go`, [persistence/transcoding_repository.goR44-R46](diffhunk://#diff-c0e4c1eb845f2ac801eb8ac51064193d0b1ba23e9be9db6c20ebf901cea1edc5R44-R46))
  - `Save` method includes a permission check before saving entities. (`persistence/transcoding_repository.go`, [persistence/transcoding_repository.goR75-R77](diffhunk://#diff-c0e4c1eb845f2ac801eb8ac51064193d0b1ba23e9be9db6c20ebf901cea1edc5R75-R77))
  - `Update` method validates admin status before updating entities. (`persistence/transcoding_repository.go`, [persistence/transcoding_repository.goR87-R89](diffhunk://#diff-c0e4c1eb845f2ac801eb8ac51064193d0b1ba23e9be9db6c20ebf901cea1edc5R87-R89))
  - `Delete` method ensures only admins can delete entities. (`persistence/transcoding_repository.go`, [persistence/transcoding_repository.goR100-R102](diffhunk://#diff-c0e4c1eb845f2ac801eb8ac51064193d0b1ba23e9be9db6c20ebf901cea1edc5R100-R102))

### Unit Tests for Permission Enforcement:

* Added `persistence/transcoding_repository_test.go` to validate RBAC functionality:
  - Tests for admin users to ensure they can create, update, and delete transcodings.
  - Tests for regular users to confirm they are denied permissions for the same operations.