### PR TITLE
fix(subsonic): Sort songs by presence of lyrics for `getLyrics`

### DIFF
--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -357,6 +357,7 @@ type MediaFileRepository interface {
 	Get(id string) (*MediaFile, error)
 	GetWithParticipants(id string) (*MediaFile, error)
 	GetAll(options ...QueryOptions) (MediaFiles, error)
+	GetAllByLyrics(options ...QueryOptions) (MediaFiles, error)
 	GetCursor(options ...QueryOptions) (MediaFileCursor, error)
 	Delete(id string) error
 	DeleteMissing(ids []string) error

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -160,6 +160,16 @@ func (r *mediaFileRepository) GetAll(options ...model.QueryOptions) (model.Media
 	return res.toModels(), nil
 }
 
+func (r *mediaFileRepository) GetAllByLyrics(options ...model.QueryOptions) (model.MediaFiles, error) {
+	sq := r.selectMediaFile().Column("lyrics != '[]'").OrderBy("lyrics desc")
+	var res dbMediaFiles
+	err := r.queryAll(sq, &res)
+	if err != nil {
+		return nil, err
+	}
+	return res.toModels(), nil
+}
+
 func (r *mediaFileRepository) GetCursor(options ...model.QueryOptions) (model.MediaFileCursor, error) {
 	sq := r.selectMediaFile(options...)
 	cursor, err := queryWithStableResults[dbMediaFile](r.sqlRepository, sq)

--- a/persistence/persistence_suite_test.go
+++ b/persistence/persistence_suite_test.go
@@ -38,6 +38,9 @@ func mf(mf model.MediaFile) model.MediaFile {
 			model.Participant{Artist: model.Artist{ID: mf.ArtistID, Name: mf.Artist}},
 		},
 	}
+	if mf.Lyrics == "" {
+		mf.Lyrics = "[]"
+	}
 	return mf
 }
 
@@ -78,11 +81,22 @@ var (
 		Path:        p("/kraft/radio/antenna.mp3"),
 		RGAlbumGain: 1.0, RGAlbumPeak: 2.0, RGTrackGain: 3.0, RGTrackPeak: 4.0,
 	})
-	testSongs = model.MediaFiles{
+	songAntennaWithLyrics = mf(model.MediaFile{
+		ID:       "1005",
+		Title:    "Antenna",
+		ArtistID: "2",
+		Artist:   "Kraftwerk",
+		AlbumID:  "103",
+		Lyrics:   `[{"lang":"xxx","line":[{"value":"This is a set of lyrics"}],"synced":false}]`,
+	})
+	songAntenna2 = mf(model.MediaFile{ID: "1006", Title: "Antenna", ArtistID: "2", Artist: "Kraftwerk", AlbumID: "103"})
+	testSongs    = model.MediaFiles{
 		songDayInALife,
 		songComeTogether,
 		songRadioactivity,
 		songAntenna,
+		songAntennaWithLyrics,
+		songAntenna2,
 	}
 )
 

--- a/server/subsonic/media_retrieval.go
+++ b/server/subsonic/media_retrieval.go
@@ -98,7 +98,7 @@ func (api *Router) GetLyrics(r *http.Request) (*responses.Subsonic, error) {
 	response := newResponse()
 	lyricsResponse := responses.Lyrics{}
 	response.Lyrics = &lyricsResponse
-	mediaFiles, err := api.ds.MediaFile(r.Context()).GetAll(filter.SongWithArtistTitle(artist, title))
+	mediaFiles, err := api.ds.MediaFile(r.Context()).GetAllByLyrics(filter.SongWithArtistTitle(artist, title))
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The current implementation of `getLyrics` fetches any songs matching the artist and title. However, this misses a case where there may be multiple matches for the same artist/song, and one has lyrics while the other doesn't. Resolve this by adding a custom SQL dynamic column that checks for the presence of lyrics.