### PR TITLE
Small update in es.json translation

### DIFF
--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -94,7 +94,7 @@
         "recentlyPlayed": "Recientes",
         "mostPlayed": "Más reproducidos",
         "starred": "Favoritos",
-        "topRated": "Los mejores calificados"
+        "topRated": "Mejor calificados"
       }
     },
     "artist": {


### PR DESCRIPTION
Changed translation of "Top Rated" from "Los Mejores Calificados" to "Mejor Calificados" for consistency purposes with other list entries. While the previous version was correct, this version is shorter and aligns better with the rest of the terms.