### PR TITLE
Add configuration tab in About dialog

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -112,6 +112,7 @@ type configOptions struct {
 	DevActivityPanelUpdateRate       time.Duration
 	DevSidebarPlaylists              bool
 	DevShowArtistPage                bool
+	DevUIShowConfig                  bool
 	DevOffsetOptimize                int
 	DevArtworkMaxRequests            int
 	DevArtworkThrottleBacklogLimit   int
@@ -553,6 +554,7 @@ func setViperDefaults() {
 	viper.SetDefault("devactivitypanelupdaterate", 300*time.Millisecond)
 	viper.SetDefault("devsidebarplaylists", true)
 	viper.SetDefault("devshowartistpage", true)
+	viper.SetDefault("devuishowconfig", true)
 	viper.SetDefault("devoffsetoptimize", 50000)
 	viper.SetDefault("devartworkmaxrequests", max(2, runtime.NumCPU()/3))
 	viper.SetDefault("devartworkthrottlebackloglimit", consts.RequestThrottleBacklogLimit)

--- a/resources/i18n/pt-br.json
+++ b/resources/i18n/pt-br.json
@@ -496,6 +496,16 @@
         "disabled": "Desligado",
         "waiting": "Aguardando"
       }
+    },
+    "tabs": {
+      "about": "Sobre",
+      "config": "Configuração"
+    },
+    "config": {
+      "configName": "Nome da Configuração",
+      "environmentVariable": "Variável de Ambiente",
+      "currentValue": "Valor Atual",
+      "configurationFile": "Arquivo de Configuração"
     }
   },
   "activity": {

--- a/resources/i18n/pt-br.json
+++ b/resources/i18n/pt-br.json
@@ -508,7 +508,9 @@
       "configurationFile": "Arquivo de Configuração",
       "exportToml": "Exportar Configuração (TOML)",
       "exportSuccess": "Configuração exportada para o clipboard em formato TOML",
-      "exportFailed": "Falha ao copiar configuração"
+      "exportFailed": "Falha ao copiar configuração",
+      "devFlagsHeader": "Flags de Desenvolvimento (sujeitas a mudança/remoção)",
+      "devFlagsComment": "Estas são configurações experimentais e podem ser removidas em versões futuras"
     }
   },
   "activity": {

--- a/resources/i18n/pt-br.json
+++ b/resources/i18n/pt-br.json
@@ -505,7 +505,10 @@
       "configName": "Nome da Configuração",
       "environmentVariable": "Variável de Ambiente",
       "currentValue": "Valor Atual",
-      "configurationFile": "Arquivo de Configuração"
+      "configurationFile": "Arquivo de Configuração",
+      "exportToml": "Exportar Configuração (TOML)",
+      "exportSuccess": "Configuração exportada para o clipboard em formato TOML",
+      "exportFailed": "Falha ao copiar configuração"
     }
   },
   "activity": {

--- a/server/nativeapi/config.go
+++ b/server/nativeapi/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"reflect"
-	"sort"
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
@@ -109,22 +108,6 @@ func flatten(ctx context.Context, entries *[]configEntry, prefix string, v refle
 	*entries = append(*entries, configEntry{Key: key, EnvVar: envVar, Value: val})
 }
 
-func sortConfigEntries(entries []configEntry) {
-	sort.Slice(entries, func(i, j int) bool {
-		keyI, keyJ := entries[i].Key, entries[j].Key
-		isDevI := strings.HasPrefix(keyI, "Dev")
-		isDevJ := strings.HasPrefix(keyJ, "Dev")
-
-		// If one is Dev and the other isn't, non-Dev comes first
-		if isDevI != isDevJ {
-			return !isDevI
-		}
-
-		// Both are Dev or both are non-Dev, sort alphabetically
-		return keyI < keyJ
-	})
-}
-
 func getConfig(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	user, _ := request.UserFrom(ctx)
@@ -141,7 +124,6 @@ func getConfig(w http.ResponseWriter, r *http.Request) {
 		fieldType := t.Field(i)
 		flatten(ctx, &entries, fieldType.Name, fieldVal)
 	}
-	sortConfigEntries(entries)
 
 	resp := configResponse{ID: "config", ConfigFile: conf.Server.ConfigFile, Config: entries}
 	w.Header().Set("Content-Type", "application/json")

--- a/server/nativeapi/config.go
+++ b/server/nativeapi/config.go
@@ -1,0 +1,71 @@
+package nativeapi
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+type configEntry struct {
+	Key   string      `json:"key"`
+	Value interface{} `json:"value"`
+}
+
+type configResponse struct {
+	ID     string        `json:"id"`
+	Config []configEntry `json:"config"`
+}
+
+func flatten(entries *[]configEntry, prefix string, v reflect.Value) {
+	if v.Kind() == reflect.Struct && v.Type().PkgPath() != "time" {
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			if !t.Field(i).IsExported() {
+				continue
+			}
+			flatten(entries, prefix+"."+t.Field(i).Name, v.Field(i))
+		}
+		return
+	}
+
+	key := strings.TrimPrefix(prefix, ".")
+	var val interface{}
+	switch v.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Array:
+		b, _ := json.Marshal(v.Interface())
+		val = string(b)
+	default:
+		val = fmt.Sprint(v.Interface())
+	}
+
+	*entries = append(*entries, configEntry{Key: key, Value: val})
+}
+
+func getConfig(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user, _ := request.UserFrom(ctx)
+	if !user.IsAdmin {
+		http.Error(w, "Config endpoint is only available to admin users", http.StatusUnauthorized)
+		return
+	}
+
+	entries := make([]configEntry, 0)
+	v := reflect.ValueOf(*conf.Server)
+	t := reflect.TypeOf(*conf.Server)
+	for i := 0; i < v.NumField(); i++ {
+		fieldVal := v.Field(i)
+		fieldType := t.Field(i)
+		flatten(&entries, fieldType.Name, fieldVal)
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Key < entries[j].Key })
+
+	resp := configResponse{ID: "config", Config: entries}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(resp)
+}

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -1,0 +1,57 @@
+package nativeapi
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sort"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("config endpoint", func() {
+	It("rejects non admin users", func() {
+		req := httptest.NewRequest("GET", "/config", nil)
+		w := httptest.NewRecorder()
+		ctx := request.WithUser(req.Context(), model.User{IsAdmin: false})
+		getConfig(w, req.WithContext(ctx))
+		Expect(w.Code).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("returns sorted configuration entries for admins", func() {
+		req := httptest.NewRequest("GET", "/config", nil)
+		w := httptest.NewRecorder()
+		ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+		getConfig(w, req.WithContext(ctx))
+		Expect(w.Code).To(Equal(http.StatusOK))
+		var resp configResponse
+		Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+		Expect(resp.ID).To(Equal("config"))
+		keys := make([]string, len(resp.Config))
+		for i, e := range resp.Config {
+			keys[i] = e.Key
+		}
+		Expect(sort.StringsAreSorted(keys)).To(BeTrue())
+	})
+
+	It("includes flattened struct fields", func() {
+		req := httptest.NewRequest("GET", "/config", nil)
+		w := httptest.NewRecorder()
+		ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+		getConfig(w, req.WithContext(ctx))
+		Expect(w.Code).To(Equal(http.StatusOK))
+		var resp configResponse
+		Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+		values := map[string]string{}
+		for _, e := range resp.Config {
+			if s, ok := e.Value.(string); ok {
+				values[e.Key] = s
+			}
+		}
+		Expect(values).To(HaveKeyWithValue("Inspect.MaxRequests", "1"))
+		Expect(values).To(HaveKeyWithValue("HTTPSecurityHeaders.CustomFrameOptionsValue", "DENY"))
+	})
+})

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"sort"
 
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	. "github.com/onsi/ginkgo/v2"
@@ -13,6 +15,10 @@ import (
 )
 
 var _ = Describe("config endpoint", func() {
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+	})
+
 	It("rejects non admin users", func() {
 		req := httptest.NewRequest("GET", "/config", nil)
 		w := httptest.NewRecorder()
@@ -84,5 +90,137 @@ var _ = Describe("config endpoint", func() {
 		Expect(envVars).To(HaveKeyWithValue("MusicFolder", "ND_MUSICFOLDER"))
 		Expect(envVars).To(HaveKeyWithValue("Scanner.Enabled", "ND_SCANNER_ENABLED"))
 		Expect(envVars).To(HaveKeyWithValue("HTTPSecurityHeaders.CustomFrameOptionsValue", "ND_HTTPSECURITYHEADERS_CUSTOMFRAMEOPTIONSVALUE"))
+	})
+
+	Context("redaction functionality", func() {
+		It("redacts sensitive values with partial masking for long values", func() {
+			// Set up test values
+			conf.Server.LastFM.ApiKey = "ba46f0e84a123456"
+			conf.Server.Spotify.Secret = "verylongsecret123"
+
+			req := httptest.NewRequest("GET", "/config", nil)
+			w := httptest.NewRecorder()
+			ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+			getConfig(w, req.WithContext(ctx))
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp configResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+
+			values := map[string]string{}
+			for _, e := range resp.Config {
+				if s, ok := e.Value.(string); ok {
+					values[e.Key] = s
+				}
+			}
+
+			Expect(values).To(HaveKeyWithValue("LastFM.ApiKey", "b**************6"))
+			Expect(values).To(HaveKeyWithValue("Spotify.Secret", "v***************3"))
+		})
+
+		It("redacts sensitive values with full masking for short values", func() {
+			// Set up test values with short secrets
+			conf.Server.LastFM.Secret = "short"
+			conf.Server.Spotify.ID = "abc123"
+
+			req := httptest.NewRequest("GET", "/config", nil)
+			w := httptest.NewRecorder()
+			ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+			getConfig(w, req.WithContext(ctx))
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp configResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+
+			values := map[string]string{}
+			for _, e := range resp.Config {
+				if s, ok := e.Value.(string); ok {
+					values[e.Key] = s
+				}
+			}
+
+			Expect(values).To(HaveKeyWithValue("LastFM.Secret", "****"))
+			Expect(values).To(HaveKeyWithValue("Spotify.ID", "****"))
+		})
+
+		It("does not redact non-sensitive values", func() {
+			conf.Server.MusicFolder = "/path/to/music"
+			conf.Server.Port = 4533
+
+			req := httptest.NewRequest("GET", "/config", nil)
+			w := httptest.NewRecorder()
+			ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+			getConfig(w, req.WithContext(ctx))
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp configResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+
+			values := map[string]string{}
+			for _, e := range resp.Config {
+				if s, ok := e.Value.(string); ok {
+					values[e.Key] = s
+				}
+			}
+
+			Expect(values).To(HaveKeyWithValue("MusicFolder", "/path/to/music"))
+			Expect(values).To(HaveKeyWithValue("Port", "4533"))
+		})
+
+		It("handles empty sensitive values", func() {
+			conf.Server.LastFM.ApiKey = ""
+			conf.Server.PasswordEncryptionKey = ""
+
+			req := httptest.NewRequest("GET", "/config", nil)
+			w := httptest.NewRecorder()
+			ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+			getConfig(w, req.WithContext(ctx))
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var resp configResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+
+			values := map[string]string{}
+			for _, e := range resp.Config {
+				if s, ok := e.Value.(string); ok {
+					values[e.Key] = s
+				}
+			}
+
+			// Empty sensitive values should remain empty
+			Expect(values["LastFM.ApiKey"]).To(Equal(""))
+			Expect(values["PasswordEncryptionKey"]).To(Equal(""))
+		})
+	})
+})
+
+var _ = Describe("redactValue function", func() {
+	It("partially masks long sensitive values", func() {
+		Expect(redactValue("LastFM.ApiKey", "ba46f0e84a")).To(Equal("b********a"))
+		Expect(redactValue("Spotify.Secret", "verylongsecret123")).To(Equal("v***************3"))
+		Expect(redactValue("PasswordEncryptionKey", "1234567890")).To(Equal("1********0"))
+	})
+
+	It("fully masks short sensitive values", func() {
+		Expect(redactValue("LastFM.Secret", "short")).To(Equal("****"))
+		Expect(redactValue("Spotify.ID", "abc")).To(Equal("****"))
+		Expect(redactValue("PasswordEncryptionKey", "12345")).To(Equal("****"))
+	})
+
+	It("does not mask non-sensitive values", func() {
+		Expect(redactValue("MusicFolder", "/path/to/music")).To(Equal("/path/to/music"))
+		Expect(redactValue("Port", "4533")).To(Equal("4533"))
+		Expect(redactValue("SomeOtherField", "secretvalue")).To(Equal("secretvalue"))
+	})
+
+	It("handles empty values", func() {
+		Expect(redactValue("LastFM.ApiKey", "")).To(Equal(""))
+		Expect(redactValue("NonSensitive", "")).To(Equal(""))
+	})
+
+	It("handles edge case values", func() {
+		Expect(redactValue("LastFM.ApiKey", "a")).To(Equal("****"))
+		Expect(redactValue("LastFM.ApiKey", "ab")).To(Equal("****"))
+		Expect(redactValue("LastFM.ApiKey", "abcdefg")).To(Equal("a*****g"))
 	})
 })

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -54,4 +54,35 @@ var _ = Describe("config endpoint", func() {
 		Expect(values).To(HaveKeyWithValue("Inspect.MaxRequests", "1"))
 		Expect(values).To(HaveKeyWithValue("HTTPSecurityHeaders.CustomFrameOptionsValue", "DENY"))
 	})
