### PR TITLE
feat(server): add option `Lastfm.ScrobbleFirstArtistOnly` to send only the first artist

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -154,10 +154,11 @@ type TagConf struct {
 }
 
 type lastfmOptions struct {
-	Enabled  bool
-	ApiKey   string
-	Secret   string
-	Language string
+	Enabled                 bool
+	ApiKey                  string
+	Secret                  string
+	Language                string
+	ScrobbleFirstArtistOnly bool
 }
 
 type spotifyOptions struct {
@@ -528,6 +529,7 @@ func setViperDefaults() {
 	viper.SetDefault("lastfm.language", "en")
 	viper.SetDefault("lastfm.apikey", "")
 	viper.SetDefault("lastfm.secret", "")
+	viper.SetDefault("lastfm.scrobblefirstartistonly", false)
 	viper.SetDefault("spotify.id", "")
 	viper.SetDefault("spotify.secret", "")
 	viper.SetDefault("listenbrainz.enabled", true)


### PR DESCRIPTION
This pull request introduces a new configuration option, `ScrobbleFirstArtistOnly`, for Last.fm integration. The option allows users to specify whether only the first listed artist should be scrobbled for tracks with multiple artists. The changes include updates to configuration handling, the Last.fm agent logic, and associated tests.

### Configuration Updates:
* Added a new field, `ScrobbleFirstArtistOnly`, to the `lastfmOptions` struct in `conf/configuration.go` to support the new configuration option.
* Set the default value for `ScrobbleFirstArtistOnly` to `false` in the `setViperDefaults` function.

### Last.fm Agent Logic:
* Introduced a new method, `getArtistForScrobble`, in `core/agents/lastfm/agent.go` to determine the artist to scrobble based on the `ScrobbleFirstArtistOnly` configuration. Updated the `NowPlaying` and `Scrobble` methods to use this logic. [[1]](diffhunk://#diff-7f166e9421fb53a385a03b60965de83f1a87ad0ce26363f86ff46f8cf07f2994R282-R296) [[2]](diffhunk://#diff-7f166e9421fb53a385a03b60965de83f1a87ad0ce26363f86ff46f8cf07f2994L315-R322)

### Tests:
* Updated the `lastfmAgent` test setup in `core/agents/lastfm/agent_test.go` to include multiple artists in the `Participants` field of the test track.
* Added a test case to verify that the `ScrobbleFirstArtistOnly` configuration correctly scrobbles only the first artist when enabled.



fixes #3791