### PR TITLE
Fix incomplete cache files on transcoding errors

### DIFF
--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -171,14 +171,15 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 			_ = fc.invalidate(ctx, key)
 			return nil, err
 		}
-		go func() {
+		go func(rCloser fscache.ReadAtCloser) {
 			if err := copyAndClose(w, reader); err != nil {
 				log.Debug(ctx, "Error storing file in cache", "cache", fc.name, "key", key, err)
+				_ = rCloser.Close()
 				_ = fc.invalidate(ctx, key)
 			} else {
 				log.Trace(ctx, "File successfully stored in cache", "cache", fc.name, "key", key)
 			}
-		}()
+		}(r)
 	}
 
 	// If it is in the cache, check if the stream is done being written. If so, return a ReadSeeker

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -116,18 +116,16 @@ var _ = Describe("File Caches", func() {
 				})
 			})
 			When("reader returns error", func() {
-				It("does not cache", func() {
+				It("does not cache and closes the stream", func() {
 					fc := callNewFileCache("test", "1KB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
-						return errFakeReader{errors.New("read failure")}, nil
+						return &errPartialReader{data: []byte("data"), err: errors.New("read failure")}, nil
 					})
 
 					s, err := fc.Get(context.Background(), &testArg{"test"})
 					Expect(err).ToNot(HaveOccurred())
-					_, _ = io.Copy(io.Discard, s)
-					// TODO How to make the fscache reader return the underlying reader error?
-					//Expect(err).To(MatchError("read failure"))
+					_, err = io.ReadAll(s)
+					Expect(err).To(MatchError("file already closed"))
 
-					// Data should not be cached (or eventually be removed from cache)
 					Eventually(func() bool {
 						s, _ = fc.Get(context.Background(), &testArg{"test"})
 						if s != nil {
@@ -148,3 +146,18 @@ func (t *testArg) Key() string { return t.s }
 type errFakeReader struct{ err error }
 
 func (e errFakeReader) Read([]byte) (int, error) { return 0, e.err }
+
+type errPartialReader struct {
+	data []byte
+	err  error
+	off  int
+}
+
+func (e *errPartialReader) Read(b []byte) (int, error) {
+	if e.off < len(e.data) {
+		n := copy(b, e.data[e.off:])
+		e.off += n
+		return n, nil
+	}
+	return 0, e.err
+}


### PR DESCRIPTION
## Summary
- close cache reader when copy to cache fails so clients see errors
- update file cache tests to ensure streams fail on reader errors

## Testing
- `make test`