### PR TITLE
Add update and clear play queue endpoints

### DIFF
--- a/model/playqueue.go
+++ b/model/playqueue.go
@@ -18,6 +18,7 @@ type PlayQueue struct {
 type PlayQueues []PlayQueue
 
 type PlayQueueRepository interface {
-	Store(queue *PlayQueue) error
+	Store(queue *PlayQueue, colNames ...string) error
 	Retrieve(userId string) (*PlayQueue, error)
+	Clear(userId string) error
 }

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -157,6 +157,8 @@ func (n *Router) addQueueRoute(r chi.Router) {
 	r.Route("/queue", func(r chi.Router) {
 		r.Get("/", getQueue(n.ds))
 		r.Post("/", saveQueue(n.ds))
+		r.Put("/", updateQueue(n.ds))
+		r.Delete("/", clearQueue(n.ds))
 	})
 }
 

--- a/server/nativeapi/queue.go
+++ b/server/nativeapi/queue.go
@@ -8,13 +8,14 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/utils/gg"
 	"github.com/navidrome/navidrome/utils/slice"
 )
 
-type queuePayload struct {
-	Ids      []string `json:"ids"`
-	Current  int      `json:"current"`
-	Position int64    `json:"position"`
+type updateQueuePayload struct {
+	Ids      *[]string `json:"ids,omitempty"`
+	Current  *int      `json:"current,omitempty"`
+	Position *int64    `json:"position,omitempty"`
 }
 
 func getQueue(ds model.DataStore) http.HandlerFunc {
@@ -45,29 +46,93 @@ func getQueue(ds model.DataStore) http.HandlerFunc {
 func saveQueue(ds model.DataStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		var payload queuePayload
+		var payload updateQueuePayload
 		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
 		user, _ := request.UserFrom(ctx)
 		client, _ := request.ClientFrom(ctx)
-		items := slice.Map(payload.Ids, func(id string) model.MediaFile {
+		ids := gg.V(payload.Ids)
+		items := slice.Map(ids, func(id string) model.MediaFile {
 			return model.MediaFile{ID: id}
 		})
-		if len(payload.Ids) > 0 && (payload.Current < 0 || payload.Current >= len(payload.Ids)) {
+		current := gg.V(payload.Current)
+		if len(ids) > 0 && (current < 0 || current >= len(ids)) {
 			http.Error(w, "current index out of bounds", http.StatusBadRequest)
 			return
 		}
 		pq := &model.PlayQueue{
 			UserID:    user.ID,
-			Current:   payload.Current,
-			Position:  max(payload.Position, 0),
+			Current:   current,
+			Position:  max(gg.V(payload.Position), 0),
 			ChangedBy: client,
 			Items:     items,
 		}
 		if err := ds.PlayQueue(ctx).Store(pq); err != nil {
 			log.Error(ctx, "Error saving queue", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func updateQueue(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		var payload updateQueuePayload
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		user, _ := request.UserFrom(ctx)
+		client, _ := request.ClientFrom(ctx)
+		pq := &model.PlayQueue{UserID: user.ID, ChangedBy: client}
+		var cols []string
+
+		if payload.Ids != nil {
+			items := slice.Map(*payload.Ids, func(id string) model.MediaFile {
+				return model.MediaFile{ID: id}
+			})
+			pq.Items = items
+			cols = append(cols, "items")
+		}
+
+		if payload.Current != nil {
+			pq.Current = *payload.Current
+			cols = append(cols, "current")
+			if payload.Ids != nil && len(*payload.Ids) > 0 && (*payload.Current < 0 || *payload.Current >= len(*payload.Ids)) {
+				http.Error(w, "current index out of bounds", http.StatusBadRequest)
+				return
+			}
+		}
+
+		if payload.Position != nil {
+			pq.Position = max(*payload.Position, 0)
+			cols = append(cols, "position")
+		}
+
+		if len(cols) == 0 {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		if err := ds.PlayQueue(ctx).Store(pq, cols...); err != nil {
+			log.Error(ctx, "Error updating queue", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func clearQueue(ds model.DataStore) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		user, _ := request.UserFrom(ctx)
+		if err := ds.PlayQueue(ctx).Clear(user.ID); err != nil {
+			log.Error(ctx, "Error clearing queue", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/server/nativeapi/queue_test.go
+++ b/server/nativeapi/queue_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/tests"
+	"github.com/navidrome/navidrome/utils/gg"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -31,7 +32,7 @@ var _ = Describe("Queue Endpoints", func() {
 
 	Describe("POST /queue", func() {
 		It("saves the queue", func() {
-			payload := queuePayload{Ids: []string{"s1", "s2"}, Current: 1, Position: 10}
+			payload := updateQueuePayload{Ids: gg.P([]string{"s1", "s2"}), Current: gg.P(1), Position: gg.P(int64(10))}
 			body, _ := json.Marshal(payload)
 			req := httptest.NewRequest("POST", "/queue", bytes.NewReader(body))
 			ctx := request.WithUser(req.Context(), user)
@@ -49,7 +50,7 @@ var _ = Describe("Queue Endpoints", func() {
 		})
 
 		It("saves an empty queue", func() {
-			payload := queuePayload{Ids: []string{}, Current: 0, Position: 0}
+			payload := updateQueuePayload{Ids: gg.P([]string{}), Current: gg.P(0), Position: gg.P(int64(0))}
 			body, _ := json.Marshal(payload)
 			req := httptest.NewRequest("POST", "/queue", bytes.NewReader(body))
 			req = req.WithContext(request.WithUser(req.Context(), user))
@@ -62,7 +63,7 @@ var _ = Describe("Queue Endpoints", func() {
 		})
 
 		It("returns bad request for invalid current index (negative)", func() {
-			payload := queuePayload{Ids: []string{"s1", "s2"}, Current: -1, Position: 10}
+			payload := updateQueuePayload{Ids: gg.P([]string{"s1", "s2"}), Current: gg.P(-1), Position: gg.P(int64(10))}
 			body, _ := json.Marshal(payload)
 			req := httptest.NewRequest("POST", "/queue", bytes.NewReader(body))
 			req = req.WithContext(request.WithUser(req.Context(), user))
@@ -74,7 +75,7 @@ var _ = Describe("Queue Endpoints", func() {
 		})
 
 		It("returns bad request for invalid current index (too large)", func() {
-			payload := queuePayload{Ids: []string{"s1", "s2"}, Current: 2, Position: 10}
+			payload := updateQueuePayload{Ids: gg.P([]string{"s1", "s2"}), Current: gg.P(2), Position: gg.P(int64(10))}
 			body, _ := json.Marshal(payload)
 			req := httptest.NewRequest("POST", "/queue", bytes.NewReader(body))
 			req = req.WithContext(request.WithUser(req.Context(), user))
@@ -96,7 +97,7 @@ var _ = Describe("Queue Endpoints", func() {
 
 		It("returns internal server error when store fails", func() {
 			repo.Err = true
-			payload := queuePayload{Ids: []string{"s1"}, Current: 0, Position: 10}
+			payload := updateQueuePayload{Ids: gg.P([]string{"s1"}), Current: gg.P(0), Position: gg.P(int64(10))}
 			body, _ := json.Marshal(payload)
 			req := httptest.NewRequest("POST", "/queue", bytes.NewReader(body))
 			req = req.WithContext(request.WithUser(req.Context(), user))
@@ -158,6 +159,70 @@ var _ = Describe("Queue Endpoints", func() {
 			w := httptest.NewRecorder()
 
 			getQueue(ds)(w, req)
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("PUT /queue", func() {
+		It("updates the queue fields", func() {
+			repo.Queue = &model.PlayQueue{UserID: user.ID}
+			payload := updateQueuePayload{Current: gg.P(2), Position: gg.P(int64(20))}
+			body, _ := json.Marshal(payload)
+			req := httptest.NewRequest("PUT", "/queue", bytes.NewReader(body))
+			ctx := request.WithUser(req.Context(), user)
+			ctx = request.WithClient(ctx, "TestClient")
+			req = req.WithContext(ctx)
+			w := httptest.NewRecorder()
+
+			updateQueue(ds)(w, req)
+			Expect(w.Code).To(Equal(http.StatusNoContent))
+			Expect(repo.Queue).ToNot(BeNil())
+			Expect(repo.Queue.Current).To(Equal(2))
+			Expect(repo.Queue.Position).To(Equal(int64(20)))
+			Expect(repo.Queue.ChangedBy).To(Equal("TestClient"))
+		})
+
+		It("returns bad request for malformed JSON", func() {
+			req := httptest.NewRequest("PUT", "/queue", bytes.NewReader([]byte("{")))
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			updateQueue(ds)(w, req)
+			Expect(w.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("returns internal server error when store fails", func() {
+			repo.Err = true
+			payload := updateQueuePayload{Position: gg.P(int64(10))}
+			body, _ := json.Marshal(payload)
+			req := httptest.NewRequest("PUT", "/queue", bytes.NewReader(body))
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			updateQueue(ds)(w, req)
+			Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		})
+	})
+
+	Describe("DELETE /queue", func() {
+		It("clears the queue", func() {
+			repo.Queue = &model.PlayQueue{UserID: user.ID, Items: model.MediaFiles{{ID: "s1"}}}
+			req := httptest.NewRequest("DELETE", "/queue", nil)
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			clearQueue(ds)(w, req)
+			Expect(w.Code).To(Equal(http.StatusNoContent))
+			Expect(repo.Queue).To(BeNil())
+		})
+
+		It("returns internal server error when clear fails", func() {
+			repo.Err = true
+			req := httptest.NewRequest("DELETE", "/queue", nil)
+			req = req.WithContext(request.WithUser(req.Context(), user))
+			w := httptest.NewRecorder()
+
+			clearQueue(ds)(w, req)
 			Expect(w.Code).To(Equal(http.StatusInternalServerError))
 		})
 	})

--- a/tests/mock_playqueue_repo.go
+++ b/tests/mock_playqueue_repo.go
@@ -8,11 +8,12 @@ import (
 
 type MockPlayQueueRepo struct {
 	model.PlayQueueRepository
-	Queue *model.PlayQueue
-	Err   bool
+	Queue    *model.PlayQueue
+	Err      bool
+	LastCols []string
 }
 
-func (m *MockPlayQueueRepo) Store(q *model.PlayQueue) error {
+func (m *MockPlayQueueRepo) Store(q *model.PlayQueue, cols ...string) error {
 	if m.Err {
 		return errors.New("error")
 	}
@@ -21,6 +22,7 @@ func (m *MockPlayQueueRepo) Store(q *model.PlayQueue) error {
 	qCopy := *q
 	qCopy.Items = copyItems
 	m.Queue = &qCopy
+	m.LastCols = cols
 	return nil
 }
 
@@ -36,4 +38,12 @@ func (m *MockPlayQueueRepo) Retrieve(userId string) (*model.PlayQueue, error) {
 	qCopy := *m.Queue
 	qCopy.Items = copyItems
 	return &qCopy, nil
+}
+
+func (m *MockPlayQueueRepo) Clear(userId string) error {
+	if m.Err {
+		return errors.New("error")
+	}
+	m.Queue = nil
+	return nil
 }


### PR DESCRIPTION
## Summary
- extend `PlayQueueRepository` with `Clear` method and optional column updates
- support partial updates in `playQueueRepository.Store`
- implement PUT and DELETE `/queue` endpoints
- reuse `updateQueuePayload` for both saving and updating the queue
- add new tests for update and clear actions

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_68498ac868ac832eb393f94994f31b27