### PR TITLE
Fix JukeboxRole logic in GetUser to respect AdminOnly setting

### DIFF
--- a/server/subsonic/users.go
+++ b/server/subsonic/users.go
@@ -4,9 +4,29 @@ import (
 	"net/http"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
 )
+
+// buildUserResponse creates a User response object from a User model
+func buildUserResponse(user model.User) responses.User {
+	userResponse := responses.User{
+		Username:          user.UserName,
+		AdminRole:         user.IsAdmin,
+		Email:             user.Email,
+		StreamRole:        true,
+		ScrobblingEnabled: true,
+		DownloadRole:      conf.Server.EnableDownloads,
+		ShareRole:         conf.Server.EnableSharing,
+	}
+
+	if conf.Server.Jukebox.Enabled {
+		userResponse.JukeboxRole = !conf.Server.Jukebox.AdminOnly || user.IsAdmin
+	}
+
+	return userResponse
+}
 
 // TODO This is a placeholder. The real one has to read this info from a config file or the database
 func (api *Router) GetUser(r *http.Request) (*responses.Subsonic, error) {
@@ -14,16 +34,10 @@ func (api *Router) GetUser(r *http.Request) (*responses.Subsonic, error) {
 	if !ok {
 		return nil, newError(responses.ErrorGeneric, "Internal error")
 	}
+
 	response := newResponse()
-	response.User = &responses.User{}
-	response.User.Username = loggedUser.UserName
-	response.User.AdminRole = loggedUser.IsAdmin
-	response.User.Email = loggedUser.Email
-	response.User.StreamRole = true
-	response.User.ScrobblingEnabled = true
-	response.User.DownloadRole = conf.Server.EnableDownloads
-	response.User.ShareRole = conf.Server.EnableSharing
-	response.User.JukeboxRole = conf.Server.Jukebox.Enabled
+	user := buildUserResponse(loggedUser)
+	response.User = &user
 	return response, nil
 }
 
@@ -32,17 +46,8 @@ func (api *Router) GetUsers(r *http.Request) (*responses.Subsonic, error) {
 	if !ok {
 		return nil, newError(responses.ErrorGeneric, "Internal error")
 	}
-	user := responses.User{}
-	user.Username = loggedUser.Name
-	user.AdminRole = loggedUser.IsAdmin
-	user.Email = loggedUser.Email
-	user.StreamRole = true
-	user.ScrobblingEnabled = true
-	user.DownloadRole = conf.Server.EnableDownloads
-	user.ShareRole = conf.Server.EnableSharing
-	if conf.Server.Jukebox.Enabled {
-		user.JukeboxRole = !conf.Server.Jukebox.AdminOnly || loggedUser.IsAdmin
-	}
+
+	user := buildUserResponse(loggedUser)
 	response := newResponse()
 	response.Users = &responses.Users{User: []responses.User{user}}
 	return response, nil

--- a/server/subsonic/users_test.go
+++ b/server/subsonic/users_test.go
@@ -1,0 +1,96 @@
+package subsonic
+
+import (
+	"context"
+	"net/http/httptest"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/server/subsonic/responses"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Users", func() {
+	var router *Router
+	var testUser model.User
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		router = &Router{}
+
+		testUser = model.User{
+			ID:       "user123",
+			UserName: "testuser",
+			Name:     "Test User",
+			Email:    "test@example.com",
+			IsAdmin:  false,
+		}
+	})
+
+	Describe("Happy path", func() {
+		It("should return consistent user data in both GetUser and GetUsers", func() {
+			conf.Server.EnableDownloads = true
+			conf.Server.EnableSharing = true
+			conf.Server.Jukebox.Enabled = false
+
+			// Create request with user in context
+			req := httptest.NewRequest("GET", "/rest/getUser", nil)
+			ctx := request.WithUser(context.Background(), testUser)
+			req = req.WithContext(ctx)
+
+			userResponse, err1 := router.GetUser(req)
+			usersResponse, err2 := router.GetUsers(req)
+
+			Expect(err1).ToNot(HaveOccurred())
+			Expect(err2).ToNot(HaveOccurred())
+
+			// Verify GetUser response structure
+			Expect(userResponse.Status).To(Equal(responses.StatusOK))
+			Expect(userResponse.User).ToNot(BeNil())
+			Expect(userResponse.User.Username).To(Equal("testuser"))
+			Expect(userResponse.User.Email).To(Equal("test@example.com"))
+			Expect(userResponse.User.AdminRole).To(BeFalse())
+			Expect(userResponse.User.StreamRole).To(BeTrue())
+			Expect(userResponse.User.ScrobblingEnabled).To(BeTrue())
+			Expect(userResponse.User.DownloadRole).To(BeTrue())
+			Expect(userResponse.User.ShareRole).To(BeTrue())
+
+			// Verify GetUsers response structure
+			Expect(usersResponse.Status).To(Equal(responses.StatusOK))
+			Expect(usersResponse.Users).ToNot(BeNil())
+			Expect(usersResponse.Users.User).To(HaveLen(1))
+
+			// Verify both methods return identical user data
+			singleUser := userResponse.User
+			userFromList := &usersResponse.Users.User[0]
+
+			Expect(singleUser.Username).To(Equal(userFromList.Username))
+			Expect(singleUser.Email).To(Equal(userFromList.Email))
+			Expect(singleUser.AdminRole).To(Equal(userFromList.AdminRole))
+			Expect(singleUser.StreamRole).To(Equal(userFromList.StreamRole))
+			Expect(singleUser.ScrobblingEnabled).To(Equal(userFromList.ScrobblingEnabled))
+			Expect(singleUser.DownloadRole).To(Equal(userFromList.DownloadRole))
+			Expect(singleUser.ShareRole).To(Equal(userFromList.ShareRole))
+			Expect(singleUser.JukeboxRole).To(Equal(userFromList.JukeboxRole))
+		})
+	})
+
+	DescribeTable("Jukebox role permissions",
+		func(jukeboxEnabled, adminOnly, isAdmin, expectedJukeboxRole bool) {
+			conf.Server.Jukebox.Enabled = jukeboxEnabled
+			conf.Server.Jukebox.AdminOnly = adminOnly
+			testUser.IsAdmin = isAdmin
+
+			response := buildUserResponse(testUser)
+			Expect(response.JukeboxRole).To(Equal(expectedJukeboxRole))
+		},
+		Entry("jukebox disabled", false, false, false, false),
+		Entry("jukebox enabled, not admin-only, regular user", true, false, false, true),
+		Entry("jukebox enabled, not admin-only, admin user", true, false, true, true),
+		Entry("jukebox enabled, admin-only, regular user", true, true, false, false),
+		Entry("jukebox enabled, admin-only, admin user", true, true, true, true),
+	)
+})


