### PR TITLE
Fix numeric comparisons for float custom tags

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -43,7 +43,7 @@ This is a music streaming server written in Go with a React frontend. The applic
 - Validate both backend and frontend interactions
 - Consider how changes will affect user experience and performance
 - Test with different music library sizes and configurations
-- Always run formatting and linting before committing changes
+- Before committing, ALWAYS run `make format lint test`, and make sure there are no issues
 
 ## Important commands
 - `make build`: Build the application

--- a/model/criteria/criteria.go
+++ b/model/criteria/criteria.go
@@ -4,6 +4,7 @@ package criteria
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/Masterminds/squirrel"
@@ -39,6 +40,9 @@ func (c Criteria) OrderBy() string {
 			mapped = "COALESCE(json_extract(media_file.participants, '$." + sortField + "[0].name'), '')"
 		} else {
 			mapped = f.field
+		}
+		if f.numeric {
+			mapped = fmt.Sprintf("CAST(%s AS REAL)", mapped)
 		}
 	}
 	if c.Order != "" {

--- a/model/criteria/criteria_test.go
+++ b/model/criteria/criteria_test.go
@@ -109,6 +109,15 @@ var _ = Describe("Criteria", func() {
 				)
 			})
 
+			It("casts numeric tags when sorting", func() {
+				AddTagNames([]string{"rate"})
+				AddNumericTags([]string{"rate"})
+				goObj.Sort = "rate"
+				gomega.Expect(goObj.OrderBy()).To(
+					gomega.Equal("CAST(COALESCE(json_extract(media_file.tags, '$.rate[0].value'), '') AS REAL) asc"),
+				)
+			})
+
 			It("sorts by random", func() {
 				newObj := goObj
 				newObj.Sort = "random"

--- a/model/criteria/fields.go
+++ b/model/criteria/fields.go
@@ -145,12 +145,25 @@ type tagCond struct {
 
 func (e tagCond) ToSql() (string, []any, error) {
 	cond, args, err := e.cond.ToSql()
+	if len(args) > 0 && isNumber(args[0]) {
+		cond = strings.ReplaceAll(cond, "value", "CAST(value AS REAL)")
+	}
 	cond = fmt.Sprintf("exists (select 1 from json_tree(tags, '$.%s') where key='value' and %s)",
 		e.tag, cond)
 	if e.not {
 		cond = "not " + cond
 	}
 	return cond, args, err
+}
+
+func isNumber(v any) bool {
+	switch v.(type) {
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return true
+	}
+	return false
 }
 
 func roleExpr(role string, cond squirrel.Sqlizer, negate bool) squirrel.Sqlizer {

--- a/model/criteria/operators_test.go
+++ b/model/criteria/operators_test.go
@@ -77,6 +77,14 @@ var _ = Describe("Operators", func() {
 			gomega.Expect(sql).To(gomega.Equal("exists (select 1 from json_tree(tags, '$.mood') where key='value' and value LIKE ?)"))
 			gomega.Expect(args).To(gomega.HaveExactElements("%Soft"))
 		})
+		It("casts numeric comparisons", func() {
+			AddTagNames([]string{"rate"})
+			op := Lt{"rate": 6}
+			sql, args, err := op.ToSql()
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(sql).To(gomega.Equal("exists (select 1 from json_tree(tags, '$.rate') where key='value' and CAST(value AS REAL) < ?)"))
+			gomega.Expect(args).To(gomega.HaveExactElements(6))
+		})
 		It("skips unknown tag names", func() {
 			op := EndsWith{"unknown": "value"}
 			sql, args, _ := op.ToSql()

--- a/model/criteria/operators_test.go
+++ b/model/criteria/operators_test.go
@@ -13,6 +13,7 @@ import (
 var _ = BeforeSuite(func() {
 	AddRoles([]string{"artist", "composer"})
 	AddTagNames([]string{"genre"})
+	AddNumericTags([]string{"rate"})
 })
 
 var _ = Describe("Operators", func() {
@@ -68,6 +69,15 @@ var _ = Describe("Operators", func() {
 		Entry("role endsWith [string]", EndsWith{"composer": "Lennon"}, "exists (select 1 from json_tree(participants, '$.composer') where key='name' and value LIKE ?)", "%Lennon"),
 	)
 
+	// TODO Validate operators that are not valid for each field type.
+	XDescribeTable("ToSQL - Invalid Operators",
+		func(op Expression, expectedError string) {
+			_, _, err := op.ToSql()
+			gomega.Expect(err).To(gomega.MatchError(expectedError))
+		},
+		Entry("numeric tag contains", Contains{"rate": 5}, "numeric tag 'rate' cannot be used with Contains operator"),
+	)
+
 	Describe("Custom Tags", func() {
 		It("generates valid SQL", func() {
 			AddTagNames([]string{"mood"})
@@ -78,7 +88,7 @@ var _ = Describe("Operators", func() {
 			gomega.Expect(args).To(gomega.HaveExactElements("%Soft"))
 		})
 		It("casts numeric comparisons", func() {
-			AddTagNames([]string{"rate"})
+			AddNumericTags([]string{"rate"})
 			op := Lt{"rate": 6}
 			sql, args, err := op.ToSql()
 			gomega.Expect(err).ToNot(gomega.HaveOccurred())

--- a/model/tag_mappings.go
+++ b/model/tag_mappings.go
@@ -162,6 +162,17 @@ func tagNames() []string {
 	return names
 }
 
+func numericTagNames() []string {
+	mappings := TagMappings()
+	names := make([]string, 0)
+	for k, cfg := range mappings {
+		if cfg.Type == TagTypeInteger || cfg.Type == TagTypeFloat {
+			names = append(names, string(k))
+		}
+	}
+	return names
+}
+
 func loadTagMappings() {
 	mappingsFile, err := resources.FS().Open("mappings.yaml")
 	if err != nil {
@@ -228,5 +239,6 @@ func init() {
 		// used in smart playlists
 		criteria.AddRoles(slices.Collect(maps.Keys(AllRoles)))
 		criteria.AddTagNames(tagNames())
+		criteria.AddNumericTags(numericTagNames())
 	})
 }


### PR DESCRIPTION
## Summary
- cast tag values to numeric when numeric args are used in smart playlist rules
- test numeric comparison for custom tag

## Testing
- `make test`