### PR TITLE
Optimize top songs lookup

### DIFF
--- a/core/external/provider_similarsongs_test.go
+++ b/core/external/provider_similarsongs_test.go
@@ -50,9 +50,9 @@ var _ = Describe("Provider - SimilarSongs", func() {
 	It("returns similar songs from main artist and similar artists", func() {
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One"}
 		similarArtist := model.Artist{ID: "artist-3", Name: "Similar Artist"}
-		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1"}
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", ArtistID: "artist-1"}
-		song3 := model.MediaFile{ID: "song-3", Title: "Song Three", ArtistID: "artist-3"}
+		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-1"}
+		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", ArtistID: "artist-1", MbzRecordingID: "mbid-2"}
+		song3 := model.MediaFile{ID: "song-3", Title: "Song Three", ArtistID: "artist-3", MbzRecordingID: "mbid-3"}
 
 		artistRepo.On("Get", "artist-1").Return(&artist1, nil).Maybe()
 		artistRepo.On("Get", "artist-3").Return(&similarArtist, nil).Maybe()
@@ -82,9 +82,8 @@ var _ = Describe("Provider - SimilarSongs", func() {
 				{Name: "Song Three", MBID: "mbid-3"},
 			}, nil).Once()
 
-		mediaFileRepo.FindByMBID("mbid-1", song1)
-		mediaFileRepo.FindByMBID("mbid-2", song2)
-		mediaFileRepo.FindByMBID("mbid-3", song3)
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song3}, nil).Once()
 
 		songs, err := provider.SimilarSongs(ctx, "artist-1", 3)
 
@@ -111,7 +110,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 
 	It("returns songs from main artist when GetSimilarArtists returns error", func() {
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One"}
-		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1"}
+		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-1"}
 
 		artistRepo.On("Get", "artist-1").Return(&artist1, nil).Maybe()
 		artistRepo.On("GetAll", mock.MatchedBy(func(opt model.QueryOptions) bool {
@@ -130,7 +129,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 				{Name: "Song One", MBID: "mbid-1"},
 			}, nil).Once()
 
-		mediaFileRepo.FindByMBID("mbid-1", song1)
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
 
 		songs, err := provider.SimilarSongs(ctx, "artist-1", 5)
 
@@ -165,8 +164,8 @@ var _ = Describe("Provider - SimilarSongs", func() {
 
 	It("respects count parameter", func() {
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One"}
-		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1"}
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", ArtistID: "artist-1"}
+		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-1"}
+		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", ArtistID: "artist-1", MbzRecordingID: "mbid-2"}
 
 		artistRepo.On("Get", "artist-1").Return(&artist1, nil).Maybe()
 		artistRepo.On("GetAll", mock.MatchedBy(func(opt model.QueryOptions) bool {
@@ -186,8 +185,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 				{Name: "Song Two", MBID: "mbid-2"},
 			}, nil).Once()
 
-		mediaFileRepo.FindByMBID("mbid-1", song1)
-		mediaFileRepo.FindByMBID("mbid-2", song2)
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
 
 		songs, err := provider.SimilarSongs(ctx, "artist-1", 1)
 

--- a/core/external/provider_topsongs_test.go
+++ b/core/external/provider_topsongs_test.go
@@ -58,11 +58,10 @@ var _ = Describe("Provider - TopSongs", func() {
 		}
 		ag.On("GetArtistTopSongs", ctx, "artist-1", "Artist One", "mbid-artist-1", 2).Return(agentSongs, nil).Once()
 
-		// Mock finding matching tracks
+		// Mock finding matching tracks (both returned in a single query)
 		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-song-1"}
 		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", ArtistID: "artist-1", MbzRecordingID: "mbid-song-2"}
-		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
-		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song2}, nil).Once()
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)
 
@@ -155,11 +154,10 @@ var _ = Describe("Provider - TopSongs", func() {
 		}
 		ag.On("GetArtistTopSongs", ctx, "artist-1", "Artist One", "mbid-artist-1", 2).Return(agentSongs, nil).Once()
 
-		// Mock finding matching tracks (only find song 1)
+		// Mock finding matching tracks (only find song 1 on bulk query)
 		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-song-1"}
-		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
-		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{}, nil).Once() // For mbid-song-2 (fails)
-		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{}, nil).Once() // For title fallback (fails)
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once() // bulk MBID query
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{}, nil).Once()      // title fallback for song2
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)
 


### PR DESCRIPTION
## Summary
- reduce DB queries when resolving artist top songs
- adjust `findMatchingTrack` and extract title search logic
- update top songs provider tests
- update similar songs provider tests

## Testing
- `make test PKG=./core/external/...`
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6844fbff398c832e98f0ed04edadf09f