### PR TITLE
Fix mpv command and template parsing

### DIFF
--- a/core/playback/mpv/mpv.go
+++ b/core/playback/mpv/mpv.go
@@ -92,7 +92,7 @@ func createMPVCommand(deviceName string, filename string, socketName string) []s
 	if len(templateArgs) > 0 {
 		cmdPath, err := mpvCommand()
 		if err == nil {
-			if templateArgs[0] == "mpv" || templateArgs[0] == "mpv.exe" || strings.Contains(templateArgs[0], "mpv") {
+			if templateArgs[0] == "mpv" || templateArgs[0] == "mpv.exe" {
 				templateArgs[0] = cmdPath
 			}
 		}

--- a/core/playback/mpv/mpv.go
+++ b/core/playback/mpv/mpv.go
@@ -16,6 +16,9 @@ import (
 )
 
 func start(ctx context.Context, args []string) (Executor, error) {
+	if len(args) == 0 {
+		return Executor{}, fmt.Errorf("no command arguments provided")
+	}
 	log.Debug("Executing mpv command", "cmd", args)
 	j := Executor{args: args}
 	j.PipeReader, j.out = io.Pipe()
@@ -75,9 +78,8 @@ func createMPVCommand(deviceName string, filename string, socketName string) []s
 	// Parse the template structure using shell parsing to handle quoted arguments
 	templateArgs, err := shellquote.Split(conf.Server.MPVCmdTemplate)
 	if err != nil {
-		// Fallback to Fields() if shell parsing fails
-		log.Warn("Failed to parse MPV command template with shell parsing, falling back to field splitting", "template", conf.Server.MPVCmdTemplate, "error", err)
-		templateArgs = strings.Fields(conf.Server.MPVCmdTemplate)
+		log.Error("Failed to parse MPV command template", "template", conf.Server.MPVCmdTemplate, err)
+		return nil
 	}
 
 	// Replace placeholders in each parsed argument to preserve spaces in substituted values

--- a/core/playback/mpv/mpv_suite_test.go
+++ b/core/playback/mpv/mpv_suite_test.go
@@ -1,0 +1,17 @@
+package mpv
+
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMPV(t *testing.T) {
+	tests.Init(t, false)
+	log.SetLevel(log.LevelFatal)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MPV Suite")
+}

--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -1,0 +1,342 @@
+package mpv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMPV(t *testing.T) {
+	tests.Init(t, false)
+	log.SetLevel(log.LevelFatal)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "MPV Suite")
+}
+
+var _ = Describe("MPV", func() {
+	var (
+		testScript string
+		outputFile string
+		tempDir    string
+	)
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+
+		// Reset MPV cache
+		mpvOnce = sync.Once{}
+		mpvPath = ""
+		mpvErr = nil
+
+		// Create temporary directory for test files
+		var err error
+		tempDir, err = os.MkdirTemp("", "mpv_test_*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { os.RemoveAll(tempDir) })
+
+		// Create output file to capture command arguments
+		outputFile = filepath.Join(tempDir, "mpv_args.txt")
+
+		// Create mock MPV script that captures arguments
+		testScript = createMockMPVScript(tempDir, outputFile)
+
+		// Configure test MPV path
+		conf.Server.MPVPath = testScript
+	})
+
+	Describe("createMPVCommand", func() {
+		Context("with default template", func() {
+			BeforeEach(func() {
+				conf.Server.MPVCmdTemplate = "mpv --audio-device=%d --no-audio-display --pause %f --input-ipc-server=%s"
+			})
+
+			It("creates correct command with simple paths", func() {
+				args := createMPVCommand("auto", "/music/test.mp3", "/tmp/socket")
+				Expect(args).To(Equal([]string{
+					testScript,
+					"--audio-device=auto",
+					"--no-audio-display",
+					"--pause",
+					"/music/test.mp3",
+					"--input-ipc-server=/tmp/socket",
+				}))
+			})
+
+			It("handles paths with spaces", func() {
+				args := createMPVCommand("auto", "/music/My Album/01 - Song.mp3", "/tmp/socket")
+				Expect(args).To(Equal([]string{
+					testScript,
+					"--audio-device=auto",
+					"--no-audio-display",
+					"--pause",
+					"/music/My Album/01 - Song.mp3",
+					"--input-ipc-server=/tmp/socket",
+				}))
+			})
+
+			It("handles complex device names", func() {
+				deviceName := "coreaudio/AppleUSBAudioEngine:Cambridge Audio :Cambridge Audio USB Audio 1.0:0000:1"
+				args := createMPVCommand(deviceName, "/music/test.mp3", "/tmp/socket")
+				Expect(args).To(Equal([]string{
+					testScript,
+					"--audio-device=" + deviceName,
+					"--no-audio-display",
+					"--pause",
+					"/music/test.mp3",
+					"--input-ipc-server=/tmp/socket",
+				}))
+			})
+		})
+
+		Context("with snapcast template (issue #3619)", func() {
+			BeforeEach(func() {
+				// This is the template that fails with naive space splitting
+				conf.Server.MPVCmdTemplate = "mpv --no-audio-display --pause %f --input-ipc-server=%s --audio-channels=stereo --audio-samplerate=48000 --audio-format=s16 --ao=pcm --ao-pcm-file=/audio/snapcast_fifo"
+			})
+
+			It("creates correct command for snapcast integration", func() {
+				args := createMPVCommand("auto", "/music/test.mp3", "/tmp/socket")
+				Expect(args).To(Equal([]string{
+					testScript,
+					"--no-audio-display",
+					"--pause",
+					"/music/test.mp3",
+					"--input-ipc-server=/tmp/socket",
+					"--audio-channels=stereo",
+					"--audio-samplerate=48000",
+					"--audio-format=s16",
+					"--ao=pcm",
+					"--ao-pcm-file=/audio/snapcast_fifo",
+				}))
+			})
+		})
+
+		Context("with wrapper script template", func() {
+			BeforeEach(func() {
+				// Test case that would break with naive splitting due to quoted arguments
+				conf.Server.MPVCmdTemplate = `/tmp/mpv.sh --no-audio-display --pause %f --input-ipc-server=%s --audio-channels=stereo`
+			})
+
+			It("handles wrapper script paths", func() {
+				args := createMPVCommand("auto", "/music/test.mp3", "/tmp/socket")
+				Expect(args).To(Equal([]string{
+					testScript, // This will be substituted by fixCmd
+					"--no-audio-display",
+					"--pause",
+					"/music/test.mp3",
+					"--input-ipc-server=/tmp/socket",
+					"--audio-channels=stereo",
+				}))
+			})
+		})
+
+		Context("with extra spaces in template", func() {
+			BeforeEach(func() {
+				conf.Server.MPVCmdTemplate = "mpv    --audio-device=%d   --no-audio-display     --pause %f --input-ipc-server=%s"
+			})
+
+			It("handles extra spaces correctly", func() {
+				args := createMPVCommand("auto", "/music/test.mp3", "/tmp/socket")
+				Expect(args).To(Equal([]string{
+					testScript,
+					"--audio-device=auto",
+					"--no-audio-display",
+					"--pause",
+					"/music/test.mp3",
+					"--input-ipc-server=/tmp/socket",
+				}))
+			})
+		})
+	})
+
+	Describe("start", func() {
+		BeforeEach(func() {
+			conf.Server.MPVCmdTemplate = "mpv --audio-device=%d --no-audio-display --pause %f --input-ipc-server=%s"
+		})
+
+		It("executes MPV command and captures arguments correctly", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			deviceName := "auto"
+			filename := "/music/test.mp3"
+			socketName := "/tmp/test_socket"
+
+			args := createMPVCommand(deviceName, filename, socketName)
+			executor, err := start(ctx, args)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait a bit for the mock script to write the output
+			time.Sleep(100 * time.Millisecond)
+
+			// Cancel the executor
+			err = executor.Cancel()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Read and verify the captured arguments
+			Eventually(func() bool {
+				_, err := os.Stat(outputFile)
+				return err == nil
+			}, "2s", "100ms").Should(BeTrue(), "Mock script should have created output file")
+
+			content, err := os.ReadFile(outputFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+			Expect(lines).To(HaveLen(6))
+			Expect(lines[0]).To(Equal(testScript))
+			Expect(lines[1]).To(Equal("--audio-device=auto"))
+			Expect(lines[2]).To(Equal("--no-audio-display"))
+			Expect(lines[3]).To(Equal("--pause"))
+			Expect(lines[4]).To(Equal("/music/test.mp3"))
+			Expect(lines[5]).To(Equal("--input-ipc-server=/tmp/test_socket"))
+		})
+
+		It("handles file paths with spaces", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+
+			deviceName := "auto"
+			filename := "/music/My Album/01 - My Song.mp3"
+			socketName := "/tmp/test socket"
+
+			args := createMPVCommand(deviceName, filename, socketName)
+			executor, err := start(ctx, args)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Wait a bit for the mock script to write the output
+			time.Sleep(100 * time.Millisecond)
+
+			// Cancel the executor
+			err = executor.Cancel()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Read and verify the captured arguments
+			Eventually(func() bool {
+				_, err := os.Stat(outputFile)
+				return err == nil
+			}, "2s", "100ms").Should(BeTrue())
+
+			content, err := os.ReadFile(outputFile)
+			Expect(err).ToNot(HaveOccurred())
+
+			lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+			Expect(lines).To(ContainElement("/music/My Album/01 - My Song.mp3"))
+			Expect(lines).To(ContainElement("--input-ipc-server=/tmp/test socket"))
+		})
+
+		Context("with complex snapcast configuration", func() {
+			BeforeEach(func() {
+				conf.Server.MPVCmdTemplate = "mpv --no-audio-display --pause %f --input-ipc-server=%s --audio-channels=stereo --audio-samplerate=48000 --audio-format=s16 --ao=pcm --ao-pcm-file=/audio/snapcast_fifo"
+			})
+
+			It("passes all snapcast arguments correctly", func() {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+
+				deviceName := "auto"
+				filename := "/music/album/track.flac"
+				socketName := "/tmp/mpv-ctrl-test.socket"
+
+				args := createMPVCommand(deviceName, filename, socketName)
+				executor, err := start(ctx, args)
+				Expect(err).ToNot(HaveOccurred())
+
+				// Wait a bit for the mock script to write the output
+				time.Sleep(100 * time.Millisecond)
+
+				// Cancel the executor
+				err = executor.Cancel()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Read and verify all arguments are passed correctly
+				Eventually(func() bool {
+					_, err := os.Stat(outputFile)
+					return err == nil
+				}, "2s", "100ms").Should(BeTrue())
+
+				content, err := os.ReadFile(outputFile)
+				Expect(err).ToNot(HaveOccurred())
+
+				lines := strings.Split(strings.TrimSpace(string(content)), "\n")
+
+				// Verify all expected arguments are present
+				Expect(lines).To(ContainElement("--no-audio-display"))
+				Expect(lines).To(ContainElement("--pause"))
+				Expect(lines).To(ContainElement("/music/album/track.flac"))
+				Expect(lines).To(ContainElement("--input-ipc-server=/tmp/mpv-ctrl-test.socket"))
+				Expect(lines).To(ContainElement("--audio-channels=stereo"))
+				Expect(lines).To(ContainElement("--audio-samplerate=48000"))
+				Expect(lines).To(ContainElement("--audio-format=s16"))
+				Expect(lines).To(ContainElement("--ao=pcm"))
+				Expect(lines).To(ContainElement("--ao-pcm-file=/audio/snapcast_fifo"))
+			})
+		})
+	})
+
+	Describe("mpvCommand", func() {
+		BeforeEach(func() {
+			// Reset the mpv command cache
+			mpvOnce = sync.Once{}
+			mpvPath = ""
+			mpvErr = nil
+		})
+
+		It("finds the configured MPV path", func() {
+			conf.Server.MPVPath = testScript
+			path, err := mpvCommand()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(path).To(Equal(testScript))
+		})
+	})
+})
+
+// createMockMPVScript creates a mock script that captures the arguments passed to it
+func createMockMPVScript(tempDir, outputFile string) string {
+	var scriptContent string
+	var scriptExt string
+
+	if runtime.GOOS == "windows" {
+		scriptExt = ".bat"
+		scriptContent = fmt.Sprintf(`@echo off
+echo %%0 > "%s"
+:loop
+if "%%~1"=="" goto end
+echo %%~1 >> "%s"
+shift
+goto loop
+:end
+timeout /t 1 >nul
+`, outputFile, outputFile)
+	} else {
+		scriptExt = ".sh"
+		scriptContent = fmt.Sprintf(`#!/bin/bash
+echo "$0" > "%s"
+for arg in "$@"; do
+    echo "$arg" >> "%s"
+done
+sleep 1
+`, outputFile, outputFile)
+	}
+
+	scriptPath := filepath.Join(tempDir, "mock_mpv"+scriptExt)
+	err := os.WriteFile(scriptPath, []byte(scriptContent), 0755) // nolint:gosec
+	if err != nil {
+		panic(fmt.Sprintf("Failed to create mock script: %v", err))
+	}
+
+	return scriptPath
+}