+
+	It("includes the config file path", func() {
+		req := httptest.NewRequest("GET", "/config", nil)
+		w := httptest.NewRecorder()
+		ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+		getConfig(w, req.WithContext(ctx))
+		Expect(w.Code).To(Equal(http.StatusOK))
+		var resp configResponse
+		Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+		Expect(resp.ConfigFile).To(Not(BeEmpty()))
+	})
+
+	It("includes environment variable names", func() {
+		req := httptest.NewRequest("GET", "/config", nil)
+		w := httptest.NewRecorder()
+		ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})
+		getConfig(w, req.WithContext(ctx))
+		Expect(w.Code).To(Equal(http.StatusOK))
+		var resp configResponse
+		Expect(json.Unmarshal(w.Body.Bytes(), &resp)).To(Succeed())
+
+		// Create a map to check specific env var mappings
+		envVars := map[string]string{}
+		for _, e := range resp.Config {
+			envVars[e.Key] = e.EnvVar
+		}
+
+		Expect(envVars).To(HaveKeyWithValue("MusicFolder", "ND_MUSICFOLDER"))
+		Expect(envVars).To(HaveKeyWithValue("Scanner.Enabled", "ND_SCANNER_ENABLED"))
+		Expect(envVars).To(HaveKeyWithValue("HTTPSecurityHeaders.CustomFrameOptionsValue", "ND_HTTPSECURITYHEADERS_CUSTOMFRAMEOPTIONSVALUE"))
+	})
 })

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -27,7 +27,7 @@ var _ = Describe("config endpoint", func() {
 		Expect(w.Code).To(Equal(http.StatusUnauthorized))
 	})
 
