### PR TITLE
Add 'Show in Playlist' context menu

### DIFF
--- a/model/playlist.go
+++ b/model/playlist.go
@@ -101,6 +101,7 @@ type PlaylistRepository interface {
 	FindByPath(path string) (*Playlist, error)
 	Delete(id string) error
 	Tracks(playlistId string, refreshSmartPlaylist bool) PlaylistTrackRepository
+	GetPlaylists(mediaFileId string) (Playlists, error)
 }
 
 type PlaylistTrack struct {

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -112,6 +112,21 @@ var _ = Describe("PlaylistRepository", func() {
 		})
 	})
 
+	Describe("GetPlaylists", func() {
+		It("returns playlists for a track", func() {
+			pls, err := repo.GetPlaylists(songRadioactivity.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pls).To(HaveLen(1))
+			Expect(pls[0].ID).To(Equal(plsBest.ID))
+		})
+
+		It("returns empty when none", func() {
+			pls, err := repo.GetPlaylists("9999")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pls).To(HaveLen(0))
+		})
+	})
+
 	Context("Smart Playlists", func() {
 		var rules *criteria.Criteria
 		BeforeEach(func() {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -59,6 +59,7 @@ func (n *Router) routes() http.Handler {
 
 		n.addPlaylistRoute(r)
 		n.addPlaylistTrackRoute(r)
+		n.addSongPlaylistsRoute(r)
 		n.addMissingFilesRoute(r)
 		n.addInspectRoute(r)
 		n.addConfigRoute(r)
@@ -138,6 +139,15 @@ func (n *Router) addPlaylistTrackRoute(r chi.Router) {
 			r.Delete("/", func(w http.ResponseWriter, r *http.Request) {
 				deleteFromPlaylist(n.ds)(w, r)
 			})
+		})
+	})
+}
+
+func (n *Router) addSongPlaylistsRoute(r chi.Router) {
+	r.Route("/song/{id}", func(r chi.Router) {
+		r.Use(server.URLParamsMiddleware)
+		r.Get("/playlists", func(w http.ResponseWriter, r *http.Request) {
+			getSongPlaylists(n.ds)(w, r)
 		})
 	})
 }

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -207,3 +207,21 @@ func reorderItem(ds model.DataStore) http.HandlerFunc {
 		}
 	}
 }
+
+func getSongPlaylists(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		p := req.Params(r)
+		trackId, _ := p.String(":id")
+		playlists, err := ds.Playlist(r.Context()).GetPlaylists(trackId)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		data, err := json.Marshal(playlists)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write(data)
+	}
+}

--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -97,6 +97,15 @@ export const SongContextMenu = ({
           }),
         ),
     },