--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -9,23 +9,13 @@ import (
 	"runtime"
 	"strings"
 	"sync"
-	"testing"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
-	"github.com/navidrome/navidrome/log"
-	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
-
-func TestMPV(t *testing.T) {
-	tests.Init(t, false)
-	log.SetLevel(log.LevelFatal)
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "MPV Suite")
-}
 
 var _ = Describe("MPV", func() {
 	var (

--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -147,6 +147,26 @@ var _ = Describe("MPV", func() {
 				}))
 			})
 		})
+		Context("with paths containing spaces in template arguments", func() {
+			BeforeEach(func() {
+				// Template with spaces in the path arguments themselves
+				conf.Server.MPVCmdTemplate = `mpv --no-audio-display --pause %f --ao-pcm-file="/audio/my folder/snapcast_fifo" --input-ipc-server=%s`
+			})
+
+			It("handles spaces in quoted template argument paths", func() {
+				args := createMPVCommand("auto", "/music/test.mp3", "/tmp/socket")
+				// This test reveals the limitation of strings.Fields() - it will split on all spaces
+				// Expected behavior would be to keep the path as one argument
+				Expect(args).To(Equal([]string{
+					testScript,
+					"--no-audio-display",
+					"--pause",
+					"/music/test.mp3",
+					"--ao-pcm-file=/audio/my folder/snapcast_fifo", // This should be one argument
+					"--input-ipc-server=/tmp/socket",
+				}))
+			})
+		})
 	})
 
 	Describe("start", func() {

--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -120,7 +120,7 @@ var _ = Describe("MPV", func() {
 			It("handles wrapper script paths", func() {
 				args := createMPVCommand("auto", "/music/test.mp3", "/tmp/socket")
 				Expect(args).To(Equal([]string{
-					testScript, // This will be substituted by fixCmd
+					"/tmp/mpv.sh",
 					"--no-audio-display",
 					"--pause",
 					"/music/test.mp3",

--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -180,7 +180,7 @@ var _ = Describe("MPV", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Wait a bit for the mock script to write the output
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 
 			// Cancel the executor
 			err = executor.Cancel()
@@ -218,7 +218,7 @@ var _ = Describe("MPV", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// Wait a bit for the mock script to write the output
-			time.Sleep(100 * time.Millisecond)
+			time.Sleep(200 * time.Millisecond)
 
 			// Cancel the executor
 			err = executor.Cancel()
@@ -256,7 +256,7 @@ var _ = Describe("MPV", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Wait a bit for the mock script to write the output
-				time.Sleep(100 * time.Millisecond)
+				time.Sleep(200 * time.Millisecond)
 
 				// Cancel the executor
 				err = executor.Cancel()
@@ -328,7 +328,9 @@ echo "$0" > "%s"
 for arg in "$@"; do
     echo "$arg" >> "%s"
 done
-sleep 1
+# Ensure file is flushed
+sync
+sleep 0.1
 `, outputFile, outputFile)
 	}
 

--- a/core/playback/mpv/track.go
+++ b/core/playback/mpv/track.go
@@ -35,6 +35,9 @@ func NewTrack(ctx context.Context, playbackDoneChannel chan bool, deviceName str
 	tmpSocketName := socketName("mpv-ctrl-", ".socket")
 
 	args := createMPVCommand(deviceName, mf.Path, tmpSocketName)
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no mpv command arguments provided")
+	}
 	exe, err := start(ctx, args)
 	if err != nil {
 		log.Error("Error starting mpv process", err)

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/kardianos/service v1.2.2
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/kr/pretty v0.3.1
 	github.com/lestrrat-go/jwx/v2 v2.1.6
 	github.com/matoous/go-nanoid/v2 v2.1.0
@@ -85,7 +86,6 @@ require (
 	github.com/gorilla/css v1.0.1 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/lann/builder v0.0.0-20180802200727-47ae307949d0 // indirect


### PR DESCRIPTION
This pull request introduces improvements to the MPV playback command handling and adds comprehensive testing for the `mpv` module. Key changes include the adoption of a shell-parsing library to handle complex command templates, better error handling for invalid arguments, and the addition of unit tests to ensure robustness.

### Improvements to MPV command handling:
* Replaced naive string splitting with `shellquote.Split` for parsing the `MPVCmdTemplate`, allowing proper handling of quoted arguments and spaces in paths.
* Enhanced error handling in `createMPVCommand` and `start` functions to return meaningful errors when arguments are invalid or missing. [[1]](diffhunk://#diff-82e1c6f991157881db00233150f0b269ffb5739bf888ad68aacfb7a2c246a037R13-R21) [[2]](diffhunk://#diff-d2cc4e3c47c0f7e4d54c013589956d458fe36095cf82d2075d3db00d9c151e13R38-R40)

### Testing enhancements:
* Added a new test suite (`mpv_suite_test.go`) and extensive unit tests (`mpv_test.go`) for the `mpv` module, covering various scenarios such as handling spaces, malformed templates, and snapcast integration. [[1]](diffhunk://#diff-177aecfb9fe54dd921dfead2acf66388d6b211d645377e9c43b84a1e6abb5cb5R1-R17) [[2]](diffhunk://#diff-8ea0ff07486ff3f5d0295775b48871f010672b7fe5f48a3f166a6544f89814e0R1-R390)

### Dependency updates:
* Added `github.com/kballard/go-shellquote` as a direct dependency in `go.mod` to support the improved command parsing logic. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R37) [[2]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L88)

Fix #3619