### PR TITLE
fix(scannner): use prometheus instance over noop if configured properly

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -6,7 +6,6 @@ import (
 	"os"
 
 	"github.com/navidrome/navidrome/core"
-	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/db"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/persistence"
@@ -69,7 +68,7 @@ func runScanner(ctx context.Context) {
 	ds := persistence.New(sqlDB)
 	pls := core.NewPlaylists(ds)
 
-	progress, err := scanner.CallScan(ctx, ds, artwork.NoopCacheWarmer(), pls, fullScan)
+	progress, err := scanner.CallScan(ctx, ds, pls, fullScan)
 	if err != nil {
 		log.Fatal(ctx, "Failed to scan", err)
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -70,7 +70,7 @@ func runScanner(ctx context.Context) {
 	ds := persistence.New(sqlDB)
 	pls := core.NewPlaylists(ds)
 
-	progress, err := scanner.CallScan(ctx, ds, artwork.NoopCacheWarmer(), pls, metrics.NewNoopInstance(), fullScan)
+	progress, err := scanner.CallScan(ctx, ds, artwork.NoopCacheWarmer(), pls, metrics.NewPrometheusInstance(ds), fullScan)
 	if err != nil {
 		log.Fatal(ctx, "Failed to scan", err)
 	}

--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/core/artwork"
-	"github.com/navidrome/navidrome/core/metrics"
 	"github.com/navidrome/navidrome/db"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/persistence"
@@ -70,7 +69,7 @@ func runScanner(ctx context.Context) {
 	ds := persistence.New(sqlDB)
 	pls := core.NewPlaylists(ds)
 
-	progress, err := scanner.CallScan(ctx, ds, artwork.NoopCacheWarmer(), pls, metrics.NewPrometheusInstance(ds), fullScan)
+	progress, err := scanner.CallScan(ctx, ds, artwork.NoopCacheWarmer(), pls, fullScan)
 	if err != nil {
 		log.Fatal(ctx, "Failed to scan", err)
 	}

--- a/scanner/controller.go
+++ b/scanner/controller.go
@@ -68,7 +68,7 @@ func (s *controller) getScanner() scanner {
 
 // CallScan starts an in-process scan of the music library.
 // This is meant to be called from the command line (see cmd/scan.go).
-func CallScan(ctx context.Context, ds model.DataStore, cw artwork.CacheWarmer, pls core.Playlists, fullScan bool) (<-chan *ProgressInfo, error) {
+func CallScan(ctx context.Context, ds model.DataStore, pls core.Playlists, fullScan bool) (<-chan *ProgressInfo, error) {
 	release, err := lockScan(ctx)
 	if err != nil {
 		return nil, err
@@ -79,7 +79,7 @@ func CallScan(ctx context.Context, ds model.DataStore, cw artwork.CacheWarmer, p
 	progress := make(chan *ProgressInfo, 100)
 	go func() {
 		defer close(progress)
-		scanner := &scannerImpl{ds: ds, cw: cw, pls: pls}
+		scanner := &scannerImpl{ds: ds, cw: artwork.NoopCacheWarmer(), pls: pls}
 		scanner.scanAll(ctx, fullScan, progress)
 	}()
 	return progress, nil

--- a/scanner/controller.go
+++ b/scanner/controller.go
@@ -63,13 +63,12 @@ func (s *controller) getScanner() scanner {
 	if conf.Server.DevExternalScanner {
 		return &scannerExternal{}
 	}
-	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls, metrics: s.metrics}
+	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls}
 }
 
 // CallScan starts an in-process scan of the music library.
 // This is meant to be called from the command line (see cmd/scan.go).
-func CallScan(ctx context.Context, ds model.DataStore, cw artwork.CacheWarmer, pls core.Playlists,
-	metrics metrics.Metrics, fullScan bool) (<-chan *ProgressInfo, error) {
+func CallScan(ctx context.Context, ds model.DataStore, cw artwork.CacheWarmer, pls core.Playlists, fullScan bool) (<-chan *ProgressInfo, error) {
 	release, err := lockScan(ctx)
 	if err != nil {
 		return nil, err
@@ -80,7 +79,7 @@ func CallScan(ctx context.Context, ds model.DataStore, cw artwork.CacheWarmer, p
 	progress := make(chan *ProgressInfo, 100)
 	go func() {
 		defer close(progress)
-		scanner := &scannerImpl{ds: ds, cw: cw, pls: pls, metrics: metrics}
+		scanner := &scannerImpl{ds: ds, cw: cw, pls: pls}
 		scanner.scanAll(ctx, fullScan, progress)
 	}()
 	return progress, nil
@@ -230,9 +229,11 @@ func (s *controller) ScanAll(requestCtx context.Context, fullScan bool) ([]strin
 	}
 	// Send the final scan status event, with totals
 	if count, folderCount, err := s.getCounters(ctx); err != nil {
+		s.metrics.WriteAfterScanMetrics(ctx, false)
 		return scanWarnings, err
 	} else {
 		scanType, elapsed, lastErr := s.getScanInfo(ctx)
+		s.metrics.WriteAfterScanMetrics(ctx, true)
 		s.sendMessage(ctx, &events.ScanStatus{
 			Scanning:    false,
 			Count:       count,

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -11,7 +11,6 @@ import (
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/core/artwork"
-	"github.com/navidrome/navidrome/core/metrics"
 	"github.com/navidrome/navidrome/db"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -19,10 +18,9 @@ import (
 )
 
 type scannerImpl struct {
-	ds      model.DataStore
-	cw      artwork.CacheWarmer
-	pls     core.Playlists
-	metrics metrics.Metrics
+	ds  model.DataStore
+	cw  artwork.CacheWarmer
+	pls core.Playlists
 }
 
 // scanState holds the state of an in-progress scan, to be passed to the various phases
@@ -111,7 +109,6 @@ func (s *scannerImpl) scanAll(ctx context.Context, fullScan bool, progress chan<
 		log.Error(ctx, "Scanner: Finished with error", "duration", time.Since(startTime), err)
 		_ = s.ds.Property(ctx).Put(consts.LastScanErrorKey, err.Error())
 		state.sendError(err)
-		s.metrics.WriteAfterScanMetrics(ctx, false)
 		return
 	}
 
@@ -121,7 +118,6 @@ func (s *scannerImpl) scanAll(ctx context.Context, fullScan bool, progress chan<
 		state.sendProgress(&ProgressInfo{ChangesDetected: true})
 	}
 
-	s.metrics.WriteAfterScanMetrics(ctx, err == nil)
 	log.Info(ctx, "Scanner: Finished scanning all libraries", "duration", time.Since(startTime))
 }
 


### PR DESCRIPTION
Proper fix: the problem with metrics not being updated was that `scanAll` was happening in a gofunc/separate process, so it was not updating the primary instance properly. Move this call outside the subprocess.

Note: `navidrome scan` will not update metrics, but this should be tackled as a separate issue.