-	It("returns configuration entries)", func() {
+	It("returns configuration entries", func() {
 		req := httptest.NewRequest("GET", "/config", nil)
 		w := httptest.NewRecorder()
 		ctx := request.WithUser(req.Context(), model.User{IsAdmin: true})

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -198,7 +198,10 @@ var _ = Describe("redactValue function", func() {
 	It("partially masks long sensitive values", func() {
 		Expect(redactValue("LastFM.ApiKey", "ba46f0e84a")).To(Equal("b********a"))
 		Expect(redactValue("Spotify.Secret", "verylongsecret123")).To(Equal("v***************3"))
-		Expect(redactValue("PasswordEncryptionKey", "1234567890")).To(Equal("1********0"))
+	})
+
+	It("fully masks long sensitive values that should be completely hidden", func() {
+		Expect(redactValue("PasswordEncryptionKey", "1234567890")).To(Equal("****"))
 	})
 
 	It("fully masks short sensitive values", func() {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -62,21 +62,8 @@ func (n *Router) routes() http.Handler {
 		n.addMissingFilesRoute(r)
 		n.addInspectRoute(r)
 		n.addConfigRoute(r)
-
-		// Keepalive endpoint to be used to keep the session valid (ex: while playing songs)
-		r.Get("/keepalive/*", func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`{"response":"ok", "id":"keepalive"}`))
-		})
-
-		// Insights status endpoint
-		r.Get("/insights/*", func(w http.ResponseWriter, r *http.Request) {
-			last, success := n.insights.LastRun(r.Context())
-			if conf.Server.EnableInsightsCollector {
-				_, _ = w.Write([]byte(`{"id":"insights_status", "lastRun":"` + last.Format("2006-01-02 15:04:05") + `", "success":` + strconv.FormatBool(success) + `}`))
-			} else {
-				_, _ = w.Write([]byte(`{"id":"insights_status", "lastRun":"disabled", "success":false}`))
-			}
-		})
+		n.addKeepAliveRoute(r)
+		n.addInsightsRoute(r)
 	})
 
 	return r
@@ -202,4 +189,21 @@ func (n *Router) addConfigRoute(r chi.Router) {
 	if conf.Server.DevUIShowConfig {
 		r.Get("/config/*", getConfig)
 	}
+}
+
+func (n *Router) addKeepAliveRoute(r chi.Router) {
+	r.Get("/keepalive/*", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"response":"ok", "id":"keepalive"}`))
+	})
+}
+
+func (n *Router) addInsightsRoute(r chi.Router) {
+	r.Get("/insights/*", func(w http.ResponseWriter, r *http.Request) {
+		last, success := n.insights.LastRun(r.Context())
+		if conf.Server.EnableInsightsCollector {
+			_, _ = w.Write([]byte(`{"id":"insights_status", "lastRun":"` + last.Format("2006-01-02 15:04:05") + `", "success":` + strconv.FormatBool(success) + `}`))
+		} else {
+			_, _ = w.Write([]byte(`{"id":"insights_status", "lastRun":"disabled", "success":false}`))
+		}
+	})
 }

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -61,6 +61,7 @@ func (n *Router) routes() http.Handler {
 		n.addPlaylistTrackRoute(r)
 		n.addMissingFilesRoute(r)
 		n.addInspectRoute(r)
+		n.addConfigRoute(r)
 
 		// Keepalive endpoint to be used to keep the session valid (ex: while playing songs)
 		r.Get("/keepalive/*", func(w http.ResponseWriter, r *http.Request) {
@@ -194,5 +195,11 @@ func (n *Router) addInspectRoute(r chi.Router) {
 			}
 			r.Get("/inspect", inspect(n.ds))
 		})
+	}
+}
+
+func (n *Router) addConfigRoute(r chi.Router) {
+	if conf.Server.DevUIShowConfig {
+		r.Get("/config/*", getConfig)
 	}
 }

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -65,6 +65,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"devSidebarPlaylists":       conf.Server.DevSidebarPlaylists,
 			"lastFMEnabled":             conf.Server.LastFM.Enabled,
 			"devShowArtistPage":         conf.Server.DevShowArtistPage,
+			"devUIShowConfig":           conf.Server.DevUIShowConfig,
 			"listenBrainzEnabled":       conf.Server.ListenBrainz.Enabled,
 			"enableExternalServices":    conf.Server.EnableExternalServices,
 			"enableReplayGain":          conf.Server.EnableReplayGain,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -304,6 +304,17 @@ var _ = Describe("serveIndex", func() {
 		Expect(config).To(HaveKeyWithValue("devShowArtistPage", true))
 	})
 
+	It("sets the devUIShowConfig", func() {
+		conf.Server.DevUIShowConfig = true
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		serveIndex(ds, fs, nil)(w, r)
+
+		config := extractAppConfig(w.Body.String())
+		Expect(config).To(HaveKeyWithValue("devUIShowConfig", true))
+	})
+
 	It("sets the listenBrainzEnabled", func() {
 		conf.Server.ListenBrainz.Enabled = true
 		r := httptest.NewRequest("GET", "/index.html", nil)

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -137,7 +137,9 @@ const Admin = (props) => {
         <Resource name="playlistTrack" />,
         <Resource name="keepalive" />,
         <Resource name="insights" />,
-        <Resource name="config" />,
+        permissions === 'admin' && config.devUIShowConfig ? (
+          <Resource name="config" />
+        ) : null,
         <Player />,
       ]}
     </RAAdmin>

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -137,6 +137,7 @@ const Admin = (props) => {
         <Resource name="playlistTrack" />,
         <Resource name="keepalive" />,
         <Resource name="insights" />,
+        <Resource name="config" />,
         <Player />,
       ]}
     </RAAdmin>

--- a/ui/src/common/SongInfo.jsx
+++ b/ui/src/common/SongInfo.jsx
@@ -138,7 +138,7 @@ export const SongInfo = (props) => {
         </Tabs>
       )}
       <div
-        hidden={tab == 1}
+        hidden={tab === 1}
         id="mapped-tags-body"
         aria-labelledby={record.rawTags ? 'mapped-tags-tab' : undefined}
       >

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -30,6 +30,7 @@ const defaultConfig = {
   enableExternalServices: true,
   enableCoverAnimation: true,
   devShowArtistPage: true,
+  devUIShowConfig: true,
   enableReplayGain: true,
   defaultDownsamplingFormat: 'opus',
   publicBaseUrl: '/share',

--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -193,6 +193,7 @@ const AboutTabContent = ({
 
 const ConfigTabContent = ({ configData }) => {
   const classes = useStyles()
+  const translate = useTranslate()
 
   return (
     <Table size="small">
@@ -204,13 +205,13 @@ const ConfigTabContent = ({ configData }) => {
             scope="col"
             className={classes.configNameColumn}
           >
-            Config Name
+            {translate('about.config.configName')}
           </TableCell>
           <TableCell align="left" component="th" scope="col">
-            Environment Variable
+            {translate('about.config.environmentVariable')}
           </TableCell>
           <TableCell align="left" component="th" scope="col">
-            Current Value
+            {translate('about.config.currentValue')}
           </TableCell>
         </TableRow>
       </TableHead>
@@ -223,7 +224,7 @@ const ConfigTabContent = ({ configData }) => {
               scope="row"
               className={classes.configNameColumn}
             >
-              Configuration File
+              {translate('about.config.configurationFile')}
             </TableCell>
             <TableCell align="left" className={classes.envVarColumn}>
               ND_CONFIGFILE

--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -272,11 +272,24 @@ const TabContent = ({
     <TableContainer component={Paper}>
       {showConfigTab && (
         <Tabs value={tab} onChange={(_, value) => setTab(value)}>
-          <Tab label={translate('about.tabs.about')} id="about-tab" />
-          <Tab label={translate('about.tabs.config')} id="config-tab" />
+          <Tab
+            label={translate('about.tabs.about')}
+            id="about-tab"
+            aria-controls="about-panel"
+          />
+          <Tab
+            label={translate('about.tabs.config')}
+            id="config-tab"
+            aria-controls="config-panel"
+          />
         </Tabs>
       )}
-      <div hidden={showConfigTab && tab === 1}>
+      <div
+        id="about-panel"
+        role="tabpanel"
+        aria-labelledby="about-tab"
+        hidden={showConfigTab && tab === 1}
+      >
         <AboutTabContent
           uiVersion={uiVersion}
           serverVersion={serverVersion}
@@ -286,7 +299,12 @@ const TabContent = ({
         />
       </div>
       {showConfigTab && (
-        <div hidden={tab === 0}>
+        <div
+          id="config-panel"
+          role="tabpanel"
+          aria-labelledby="config-tab"
+          hidden={tab === 0}
+        >
           <ConfigTabContent configData={configData} />
         </div>
       )}

--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -30,11 +30,15 @@ const useStyles = makeStyles({
     overflowWrap: 'break-word',
   },
   envVarColumn: {
+    maxWidth: '200px',
+    width: '200px',
     fontFamily: 'monospace',
     wordWrap: 'break-word',
     overflowWrap: 'break-word',
   },
   configFileValue: {
+    maxWidth: '300px',
+    width: '300px',
     fontFamily: 'monospace',
     wordBreak: 'break-all',
   },
@@ -106,9 +110,15 @@ const ShowVersion = ({ uiVersion, serverVersion }) => {
   )
 }
 
-const AboutTabContent = ({ uiVersion, serverVersion, insightsData, loading, permissions }) => {
+const AboutTabContent = ({
+  uiVersion,
+  serverVersion,
+  insightsData,
+  loading,
+  permissions,
+}) => {
   const translate = useTranslate()
-  
+
   const lastRun = !loading && insightsData?.lastRun
   let insightsStatus = 'N/A'
   if (lastRun === 'disabled') {
@@ -244,7 +254,17 @@ const ConfigTabContent = ({ configData }) => {
   )
 }
 
-const TabContent = ({ tab, setTab, showConfigTab, uiVersion, serverVersion, insightsData, loading, permissions, configData }) => {
+const TabContent = ({
+  tab,
+  setTab,
+  showConfigTab,
+  uiVersion,
+  serverVersion,
+  insightsData,
+  loading,
+  permissions,
+  configData,
+}) => {
   const translate = useTranslate()
 
   return (
@@ -276,7 +296,10 @@ const TabContent = ({ tab, setTab, showConfigTab, uiVersion, serverVersion, insi
 const AboutDialog = ({ open, onClose }) => {
   const translate = useTranslate()
   const { permissions } = usePermissions()
-  const { data: insightsData, loading } = useGetOne('insights', 'insights_status')
+  const { data: insightsData, loading } = useGetOne(
+    'insights',
+    'insights_status',
+  )
   const [serverVersion, setServerVersion] = useState('')
   const showConfigTab = permissions === 'admin' && config.devUIShowConfig
   const [tab, setTab] = useState(0)

--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -223,7 +223,7 @@ const ConfigTabContent = ({ configData }) => {
   const copyAllConfig = () => {
     if (!configData) return
 
-    const tomlContent = configToToml(configData)
+    const tomlContent = configToToml(configData, translate)
 
     navigator.clipboard
       .writeText(tomlContent)
@@ -327,7 +327,7 @@ const ConfigTabContent = ({ configData }) => {
                     component="div"
                     style={{ fontWeight: 600 }}
                   >
-                    🚧 Development Flags (subject to change/removal)
+                    🚧 {translate('about.config.devFlagsHeader')}
                   </Typography>
                 </TableCell>
               </TableRow>

--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -219,7 +219,6 @@ const ConfigTabContent = ({ configData }) => {
   const classes = useStyles()
   const translate = useTranslate()
   const notify = useNotify()
-  const [copySuccess, setCopySuccess] = useState('')
 
   if (!configData || !configData.config) {
     return null
@@ -234,14 +233,10 @@ const ConfigTabContent = ({ configData }) => {
     try {
       const tomlContent = configToToml(configData, translate)
       await navigator.clipboard.writeText(tomlContent)
-      setCopySuccess(translate('about.config.exportSuccess'))
-      setTimeout(() => setCopySuccess(''), 3000)
       notify(translate('about.config.exportSuccess'), 'info')
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('Failed to copy TOML:', err)
-      setCopySuccess(translate('about.config.exportFailed'))
-      setTimeout(() => setCopySuccess(''), 3000)
       notify(translate('about.config.exportFailed'), 'error')
     }
   }
@@ -407,7 +402,6 @@ const TabContent = ({
 }
 
 const AboutDialog = ({ open, onClose }) => {
-  const translate = useTranslate()
   const { permissions } = usePermissions()
   const { data: insightsData, loading } = useGetOne(
     'insights',
@@ -443,7 +437,7 @@ const AboutDialog = ({ open, onClose }) => {
       aria-labelledby="about-dialog-title"
       open={open}
       fullWidth={true}
-      maxWidth={expanded ? 'md' : 'sm'}
+      maxWidth={expanded ? 'lg' : 'sm'}
       style={{ transition: 'max-width 300ms ease' }}
     >
       <DialogTitle id="about-dialog-title" onClose={onClose}>

--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -226,7 +226,9 @@ const ConfigTabContent = ({ configData }) => {
   }
 
   // Use the shared separation and sorting logic
-  const { regularConfigs, devConfigs } = separateAndSortConfigs(configData.config)
+  const { regularConfigs, devConfigs } = separateAndSortConfigs(
+    configData.config,
+  )
 
   const handleCopyToml = async () => {
     try {
@@ -236,6 +238,7 @@ const ConfigTabContent = ({ configData }) => {
       setTimeout(() => setCopySuccess(''), 3000)
       notify(translate('about.config.exportSuccess'), 'info')
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.error('Failed to copy TOML:', err)
       setCopySuccess(translate('about.config.exportFailed'))
       setTimeout(() => setCopySuccess(''), 3000)

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -502,6 +502,12 @@
     "tabs": {
       "about": "About",
       "config": "Configuration"
+    },
+    "config": {
+      "configName": "Config Name",
+      "environmentVariable": "Environment Variable",
+      "currentValue": "Current Value",
+      "configurationFile": "Configuration File"
     }
   },
   "activity": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -507,7 +507,10 @@
       "configName": "Config Name",
       "environmentVariable": "Environment Variable",
       "currentValue": "Current Value",
-      "configurationFile": "Configuration File"
+      "configurationFile": "Configuration File",
+      "exportToml": "Export Configuration (TOML)",
+      "exportSuccess": "Configuration exported to clipboard in TOML format",
+      "exportFailed": "Failed to copy configuration"
     }
   },
   "activity": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -498,6 +498,10 @@
         "disabled": "Disabled",
         "waiting": "Waiting"
       }
+    },
+    "tabs": {
+      "about": "About",
+      "config": "Configuration"
     }
   },
   "activity": {

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -510,7 +510,9 @@
       "configurationFile": "Configuration File",
       "exportToml": "Export Configuration (TOML)",
       "exportSuccess": "Configuration exported to clipboard in TOML format",
-      "exportFailed": "Failed to copy configuration"
+      "exportFailed": "Failed to copy configuration",
+      "devFlagsHeader": "Development Flags (subject to change/removal)",
+      "devFlagsComment": "These are experimental settings and may be removed in future versions"
     }
   },
   "activity": {

--- a/ui/src/utils/toml.js
+++ b/ui/src/utils/toml.js
@@ -1,0 +1,153 @@
+/**
+ * TOML utility functions for configuration export
+ */
+
+/**
+ * Converts a value to proper TOML format
+ * @param {*} value - The value to format
+ * @returns {string} - The TOML-formatted value
+ */
+export const formatTomlValue = (value) => {
+  if (value === null || value === undefined) {
+    return '""'
+  }
+  
+  const str = String(value)
+  
+  // Boolean values
+  if (str === 'true' || str === 'false') {
+    return str
+  }
+  
+  // Numbers (integers and floats)
+  if (/^-?\d+$/.test(str)) {
+    return str // Integer
+  }
+  if (/^-?\d*\.\d+$/.test(str)) {
+    return str // Float
+  }
+  
+  // Duration values (like "300ms", "1s", "5m")
+  if (/^\d+(\.\d+)?(ns|us|µs|ms|s|m|h)$/.test(str)) {
+    return `"${str}"`
+  }
+  
+  // Arrays/JSON objects
+  if (str.startsWith('[') || str.startsWith('{')) {
+    try {
+      JSON.parse(str)
+      return `"""${str}"""`
+    } catch {
+      return `"${str.replace(/"/g, '\\"')}"`
+    }
+  }
+  
+  // String values (escape quotes)
+  return `"${str.replace(/"/g, '\\"')}"`
+}
+
+/**
+ * Converts nested keys to TOML sections
+ * @param {Array} configs - Array of config objects with key and value
+ * @returns {Object} - Object with sections and rootKeys
+ */
+export const buildTomlSections = (configs) => {
+  const sections = {}
+  const rootKeys = []
+  
+  configs.forEach(({ key, value }) => {
+    if (key.includes('.')) {
+      const parts = key.split('.')
+      const sectionName = parts[0]
+      const keyName = parts.slice(1).join('.')
+      
+      if (!sections[sectionName]) {
+        sections[sectionName] = []
+      }
+      sections[sectionName].push({ key: keyName, value })
+    } else {
+      rootKeys.push({ key, value })
+    }
+  })
+  
+  return { sections, rootKeys }
+}
+
+/**
+ * Converts configuration data to TOML format
+ * @param {Object} configData - The configuration data object
+ * @returns {string} - The TOML-formatted configuration
+ */
+export const configToToml = (configData) => {
+  let tomlContent = `# Navidrome Configuration\n# Generated on ${new Date().toISOString()}\n\n`
+  
+  // Separate regular and dev configs
+  const regularConfigs = []
+  const devConfigs = []
+  
+  configData.config?.forEach(({ key, value }) => {
+    // Skip configFile as it's displayed separately
+    if (key === 'ConfigFile') {
+      return
+    }
+    
+    if (key.startsWith('Dev')) {
+      devConfigs.push({ key, value })
+    } else {
+      regularConfigs.push({ key, value })
+    }
+  })
+
+  // Process regular configs
+  const { sections: regularSections, rootKeys: regularRootKeys } =
+    buildTomlSections(regularConfigs)
+  
+  // Add root-level keys first
+  if (regularRootKeys.length > 0) {
+    regularRootKeys.forEach(({ key, value }) => {
+      tomlContent += `${key} = ${formatTomlValue(value)}\n`
+    })
+    tomlContent += '\n'
+  }
+  
+  // Add sections
+  Object.keys(regularSections)
+    .sort()
+    .forEach((sectionName) => {
+      tomlContent += `[${sectionName}]\n`
+      regularSections[sectionName].forEach(({ key, value }) => {
+        tomlContent += `${key} = ${formatTomlValue(value)}\n`
+      })
+      tomlContent += '\n'
+    })
+
+  // Add dev configs if any
+  if (devConfigs.length > 0) {
+    tomlContent += `# Development Flags (subject to change/removal)\n`
+    tomlContent += `# These are experimental settings and may be removed in future versions\n\n`
+    
+    const { sections: devSections, rootKeys: devRootKeys } =
+      buildTomlSections(devConfigs)
+    
+    // Add dev root-level keys
+    devRootKeys.forEach(({ key, value }) => {
+      tomlContent += `${key} = ${formatTomlValue(value)}\n`
+    })
+    if (devRootKeys.length > 0) {
+      tomlContent += '\n'
+    }
+    
+    // Add dev sections
+    Object.keys(devSections)
+      .sort()
+      .forEach((sectionName) => {
+        tomlContent += `[${sectionName}]\n`
+        devSections[sectionName].forEach(({ key, value }) => {
+          tomlContent += `${key} = ${formatTomlValue(value)}\n`
+        })
+        tomlContent += '\n'
+      })
+  }
+
+  return tomlContent
+} 

