### PR TITLE
Rename SimilarSongs to ArtistRadio

### DIFF
--- a/core/external/provider.go
+++ b/core/external/provider.go
@@ -35,7 +35,7 @@ const (
 type Provider interface {
 	UpdateAlbumInfo(ctx context.Context, id string) (*model.Album, error)
 	UpdateArtistInfo(ctx context.Context, id string, count int, includeNotPresent bool) (*model.Artist, error)
-	SimilarSongs(ctx context.Context, id string, count int) (model.MediaFiles, error)
+	ArtistRadio(ctx context.Context, id string, count int) (model.MediaFiles, error)
 	TopSongs(ctx context.Context, artist string, count int) (model.MediaFiles, error)
 	ArtistImage(ctx context.Context, id string) (*url.URL, error)
 	AlbumImage(ctx context.Context, id string) (*url.URL, error)
@@ -258,7 +258,7 @@ func (e *provider) populateArtistInfo(ctx context.Context, artist auxArtist) (au
 	return artist, nil
 }
 
-func (e *provider) SimilarSongs(ctx context.Context, id string, count int) (model.MediaFiles, error) {
+func (e *provider) ArtistRadio(ctx context.Context, id string, count int) (model.MediaFiles, error) {
 	artist, err := e.getArtist(ctx, id)
 	if err != nil {
 		return nil, err
@@ -266,14 +266,14 @@ func (e *provider) SimilarSongs(ctx context.Context, id string, count int) (mode
 
 	e.callGetSimilar(ctx, e.ag, &artist, 15, false)
 	if utils.IsCtxDone(ctx) {
-		log.Warn(ctx, "SimilarSongs call canceled", ctx.Err())
+		log.Warn(ctx, "ArtistRadio call canceled", ctx.Err())
 		return nil, ctx.Err()
 	}
 
 	weightedSongs := random.NewWeightedChooser[model.MediaFile]()
 	addArtist := func(a model.Artist, weightedSongs *random.WeightedChooser[model.MediaFile], count, artistWeight int) error {
 		if utils.IsCtxDone(ctx) {
-			log.Warn(ctx, "SimilarSongs call canceled", ctx.Err())
+			log.Warn(ctx, "ArtistRadio call canceled", ctx.Err())
 			return ctx.Err()
 		}
 

--- a/core/external/provider_artistradio_test.go
+++ b/core/external/provider_artistradio_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var _ = Describe("Provider - SimilarSongs", func() {
+var _ = Describe("Provider - ArtistRadio", func() {
 	var ds model.DataStore
 	var provider Provider
 	var mockAgent *mockSimilarArtistAgent
@@ -85,7 +85,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song3}, nil).Once()
 
-		songs, err := provider.SimilarSongs(ctx, "artist-1", 3)
+		songs, err := provider.ArtistRadio(ctx, "artist-1", 3)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(songs).To(HaveLen(3))
@@ -102,7 +102,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 			return opt.Max == 1 && opt.Filters != nil
 		})).Return(model.Artists{}, nil).Maybe()
 
-		songs, err := provider.SimilarSongs(ctx, "artist-unknown-artist", 5)
+		songs, err := provider.ArtistRadio(ctx, "artist-unknown-artist", 5)
 
 		Expect(err).To(Equal(model.ErrNotFound))
 		Expect(songs).To(BeNil())
@@ -131,7 +131,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
 
-		songs, err := provider.SimilarSongs(ctx, "artist-1", 5)
+		songs, err := provider.ArtistRadio(ctx, "artist-1", 5)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(songs).To(HaveLen(1))
@@ -156,7 +156,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 		mockAgent.On("GetArtistTopSongs", mock.Anything, "artist-1", "Artist One", "", mock.Anything).
 			Return(nil, errors.New("error getting top songs")).Once()
 
-		songs, err := provider.SimilarSongs(ctx, "artist-1", 5)
+		songs, err := provider.ArtistRadio(ctx, "artist-1", 5)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(songs).To(BeEmpty())
@@ -187,7 +187,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
 
-		songs, err := provider.SimilarSongs(ctx, "artist-1", 1)
+		songs, err := provider.ArtistRadio(ctx, "artist-1", 1)
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(songs).To(HaveLen(1))

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -343,7 +343,7 @@ func (api *Router) GetSimilarSongs(r *http.Request) (*responses.Subsonic, error)
 	}
 	count := p.IntOr("count", 50)
 
-	songs, err := api.provider.SimilarSongs(ctx, id, count)
+	songs, err := api.provider.ArtistRadio(ctx, id, count)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- rename `Provider.SimilarSongs` to `Provider.ArtistRadio`
- update server code and tests for new method

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_b_6856054ce938832eb4fe7ba7d4d7bd59