### PR TITLE
fix(provider): ensure that similar artists retreived from provider are no more than limit

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -126,6 +126,7 @@ type configOptions struct {
 	DevInsightsInitialDelay          time.Duration
 	DevEnablePlayerInsights          bool
 	DevPluginCompilationTimeout      time.Duration
+	DevExternalArtistFetchMultiplier float64
 }
 
 type scannerOptions struct {
@@ -590,6 +591,7 @@ func setViperDefaults() {
 	viper.SetDefault("devinsightsinitialdelay", consts.InsightsInitialDelay)
 	viper.SetDefault("devenableplayerinsights", true)
 	viper.SetDefault("devplugincompilationtimeout", time.Minute)
+	viper.SetDefault("devexternalartistfetchmultiplier", 1.5)
 }
 
 func init() {

--- a/core/external/provider.go
+++ b/core/external/provider.go
@@ -559,7 +559,7 @@ func (e *provider) callGetSimilar(ctx context.Context, agent agents.ArtistSimila
 		return
 	}
 	start := time.Now()
-	sa, err := e.mapSimilarArtists(ctx, similar, includeNotPresent)
+	sa, err := e.mapSimilarArtists(ctx, similar, limit, includeNotPresent)
 	log.Debug(ctx, "Mapped Similar Artists", "artist", artist.Name, "numSimilar", len(sa), "elapsed", time.Since(start))
 	if err != nil {
 		return
@@ -567,7 +567,7 @@ func (e *provider) callGetSimilar(ctx context.Context, agent agents.ArtistSimila
 	artist.SimilarArtists = sa
 }
 
-func (e *provider) mapSimilarArtists(ctx context.Context, similar []agents.Artist, includeNotPresent bool) (model.Artists, error) {
+func (e *provider) mapSimilarArtists(ctx context.Context, similar []agents.Artist, limit int, includeNotPresent bool) (model.Artists, error) {
 	var result model.Artists
 	var notPresent []string
 
@@ -590,21 +590,33 @@ func (e *provider) mapSimilarArtists(ctx context.Context, similar []agents.Artis
 		artistMap[artist.Name] = artist
 	}
 
+	count := 0
+
 	// Process the similar artists
 	for _, s := range similar {
 		if artist, found := artistMap[s.Name]; found {
 			result = append(result, artist)
+			count++
+
+			if count >= limit {
+				break
+			}
 		} else {
 			notPresent = append(notPresent, s.Name)
 		}
 	}
 
 	// Then fill up with non-present artists
-	if includeNotPresent {
+	if includeNotPresent && count < limit {
 		for _, s := range notPresent {
 			// Let the ID empty to indicate that the artist is not present in the DB
 			sa := model.Artist{Name: s}
 			result = append(result, sa)
+
+			count++
+			if count >= limit {
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Since providers may not know what artists are in the DB and thus return more than the limit, filter the artists _after_ the fact to ensure that no more than `limit` number of similar artists are returned.