### PR DESCRIPTION
## Description

Fixes the bug where `GetUser` was incorrectly setting `jukeboxRole` to `true` for all users when jukebox was enabled, regardless of the `Jukebox.AdminOnly` configuration setting.

This PR also refactors the code to eliminate duplication between `GetUser` and `GetUsers` methods.

## Changes Made

### 🐛 **Primary Fix: JukeboxRole Logic**
- Fixed `GetUser` method to properly implement jukebox role logic: `!conf.Server.Jukebox.AdminOnly || user.IsAdmin`
- Previously it was simply setting `JukeboxRole = conf.Server.Jukebox.Enabled` ignoring the AdminOnly setting

### 🔄 **Code Refactoring**
- **Extracted `buildUserResponse()` helper function** to eliminate ~30 lines of duplicated code between `GetUser` and `GetUsers`
- **Fixed username field inconsistency**: `GetUsers` was incorrectly using `loggedUser.Name` instead of `loggedUser.UserName`
- **Improved maintainability**: User response logic is now centralized in one location

### ✅ **Added Comprehensive Tests**
- **Happy path tests** ensuring both methods work correctly and return consistent data
- **Jukebox role permission tests** using `DescribeTable` to cover all scenarios:
  - Jukebox disabled → `jukeboxRole: false`
  - Jukebox enabled, not admin-only → `jukeboxRole: true` (for all users)
  - Jukebox enabled, admin-only → `jukeboxRole: true` (admin only), `jukeboxRole: false` (regular users)

## Testing

All existing tests pass, and new comprehensive tests cover the fixed functionality:

```bash
$ make test PKG=./server/subsonic/...
# All tests pass ✅
```

The new tests specifically validate that:
- Non-admin users get `jukeboxRole: false` when `Jukebox.AdminOnly = true`
- Admin users get `jukeboxRole: true` when jukebox is enabled
- Both `GetUser` and `GetUsers` return identical user data (consistency)

## Fixes

Closes #4160

## Breaking Changes

None. This is a bug fix that corrects the behavior to match the expected specification.

Before this fix:
- `GetUser` ignored `Jukebox.AdminOnly` setting
- Non-admin users incorrectly received `jukeboxRole: true` when `Jukebox.AdminOnly = true`

After this fix:
- `GetUser` properly respects `Jukebox.AdminOnly` setting  
- Non-admin users correctly receive `jukeboxRole: false` when `Jukebox.AdminOnly = true`