### PR TITLE
Fix UI test warnings

### DIFF
--- a/ui/src/audioplayer/AudioTitle.test.jsx
+++ b/ui/src/audioplayer/AudioTitle.test.jsx
@@ -12,6 +12,7 @@ vi.mock('@material-ui/core', async () => {
 })
 
 vi.mock('react-router-dom', () => ({
+  // eslint-disable-next-line react/display-name
   Link: React.forwardRef(({ to, children, ...props }, ref) => (
     <a href={to} ref={ref} {...props}>
       {children}

--- a/ui/src/audioplayer/AudioTitle.test.jsx
+++ b/ui/src/audioplayer/AudioTitle.test.jsx
@@ -12,11 +12,11 @@ vi.mock('@material-ui/core', async () => {
 })
 
 vi.mock('react-router-dom', () => ({
-  Link: ({ to, children, ...props }) => (
-    <a href={to} {...props}>
+  Link: React.forwardRef(({ to, children, ...props }, ref) => (
+    <a href={to} ref={ref} {...props}>
       {children}
     </a>
-  ),
+  )),
 }))
 
 vi.mock('react-dnd', () => ({

--- a/ui/src/dialogs/SaveQueueDialog.jsx
+++ b/ui/src/dialogs/SaveQueueDialog.jsx
@@ -57,7 +57,10 @@ export const SaveQueueDialog = () => {
         return res
       })
       .then((res) => {
-        notify('ra.notification.created', 'info', { smart_count: 1 })
+        notify('ra.notification.created', {
+          type: 'info',
+          messageArgs: { smart_count: 1 },
+        })
         dispatch(closeSaveQueueDialog())
         refresh()
         history.push(`/playlist/${res.data.id}/show`)


### PR DESCRIPTION
## Summary
- use forwardRef in `AudioTitle` test mock to avoid ref warnings
- update notification call syntax in `SaveQueueDialog`

## Testing
- `npm run prettier`
- `npm run lint`
- `npm run check-formatting`
- `npm test`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_6844941125d0832e9cdf65520b73056e