--- a/ui/src/utils/toml.js
+++ b/ui/src/utils/toml.js
@@ -67,12 +67,12 @@ export const formatTomlValue = (value) => {
       JSON.parse(str)
       return `"""${str}"""`
     } catch {
-      return `"${str.replace(/"/g, '\\"')}"`
+      return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
     }
   }
 
-  // String values (escape quotes)
-  return `"${str.replace(/"/g, '\\"')}"`
+  // String values (escape backslashes and quotes)
+  return `"${str.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`
 }
 
 /**

--- a/ui/src/utils/toml.js
+++ b/ui/src/utils/toml.js
@@ -76,9 +76,10 @@ export const buildTomlSections = (configs) => {
 /**
  * Converts configuration data to TOML format
  * @param {Object} configData - The configuration data object
+ * @param {Function} translate - Translation function for internationalization
  * @returns {string} - The TOML-formatted configuration
  */
-export const configToToml = (configData) => {
+export const configToToml = (configData, translate = (key) => key) => {
   let tomlContent = `# Navidrome Configuration\n# Generated on ${new Date().toISOString()}\n\n`
   
   // Separate regular and dev configs
@@ -123,8 +124,8 @@ export const configToToml = (configData) => {
 
   // Add dev configs if any
   if (devConfigs.length > 0) {
-    tomlContent += `# Development Flags (subject to change/removal)\n`
-    tomlContent += `# These are experimental settings and may be removed in future versions\n\n`
+    tomlContent += `# ${translate('about.config.devFlagsHeader')}\n`
+    tomlContent += `# ${translate('about.config.devFlagsComment')}\n\n`
     
     const { sections: devSections, rootKeys: devRootKeys } =
       buildTomlSections(devConfigs)

--- a/ui/src/utils/toml.test.js
+++ b/ui/src/utils/toml.test.js
@@ -1,0 +1,345 @@
+import { describe, it, expect } from 'vitest'
+import { formatTomlValue, buildTomlSections, configToToml, separateAndSortConfigs } from './toml'
+
+describe('formatTomlValue', () => {
+  it('handles null and undefined values', () => {
+    expect(formatTomlValue(null)).toBe('""')
+    expect(formatTomlValue(undefined)).toBe('""')
+  })
+
+  it('handles boolean values', () => {
+    expect(formatTomlValue('true')).toBe('true')
+    expect(formatTomlValue('false')).toBe('false')
+    expect(formatTomlValue(true)).toBe('true')
+    expect(formatTomlValue(false)).toBe('false')
+  })
+
+  it('handles integer values', () => {
+    expect(formatTomlValue('123')).toBe('123')
+    expect(formatTomlValue('-456')).toBe('-456')
+    expect(formatTomlValue('0')).toBe('0')
+    expect(formatTomlValue(789)).toBe('789')
+  })
+
+  it('handles float values', () => {
+    expect(formatTomlValue('123.45')).toBe('123.45')
+    expect(formatTomlValue('-67.89')).toBe('-67.89')
+    expect(formatTomlValue('0.0')).toBe('0.0')
+    expect(formatTomlValue(12.34)).toBe('12.34')
+  })
+
+  it('handles duration values', () => {
+    expect(formatTomlValue('300ms')).toBe('"300ms"')
+    expect(formatTomlValue('5s')).toBe('"5s"')
+    expect(formatTomlValue('10m')).toBe('"10m"')
+    expect(formatTomlValue('2h')).toBe('"2h"')
+    expect(formatTomlValue('1.5s')).toBe('"1.5s"')
+  })
+
+  it('handles JSON arrays and objects', () => {
+    expect(formatTomlValue('["item1", "item2"]')).toBe('"""["item1", "item2"]"""')
+    expect(formatTomlValue('{"key": "value"}')).toBe('"""{"key": "value"}"""')
+  })
+
+  it('handles invalid JSON as regular strings', () => {
+    expect(formatTomlValue('[invalid json')).toBe('"[invalid json"')
+    expect(formatTomlValue('{broken')).toBe('"{broken"')
+  })
+
+  it('handles regular strings with quote escaping', () => {
+    expect(formatTomlValue('simple string')).toBe('"simple string"')
+    expect(formatTomlValue('string with "quotes"')).toBe('"string with \\"quotes\\""')
+    expect(formatTomlValue('/path/to/file')).toBe('"/path/to/file"')
+  })
+
+  it('handles empty strings', () => {
+    expect(formatTomlValue('')).toBe('""')
+  })
+})
+
+describe('buildTomlSections', () => {
+  it('separates root keys from nested keys', () => {
+    const configs = [
+      { key: 'RootKey1', value: 'value1' },
+      { key: 'Section.NestedKey', value: 'value2' },
+      { key: 'RootKey2', value: 'value3' },
+      { key: 'Section.AnotherKey', value: 'value4' },
+      { key: 'AnotherSection.Key', value: 'value5' }
+    ]
+
+    const result = buildTomlSections(configs)
+
+    expect(result.rootKeys).toEqual([
+      { key: 'RootKey1', value: 'value1' },
+      { key: 'RootKey2', value: 'value3' }
+    ])
+
+    expect(result.sections).toEqual({
+      Section: [
+        { key: 'NestedKey', value: 'value2' },
+        { key: 'AnotherKey', value: 'value4' }
+      ],
+      AnotherSection: [
+        { key: 'Key', value: 'value5' }
+      ]
+    })
+  })
+
+  it('handles deeply nested keys', () => {
+    const configs = [
+      { key: 'Section.SubSection.DeepKey', value: 'deepValue' }
+    ]
+
+    const result = buildTomlSections(configs)
+
+    expect(result.rootKeys).toEqual([])
+    expect(result.sections).toEqual({
+      Section: [
+        { key: 'SubSection.DeepKey', value: 'deepValue' }
+      ]
+    })
+  })
+
+  it('handles empty input', () => {
+    const result = buildTomlSections([])
+
+    expect(result.rootKeys).toEqual([])
+    expect(result.sections).toEqual({})
+  })
+})
+
+describe('configToToml', () => {
+  const mockTranslate = (key) => {
+    const translations = {
+      'about.config.devFlagsHeader': 'Development Flags (subject to change/removal)',
+      'about.config.devFlagsComment': 'These are experimental settings and may be removed in future versions'
+    }
+    return translations[key] || key
+  }
+
+  it('generates TOML with header and timestamp', () => {
+    const configData = {
+      config: [
+        { key: 'TestKey', value: 'testValue' }
+      ]
+    }
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).toContain('# Navidrome Configuration')
+    expect(result).toContain('# Generated on')
+    expect(result).toContain('TestKey = "testValue"')
+  })
+
+  it('separates and sorts regular and dev configs', () => {
+    const configData = {
+      config: [
+        { key: 'ZRegularKey', value: 'regularValue' },
+        { key: 'DevTestFlag', value: 'true' },
+        { key: 'ARegularKey', value: 'anotherValue' },
+        { key: 'DevAnotherFlag', value: 'false' }
+      ]
+    }
+
+    const result = configToToml(configData, mockTranslate)
+
+    // Check that regular configs come first and are sorted
+    const lines = result.split('\n')
+    const aRegularIndex = lines.findIndex(line => line.includes('ARegularKey'))
+    const zRegularIndex = lines.findIndex(line => line.includes('ZRegularKey'))
+    const devHeaderIndex = lines.findIndex(line => line.includes('Development Flags'))
+    const devAnotherIndex = lines.findIndex(line => line.includes('DevAnotherFlag'))
+    const devTestIndex = lines.findIndex(line => line.includes('DevTestFlag'))
+
+    expect(aRegularIndex).toBeLessThan(zRegularIndex)
+    expect(zRegularIndex).toBeLessThan(devHeaderIndex)
+    expect(devHeaderIndex).toBeLessThan(devAnotherIndex)
+    expect(devAnotherIndex).toBeLessThan(devTestIndex)
+  })
+
+  it('skips ConfigFile entries', () => {
+    const configData = {
+      config: [
+        { key: 'ConfigFile', value: '/path/to/config.toml' },
+        { key: 'TestKey', value: 'testValue' }
+      ]
+    }
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).not.toContain('ConfigFile =')
+    expect(result).toContain('TestKey = "testValue"')
+  })
+
+  it('handles sections correctly', () => {
+    const configData = {
+      config: [
+        { key: 'RootKey', value: 'rootValue' },
+        { key: 'Section.NestedKey', value: 'nestedValue' },
+        { key: 'Section.AnotherKey', value: 'anotherValue' }
+      ]
+    }
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).toContain('RootKey = "rootValue"')
+    expect(result).toContain('[Section]')
+    expect(result).toContain('NestedKey = "nestedValue"')
+    expect(result).toContain('AnotherKey = "anotherValue"')
+  })
+
+  it('includes dev flags header when dev configs exist', () => {
+    const configData = {
+      config: [
+        { key: 'RegularKey', value: 'regularValue' },
+        { key: 'DevTestFlag', value: 'true' }
+      ]
+    }
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).toContain('# Development Flags (subject to change/removal)')
+    expect(result).toContain('# These are experimental settings and may be removed in future versions')
+    expect(result).toContain('DevTestFlag = true')
+  })
+
+  it('does not include dev flags header when no dev configs exist', () => {
+    const configData = {
+      config: [
+        { key: 'RegularKey', value: 'regularValue' }
+      ]
+    }
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).not.toContain('Development Flags')
+    expect(result).toContain('RegularKey = "regularValue"')
+  })
+
+  it('handles empty config data', () => {
+    const configData = { config: [] }
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).toContain('# Navidrome Configuration')
+    expect(result).not.toContain('Development Flags')
+  })
+
+  it('handles missing config array', () => {
+    const configData = {}
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).toContain('# Navidrome Configuration')
+    expect(result).not.toContain('Development Flags')
+  })
+
+  it('works without translate function', () => {
+    const configData = {
+      config: [
+        { key: 'DevTestFlag', value: 'true' }
+      ]
+    }
+
+    const result = configToToml(configData)
+
+    expect(result).toContain('# about.config.devFlagsHeader')
+    expect(result).toContain('# about.config.devFlagsComment')
+    expect(result).toContain('DevTestFlag = true')
+  })
+
+  it('handles various data types correctly', () => {
+    const configData = {
+      config: [
+        { key: 'StringValue', value: 'test string' },
+        { key: 'BooleanValue', value: 'true' },
+        { key: 'IntegerValue', value: '42' },
+        { key: 'FloatValue', value: '3.14' },
+        { key: 'DurationValue', value: '5s' },
+        { key: 'ArrayValue', value: '["item1", "item2"]' }
+      ]
+    }
+
+    const result = configToToml(configData, mockTranslate)
+
+    expect(result).toContain('StringValue = "test string"')
+    expect(result).toContain('BooleanValue = true')
+    expect(result).toContain('IntegerValue = 42')
+    expect(result).toContain('FloatValue = 3.14')
+    expect(result).toContain('DurationValue = "5s"')
+    expect(result).toContain('ArrayValue = """["item1", "item2"]"""')
+  })
+})
+
+describe('separateAndSortConfigs', () => {
+  it('separates regular and dev configs correctly', () => {
+    const configs = [
+      { key: 'RegularKey1', value: 'value1' },
+      { key: 'DevTestFlag', value: 'true' },
+      { key: 'AnotherRegular', value: 'value2' },
+      { key: 'DevAnotherFlag', value: 'false' }
+    ]
+
+    const result = separateAndSortConfigs(configs)
+
+    expect(result.regularConfigs).toEqual([
+      { key: 'AnotherRegular', value: 'value2' },
+      { key: 'RegularKey1', value: 'value1' }
+    ])
+
+    expect(result.devConfigs).toEqual([
+      { key: 'DevAnotherFlag', value: 'false' },
+      { key: 'DevTestFlag', value: 'true' }
+    ])
+  })
+
+  it('skips ConfigFile entries', () => {
+    const configs = [
+      { key: 'ConfigFile', value: '/path/to/config.toml' },
+      { key: 'RegularKey', value: 'value' },
+      { key: 'DevFlag', value: 'true' }
+    ]
+
+    const result = separateAndSortConfigs(configs)
+
+    expect(result.regularConfigs).toEqual([
+      { key: 'RegularKey', value: 'value' }
+    ])
+    expect(result.devConfigs).toEqual([
+      { key: 'DevFlag', value: 'true' }
+    ])
+  })
+
+  it('handles empty input', () => {
+    const result = separateAndSortConfigs([])
+
+    expect(result.regularConfigs).toEqual([])
+    expect(result.devConfigs).toEqual([])
+  })
+
+  it('handles null/undefined input', () => {
+    const result1 = separateAndSortConfigs(null)
+    const result2 = separateAndSortConfigs(undefined)
+
+    expect(result1.regularConfigs).toEqual([])
+    expect(result1.devConfigs).toEqual([])
+    expect(result2.regularConfigs).toEqual([])
+    expect(result2.devConfigs).toEqual([])
+  })
+
+  it('sorts configs alphabetically', () => {
+    const configs = [
+      { key: 'ZRegular', value: 'z' },
+      { key: 'ARegular', value: 'a' },
+      { key: 'DevZ', value: 'z' },
+      { key: 'DevA', value: 'a' }
+    ]
+
+    const result = separateAndSortConfigs(configs)
+
+    expect(result.regularConfigs[0].key).toBe('ARegular')
+    expect(result.regularConfigs[1].key).toBe('ZRegular')
+    expect(result.devConfigs[0].key).toBe('DevA')
+    expect(result.devConfigs[1].key).toBe('DevZ')
+  })
+}) 

