### PR TITLE
bugfix(playlist): reset page to 1 on playlist change - #1676

### DIFF
--- a/ui/src/playlist/PlaylistSongs.jsx
+++ b/ui/src/playlist/PlaylistSongs.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react'
+import React, { useCallback, useEffect, useMemo } from 'react'
 import {
   BulkActionsToolbar,
   ListToolbar,
@@ -84,7 +84,8 @@ const ReorderableList = ({ readOnly, children, ...rest }) => {
 
 const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   const listContext = useListContext()
-  const { data, ids, selectedIds, onUnselectItems, refetch } = listContext
+  const { data, ids, selectedIds, onUnselectItems, refetch, setPage } =
+    listContext
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
@@ -92,6 +93,11 @@ const PlaylistSongs = ({ playlistId, readOnly, actions, ...props }) => {
   const notify = useNotify()
   const version = useVersion()
   useResourceRefresh('song', 'playlist')
+
+  useEffect(() => {
+    setPage(1)
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }, [playlistId, setPage])
 
   const onAddToPlaylist = useCallback(
     (pls) => {


### PR DESCRIPTION
## Reset page to 1 when changing playlists
------

Closes: #1676, #3225

This PR addresses an issue, where being on page 2 or greater of a playlist, then immediately navigating to a different playlist that has less pages than the current page number will result in an 'empty' page with no songs or pagination options.

This is achieved via the `useEffect` hook in the `PlaylistSongs` component, calling `setPage(1)` whenever the playlist changes. It will also automatically scroll to the top of the page, but this can be removed if it is undesirable. 