### PR TITLE
fix(prometheus): report subsonic error code

### DIFF
--- a/core/metrics/prometheus.go
+++ b/core/metrics/prometheus.go
@@ -20,7 +20,7 @@ import (
 type Metrics interface {
 	WriteInitialMetrics(ctx context.Context)
 	WriteAfterScanMetrics(ctx context.Context, success bool)
-	RecordRequest(ctx context.Context, endpoint, method, client string, status int, elapsed int64)
+	RecordRequest(ctx context.Context, endpoint, method, client string, status int32, elapsed int64)
 	RecordPluginRequest(ctx context.Context, plugin, method string, ok bool, elapsed int64)
 	GetHandler() http.Handler
 }
@@ -56,7 +56,7 @@ func (m *metrics) WriteAfterScanMetrics(ctx context.Context, success bool) {
 	getPrometheusMetrics().mediaScansCounter.With(scanLabels).Inc()
 }
 
-func (m *metrics) RecordRequest(_ context.Context, endpoint, method, client string, status int, elapsed int64) {
+func (m *metrics) RecordRequest(_ context.Context, endpoint, method, client string, status int32, elapsed int64) {
 	httpLabel := prometheus.Labels{
 		"endpoint": endpoint,
 		"method":   method,
@@ -233,7 +233,7 @@ func (n noopMetrics) WriteInitialMetrics(context.Context) {}
 
 func (n noopMetrics) WriteAfterScanMetrics(context.Context, bool) {}
 
-func (n noopMetrics) RecordRequest(context.Context, string, string, string, int, int64) {}
+func (n noopMetrics) RecordRequest(context.Context, string, string, string, int32, int64) {}
 
 func (n noopMetrics) RecordPluginRequest(context.Context, string, string, bool, int64) {}
 

--- a/model/request/request.go
+++ b/model/request/request.go
@@ -17,8 +17,7 @@ const (
 	Transcoding    = contextKey("transcoding")
 	ClientUniqueId = contextKey("clientUniqueId")
 	ReverseProxyIp = contextKey("reverseProxyIp")
-	InternalAuth   = contextKey("internalAuth")  // Used for internal API calls, e.g., from the plugins
-	ErrorPointer   = contextKey("statusPointer") // used save the status for Subsonic requests
+	InternalAuth   = contextKey("internalAuth") // Used for internal API calls, e.g., from the plugins
 )
 
 var allKeys = []contextKey{
@@ -31,7 +30,6 @@ var allKeys = []contextKey{
 	ClientUniqueId,
 	ReverseProxyIp,
 	InternalAuth,
-	ErrorPointer,
 }
 
 func WithUser(ctx context.Context, u model.User) context.Context {
@@ -68,10 +66,6 @@ func WithReverseProxyIp(ctx context.Context, reverseProxyIp string) context.Cont
 
 func WithInternalAuth(ctx context.Context, username string) context.Context {
 	return context.WithValue(ctx, InternalAuth, username)
-}
-
-func WithErrorPointer(ctx context.Context, status *int32) context.Context {
-	return context.WithValue(ctx, ErrorPointer, status)
 }
 
 func UserFrom(ctx context.Context) (model.User, bool) {
@@ -121,11 +115,6 @@ func InternalAuthFrom(ctx context.Context) (string, bool) {
 		}
 	}
 	return "", false
-}
-
-func ErrorPointerFrom(ctx context.Context) (*int32, bool) {
-	v, ok := ctx.Value(ErrorPointer).(*int32)
-	return v, ok
 }
 
 func AddValues(ctx, requestCtx context.Context) context.Context {

--- a/model/request/request.go
+++ b/model/request/request.go
@@ -17,7 +17,8 @@ const (
 	Transcoding    = contextKey("transcoding")
 	ClientUniqueId = contextKey("clientUniqueId")
 	ReverseProxyIp = contextKey("reverseProxyIp")
-	InternalAuth   = contextKey("internalAuth") // Used for internal API calls, e.g., from the plugins
+	InternalAuth   = contextKey("internalAuth")  // Used for internal API calls, e.g., from the plugins
+	ErrorPointer   = contextKey("statusPointer") // used save the status for Subsonic requests
 )
 
 var allKeys = []contextKey{
@@ -30,6 +31,7 @@ var allKeys = []contextKey{
 	ClientUniqueId,
 	ReverseProxyIp,
 	InternalAuth,
+	ErrorPointer,
 }
 
 func WithUser(ctx context.Context, u model.User) context.Context {
@@ -66,6 +68,10 @@ func WithReverseProxyIp(ctx context.Context, reverseProxyIp string) context.Cont
 
 func WithInternalAuth(ctx context.Context, username string) context.Context {
 	return context.WithValue(ctx, InternalAuth, username)
+}
+
+func WithErrorPointer(ctx context.Context, status *int32) context.Context {
+	return context.WithValue(ctx, ErrorPointer, status)
 }
 
 func UserFrom(ctx context.Context) (model.User, bool) {
@@ -115,6 +121,11 @@ func InternalAuthFrom(ctx context.Context) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func ErrorPointerFrom(ctx context.Context) (*int32, bool) {
+	v, ok := ctx.Value(ErrorPointer).(*int32)
+	return v, ok
 }
 
 func AddValues(ctx, requestCtx context.Context) context.Context {

--- a/server/subsonic/api_test.go
+++ b/server/subsonic/api_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
 	"github.com/navidrome/navidrome/utils/gg"
 	. "github.com/onsi/ginkgo/v2"
@@ -109,4 +110,18 @@ var _ = Describe("sendResponse", func() {
 		})
 	})
 
+	It("updates status pointer when an error occurs", func() {
+		pointer := int32(0)
+
+		ctx := request.WithErrorPointer(r.Context(), &pointer)
+		r = r.WithContext(ctx)
+
+		payload.Status = responses.StatusFailed
+		payload.Error = &responses.Error{Code: responses.ErrorDataNotFound}
+
+		sendResponse(w, r, payload)
+		Expect(w.Code).To(Equal(http.StatusOK))
+
+		Expect(pointer).To(Equal(responses.ErrorDataNotFound))
+	})
 })

--- a/server/subsonic/api_test.go
+++ b/server/subsonic/api_test.go
@@ -8,11 +8,11 @@ import (
 	"net/http/httptest"
 	"strings"
 
-	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
 	"github.com/navidrome/navidrome/utils/gg"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/net/context"
 )
 
 var _ = Describe("sendResponse", func() {
@@ -113,7 +113,7 @@ var _ = Describe("sendResponse", func() {
 	It("updates status pointer when an error occurs", func() {
 		pointer := int32(0)
 
-		ctx := request.WithErrorPointer(r.Context(), &pointer)
+		ctx := context.WithValue(r.Context(), subsonicErrorPointer, &pointer)
 		r = r.WithContext(ctx)
 
 		payload.Status = responses.StatusFailed

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-chi/chi/v5/middleware"
 	ua "github.com/mileusna/useragent"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
@@ -225,22 +226,35 @@ func playerIDCookieName(userName string) string {
 	return cookieName
 }
 
+const subsonicErrorPointer = "subsonicErrorPointer"
+
 func recordStats(metrics metrics.Metrics) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		fn := func(w http.ResponseWriter, r *http.Request) {
-			status := int32(0)
-			contextWithStatus := request.WithErrorPointer(r.Context(), &status)
+			ww := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+
+			status := int32(-1)
+			contextWithStatus := context.WithValue(r.Context(), subsonicErrorPointer, &status)
 
 			start := time.Now()
 			defer func() {
+				elapsed := time.Since(start).Milliseconds()
+
 				// We want to get the client name (even if not present for certain endpoints)
 				p := req.Params(r)
 				client, _ := p.String("c")
 
-				metrics.RecordRequest(r.Context(), strings.Replace(r.URL.Path, ".view", "", 1), r.Method, client, status, time.Since(start).Milliseconds())
+				// If there is no Subsonic status (e.g., HTTP 501 not implemented), fallback to HTTP
+				if status == -1 {
+					status = int32(ww.Status())
+				}
+
+				shortPath := strings.Replace(r.URL.Path, ".view", "", 1)
+
+				metrics.RecordRequest(r.Context(), shortPath, r.Method, client, status, elapsed)
 			}()
 
-			next.ServeHTTP(w, r.WithContext(contextWithStatus))
+			next.ServeHTTP(ww, r.WithContext(contextWithStatus))
 		}
 		return http.HandlerFunc(fn)
 	}


### PR DESCRIPTION
The current implementation was using HTTP status code, which is almost always 200. Instead, pass in a pointer to the error code and update `sendResponse` and use that instead.