--- a/ui/src/utils/toml.test.js
+++ b/ui/src/utils/toml.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest'
-import { formatTomlValue, buildTomlSections, configToToml, separateAndSortConfigs } from './toml'
+import {
+  formatTomlValue,
+  buildTomlSections,
+  configToToml,
+  separateAndSortConfigs,
+} from './toml'
 
 describe('formatTomlValue', () => {
   it('handles null and undefined values', () => {
@@ -37,7 +42,9 @@ describe('formatTomlValue', () => {
   })
 
   it('handles JSON arrays and objects', () => {
-    expect(formatTomlValue('["item1", "item2"]')).toBe('"""["item1", "item2"]"""')
+    expect(formatTomlValue('["item1", "item2"]')).toBe(
+      '"""["item1", "item2"]"""',
+    )
     expect(formatTomlValue('{"key": "value"}')).toBe('"""{"key": "value"}"""')
   })
 
@@ -48,7 +55,9 @@ describe('formatTomlValue', () => {
 
   it('handles regular strings with quote escaping', () => {
     expect(formatTomlValue('simple string')).toBe('"simple string"')
-    expect(formatTomlValue('string with "quotes"')).toBe('"string with \\"quotes\\""')
+    expect(formatTomlValue('string with "quotes"')).toBe(
+      '"string with \\"quotes\\""',
+    )
     expect(formatTomlValue('/path/to/file')).toBe('"/path/to/file"')
   })
 
@@ -64,39 +73,33 @@ describe('buildTomlSections', () => {
       { key: 'Section.NestedKey', value: 'value2' },
       { key: 'RootKey2', value: 'value3' },
       { key: 'Section.AnotherKey', value: 'value4' },
-      { key: 'AnotherSection.Key', value: 'value5' }
+      { key: 'AnotherSection.Key', value: 'value5' },
     ]
 
     const result = buildTomlSections(configs)
 
     expect(result.rootKeys).toEqual([
       { key: 'RootKey1', value: 'value1' },
-      { key: 'RootKey2', value: 'value3' }
+      { key: 'RootKey2', value: 'value3' },
     ])
 
     expect(result.sections).toEqual({
       Section: [
         { key: 'NestedKey', value: 'value2' },
-        { key: 'AnotherKey', value: 'value4' }
+        { key: 'AnotherKey', value: 'value4' },
       ],
-      AnotherSection: [
-        { key: 'Key', value: 'value5' }
-      ]
+      AnotherSection: [{ key: 'Key', value: 'value5' }],
     })
   })
 
   it('handles deeply nested keys', () => {
-    const configs = [
-      { key: 'Section.SubSection.DeepKey', value: 'deepValue' }
-    ]
+    const configs = [{ key: 'Section.SubSection.DeepKey', value: 'deepValue' }]
 
     const result = buildTomlSections(configs)
 
     expect(result.rootKeys).toEqual([])
     expect(result.sections).toEqual({
-      Section: [
-        { key: 'SubSection.DeepKey', value: 'deepValue' }
-      ]
+      Section: [{ key: 'SubSection.DeepKey', value: 'deepValue' }],
     })
   })
 
@@ -111,17 +114,17 @@ describe('buildTomlSections', () => {
 describe('configToToml', () => {
   const mockTranslate = (key) => {
     const translations = {
-      'about.config.devFlagsHeader': 'Development Flags (subject to change/removal)',
-      'about.config.devFlagsComment': 'These are experimental settings and may be removed in future versions'
+      'about.config.devFlagsHeader':
+        'Development Flags (subject to change/removal)',
+      'about.config.devFlagsComment':
+        'These are experimental settings and may be removed in future versions',
     }
     return translations[key] || key
   }
 
   it('generates TOML with header and timestamp', () => {
     const configData = {
-      config: [
-        { key: 'TestKey', value: 'testValue' }
-      ]
+      config: [{ key: 'TestKey', value: 'testValue' }],
     }
 
     const result = configToToml(configData, mockTranslate)
@@ -137,19 +140,27 @@ describe('configToToml', () => {
         { key: 'ZRegularKey', value: 'regularValue' },
         { key: 'DevTestFlag', value: 'true' },
         { key: 'ARegularKey', value: 'anotherValue' },
-        { key: 'DevAnotherFlag', value: 'false' }
-      ]
+        { key: 'DevAnotherFlag', value: 'false' },
+      ],
     }
 
     const result = configToToml(configData, mockTranslate)
 
     // Check that regular configs come first and are sorted
     const lines = result.split('\n')
-    const aRegularIndex = lines.findIndex(line => line.includes('ARegularKey'))
-    const zRegularIndex = lines.findIndex(line => line.includes('ZRegularKey'))
-    const devHeaderIndex = lines.findIndex(line => line.includes('Development Flags'))
-    const devAnotherIndex = lines.findIndex(line => line.includes('DevAnotherFlag'))
-    const devTestIndex = lines.findIndex(line => line.includes('DevTestFlag'))
+    const aRegularIndex = lines.findIndex((line) =>
+      line.includes('ARegularKey'),
+    )
+    const zRegularIndex = lines.findIndex((line) =>
+      line.includes('ZRegularKey'),
+    )
+    const devHeaderIndex = lines.findIndex((line) =>
+      line.includes('Development Flags'),
+    )
+    const devAnotherIndex = lines.findIndex((line) =>
+      line.includes('DevAnotherFlag'),
+    )
+    const devTestIndex = lines.findIndex((line) => line.includes('DevTestFlag'))
 
     expect(aRegularIndex).toBeLessThan(zRegularIndex)
     expect(zRegularIndex).toBeLessThan(devHeaderIndex)
@@ -161,8 +172,8 @@ describe('configToToml', () => {
     const configData = {
       config: [
         { key: 'ConfigFile', value: '/path/to/config.toml' },
-        { key: 'TestKey', value: 'testValue' }
-      ]
+        { key: 'TestKey', value: 'testValue' },
+      ],
     }
 
     const result = configToToml(configData, mockTranslate)
@@ -176,8 +187,8 @@ describe('configToToml', () => {
       config: [
         { key: 'RootKey', value: 'rootValue' },
         { key: 'Section.NestedKey', value: 'nestedValue' },
-        { key: 'Section.AnotherKey', value: 'anotherValue' }
-      ]
+        { key: 'Section.AnotherKey', value: 'anotherValue' },
+      ],
     }
 
     const result = configToToml(configData, mockTranslate)
@@ -192,22 +203,22 @@ describe('configToToml', () => {
     const configData = {
       config: [
         { key: 'RegularKey', value: 'regularValue' },
-        { key: 'DevTestFlag', value: 'true' }
-      ]
+        { key: 'DevTestFlag', value: 'true' },
+      ],
     }
 
     const result = configToToml(configData, mockTranslate)
 
     expect(result).toContain('# Development Flags (subject to change/removal)')
-    expect(result).toContain('# These are experimental settings and may be removed in future versions')
+    expect(result).toContain(
+      '# These are experimental settings and may be removed in future versions',
+    )
     expect(result).toContain('DevTestFlag = true')
   })
 
   it('does not include dev flags header when no dev configs exist', () => {
     const configData = {
-      config: [
-        { key: 'RegularKey', value: 'regularValue' }
-      ]
+      config: [{ key: 'RegularKey', value: 'regularValue' }],
     }
 
     const result = configToToml(configData, mockTranslate)
@@ -236,9 +247,7 @@ describe('configToToml', () => {
 
   it('works without translate function', () => {
     const configData = {
-      config: [
-        { key: 'DevTestFlag', value: 'true' }
-      ]
+      config: [{ key: 'DevTestFlag', value: 'true' }],
     }
 
     const result = configToToml(configData)
@@ -256,8 +265,8 @@ describe('configToToml', () => {
         { key: 'IntegerValue', value: '42' },
         { key: 'FloatValue', value: '3.14' },
         { key: 'DurationValue', value: '5s' },
-        { key: 'ArrayValue', value: '["item1", "item2"]' }
-      ]
+        { key: 'ArrayValue', value: '["item1", "item2"]' },
+      ],
     }
 
     const result = configToToml(configData, mockTranslate)
@@ -277,19 +286,19 @@ describe('separateAndSortConfigs', () => {
       { key: 'RegularKey1', value: 'value1' },
       { key: 'DevTestFlag', value: 'true' },
       { key: 'AnotherRegular', value: 'value2' },
-      { key: 'DevAnotherFlag', value: 'false' }
+      { key: 'DevAnotherFlag', value: 'false' },
     ]
 
     const result = separateAndSortConfigs(configs)
 
     expect(result.regularConfigs).toEqual([
       { key: 'AnotherRegular', value: 'value2' },
-      { key: 'RegularKey1', value: 'value1' }
+      { key: 'RegularKey1', value: 'value1' },
     ])
 
     expect(result.devConfigs).toEqual([
       { key: 'DevAnotherFlag', value: 'false' },
-      { key: 'DevTestFlag', value: 'true' }
+      { key: 'DevTestFlag', value: 'true' },
     ])
   })
 
@@ -297,17 +306,15 @@ describe('separateAndSortConfigs', () => {
     const configs = [
       { key: 'ConfigFile', value: '/path/to/config.toml' },
       { key: 'RegularKey', value: 'value' },
-      { key: 'DevFlag', value: 'true' }
+      { key: 'DevFlag', value: 'true' },
     ]
 
     const result = separateAndSortConfigs(configs)
 
     expect(result.regularConfigs).toEqual([
-      { key: 'RegularKey', value: 'value' }
+      { key: 'RegularKey', value: 'value' },
     ])
-    expect(result.devConfigs).toEqual([
-      { key: 'DevFlag', value: 'true' }
-    ])
+    expect(result.devConfigs).toEqual([{ key: 'DevFlag', value: 'true' }])
   })
 
   it('handles empty input', () => {
@@ -332,7 +339,7 @@ describe('separateAndSortConfigs', () => {
       { key: 'ZRegular', value: 'z' },
       { key: 'ARegular', value: 'a' },
       { key: 'DevZ', value: 'z' },
-      { key: 'DevA', value: 'a' }
+      { key: 'DevA', value: 'a' },
     ]
 
     const result = separateAndSortConfigs(configs)
@@ -342,4 +349,4 @@ describe('separateAndSortConfigs', () => {
     expect(result.devConfigs[0].key).toBe('DevA')
     expect(result.devConfigs[1].key).toBe('DevZ')
   })
-}) 
+})

--- a/ui/src/utils/toml.test.js
+++ b/ui/src/utils/toml.test.js
@@ -61,6 +61,17 @@ describe('formatTomlValue', () => {
     expect(formatTomlValue('/path/to/file')).toBe('"/path/to/file"')
   })
 
+  it('handles strings with backslashes and quotes', () => {
+    expect(formatTomlValue('C:\\Program Files\\app')).toBe(
+      '"C:\\\\Program Files\\\\app"',
+    )
+    expect(formatTomlValue('path\\to"file')).toBe('"path\\\\to\\"file"')
+    expect(formatTomlValue('backslash\\ and "quote"')).toBe(
+      '"backslash\\\\ and \\"quote\\""',
+    )
+    expect(formatTomlValue('single\\backslash')).toBe('"single\\\\backslash"')
+  })
+
   it('handles empty strings', () => {
     expect(formatTomlValue('')).toBe('""')
   })


### PR DESCRIPTION
## Summary

- Added the `DevUIShowConfig` flag to expose configuration options through the UI and set its default to `true`
- Included the new flag in the UI configuration injection so the front end can display the config tab when enabled
- Registered the /config route and implemented the handler to list all configuration values with admin-only access
- Updated the front-end default config to respect devUIShowConfig and added translations for the new tab
- Modified AboutDialog to include the new “Configuration” tab for admin users, fetching data from the new endpoint
- Redact sensitive information (APIKeys, Secrets) server-side

## Testing
- `make test PKG=./...`
- `npm run lint`
- `npm run check-formatting`
- `npm run test`
- `npm run type-check`
