### PR TITLE
Fix page titles for radios, shares and show pages

### DIFF
--- a/ui/src/album/AlbumShow.jsx
+++ b/ui/src/album/AlbumShow.jsx
@@ -4,12 +4,13 @@ import {
   ShowContextProvider,
   useShowContext,
   useShowController,
+  Title as RaTitle,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import AlbumSongs from './AlbumSongs'
 import AlbumDetails from './AlbumDetails'
 import AlbumActions from './AlbumActions'
-import { useResourceRefresh } from '../common'
+import { useResourceRefresh, Title } from '../common'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -30,6 +31,7 @@ const AlbumShowLayout = (props) => {
 
   return (
     <>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
       {record && <AlbumDetails {...context} />}
       {record && (
         <ReferenceManyField

--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -7,12 +7,13 @@ import {
   useShowContext,
   ReferenceManyField,
   Pagination,
+  Title as RaTitle,
 } from 'react-admin'
 import subsonic from '../subsonic'
 import AlbumGridView from '../album/AlbumGridView'
 import MobileArtistDetails from './MobileArtistDetails'
 import DesktopArtistDetails from './DesktopArtistDetails'
-import { useAlbumsPerPage, useResourceRefresh } from '../common/index.js'
+import { useAlbumsPerPage, useResourceRefresh, Title } from '../common/index.js'
 
 const ArtistDetails = (props) => {
   const record = useRecordContext(props)
@@ -76,6 +77,7 @@ const ArtistShowLayout = (props) => {
 
   return (
     <>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
       {record && <ArtistDetails />}
       {record && (
         <ReferenceManyField

--- a/ui/src/playlist/PlaylistShow.jsx
+++ b/ui/src/playlist/PlaylistShow.jsx
@@ -5,6 +5,7 @@ import {
   useShowContext,
   useShowController,
   Pagination,
+  Title as RaTitle,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
 import PlaylistDetails from './PlaylistDetails'
@@ -31,6 +32,7 @@ const PlaylistShowLayout = (props) => {
 
   return (
     <>
+      {record && <RaTitle title={<Title subTitle={record.name} />} />}
       {record && <PlaylistDetails {...context} />}
       {record && (
         <ReferenceManyField

--- a/ui/src/radio/RadioList.jsx
+++ b/ui/src/radio/RadioList.jsx
@@ -6,7 +6,6 @@ import {
   DateField,
   EditButton,
   Filter,
-  List,
   sanitizeListRestProps,
   SearchInput,
   SimpleList,
@@ -15,6 +14,7 @@ import {
   UrlField,
   useTranslate,
 } from 'react-admin'
+import { List } from '../common'
 import { ToggleFieldsMenu, useSelectedFields } from '../common'
 import { StreamField } from './StreamField'
 import { setTrack } from '../actions'

--- a/ui/src/share/ShareList.jsx
+++ b/ui/src/share/ShareList.jsx
@@ -2,13 +2,13 @@ import {
   Datagrid,
   FunctionField,
   BooleanField,
-  List,
   NumberField,
   SimpleList,
   TextField,
   useNotify,
   useTranslate,
 } from 'react-admin'
+import { List } from '../common'
 import React from 'react'
 import { IconButton, Link, useMediaQuery } from '@material-ui/core'
 import ShareIcon from '@material-ui/icons/Share'


### PR DESCRIPTION
## Summary
- import common `List` in Radios and Shares lists so title matches other resources
- display portal titles for AlbumShow, PlaylistShow and ArtistShow

## Testing
- `npm run lint`
- `npm run check-formatting`
- `npm run test`
- `make test`
