### PR TITLE
fix(ui): update song fetching logic to disable for radio

### DIFF
--- a/ui/src/audioplayer/PlayerToolbar.jsx
+++ b/ui/src/audioplayer/PlayerToolbar.jsx
@@ -57,7 +57,7 @@ const useStyles = makeStyles((theme) => ({
 
 const PlayerToolbar = ({ id, isRadio }) => {
   const dispatch = useDispatch()
-  const { data, loading } = useGetOne('song', id, { enabled: !!id })
+  const { data, loading } = useGetOne('song', id, { enabled: !!id && !isRadio })
   const [toggleLove, toggling] = useToggleLove('song', data)
   const isDesktop = useMediaQuery('(min-width:810px)')
   const classes = useStyles()


### PR DESCRIPTION
This pull request includes a small change to the `PlayerToolbar` component in `ui/src/audioplayer/PlayerToolbar.jsx`. The change modifies the conditions under which the `useGetOne` hook is enabled to ensure it is not triggered when `isRadio` is true.

fix #4145
