### PR TITLE
Fix playlist details overflow in spotify-based themes

### DIFF
--- a/ui/src/themes/nord.js
+++ b/ui/src/themes/nord.js
@@ -259,7 +259,6 @@ export default {
       },
       details: {
         fontSize: '.875rem',
-        minWidth: '75vw',
         color: 'rgba(255,255,255, 0.8)',
       },
     },

--- a/ui/src/themes/playlistDetails.test.js
+++ b/ui/src/themes/playlistDetails.test.js
@@ -1,0 +1,19 @@
+import SpotifyTheme from './spotify'
+import NordTheme from './nord'
+import LigeraTheme from './ligera'
+import { describe, it, expect } from 'vitest'
+
+describe('NDPlaylistDetails styles', () => {
+  const themes = [
+    ['SpotifyTheme', SpotifyTheme],
+    ['NordTheme', NordTheme],
+    ['LigeraTheme', LigeraTheme],
+  ]
+
+  it.each(themes)('%s should not set minWidth on details', (_, theme) => {
+    const details = theme.overrides?.NDPlaylistDetails?.details
+    expect(
+      details && 'minWidth' in details ? details.minWidth : undefined,
+    ).toBeUndefined()
+  })
+})

--- a/ui/src/themes/spotify.js
+++ b/ui/src/themes/spotify.js
@@ -204,7 +204,6 @@ export default {
       },
       details: {
         fontSize: '.875rem',
-        minWidth: '75vw',
         color: 'rgba(255,255,255, 0.8)',
       },
     },


### PR DESCRIPTION
## Summary
- add regression test for playlist details width across spotify-based themes
- ensure no minWidth is set on playlist details in Spotify-ish, Nord, and Ligera themes

## Testing
- `npm run lint`
- `npm run check-formatting`
- `npm test`
- `timeout 60 make test`


------
https://chatgpt.com/codex/tasks/task_b_68444a3a9c54832eb80e8b432b31dfc8