+    showInPlaylist: {
+      enabled: true,
+      label:
+        translate('resources.song.actions.showInPlaylist') +
+        (playlists.length > 0 ? ' ►' : ''),
+      action: (record, e) => {
+        setPlaylistAnchorEl(e.currentTarget)
+      },
+    },
     share: {
       enabled: config.enableSharing,
       label: translate('ra.action.share'),
@@ -153,6 +162,7 @@ export const SongContextMenu = ({
           setPlaylistsLoaded(true)
         })
         .catch((error) => {
+          // eslint-disable-next-line no-console
           console.error('Failed to fetch playlists:', error)
           setPlaylists([])
           setPlaylistsLoaded(true)
@@ -168,15 +178,18 @@ export const SongContextMenu = ({
 
   const handleItemClick = (e) => {
     e.preventDefault()
-    setAnchorEl(null)
     const key = e.target.getAttribute('value')
-    options[key].action(record)
-    e.stopPropagation()
-  }
+    const action = options[key].action
 
-  const handleShowInPlaylist = (e) => {
+    if (key === 'showInPlaylist') {
+      // For showInPlaylist, we keep the main menu open and show submenu
+      action(record, e)
+    } else {
+      // For other actions, close the main menu
+      setAnchorEl(null)
+      action(record)
+    }
     e.stopPropagation()
-    setPlaylistAnchorEl(e.currentTarget)
   }
 
   const handlePlaylistClose = (e) => {
@@ -223,15 +236,16 @@ export const SongContextMenu = ({
         {Object.keys(options).map(
           (key) =>
             options[key].enabled && (
-              <MenuItem value={key} key={key} onClick={handleItemClick}>
+              <MenuItem
+                value={key}
+                key={key}
+                onClick={handleItemClick}
+                disabled={key === 'showInPlaylist' && !playlists.length}
+              >
                 {options[key].label}
               </MenuItem>
             ),
         )}
-        <MenuItem onClick={handleShowInPlaylist} disabled={!playlists.length}>
-          {translate('resources.song.actions.showInPlaylist')}
-          {playlists.length > 0 && ' ►'}
-        </MenuItem>
       </Menu>
       <Menu
         anchorEl={playlistAnchorEl}

--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -1,7 +1,12 @@
 import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { useDispatch } from 'react-redux'
-import { useNotify, usePermissions, useTranslate } from 'react-admin'
+import {
+  useNotify,
+  usePermissions,
+  useTranslate,
+  useDataProvider,
+} from 'react-admin'
 import { IconButton, Menu, MenuItem } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import MoreVertIcon from '@material-ui/icons/MoreVert'
@@ -59,6 +64,7 @@ export const SongContextMenu = ({
   const dispatch = useDispatch()
   const translate = useTranslate()
   const notify = useNotify()
+  const dataProvider = useDataProvider()
   const [anchorEl, setAnchorEl] = useState(null)
   const [playlistAnchorEl, setPlaylistAnchorEl] = useState(null)
   const [playlists, setPlaylists] = useState([])
@@ -142,10 +148,17 @@ export const SongContextMenu = ({
     setAnchorEl(e.currentTarget)
     if (!playlistsLoaded) {
       const id = record.mediaFileId || record.id
-      httpClient(`${REST_URL}/song/${id}/playlists`).then((res) => {
-        setPlaylists(res.json)
-        setPlaylistsLoaded(true)
-      })
+      dataProvider
+        .getPlaylists('song', { id })
+        .then((res) => {
+          setPlaylists(res.data)
+          setPlaylistsLoaded(true)
+        })
+        .catch((error) => {
+          console.error('Failed to fetch playlists:', error)
+          setPlaylists([])
+          setPlaylistsLoaded(true)
+        })
     }
     e.stopPropagation()
   }
@@ -214,10 +227,7 @@ export const SongContextMenu = ({
               </MenuItem>
             ),
         )}
-        <MenuItem
-          onClick={handleShowInPlaylist}
-          disabled={!playlists.length}
-        >
+        <MenuItem onClick={handleShowInPlaylist} disabled={!playlists.length}>
           {translate('resources.song.actions.showInPlaylist')}
           {playlists.length > 0 && ' ►'}
         </MenuItem>

--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -179,8 +179,11 @@ export const SongContextMenu = ({
     setPlaylistAnchorEl(e.currentTarget)
   }
 
-  const handlePlaylistClose = () => {
+  const handlePlaylistClose = (e) => {
     setPlaylistAnchorEl(null)
+    if (e) {
+      e.stopPropagation()
+    }
   }
 
   const handleMainMenuClose = (e) => {

--- a/ui/src/common/SongContextMenu.jsx
+++ b/ui/src/common/SongContextMenu.jsx
@@ -25,9 +25,7 @@ import {
 import { LoveButton } from './LoveButton'
 import config from '../config'
 import { formatBytes } from '../utils'
-import { httpClient } from '../dataProvider'
 import { useRedirect } from 'react-admin'
-import { REST_URL } from '../consts'
 
 const useStyles = makeStyles({
   noWrap: {
@@ -125,8 +123,8 @@ export const SongContextMenu = ({
         if (permissions === 'admin' && !record.missing) {
           try {
             let id = record.mediaFileId ?? record.id
-            const data = await httpClient(`/api/inspect?id=${id}`)
-            fullRecord = { ...record, rawTags: data.json.rawTags }
+            const data = await dataProvider.inspect(id)
+            fullRecord = { ...record, rawTags: data.data.rawTags }
           } catch (error) {
             notify(
               translate('ra.notification.http_error') + ': ' + error.message,
@@ -149,7 +147,7 @@ export const SongContextMenu = ({
     if (!playlistsLoaded) {
       const id = record.mediaFileId || record.id
       dataProvider
-        .getPlaylists('song', { id })
+        .getPlaylists(id)
         .then((res) => {
           setPlaylists(res.data)
           setPlaylistsLoaded(true)

--- a/ui/src/common/SongContextMenu.test.jsx
+++ b/ui/src/common/SongContextMenu.test.jsx
@@ -21,6 +21,9 @@ vi.mock('react-admin', async (importOriginal) => {
       getPlaylists: vi.fn().mockResolvedValue({
         data: [{ id: 'pl1', name: 'Pl 1' }],
       }),
+      inspect: vi.fn().mockResolvedValue({
+        data: { rawTags: {} },
+      }),
     }),
   }
 })

--- a/ui/src/common/SongContextMenu.test.jsx
+++ b/ui/src/common/SongContextMenu.test.jsx
@@ -17,6 +17,11 @@ vi.mock('react-admin', async (importOriginal) => {
     useRedirect: () => (url) => {
       window.location.hash = `#${url}`
     },
+    useDataProvider: () => ({
+      getPlaylists: vi.fn().mockResolvedValue({
+        data: [{ id: 'pl1', name: 'Pl 1' }],
+      }),
+    }),
   }
 })
 
@@ -27,10 +32,6 @@ describe('SongContextMenu', () => {
   })
 
   it('navigates to playlist when selected', async () => {
-    const dataProvider = await import('../dataProvider')
-    dataProvider.httpClient.mockResolvedValue({
-      json: [{ id: 'pl1', name: 'Pl 1' }],
-    })
     render(
       <TestContext>
         <SongContextMenu record={{ id: 'song1', size: 1 }} resource="song" />

--- a/ui/src/common/SongContextMenu.test.jsx
+++ b/ui/src/common/SongContextMenu.test.jsx
@@ -61,22 +61,22 @@ describe('SongContextMenu', () => {
         </div>
       </TestContext>,
     )
-    
+
     // Open main menu
     fireEvent.click(screen.getAllByRole('button')[1])
     await waitFor(() =>
       screen.getByText(/resources\.song\.actions\.showInPlaylist/),
     )
-    
+
     // Open playlist submenu
     fireEvent.click(
       screen.getByText(/resources\.song\.actions\.showInPlaylist/),
     )
     await waitFor(() => screen.getByText('Pl 1'))
-    
+
     // Click outside the playlist submenu (should close it without triggering parent click)
     fireEvent.click(document.body)
-    
+
     expect(mockOnClick).not.toHaveBeenCalled()
   })
 })

--- a/ui/src/common/SongContextMenu.test.jsx
+++ b/ui/src/common/SongContextMenu.test.jsx
@@ -51,4 +51,32 @@ describe('SongContextMenu', () => {
     fireEvent.click(screen.getByText('Pl 1'))
     expect(window.location.hash).toBe('#/playlist/pl1/show')
   })
+
+  it('stops event propagation when playlist submenu is closed', async () => {
+    const mockOnClick = vi.fn()
+    render(
+      <TestContext>
+        <div onClick={mockOnClick}>
+          <SongContextMenu record={{ id: 'song1', size: 1 }} resource="song" />
+        </div>
+      </TestContext>,
+    )
+    
+    // Open main menu
+    fireEvent.click(screen.getAllByRole('button')[1])
+    await waitFor(() =>
+      screen.getByText(/resources\.song\.actions\.showInPlaylist/),
+    )
+    
+    // Open playlist submenu
+    fireEvent.click(
+      screen.getByText(/resources\.song\.actions\.showInPlaylist/),
+    )
+    await waitFor(() => screen.getByText('Pl 1'))
+    
+    // Click outside the playlist submenu (should close it without triggering parent click)
+    fireEvent.click(document.body)
+    
+    expect(mockOnClick).not.toHaveBeenCalled()
+  })
 })

--- a/ui/src/common/SongContextMenu.test.jsx
+++ b/ui/src/common/SongContextMenu.test.jsx
@@ -38,10 +38,10 @@ describe('SongContextMenu', () => {
     )
     fireEvent.click(screen.getAllByRole('button')[1])
     await waitFor(() =>
-      screen.getByText('resources.song.actions.showInPlaylist'),
+      screen.getByText(/resources\.song\.actions\.showInPlaylist/),
     )
-    fireEvent.mouseEnter(
-      screen.getByText('resources.song.actions.showInPlaylist'),
+    fireEvent.click(
+      screen.getByText(/resources\.song\.actions\.showInPlaylist/),
     )
     await waitFor(() => screen.getByText('Pl 1'))
     fireEvent.click(screen.getByText('Pl 1'))

--- a/ui/src/common/SongContextMenu.test.jsx
+++ b/ui/src/common/SongContextMenu.test.jsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { render, fireEvent, screen, waitFor } from '@testing-library/react'
+import { TestContext } from 'ra-test'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { SongContextMenu } from './SongContextMenu'
+
+vi.mock('../dataProvider', () => ({
+  httpClient: vi.fn(),
+}))
+
+vi.mock('react-redux', () => ({ useDispatch: () => vi.fn() }))
+
+vi.mock('react-admin', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useRedirect: () => (url) => {
+      window.location.hash = `#${url}`
+    },
+  }
+})
+
+describe('SongContextMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    window.location.hash = ''
+  })
+
+  it('navigates to playlist when selected', async () => {
+    const dataProvider = await import('../dataProvider')
+    dataProvider.httpClient.mockResolvedValue({
+      json: [{ id: 'pl1', name: 'Pl 1' }],
+    })
+    render(
+      <TestContext>
+        <SongContextMenu record={{ id: 'song1', size: 1 }} resource="song" />
+      </TestContext>,
+    )
+    fireEvent.click(screen.getAllByRole('button')[1])
+    await waitFor(() =>
+      screen.getByText('resources.song.actions.showInPlaylist'),
+    )
+    fireEvent.mouseEnter(
+      screen.getByText('resources.song.actions.showInPlaylist'),
+    )
+    await waitFor(() => screen.getByText('Pl 1'))
+    fireEvent.click(screen.getByText('Pl 1'))
+    expect(window.location.hash).toBe('#/playlist/pl1/show')
+  })
+})

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -90,10 +90,15 @@ const wrapperDataProvider = {
       body: JSON.stringify(data),
     }).then(({ json }) => ({ data: json }))
   },
-  getPlaylists: (resource, params) => {
-    return httpClient(`${REST_URL}/song/${params.id}/playlists`).then(
+  getPlaylists: (songId) => {
+    return httpClient(`${REST_URL}/song/${songId}/playlists`).then(
       ({ json }) => ({ data: json }),
     )
+  },
+  inspect: (songId) => {
+    return httpClient(`${REST_URL}/inspect?id=${songId}`).then(({ json }) => ({
+      data: json,
+    }))
   },
 }
 

--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -90,6 +90,11 @@ const wrapperDataProvider = {
       body: JSON.stringify(data),
     }).then(({ json }) => ({ data: json }))
   },
+  getPlaylists: (resource, params) => {
+    return httpClient(`${REST_URL}/song/${params.id}/playlists`).then(
+      ({ json }) => ({ data: json }),
+    )
+  },
 }
 
 export default wrapperDataProvider

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -41,6 +41,7 @@
         "addToQueue": "Play Later",
         "playNow": "Play Now",
         "addToPlaylist": "Add to Playlist",
+        "showInPlaylist": "Show in Playlist",
         "shuffleAll": "Shuffle All",
         "download": "Download",
         "playNext": "Play Next",


### PR DESCRIPTION
## Summary
- expose GetPlaylists method on PlaylistRepository
- add REST endpoint to list playlists for a track
- extend SongContextMenu with Show in Playlist submenu
- add translations and tests

## Testing
- `make test`
- `npm run lint`
- `npm run check-formatting`
- `npm test`
- `npm run type-check`
