### PR TITLE
Clear dangling music from BFR migration 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,7 @@ music
 docker-compose.yml
 !contrib/docker-compose.yml
 binaries
-navidrome-master
+navidrome-*
 AGENTS.md
 *.exe
 *.test

--- a/db/migrations/20250701010105_remove_dangling_items.sql
+++ b/db/migrations/20250701010105_remove_dangling_items.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+-- +goose StatementBegin
+update media_file set missing = 1 where folder_id = '';
+update album set missing = 1 where folder_ids = '[]';
+-- +goose StatementEnd
+
+-- +goose Down


### PR DESCRIPTION
When upgrading from version 0.54.5 or older (pre-BFR), there are some edge cases that can cause albums and songs to be duplicated in a library, and because of bad DB relationships, they are never deleted/marked as missing, with no way to removing them from the DB.

This PR marks these items as missing on startup, so they become deletable from the Missing Files view.

Should fix #4081