### PR TITLE
Fix artist stats not refreshing during quick scan and after missing file deletion

### DIFF
--- a/model/request/request.go
+++ b/model/request/request.go
@@ -29,6 +29,7 @@ var allKeys = []contextKey{
 	Transcoding,
 	ClientUniqueId,
 	ReverseProxyIp,
+	InternalAuth,
 }
 
 func WithUser(ctx context.Context, u model.User) context.Context {

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -303,12 +303,11 @@ func (r *artistRepository) RefreshStats(allArtists bool) (int64, error) {
 		}
 		log.Debug(r.ctx, "RefreshStats: Refreshing all artists.", "count", len(allTouchedArtistIDs))
 	} else {
-		// Only refresh artists with updated media files
+		// Only refresh artists with updated timestamps
 		touchedArtistsQuerySQL := `
-        SELECT DISTINCT mfa.artist_id
-        FROM media_file_artists mfa
-        JOIN media_file mf ON mfa.media_file_id = mf.id
-        WHERE mf.updated_at > (SELECT last_scan_at FROM library ORDER BY last_scan_at ASC LIMIT 1)
+        SELECT DISTINCT id
+        FROM artist
+        WHERE updated_at > (SELECT last_scan_at FROM library ORDER BY last_scan_at ASC LIMIT 1)
         `
 		if err := r.db.NewQuery(touchedArtistsQuerySQL).Column(&allTouchedArtistIDs); err != nil {
 			return 0, fmt.Errorf("fetching touched artist IDs: %w", err)

--- a/scanner/phase_1_folders.go
+++ b/scanner/phase_1_folders.go
@@ -345,7 +345,7 @@ func (p *phaseFolders) persistChanges(entry *folderEntry) (*folderEntry, error) 
 		// Save all new/modified artists to DB. Their information will be incomplete, but they will be refreshed later
 		for i := range entry.artists {
 			err = artistRepo.Put(&entry.artists[i], "name",
-				"mbz_artist_id", "sort_artist_name", "order_artist_name", "full_text")
+				"mbz_artist_id", "sort_artist_name", "order_artist_name", "full_text", "updated_at")
 			if err != nil {
 				log.Error(p.ctx, "Scanner: Error persisting artist to DB", "folder", entry.path, "artist", entry.artists[i].Name, err)
 				return err

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -615,6 +615,8 @@ var _ = Describe("Scanner", Ordered, func() {
 
 	Describe("RefreshStats", func() {
 		var refreshStatsCalls []bool
+		var fsys storagetest.FakeFS
+		var help func(...map[string]any) *fstest.MapFile
 
 		BeforeEach(func() {
 			refreshStatsCalls = nil
@@ -627,9 +629,9 @@ var _ = Describe("Scanner", Ordered, func() {
 			}
 
 			// Create a simple filesystem for testing
-			revolver := template(_t{"albumartist": "The Beatles", "album": "Revolver", "year": 1966})
-			createFS(fstest.MapFS{
-				"The Beatles/Revolver/01 - Taxman.mp3": revolver(track(1, "Taxman")),
+			help = template(_t{"albumartist": "The Beatles", "album": "Help!", "year": 1965})
+			fsys = createFS(fstest.MapFS{
+				"The Beatles/Help!/01 - Help!.mp3": help(track(1, "Help!")),
 			})
 		})
 
@@ -648,18 +650,59 @@ var _ = Describe("Scanner", Ordered, func() {
 			refreshStatsCalls = nil
 
 			// Add a new file to trigger changes detection
-			revolver := template(_t{"albumartist": "The Beatles", "album": "Revolver", "year": 1966})
-			fsys := createFS(fstest.MapFS{
-				"The Beatles/Revolver/01 - Taxman.mp3":        revolver(track(1, "Taxman")),
-				"The Beatles/Revolver/02 - Eleanor Rigby.mp3": revolver(track(2, "Eleanor Rigby")),
-			})
-			_ = fsys
+			fsys.Add("The Beatles/Help!/02 - The Night Before.mp3", help(track(2, "The Night Before")))
 
 			// Do an incremental scan
 			Expect(runScanner(ctx, false)).To(Succeed())
 
 			Expect(refreshStatsCalls).To(HaveLen(1))
 			Expect(refreshStatsCalls[0]).To(BeFalse(), "RefreshStats should be called with allArtists=false for incremental scans")
+		})
+
+		It("should update artist stats during quick scans when new albums are added", func() {
+			// Don't use the mocked artist repo for this test - we need the real one
+			ds.MockedArtist = nil
+
+			By("Initial scan with one album")
+			Expect(runScanner(ctx, true)).To(Succeed())
+
+			// Verify initial artist stats - should have 1 album, 1 song
+			artists, err := ds.Artist(ctx).GetAll(model.QueryOptions{
+				Filters: squirrel.Eq{"name": "The Beatles"},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(artists).To(HaveLen(1))
+			artist := artists[0]
+			Expect(artist.AlbumCount).To(Equal(1)) // 1 album
+			Expect(artist.SongCount).To(Equal(1))  // 1 song
+
+			By("Adding files to an existing directory during incremental scan")
+			// Add more files to the existing Help! album - this should trigger artist stats update during incremental scan
+			fsys.Add("The Beatles/Help!/02 - The Night Before.mp3", help(track(2, "The Night Before")))
+			fsys.Add("The Beatles/Help!/03 - You've Got to Hide Your Love Away.mp3", help(track(3, "You've Got to Hide Your Love Away")))
+
+			// Do a quick scan (incremental)
+			Expect(runScanner(ctx, false)).To(Succeed())
+
+			By("Verifying artist stats were updated correctly")
+			// Fetch the artist again to check updated stats
+			artists, err = ds.Artist(ctx).GetAll(model.QueryOptions{
+				Filters: squirrel.Eq{"name": "The Beatles"},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(artists).To(HaveLen(1))
+			updatedArtist := artists[0]
+
+			// Should now have 1 album and 3 songs total
+			// This is the key test - that artist stats are updated during quick scans
+			Expect(updatedArtist.AlbumCount).To(Equal(1)) // 1 album
+			Expect(updatedArtist.SongCount).To(Equal(3))  // 3 songs
+
+			// Also verify that role-specific stats are updated (albumartist role)
+			Expect(updatedArtist.Stats).To(HaveKey(model.RoleAlbumArtist))
+			albumArtistStats := updatedArtist.Stats[model.RoleAlbumArtist]
+			Expect(albumArtistStats.AlbumCount).To(Equal(1)) // 1 album
+			Expect(albumArtistStats.SongCount).To(Equal(3))  // 3 songs
 		})
 	})
 })


### PR DESCRIPTION
## Problem

Artist statistics were not being refreshed correctly in two scenarios:

1. **During quick scans**: Newly added albums didn't result in their artists being marked as "touched", so incremental RefreshStats operations would skip them
2. **After missing file deletion**: When missing files were deleted, related artists weren't being updated, leaving stale statistics

## Root Cause

The issue stemmed from the RefreshStats method relying on artist `updated_at` timestamps to determine which artists need refreshing, but:
- During scanning, artists were saved without updating the `updated_at` field
- During missing file deletion, artist records remained untouched even though their stats should change

## Solution

**Two-part fix:**

### 1. Scanner Fix (`scanner/phase_1_folders.go`)
- Added `"updated_at"` to the list of columns when calling `artistRepo.Put()`
- Ensures artists get proper timestamps when created/updated during scanning

### 2. Missing File Deletion Fix (`server/nativeapi/missing.go`) 
- Added background `RefreshStats(true)` call after successful missing file deletion
- Uses fire-and-forget goroutine to avoid blocking API response
- Includes proper error logging for monitoring

### 3. RefreshStats Simplification (`persistence/artist_repository.go`)
- Simplified incremental refresh query to use `updated_at > last_scan_at` directly
- More straightforward logic that leverages the fixed timestamp handling

## Key Benefits

- **Quick scans now work correctly**: Artists touched during scanning are properly refreshed
- **Missing file operations are accurate**: Artist stats are updated after file deletions  
- **Non-blocking**: Missing file API calls return immediately while stats refresh in background
- **Observable**: Proper logging for monitoring background operations
- **Simple & robust**: Minimal code changes following existing patterns

## Files Changed

- `scanner/phase_1_folders.go`: Include "updated_at" in artist Put columns
- `persistence/artist_repository.go`: Simplified RefreshStats query logic  
- `server/nativeapi/missing.go`: Background RefreshStats after file deletion

This ensures artist statistics are always accurate for both scanning and missing file management operations.