### PR TITLE
Add prometheus metrics to subsonic and plugins

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,8 +122,7 @@ func startServer(ctx context.Context) func() error {
 		if conf.Server.Prometheus.Enabled {
 			p := CreatePrometheus()
 			// blocking call because takes <100ms but useful if fails
-			ds := CreateDataStore()
-			p.WriteInitialMetrics(ctx, ds)
+			p.WriteInitialMetrics(ctx)
 			a.MountRouter("Prometheus metrics", conf.Server.Prometheus.MetricsPath, p.GetHandler())
 		}
 		if conf.Server.DevEnableProfiler {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -122,7 +122,8 @@ func startServer(ctx context.Context) func() error {
 		if conf.Server.Prometheus.Enabled {
 			p := CreatePrometheus()
 			// blocking call because takes <100ms but useful if fails
-			p.WriteInitialMetrics(ctx)
+			ds := CreateDataStore()
+			p.WriteInitialMetrics(ctx, ds)
 			a.MountRouter("Prometheus metrics", conf.Server.Prometheus.MetricsPath, p.GetHandler())
 		}
 		if conf.Server.DevEnableProfiler {

--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -67,7 +67,8 @@ func CreateSubsonicAPIRouter(ctx context.Context) *subsonic.Router {
 	dataStore := persistence.New(sqlDB)
 	fileCache := artwork.GetImageCache()
 	fFmpeg := ffmpeg.New()
-	manager := plugins.GetManager(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
+	manager := plugins.GetManager(dataStore, metricsMetrics)
 	agentsAgents := agents.GetAgents(dataStore, manager)
 	provider := external.NewProvider(dataStore, agentsAgents)
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, provider)
@@ -79,11 +80,10 @@ func CreateSubsonicAPIRouter(ctx context.Context) *subsonic.Router {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	metricsMetrics := metrics.GetPrometheusInstance()
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	playTracker := scrobbler.GetPlayTracker(dataStore, broker, manager)
 	playbackServer := playback.GetInstance(dataStore)
-	router := subsonic.New(dataStore, artworkArtwork, mediaStreamer, archiver, players, provider, scannerScanner, broker, playlists, playTracker, share, playbackServer)
+	router := subsonic.New(dataStore, artworkArtwork, mediaStreamer, archiver, players, provider, scannerScanner, broker, playlists, playTracker, share, playbackServer, metricsMetrics)
 	return router
 }
 
@@ -92,7 +92,8 @@ func CreatePublicRouter() *public.Router {
 	dataStore := persistence.New(sqlDB)
 	fileCache := artwork.GetImageCache()
 	fFmpeg := ffmpeg.New()
-	manager := plugins.GetManager(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
+	manager := plugins.GetManager(dataStore, metricsMetrics)
 	agentsAgents := agents.GetAgents(dataStore, manager)
 	provider := external.NewProvider(dataStore, agentsAgents)
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, provider)
@@ -126,7 +127,9 @@ func CreateInsights() metrics.Insights {
 }
 
 func CreatePrometheus() metrics.Metrics {
-	metricsMetrics := metrics.GetPrometheusInstance()
+	sqlDB := db.Db()
+	dataStore := persistence.New(sqlDB)
+	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
 	return metricsMetrics
 }
 
@@ -135,14 +138,14 @@ func CreateScanner(ctx context.Context) scanner.Scanner {
 	dataStore := persistence.New(sqlDB)
 	fileCache := artwork.GetImageCache()
 	fFmpeg := ffmpeg.New()
-	manager := plugins.GetManager(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
+	manager := plugins.GetManager(dataStore, metricsMetrics)
 	agentsAgents := agents.GetAgents(dataStore, manager)
 	provider := external.NewProvider(dataStore, agentsAgents)
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, provider)
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	metricsMetrics := metrics.GetPrometheusInstance()
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	return scannerScanner
 }
@@ -152,14 +155,14 @@ func CreateScanWatcher(ctx context.Context) scanner.Watcher {
 	dataStore := persistence.New(sqlDB)
 	fileCache := artwork.GetImageCache()
 	fFmpeg := ffmpeg.New()
-	manager := plugins.GetManager(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
+	manager := plugins.GetManager(dataStore, metricsMetrics)
 	agentsAgents := agents.GetAgents(dataStore, manager)
 	provider := external.NewProvider(dataStore, agentsAgents)
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, provider)
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	metricsMetrics := metrics.GetPrometheusInstance()
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	watcher := scanner.NewWatcher(dataStore, scannerScanner)
 	return watcher
@@ -175,7 +178,8 @@ func GetPlaybackServer() playback.PlaybackServer {
 func getPluginManager() *plugins.Manager {
 	sqlDB := db.Db()
 	dataStore := persistence.New(sqlDB)
-	manager := plugins.GetManager(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
+	manager := plugins.GetManager(dataStore, metricsMetrics)
 	return manager
 }
 

--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -79,7 +79,7 @@ func CreateSubsonicAPIRouter(ctx context.Context) *subsonic.Router {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	metricsMetrics := metrics.NewPrometheusInstance(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance()
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	playTracker := scrobbler.GetPlayTracker(dataStore, broker, manager)
 	playbackServer := playback.GetInstance(dataStore)
@@ -126,9 +126,7 @@ func CreateInsights() metrics.Insights {
 }
 
 func CreatePrometheus() metrics.Metrics {
-	sqlDB := db.Db()
-	dataStore := persistence.New(sqlDB)
-	metricsMetrics := metrics.NewPrometheusInstance(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance()
 	return metricsMetrics
 }
 
@@ -144,7 +142,7 @@ func CreateScanner(ctx context.Context) scanner.Scanner {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	metricsMetrics := metrics.NewPrometheusInstance(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance()
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	return scannerScanner
 }
@@ -161,7 +159,7 @@ func CreateScanWatcher(ctx context.Context) scanner.Watcher {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	broker := events.GetBroker()
 	playlists := core.NewPlaylists(dataStore)
-	metricsMetrics := metrics.NewPrometheusInstance(dataStore)
+	metricsMetrics := metrics.GetPrometheusInstance()
 	scannerScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlists, metricsMetrics)
 	watcher := scanner.NewWatcher(dataStore, scannerScanner)
 	return watcher
@@ -183,7 +181,7 @@ func getPluginManager() *plugins.Manager {
 
 // wire_injectors.go:
 
-var allProviders = wire.NewSet(core.Set, artwork.Set, server.New, subsonic.New, nativeapi.New, public.New, persistence.New, lastfm.NewRouter, listenbrainz.NewRouter, events.GetBroker, scanner.New, scanner.NewWatcher, plugins.GetManager, metrics.NewPrometheusInstance, db.Db, wire.Bind(new(agents.PluginLoader), new(*plugins.Manager)), wire.Bind(new(scrobbler.PluginLoader), new(*plugins.Manager)))
+var allProviders = wire.NewSet(core.Set, artwork.Set, server.New, subsonic.New, nativeapi.New, public.New, persistence.New, lastfm.NewRouter, listenbrainz.NewRouter, events.GetBroker, scanner.New, scanner.NewWatcher, plugins.GetManager, metrics.GetPrometheusInstance, db.Db, wire.Bind(new(agents.PluginLoader), new(*plugins.Manager)), wire.Bind(new(scrobbler.PluginLoader), new(*plugins.Manager)))
 
 func GetPluginManager(ctx context.Context) *plugins.Manager {
 	manager := getPluginManager()

--- a/cmd/wire_injectors.go
+++ b/cmd/wire_injectors.go
@@ -40,7 +40,7 @@ var allProviders = wire.NewSet(
 	scanner.New,
 	scanner.NewWatcher,
 	plugins.GetManager,
-	metrics.NewPrometheusInstance,
+	metrics.GetPrometheusInstance,
 	db.Db,
 	wire.Bind(new(agents.PluginLoader), new(*plugins.Manager)),
 	wire.Bind(new(scrobbler.PluginLoader), new(*plugins.Manager)),

--- a/plugins/adapter_media_agent.go
+++ b/plugins/adapter_media_agent.go
@@ -10,22 +10,23 @@ import (
 )
 
 // NewWasmMediaAgent creates a new adapter for a MetadataAgent plugin
-func newWasmMediaAgent(wasmPath, pluginID string, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmMediaAgent(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewMetadataAgentPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating media metadata service plugin", "plugin", pluginID, "path", wasmPath, err)
 		return nil
 	}
 	return &wasmMediaAgent{
-		wasmBasePlugin: &wasmBasePlugin[api.MetadataAgent, *api.MetadataAgentPlugin]{
-			wasmPath:   wasmPath,
-			id:         pluginID,
-			capability: CapabilityMetadataAgent,
-			loader:     loader,
-			loadFunc: func(ctx context.Context, l *api.MetadataAgentPlugin, path string) (api.MetadataAgent, error) {
+		wasmBasePlugin: newWasmBasePlugin[api.MetadataAgent, *api.MetadataAgentPlugin](
+			wasmPath,
+			pluginID,
+			CapabilityMetadataAgent,
+			m.metrics,
+			loader,
+			func(ctx context.Context, l *api.MetadataAgentPlugin, path string) (api.MetadataAgent, error) {
 				return l.Load(ctx, path)
 			},
-		},
+		),
 	}
 }
 

--- a/plugins/adapter_media_agent_test.go
+++ b/plugins/adapter_media_agent_test.go
@@ -23,7 +23,7 @@ var _ = Describe("Adapter Media Agent", func() {
 		DeferCleanup(configtest.SetupConfig())
 		conf.Server.Plugins.Folder = testDataDir
 
-		mgr = createManager(nil)
+		mgr = createManager(nil, nil)
 		mgr.ScanPlugins()
 	})
 

--- a/plugins/adapter_scheduler_callback.go
+++ b/plugins/adapter_scheduler_callback.go
@@ -9,22 +9,23 @@ import (
 )
 
 // newWasmSchedulerCallback creates a new adapter for a SchedulerCallback plugin
-func newWasmSchedulerCallback(wasmPath, pluginID string, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmSchedulerCallback(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewSchedulerCallbackPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating scheduler callback plugin", "plugin", pluginID, "path", wasmPath, err)
 		return nil
 	}
 	return &wasmSchedulerCallback{
-		wasmBasePlugin: &wasmBasePlugin[api.SchedulerCallback, *api.SchedulerCallbackPlugin]{
-			wasmPath:   wasmPath,
-			id:         pluginID,
-			capability: CapabilitySchedulerCallback,
-			loader:     loader,
-			loadFunc: func(ctx context.Context, l *api.SchedulerCallbackPlugin, path string) (api.SchedulerCallback, error) {
+		wasmBasePlugin: newWasmBasePlugin[api.SchedulerCallback, *api.SchedulerCallbackPlugin](
+			wasmPath,
+			pluginID,
+			CapabilitySchedulerCallback,
+			m.metrics,
+			loader,
+			func(ctx context.Context, l *api.SchedulerCallbackPlugin, path string) (api.SchedulerCallback, error) {
 				return l.Load(ctx, path)
 			},
-		},
+		),
 	}
 }
 

--- a/plugins/adapter_scrobbler.go
+++ b/plugins/adapter_scrobbler.go
@@ -12,22 +12,23 @@ import (
 	"github.com/tetratelabs/wazero"
 )
 
-func newWasmScrobblerPlugin(wasmPath, pluginID string, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmScrobblerPlugin(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewScrobblerPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating scrobbler service plugin", "plugin", pluginID, "path", wasmPath, err)
 		return nil
 	}
 	return &wasmScrobblerPlugin{
-		wasmBasePlugin: &wasmBasePlugin[api.Scrobbler, *api.ScrobblerPlugin]{
-			wasmPath:   wasmPath,
-			id:         pluginID,
-			capability: CapabilityScrobbler,
-			loader:     loader,
-			loadFunc: func(ctx context.Context, l *api.ScrobblerPlugin, path string) (api.Scrobbler, error) {
+		wasmBasePlugin: newWasmBasePlugin[api.Scrobbler, *api.ScrobblerPlugin](
+			wasmPath,
+			pluginID,
+			CapabilityScrobbler,
+			m.metrics,
+			loader,
+			func(ctx context.Context, l *api.ScrobblerPlugin, path string) (api.Scrobbler, error) {
 				return l.Load(ctx, path)
 			},
-		},
+		),
 	}
 }
 

--- a/plugins/adapter_websocket_callback.go
+++ b/plugins/adapter_websocket_callback.go
@@ -9,22 +9,23 @@ import (
 )
 
 // newWasmWebSocketCallback creates a new adapter for a WebSocketCallback plugin
-func newWasmWebSocketCallback(wasmPath, pluginID string, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmWebSocketCallback(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewWebSocketCallbackPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating WebSocket callback plugin", "plugin", pluginID, "path", wasmPath, err)
 		return nil
 	}
 	return &wasmWebSocketCallback{
-		wasmBasePlugin: &wasmBasePlugin[api.WebSocketCallback, *api.WebSocketCallbackPlugin]{
-			wasmPath:   wasmPath,
-			id:         pluginID,
-			capability: CapabilityWebSocketCallback,
-			loader:     loader,
-			loadFunc: func(ctx context.Context, l *api.WebSocketCallbackPlugin, path string) (api.WebSocketCallback, error) {
+		wasmBasePlugin: newWasmBasePlugin[api.WebSocketCallback, *api.WebSocketCallbackPlugin](
+			wasmPath,
+			pluginID,
+			CapabilityWebSocketCallback,
+			m.metrics,
+			loader,
+			func(ctx context.Context, l *api.WebSocketCallbackPlugin, path string) (api.WebSocketCallback, error) {
 				return l.Load(ctx, path)
 			},
-		},
+		),
 	}
 }
 

--- a/plugins/host_scheduler_test.go
+++ b/plugins/host_scheduler_test.go
@@ -16,7 +16,7 @@ var _ = Describe("SchedulerService", func() {
 	)
 
 	BeforeEach(func() {
-		manager = createManager(nil)
+		manager = createManager(nil, nil)
 		ss = manager.schedulerService
 	})
 

--- a/plugins/host_websocket_test.go
+++ b/plugins/host_websocket_test.go
@@ -84,7 +84,7 @@ var _ = Describe("WebSocket Host Service", func() {
 		DeferCleanup(server.Close)
 
 		// Create a new manager and websocket service
-		manager = createManager(nil)
+		manager = createManager(nil, nil)
 		wsService = newWebsocketService(manager)
 	})
 

--- a/plugins/manager_test.go
+++ b/plugins/manager_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Plugin Manager", func() {
 		conf.Server.Plugins.Folder = testDataDir
 
 		ctx = GinkgoT().Context()
-		mgr = createManager(nil)
+		mgr = createManager(nil, nil)
 		mgr.ScanPlugins()
 	})
 
@@ -85,7 +85,7 @@ var _ = Describe("Plugin Manager", func() {
 			})
 
 			conf.Server.Plugins.Folder = tempPluginsDir
-			m = createManager(nil)
+			m = createManager(nil, nil)
 		})
 
 		// Helper to create a complete valid plugin for manager testing

--- a/plugins/manifest_permissions_test.go
+++ b/plugins/manifest_permissions_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Plugin Permissions", func() {
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
 		ctx = context.Background()
-		mgr = createManager(nil)
+		mgr = createManager(nil, nil)
 		tempDir = GinkgoT().TempDir()
 	})
 

--- a/plugins/runtime_test.go
+++ b/plugins/runtime_test.go
@@ -40,7 +40,7 @@ var _ = Describe("CachingRuntime", func() {
 
 	BeforeEach(func() {
 		ctx = GinkgoT().Context()
-		mgr = createManager(nil)
+		mgr = createManager(nil, nil)
 		// Add permissions for the test plugin using typed struct
 		permissions := schema.PluginManifestPermissions{
 			Http: &schema.PluginManifestPermissionsHttp{
@@ -58,6 +58,7 @@ var _ = Describe("CachingRuntime", func() {
 		plugin = newWasmScrobblerPlugin(
 			filepath.Join(testDataDir, "fake_scrobbler", "plugin.wasm"),
 			"fake_scrobbler",
+			mgr,
 			rtFunc,
 			wazero.NewModuleConfig().WithStartFunctions("_initialize"),
 		).(*wasmScrobblerPlugin)

--- a/scanner/controller.go
+++ b/scanner/controller.go
@@ -222,11 +222,11 @@ func (s *controller) ScanAll(requestCtx context.Context, fullScan bool) ([]strin
 	}
 	// Send the final scan status event, with totals
 	if count, folderCount, err := s.getCounters(ctx); err != nil {
-		s.metrics.WriteAfterScanMetrics(ctx, s.ds, false)
+		s.metrics.WriteAfterScanMetrics(ctx, false)
 		return scanWarnings, err
 	} else {
 		scanType, elapsed, lastErr := s.getScanInfo(ctx)
-		s.metrics.WriteAfterScanMetrics(ctx, s.ds, true)
+		s.metrics.WriteAfterScanMetrics(ctx, true)
 		s.sendMessage(ctx, &events.ScanStatus{
 			Scanning:    false,
 			Count:       count,

--- a/scanner/controller.go
+++ b/scanner/controller.go
@@ -222,11 +222,11 @@ func (s *controller) ScanAll(requestCtx context.Context, fullScan bool) ([]strin
 	}
 	// Send the final scan status event, with totals
 	if count, folderCount, err := s.getCounters(ctx); err != nil {
-		s.metrics.WriteAfterScanMetrics(ctx, false)
+		s.metrics.WriteAfterScanMetrics(ctx, s.ds, false)
 		return scanWarnings, err
 	} else {
 		scanType, elapsed, lastErr := s.getScanInfo(ctx)
-		s.metrics.WriteAfterScanMetrics(ctx, true)
+		s.metrics.WriteAfterScanMetrics(ctx, s.ds, true)
 		s.sendMessage(ctx, &events.ScanStatus{
 			Scanning:    false,
 			Count:       count,

--- a/server/subsonic/album_lists_test.go
+++ b/server/subsonic/album_lists_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Album Lists", func() {
 	BeforeEach(func() {
 		ds = &tests.MockDataStore{}
 		mockRepo = ds.Album(ctx).(*tests.MockAlbumRepo)
-		router = New(ds, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		router = New(ds, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w = httptest.NewRecorder()
 	})
 

--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -13,6 +13,7 @@ import (
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/core/external"
+	"github.com/navidrome/navidrome/core/metrics"
 	"github.com/navidrome/navidrome/core/playback"
 	"github.com/navidrome/navidrome/core/scrobbler"
 	"github.com/navidrome/navidrome/log"
@@ -69,6 +70,12 @@ func New(ds model.DataStore, artwork artwork.Artwork, streamer core.MediaStreame
 
 func (api *Router) routes() http.Handler {
 	r := chi.NewRouter()
+
+	if conf.Server.Prometheus.Enabled {
+		metrics := metrics.GetPrometheusInstance()
+		r.Use(recordStats(metrics))
+	}
+
 	r.Use(postFormToQueryParams)
 
 	// Public

--- a/server/subsonic/media_annotation_test.go
+++ b/server/subsonic/media_annotation_test.go
@@ -27,7 +27,7 @@ var _ = Describe("MediaAnnotationController", func() {
 		ds = &tests.MockDataStore{}
 		playTracker = &fakePlayTracker{}
 		eventBroker = &fakeEventBroker{}
-		router = New(ds, nil, nil, nil, nil, nil, nil, eventBroker, nil, playTracker, nil, nil)
+		router = New(ds, nil, nil, nil, nil, nil, nil, eventBroker, nil, playTracker, nil, nil, nil)
 	})
 
 	Describe("Scrobble", func() {

--- a/server/subsonic/media_retrieval_test.go
+++ b/server/subsonic/media_retrieval_test.go
@@ -33,7 +33,7 @@ var _ = Describe("MediaRetrievalController", func() {
 			MockedMediaFile: mockRepo,
 		}
 		artwork = &fakeArtwork{data: "image data"}
-		router = New(ds, artwork, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		router = New(ds, artwork, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w = httptest.NewRecorder()
 		DeferCleanup(configtest.SetupConfig())
 		conf.Server.LyricsPriority = "embedded,.lrc"

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -233,7 +233,11 @@ func recordStats(metrics metrics.Metrics) func(next http.Handler) http.Handler {
 
 			start := time.Now()
 			defer func() {
-				metrics.RecordRequest(r.Context(), r.URL.Path, r.Method, ww.Status(), time.Since(start).Milliseconds())
+				// We want to get the client name (even if not present for certain endpoints)
+				p := req.Params(r)
+				client, _ := p.String("c")
+
+				metrics.RecordRequest(r.Context(), r.URL.Path, r.Method, client, ww.Status(), time.Since(start).Milliseconds())
 			}()
 
 			next.ServeHTTP(ww, r)

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -237,7 +237,7 @@ func recordStats(metrics metrics.Metrics) func(next http.Handler) http.Handler {
 				p := req.Params(r)
 				client, _ := p.String("c")
 
-				metrics.RecordRequest(r.Context(), r.URL.Path, r.Method, client, ww.Status(), time.Since(start).Milliseconds())
+				metrics.RecordRequest(r.Context(), strings.Replace(r.URL.Path, ".view", "", 1), r.Method, client, ww.Status(), time.Since(start).Milliseconds())
 			}()
 
 			next.ServeHTTP(ww, r)

--- a/server/subsonic/opensubsonic_test.go
+++ b/server/subsonic/opensubsonic_test.go
@@ -19,7 +19,7 @@ var _ = Describe("GetOpenSubsonicExtensions", func() {
 	)
 
 	BeforeEach(func() {
-		router = subsonic.New(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		router = subsonic.New(nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w = httptest.NewRecorder()
 		r = httptest.NewRequest("GET", "/getOpenSubsonicExtensions?f=json", nil)
 	})

--- a/server/subsonic/playlists_test.go
+++ b/server/subsonic/playlists_test.go
@@ -20,7 +20,7 @@ var _ = Describe("UpdatePlaylist", func() {
 	BeforeEach(func() {
 		ds = &tests.MockDataStore{}
 		playlists = &fakePlaylists{}
-		router = New(ds, nil, nil, nil, nil, nil, nil, nil, playlists, nil, nil, nil)
+		router = New(ds, nil, nil, nil, nil, nil, nil, nil, playlists, nil, nil, nil, nil)
 	})
 
 	It("clears the comment when parameter is empty", func() {


### PR DESCRIPTION
This exposes the following metrics:

- Subsonic
  - Method counts by endpoint, HTTP method, and HTTP code
  - Latency (50%, 90%, 99% quartiles), as well as total elapsed
- Plugin
  - Calls by plugin name, method, and whether the response is ok. Note that this _should_ ignore nil/not implemented responses.
  - Same latency calculations as latency

Note that prometheus is now a singleton, so that it can be passed around much easier to plugins.
Consequently, the scan metrics require passing in the database now.

I'd like to also support native API, but that's trickier as there are URL fragments.