### PR TITLE
feat: MBID search functionality for albums, artists and songs

### DIFF
--- a/db/migrations/20250701010107_add_mbid_indexes.sql
+++ b/db/migrations/20250701010107_add_mbid_indexes.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Add indexes for MBID fields to improve lookup performance
+-- Artists table
+create index if not exists artist_mbz_artist_id
+	on artist (mbz_artist_id);
+
+-- Albums table  
+create index if not exists album_mbz_album_id
+	on album (mbz_album_id);
+
+-- Media files table
+create index if not exists media_file_mbz_release_track_id
+	on media_file (mbz_release_track_id);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+-- Remove MBID indexes
+drop index if exists artist_mbz_artist_id;
+drop index if exists album_mbz_album_id;
+drop index if exists media_file_mbz_release_track_id;
+
+-- +goose StatementEnd

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -113,7 +113,7 @@ func NewAlbumRepository(ctx context.Context, db dbx.Builder) model.AlbumReposito
 var albumFilters = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
 		"id":              idFilter("album"),
-		"name":            fullTextFilter("album"),
+		"name":            fullTextFilter("album", "mbz_album_id", "mbz_release_group_id"),
 		"compilation":     booleanFilter,
 		"artist_id":       artistFilter,
 		"year":            yearFilter,

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -12,6 +12,7 @@ import (
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
+	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -347,11 +348,18 @@ func (r *albumRepository) purgeEmpty() error {
 
 func (r *albumRepository) Search(q string, offset int, size int, includeMissing bool) (model.Albums, error) {
 	var res dbAlbums
-	err := r.doSearch(r.selectAlbum(), q, offset, size, includeMissing, &res, "name")
-	if err != nil {
-		return nil, err
+	if uuid.Validate(q) == nil {
+		err := r.searchByMBID(r.selectAlbum(), q, []string{"mbz_album_id", "mbz_release_group_id"}, includeMissing, &res)
+		if err != nil {
+			return nil, fmt.Errorf("searching album by MBID %q: %w", q, err)
+		}
+	} else {
+		err := r.doSearch(r.selectAlbum(), q, offset, size, includeMissing, &res, "name")
+		if err != nil {
+			return nil, fmt.Errorf("searching album by query %q: %w", q, err)
+		}
 	}
-	return res.toModels(), err
+	return res.toModels(), nil
 }
 
 func (r *albumRepository) Count(options ...rest.QueryOptions) (int64, error) {

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -114,7 +114,7 @@ func NewArtistRepository(ctx context.Context, db dbx.Builder) model.ArtistReposi
 	r.tableName = "artist" // To be used by the idFilter below
 	r.registerModel(&model.Artist{}, map[string]filterFunc{
 		"id":      idFilter(r.tableName),
-		"name":    fullTextFilter(r.tableName),
+		"name":    fullTextFilter(r.tableName, "mbz_artist_id"),
 		"starred": booleanFilter,
 		"role":    roleFilter,
 		"missing": booleanFilter,

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -11,6 +11,7 @@ import (
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
+	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -433,12 +434,19 @@ func (r *artistRepository) RefreshStats(allArtists bool) (int64, error) {
 }
 
 func (r *artistRepository) Search(q string, offset int, size int, includeMissing bool) (model.Artists, error) {
-	var dba dbArtists
-	err := r.doSearch(r.selectArtist(), q, offset, size, includeMissing, &dba, "json_extract(stats, '$.total.m') desc", "name")
-	if err != nil {
-		return nil, err
+	var res dbArtists
+	if uuid.Validate(q) == nil {
+		err := r.searchByMBID(r.selectArtist(), q, []string{"mbz_artist_id"}, includeMissing, &res)
+		if err != nil {
+			return nil, fmt.Errorf("searching artist by MBID %q: %w", q, err)
+		}
+	} else {
+		err := r.doSearch(r.selectArtist(), q, offset, size, includeMissing, &res, "json_extract(stats, '$.total.m') desc", "name")
+		if err != nil {
+			return nil, fmt.Errorf("searching artist by query %q: %w", q, err)
+		}
 	}
-	return dba.toModels(), nil
+	return res.toModels(), nil
 }
 
 func (r *artistRepository) Count(options ...rest.QueryOptions) (int64, error) {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -91,7 +91,7 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
 		"id":         idFilter("media_file"),
-		"title":      fullTextFilter("media_file"),
+		"title":      fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
 		"starred":    booleanFilter,
 		"genre_id":   tagIDFilter,
 		"missing":    booleanFilter,

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"reflect"
@@ -105,8 +106,15 @@ func booleanFilter(field string, value any) Sqlizer {
 	return Eq{field: v == "true"}
 }
 
-func fullTextFilter(tableName string) func(string, any) Sqlizer {
-	return func(field string, value any) Sqlizer { return fullTextExpr(tableName, value.(string)) }
+func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {
+	return func(field string, value any) Sqlizer {
+		v := strings.ToLower(value.(string))
+		cond := cmp.Or(
+			mbidExpr(tableName, v, mbidFields...),
+			fullTextExpr(tableName, v),
+		)
+		return cond
+	}
 }
 
 func substringFilter(field string, value any) Sqlizer {

--- a/persistence/sql_restful_test.go
+++ b/persistence/sql_restful_test.go
@@ -2,9 +2,12 @@ package persistence
 
 import (
 	"context"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -66,4 +69,167 @@ var _ = Describe("sqlRestful", func() {
 			Expect(r.parseRestFilters(context.Background(), options)).To(Equal(squirrel.And{squirrel.Gt{"test": 100}}))
 		})
 	})
+
+	Describe("fullTextFilter function", func() {
+		var filter filterFunc
+		var tableName string
+		var mbidFields []string
+
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
+			tableName = "test_table"
+			mbidFields = []string{"mbid", "artist_mbid"}
+			filter = fullTextFilter(tableName, mbidFields...)
+		})
+
+		Context("when value is a valid UUID", func() {
+			It("returns only the mbid filter (precedence over full text)", func() {
+				uuid := "550e8400-e29b-41d4-a716-446655440000"
+				result := filter("search", uuid)
+
+				expected := squirrel.Or{
+					squirrel.Eq{"test_table.mbid": uuid},
+					squirrel.Eq{"test_table.artist_mbid": uuid},
+				}
+				Expect(result).To(Equal(expected))
+			})
+
+			It("falls back to full text when no mbid fields are provided", func() {
+				noMbidFilter := fullTextFilter(tableName)
+				uuid := "550e8400-e29b-41d4-a716-446655440000"
+				result := noMbidFilter("search", uuid)
+
+				// mbidExpr with no fields returns nil, so cmp.Or falls back to fullTextExpr
+				expected := squirrel.And{
+					squirrel.Like{"test_table.full_text": "% 550e8400-e29b-41d4-a716-446655440000%"},
+				}
+				Expect(result).To(Equal(expected))
+			})
+		})
+
+		Context("when value is not a valid UUID", func() {
+			It("returns full text search condition only", func() {
+				result := filter("search", "beatles")
+
+				// mbidExpr returns nil for non-UUIDs, so fullTextExpr result is returned directly
+				expected := squirrel.And{
+					squirrel.Like{"test_table.full_text": "% beatles%"},
+				}
+				Expect(result).To(Equal(expected))
+			})
+
+			It("handles multi-word search terms", func() {
+				result := filter("search", "the beatles abbey road")
+
+				// Should return And condition directly
+				andCondition, ok := result.(squirrel.And)
+				Expect(ok).To(BeTrue())
+				Expect(andCondition).To(HaveLen(4))
+
+				// Check that all words are present (order may vary)
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% the%"}))
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% beatles%"}))
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% abbey%"}))
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% road%"}))
+			})
+		})
+
+		Context("when SearchFullString config changes behavior", func() {
+			It("uses different separator with SearchFullString=false", func() {
+				conf.Server.SearchFullString = false
+				result := filter("search", "test query")
+
+				andCondition, ok := result.(squirrel.And)
+				Expect(ok).To(BeTrue())
+				Expect(andCondition).To(HaveLen(2))
+
+				// Check that all words are present with leading space (order may vary)
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% test%"}))
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% query%"}))
+			})
+
+			It("uses no separator with SearchFullString=true", func() {
+				conf.Server.SearchFullString = true
+				result := filter("search", "test query")
+
+				andCondition, ok := result.(squirrel.And)
+				Expect(ok).To(BeTrue())
+				Expect(andCondition).To(HaveLen(2))
+
+				// Check that all words are present without leading space (order may vary)
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "%test%"}))
+				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "%query%"}))
+			})
+		})
+
+		Context("edge cases", func() {
+			It("returns nil for empty string", func() {
+				result := filter("search", "")
+				Expect(result).To(BeNil())
+			})
+
+			It("returns nil for string with only whitespace", func() {
+				result := filter("search", "   ")
+				Expect(result).To(BeNil())
+			})
+
+			It("handles special characters that are sanitized", func() {
+				result := filter("search", "don't")
+
+				expected := squirrel.And{
+					squirrel.Like{"test_table.full_text": "% dont%"}, // str.SanitizeStrings removes quotes
+				}
+				Expect(result).To(Equal(expected))
+			})
+
+			It("returns nil for single quote (SQL injection protection)", func() {
+				result := filter("search", "'")
+				Expect(result).To(BeNil())
+			})
+
+			It("handles mixed case UUIDs", func() {
+				uuid := "550E8400-E29B-41D4-A716-446655440000"
+				result := filter("search", uuid)
+
+				// Should return only mbid filter (uppercase UUID should work)
+				expected := squirrel.Or{
+					squirrel.Eq{"test_table.mbid": strings.ToLower(uuid)},
+					squirrel.Eq{"test_table.artist_mbid": strings.ToLower(uuid)},
+				}
+				Expect(result).To(Equal(expected))
+			})
+
+			It("handles invalid UUID format gracefully", func() {
+				result := filter("search", "550e8400-invalid-uuid")
+
+				// Should return full text filter since UUID is invalid
+				expected := squirrel.And{
+					squirrel.Like{"test_table.full_text": "% 550e8400-invalid-uuid%"},
+				}
+				Expect(result).To(Equal(expected))
+			})
+
+			It("handles empty mbid fields array", func() {
+				emptyMbidFilter := fullTextFilter(tableName, []string{}...)
+				result := emptyMbidFilter("search", "test")
+
+				// mbidExpr with empty fields returns nil, so cmp.Or falls back to fullTextExpr
+				expected := squirrel.And{
+					squirrel.Like{"test_table.full_text": "% test%"},
+				}
+				Expect(result).To(Equal(expected))
+			})
+
+			It("converts value to lowercase before processing", func() {
+				result := filter("search", "TEST")
+
+				// The function converts to lowercase internally
+				expected := squirrel.And{
+					squirrel.Like{"test_table.full_text": "% test%"},
+				}
+				Expect(result).To(Equal(expected))
+			})
+		})
+	})
+
 })

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -52,6 +52,7 @@ func mbidExpr(tableName, mbid string, mbidFields ...string) Sqlizer {
 	if uuid.Validate(mbid) != nil || len(mbidFields) == 0 {
 		return nil
 	}
+	mbid = strings.ToLower(mbid)
 	var cond []Sqlizer
 	for _, mbidField := range mbidFields {
 		cond = append(cond, Eq{tableName + "." + mbidField: mbid})


### PR DESCRIPTION
### Description
This PR enhances the Subsonic API search functionality to support searching by MusicBrainz ID (MBID) for albums, artists, and media files. This improvement provides more accurate and efficient searches when users have MBID information available.

The implementation prioritizes MBID searches over full-text searches when valid UUIDs are detected, providing better search accuracy for users with MusicBrainz-tagged music libraries.

### Type of Change
- [x] New feature

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test
1. Start Navidrome with a music library that contains tracks with MBID metadata
2. Use the search functionality with valid MBID values (UUIDs)
3. Verify that searches return appropriate results for albums, artists, and tracks with matching MBIDs
4. Run the test suite: `make test PKG=./persistence/...`

### Technical Details

**Key Changes:**
- Updated `fullTextFilter` function to accept additional MBID fields for enhanced search capabilities
- Modified album, artist, and media file repositories to support MBID-based searches
- Added database indexes for MBID fields to optimize search performance
- Enhanced search logic to prioritize MBID matches over full-text searches when valid UUIDs are detected

**Database Changes:**
- Added indexes on MBID fields (`mbz_album_id`, `mbz_artist_id`) for albums and artists
- New migration: `20250701010107_add_mbid_indexes.sql`

**Code Changes:**
- `persistence/sql_restful.go`: Enhanced fullTextFilter to handle MBID searches
- `persistence/album_repository.go`: Added MBID field to search configuration
- `persistence/artist_repository.go`: Added MBID field to search configuration  
- `persistence/mediafile_repository.go`: Added MBID field to search configuration
- `persistence/sql_search.go`: Enhanced search logic for MBID support

**Test Coverage:**
- Comprehensive unit tests for fullTextFilter with MBID functionality
- Tests covering UUID validation and MBID precedence over full-text search
- Tests for edge cases including missing entries and various search configurations
- Added tests in `persistence/sql_restful_test.go`, `persistence/artist_repository_test.go`, and `persistence/mediafile_repository_test.go`

### Additional Notes
This enhancement maintains backward compatibility while improving search accuracy for users with MusicBrainz-tagged music libraries. The implementation follows the existing patterns in the codebase and includes proper error handling and comprehensive test coverage.

The feature automatically detects when a search query is a valid UUID (MBID format) and prioritizes MBID-based searches in those cases, falling back to traditional full-text search for non-UUID queries.