### PR TITLE
fix: update GoReleaser configurations

### DIFF
--- a/release/goreleaser.yml
+++ b/release/goreleaser.yml
@@ -25,7 +25,8 @@ builds:
 archives:
   - format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ with .Arm }}{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}'
 
 checksum:


### PR DESCRIPTION
## PR Summary
This small PR updates the GoReleaser configuration to resolve the following warnings which you can find in the [CI logs](https://github.com/navidrome/navidrome/actions/runs/15662056257/job/44121333198#step:6:28): 
```
DEPRECATED: archives.format_overrides.format should not be used anymore, check https://goreleaser.com/deprecations#archivesformat_overridesformat for more info
```