### PR TITLE
fix: ensure full scan refreshes all artist stats

### DIFF
--- a/model/artist.go
+++ b/model/artist.go
@@ -82,7 +82,7 @@ type ArtistRepository interface {
 
 	// The following methods are used exclusively by the scanner:
 	RefreshPlayCounts() (int64, error)
-	RefreshStats() (int64, error)
+	RefreshStats(allArtists bool) (int64, error)
 
 	AnnotatedRepository
 	SearchableRepository[Artists]

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -292,25 +292,34 @@ on conflict (user_id, item_id, item_type) do update
 }
 
 // RefreshStats updates the stats field for artists whose associated media files were updated after the oldest recorded library scan time.
-// It processes artists in batches to handle potentially large updates.
-func (r *artistRepository) RefreshStats() (int64, error) {
-	touchedArtistsQuerySQL := `
+// When allArtists is true, it refreshes stats for all artists. It processes artists in batches to handle potentially large updates.
+func (r *artistRepository) RefreshStats(allArtists bool) (int64, error) {
+	var allTouchedArtistIDs []string
+	if allArtists {
+		// Refresh stats for all artists
+		touchedArtistsQuerySQL := `SELECT DISTINCT id FROM artist WHERE id <> ''`
+		if err := r.db.NewQuery(touchedArtistsQuerySQL).Column(&allTouchedArtistIDs); err != nil {
+			return 0, fmt.Errorf("fetching all artist IDs: %w", err)
+		}
+		log.Debug(r.ctx, "RefreshStats: Refreshing all artists.", "count", len(allTouchedArtistIDs))
+	} else {
+		// Only refresh artists with updated media files
+		touchedArtistsQuerySQL := `
         SELECT DISTINCT mfa.artist_id
         FROM media_file_artists mfa
         JOIN media_file mf ON mfa.media_file_id = mf.id
         WHERE mf.updated_at > (SELECT last_scan_at FROM library ORDER BY last_scan_at ASC LIMIT 1)
         `
-
-	var allTouchedArtistIDs []string
-	if err := r.db.NewQuery(touchedArtistsQuerySQL).Column(&allTouchedArtistIDs); err != nil {
-		return 0, fmt.Errorf("fetching touched artist IDs: %w", err)
+		if err := r.db.NewQuery(touchedArtistsQuerySQL).Column(&allTouchedArtistIDs); err != nil {
+			return 0, fmt.Errorf("fetching touched artist IDs: %w", err)
+		}
+		log.Debug(r.ctx, "RefreshStats: Refreshing touched artists.", "count", len(allTouchedArtistIDs))
 	}
 
 	if len(allTouchedArtistIDs) == 0 {
 		log.Debug(r.ctx, "RefreshStats: No artists to update.")
 		return 0, nil
 	}
-	log.Debug(r.ctx, "RefreshStats: Found artists to update.", "count", len(allTouchedArtistIDs))
 
 	// Template for the batch update with placeholder markers that we'll replace
 	batchUpdateStatsSQL := `

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -297,8 +297,8 @@ func (r *artistRepository) RefreshStats(allArtists bool) (int64, error) {
 	var allTouchedArtistIDs []string
 	if allArtists {
 		// Refresh stats for all artists
-		touchedArtistsQuerySQL := `SELECT DISTINCT id FROM artist WHERE id <> ''`
-		if err := r.db.NewQuery(touchedArtistsQuerySQL).Column(&allTouchedArtistIDs); err != nil {
+		allArtistsQuerySQL := `SELECT DISTINCT id FROM artist WHERE id <> ''`
+		if err := r.db.NewQuery(allArtistsQuerySQL).Column(&allTouchedArtistIDs); err != nil {
 			return 0, fmt.Errorf("fetching all artist IDs: %w", err)
 		}
 		log.Debug(r.ctx, "RefreshStats: Refreshing all artists.", "count", len(allTouchedArtistIDs))

--- a/tests/mock_artist_repo.go
+++ b/tests/mock_artist_repo.go
@@ -94,4 +94,18 @@ func (m *MockArtistRepo) UpdateExternalInfo(artist *model.Artist) error {
 	return nil
 }
 
+func (m *MockArtistRepo) RefreshStats(allArtists bool) (int64, error) {
+	if m.Err {
+		return 0, errors.New("mock repo error")
+	}
+	return int64(len(m.Data)), nil
+}
+
+func (m *MockArtistRepo) RefreshPlayCounts() (int64, error) {
+	if m.Err {
+		return 0, errors.New("mock repo error")
+	}
+	return int64(len(m.Data)), nil
+}
+
 var _ model.ArtistRepository = (*MockArtistRepo)(nil)


### PR DESCRIPTION
## Problem

After PR #4059, full scans were not forcing a refresh of all artists. During a full scan, only artists with recently updated media files would have their stats refreshed, leaving other artists with potentially stale statistics.

## Solution

This PR implements a clean solution that ensures all artist stats are refreshed during full scans:

### Changes Made

1. **Set `changesDetected = true` for full scans** - This ensures all maintenance operations (GC, library stats refresh, etc.) run automatically during full scans

2. **Add `allArtists` parameter to `RefreshStats()`** - Makes the intent explicit:
   - When `allArtists = true`: Refresh stats for **all artists** 
   - When `allArtists = false`: Refresh stats for **touched artists only** (original behavior)

3. **Pass `fullScan` state to `RefreshStats`** - The scanner now passes `state.fullScan` as the `allArtists` parameter

4. **Update mock repository** - Updated test mock to match the new interface

### Benefits

- ✅ **Explicit intent**: The `allArtists` parameter makes it crystal clear what the method does
- ✅ **Automatic maintenance**: All maintenance operations run during full scans without additional conditional checks
- ✅ **Simple & maintainable**: Single point of control, no need for dual conditions throughout the codebase
- ✅ **Future-proof**: New maintenance operations will automatically work with full scans

### Testing

- All existing tests pass
- Code is properly formatted and linted
- No breaking changes to existing functionality

## Related Issues

Fixes #4246
Related to PR #4059

## Behavior

- **Full Scan**: `changesDetected = true` → All maintenance runs → `RefreshStats(true)` → Refreshes **all artists**
- **Quick Scan**: `changesDetected` set only when actual changes detected → `RefreshStats(false)` → Refreshes **touched artists only**