### PR TITLE
Add EnableNowPlaying configuration

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -80,6 +80,7 @@ type configOptions struct {
 	DefaultUIVolume                 int
 	EnableReplayGain                bool
 	EnableCoverAnimation            bool
+	EnableNowPlaying                bool
 	GATrackingID                    string
 	EnableLogRedacting              bool
 	AuthRequestLimit                int
@@ -491,6 +492,7 @@ func setViperDefaults() {
 	viper.SetDefault("defaultuivolume", consts.DefaultUIVolume)
 	viper.SetDefault("enablereplaygain", true)
 	viper.SetDefault("enablecoveranimation", true)
+	viper.SetDefault("enablenowplaying", true)
 	viper.SetDefault("enablesharing", false)
 	viper.SetDefault("shareurl", "")
 	viper.SetDefault("defaultshareexpiration", 8760*time.Hour)

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -176,6 +176,7 @@ var staticData = sync.OnceValue(func() insights.Data {
 	data.Config.DefaultBackgroundURLSet = conf.Server.UILoginBackgroundURL == consts.DefaultUILoginBackgroundURL
 	data.Config.EnableArtworkPrecache = conf.Server.EnableArtworkPrecache
 	data.Config.EnableCoverAnimation = conf.Server.EnableCoverAnimation
+	data.Config.EnableNowPlaying = conf.Server.EnableNowPlaying
 	data.Config.EnableDownloads = conf.Server.EnableDownloads
 	data.Config.EnableSharing = conf.Server.EnableSharing
 	data.Config.EnableStarRating = conf.Server.EnableStarRating

--- a/core/metrics/insights/data.go
+++ b/core/metrics/insights/data.go
@@ -60,6 +60,7 @@ type Data struct {
 		EnableJukebox           bool   `json:"enableJukebox,omitempty"`
 		EnablePrometheus        bool   `json:"enablePrometheus,omitempty"`
 		EnableCoverAnimation    bool   `json:"enableCoverAnimation,omitempty"`
+		EnableNowPlaying        bool   `json:"enableNowPlaying,omitempty"`
 		SessionTimeout          uint64 `json:"sessionTimeout,omitempty"`
 		SearchFullString        bool   `json:"searchFullString,omitempty"`
 		RecentlyAddedByModTime  bool   `json:"recentlyAddedByModTime,omitempty"`

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -55,6 +55,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"defaultLanguage":           conf.Server.DefaultLanguage,
 			"defaultUIVolume":           conf.Server.DefaultUIVolume,
 			"enableCoverAnimation":      conf.Server.EnableCoverAnimation,
+			"enableNowPlaying":          conf.Server.EnableNowPlaying,
 			"gaTrackingId":              conf.Server.GATrackingID,
 			"losslessFormats":           strings.ToUpper(strings.Join(mime.LosslessFormats, ",")),
 			"devActivityPanel":          conf.Server.DevActivityPanel,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -196,6 +196,17 @@ var _ = Describe("serveIndex", func() {
 		Expect(config).To(HaveKeyWithValue("enableCoverAnimation", true))
 	})
 
+	It("sets the enableNowPlaying", func() {
+		conf.Server.EnableNowPlaying = true
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		serveIndex(ds, fs, nil)(w, r)
+
+		config := extractAppConfig(w.Body.String())
+		Expect(config).To(HaveKeyWithValue("enableNowPlaying", true))
+	})
+
 	It("sets the gaTrackingId", func() {
 		conf.Server.GATrackingID = "UA-12345"
 		r := httptest.NewRequest("GET", "/index.html", nil)

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -29,6 +29,7 @@ const defaultConfig = {
   listenBrainzEnabled: true,
   enableExternalServices: true,
   enableCoverAnimation: true,
+  enableNowPlaying: true,
   devShowArtistPage: true,
   devUIShowConfig: true,
   enableReplayGain: true,

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -120,9 +120,9 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
 
   return (
     <>
-      {config.devActivityPanel && permissions === 'admin' && (
-        <NowPlayingPanel />
-      )}
+      {config.devActivityPanel &&
+        permissions === 'admin' &&
+        config.enableNowPlaying && <NowPlayingPanel />}
       {config.devActivityPanel && permissions === 'admin' && <ActivityPanel />}
       <UserMenu {...rest}>
         <PersonalMenu sidebarIsOpen={true} onClick={onClick} />

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, beforeEach, vi } from 'vitest'
+import { Provider } from 'react-redux'
+import { createStore, combineReducers } from 'redux'
+import { activityReducer } from '../reducers'
+import AppBar from './AppBar'
+import config from '../config'
+
+let store
+
+vi.mock('react-admin', () => ({
+  AppBar: ({ userMenu }) => <div data-testid="appbar">{userMenu}</div>,
+  useTranslate: () => (x) => x,
+  usePermissions: () => ({ permissions: 'admin' }),
+  getResources: () => [],
+}))
+
+vi.mock('./NowPlayingPanel', () => ({
+  default: () => <div data-testid="now-playing-panel" />,
+}))
+vi.mock('./ActivityPanel', () => ({
+  default: () => <div data-testid="activity-panel" />,
+}))
+vi.mock('./PersonalMenu', () => ({
+  default: () => <div />,
+}))
+vi.mock('./UserMenu', () => ({
+  default: ({ children }) => <div>{children}</div>,
+}))
+vi.mock('../dialogs/Dialogs', () => ({
+  Dialogs: () => <div />,
+}))
+vi.mock('../dialogs', () => ({
+  AboutDialog: () => <div />,
+}))
+
+describe('<AppBar />', () => {
+  beforeEach(() => {
+    config.devActivityPanel = true
+    config.enableNowPlaying = true
+    store = createStore(combineReducers({ activity: activityReducer }), {
+      activity: { nowPlayingCount: 0 },
+    })
+  })
+
+  it('renders NowPlayingPanel when enabled', () => {
+    render(
+      <Provider store={store}>
+        <AppBar />
+      </Provider>,
+    )
+    expect(screen.getByTestId('now-playing-panel')).toBeInTheDocument()
+  })
+
+  it('hides NowPlayingPanel when disabled', () => {
+    config.enableNowPlaying = false
+    render(
+      <Provider store={store}>
+        <AppBar />
+      </Provider>,
+    )
+    expect(screen.queryByTestId('now-playing-panel')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add `EnableNowPlaying` config option with default true
- expose value in insights metrics and in UI config injection
- update web UI to respect new option
- create tests for new behaviour

## Testing
- `npm run lint`
- `npm run check-formatting`
- `npm run test`
- `npm run type-check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_b_684ae2b85c98832e93dfd5e40aef4cfc