### PR TITLE
(WIP) refactor(jukebox):Singleton MPV Instance - #3256

### DIFF
--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
-	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -318,38 +317,6 @@ var _ = Describe("MPV", func() {
 			path, err := mpvCommand()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(path).To(Equal(testScript))
-		})
-	})
-
-	Describe("NewTrack integration", func() {
-		var testMediaFile model.MediaFile
-
-		BeforeEach(func() {
-			DeferCleanup(configtest.SetupConfig())
-			conf.Server.MPVPath = testScript
-
-			// Create a test media file
-			testMediaFile = model.MediaFile{
-				ID:   "test-id",
-				Path: "/music/test.mp3",
-			}
-		})
-
-		Context("with malformed template", func() {
-			BeforeEach(func() {
-				// Template with unmatched quotes that will cause shell parsing to fail
-				conf.Server.MPVCmdTemplate = `mpv --no-audio-display --pause %f --input-ipc-server=%s --ao-pcm-file="/unclosed/quote`
-			})
-
-			It("returns error when createMPVCommand fails", func() {
-				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-				defer cancel()
-
-				playbackDone := make(chan bool, 1)
-				_, err := NewTrack(ctx, playbackDone, "auto", testMediaFile)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("no mpv command arguments provided"))
-			})
 		})
 	})
 })


### PR DESCRIPTION
Meant to open this as a draft PR 🤦  Here now. 

Would love some help getting this over the finish line. Creating a file with `mkfifo /tmp/navidrome` and running navidrome (this branch) and snapcast on the same system seems to work. Running snapcast via docker and navidrome locally does not work on my mac. Might have something to do with file binding, or how the pipe works, idk.

Template command
```toml
MPVCmdTemplate = "mpv --no-audio-display --pause --keep-open=always --no-video --vid=no --ytdl=no --idle %f --input-ipc-server=%s --audio-channels=stereo --audio-samplerate=48000 --audio-format=s16 --ao=pcm --ao-pcm-file=/tmp/navififo --log-file=log.log"
```

Currently, can start and stop playback on specific songs. Clicking next causes it to skip to the end of a playlist. Need to modify how the new `LoadFile` function is being called to have it only load files that will actually be played

Closes #3256 

## Description
Switches to using a singleton instance of MPV and the attached socket, and controlling all subsequent requests by modifying an idle play stream linked to a file created by `mkfifo`.

## Changes 
- Moves the control of the MPV command from track creation to server start-up/shut-down.
- Updates the commands for the Track model to control the existing IPC socket instead of creating a new one,
- Updates the default MPV Command Template to stay idle and ensure no attempts at video output occur

Screenshots or Videos

Related Issues and Pull Requests(if any)
