### PR TITLE
refactor: optimize agent loading logic and remove redundant caching

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -175,7 +175,7 @@ func GetPlaybackServer() playback.PlaybackServer {
 	return playbackServer
 }
 
-func getPluginManager() *plugins.Manager {
+func getPluginManager() plugins.Manager {
 	sqlDB := db.Db()
 	dataStore := persistence.New(sqlDB)
 	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
@@ -185,9 +185,9 @@ func getPluginManager() *plugins.Manager {
 
 // wire_injectors.go:
 
-var allProviders = wire.NewSet(core.Set, artwork.Set, server.New, subsonic.New, nativeapi.New, public.New, persistence.New, lastfm.NewRouter, listenbrainz.NewRouter, events.GetBroker, scanner.New, scanner.NewWatcher, plugins.GetManager, metrics.GetPrometheusInstance, db.Db, wire.Bind(new(agents.PluginLoader), new(*plugins.Manager)), wire.Bind(new(scrobbler.PluginLoader), new(*plugins.Manager)))
+var allProviders = wire.NewSet(core.Set, artwork.Set, server.New, subsonic.New, nativeapi.New, public.New, persistence.New, lastfm.NewRouter, listenbrainz.NewRouter, events.GetBroker, scanner.New, scanner.NewWatcher, plugins.GetManager, metrics.GetPrometheusInstance, db.Db, wire.Bind(new(agents.PluginLoader), new(plugins.Manager)), wire.Bind(new(scrobbler.PluginLoader), new(plugins.Manager)))
 
-func GetPluginManager(ctx context.Context) *plugins.Manager {
+func GetPluginManager(ctx context.Context) plugins.Manager {
 	manager := getPluginManager()
 	manager.SetSubsonicRouter(CreateSubsonicAPIRouter(ctx))
 	return manager

--- a/cmd/wire_injectors.go
+++ b/cmd/wire_injectors.go
@@ -42,8 +42,8 @@ var allProviders = wire.NewSet(
 	plugins.GetManager,
 	metrics.GetPrometheusInstance,
 	db.Db,
-	wire.Bind(new(agents.PluginLoader), new(*plugins.Manager)),
-	wire.Bind(new(scrobbler.PluginLoader), new(*plugins.Manager)),
+	wire.Bind(new(agents.PluginLoader), new(plugins.Manager)),
+	wire.Bind(new(scrobbler.PluginLoader), new(plugins.Manager)),
 )
 
 func CreateDataStore() model.DataStore {
@@ -118,13 +118,13 @@ func GetPlaybackServer() playback.PlaybackServer {
 	))
 }
 
-func getPluginManager() *plugins.Manager {
+func getPluginManager() plugins.Manager {
 	panic(wire.Build(
 		allProviders,
 	))
 }
 
-func GetPluginManager(ctx context.Context) *plugins.Manager {
+func GetPluginManager(ctx context.Context) plugins.Manager {
 	manager := getPluginManager()
 	manager.SetSubsonicRouter(CreateSubsonicAPIRouter(ctx))
 	return manager

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -264,13 +264,15 @@ func Load(noConfigDump bool) {
 		os.Exit(1)
 	}
 
-	if Server.Plugins.Folder == "" {
-		Server.Plugins.Folder = filepath.Join(Server.DataFolder, "plugins")
-	}
-	err = os.MkdirAll(Server.Plugins.Folder, 0700)
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "FATAL: Error creating plugins path:", err)
-		os.Exit(1)
+	if Server.Plugins.Enabled {
+		if Server.Plugins.Folder == "" {
+			Server.Plugins.Folder = filepath.Join(Server.DataFolder, "plugins")
+		}
+		err = os.MkdirAll(Server.Plugins.Folder, 0700)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "FATAL: Error creating plugins path:", err)
+			os.Exit(1)
+		}
 	}
 
 	Server.ConfigFile = viper.GetViper().ConfigFileUsed()

--- a/core/agents/agents.go
+++ b/core/agents/agents.go
@@ -68,13 +68,7 @@ func (a *Agents) getEnabledAgentNames() []enabledAgent {
 	configuredAgents := strings.Split(conf.Server.Agents, ",")
 
 	// Always add LocalAgentName if not already included
-	hasLocalAgent := false
-	for _, name := range configuredAgents {
-		if name == LocalAgentName {
-			hasLocalAgent = true
-			break
-		}
-	}
+	hasLocalAgent := slices.Contains(configuredAgents, LocalAgentName)
 	if !hasLocalAgent {
 		configuredAgents = append(configuredAgents, LocalAgentName)
 	}

--- a/core/agents/agents_test.go
+++ b/core/agents/agents_test.go
@@ -56,8 +56,8 @@ var _ = Describe("Agents", func() {
 
 		It("does not register disabled agents", func() {
 			var ags []string
-			for _, name := range ag.getEnabledAgentNames() {
-				agent := ag.getAgent(name)
+			for _, enabledAgent := range ag.getEnabledAgentNames() {
+				agent := ag.getAgent(enabledAgent)
 				if agent != nil {
 					ags = append(ags, agent.AgentName())
 				}

--- a/plugins/adapter_media_agent.go
+++ b/plugins/adapter_media_agent.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewWasmMediaAgent creates a new adapter for a MetadataAgent plugin
-func newWasmMediaAgent(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmMediaAgent(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewMetadataAgentPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating media metadata service plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/adapter_media_agent_test.go
+++ b/plugins/adapter_media_agent_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("Adapter Media Agent", func() {
 	var ctx context.Context
-	var mgr *Manager
+	var mgr *managerImpl
 
 	BeforeEach(func() {
 		ctx = GinkgoT().Context()

--- a/plugins/adapter_scheduler_callback.go
+++ b/plugins/adapter_scheduler_callback.go
@@ -9,7 +9,7 @@ import (
 )
 
 // newWasmSchedulerCallback creates a new adapter for a SchedulerCallback plugin
-func newWasmSchedulerCallback(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmSchedulerCallback(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewSchedulerCallbackPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating scheduler callback plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/adapter_scrobbler.go
+++ b/plugins/adapter_scrobbler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tetratelabs/wazero"
 )
 
-func newWasmScrobblerPlugin(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmScrobblerPlugin(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewScrobblerPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating scrobbler service plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/adapter_websocket_callback.go
+++ b/plugins/adapter_websocket_callback.go
@@ -9,7 +9,7 @@ import (
 )
 
 // newWasmWebSocketCallback creates a new adapter for a WebSocketCallback plugin
-func newWasmWebSocketCallback(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmWebSocketCallback(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewWebSocketCallbackPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating WebSocket callback plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/host_scheduler.go
+++ b/plugins/host_scheduler.go
@@ -49,13 +49,13 @@ func (s SchedulerHostFunctions) CancelSchedule(ctx context.Context, req *schedul
 type schedulerService struct {
 	// Map of schedule IDs to their callback info
 	schedules  map[string]*ScheduledCallback
-	manager    *Manager
+	manager    *managerImpl
 	navidSched navidsched.Scheduler // Navidrome scheduler for recurring jobs
 	mu         sync.Mutex
 }
 
 // newSchedulerService creates a new schedulerService instance
-func newSchedulerService(manager *Manager) *schedulerService {
+func newSchedulerService(manager *managerImpl) *schedulerService {
 	return &schedulerService{
 		schedules:  make(map[string]*ScheduledCallback),
 		manager:    manager,

--- a/plugins/host_scheduler_test.go
+++ b/plugins/host_scheduler_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("SchedulerService", func() {
 	var (
 		ss         *schedulerService
-		manager    *Manager
+		manager    *managerImpl
 		pluginName = "test_plugin"
 	)
 

--- a/plugins/host_websocket.go
+++ b/plugins/host_websocket.go
@@ -50,12 +50,12 @@ func (s WebSocketHostFunctions) Close(ctx context.Context, req *websocket.CloseR
 // websocketService implements the WebSocket service functionality
 type websocketService struct {
 	connections map[string]*WebSocketConnection
-	manager     *Manager
+	manager     *managerImpl
 	mu          sync.RWMutex
 }
 
 // newWebsocketService creates a new websocketService instance
-func newWebsocketService(manager *Manager) *websocketService {
+func newWebsocketService(manager *managerImpl) *websocketService {
 	return &websocketService{
 		connections: make(map[string]*WebSocketConnection),
 		manager:     manager,

--- a/plugins/host_websocket_test.go
+++ b/plugins/host_websocket_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("WebSocket Host Service", func() {
 	var (
 		wsService      *websocketService
-		manager        *Manager
+		manager        *managerImpl
 		ctx            context.Context
 		server         *httptest.Server
 		upgrader       gorillaws.Upgrader

--- a/plugins/manager_test.go
+++ b/plugins/manager_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Plugin Manager", func() {
-	var mgr *Manager
+var _ = Describe("Plugin managerImpl", func() {
+	var mgr *managerImpl
 	var ctx context.Context
 
 	BeforeEach(func() {
@@ -76,7 +76,7 @@ var _ = Describe("Plugin Manager", func() {
 
 	Describe("ScanPlugins", func() {
 		var tempPluginsDir string
-		var m *Manager
+		var m *managerImpl
 
 		BeforeEach(func() {
 			tempPluginsDir, _ = os.MkdirTemp("", "navidrome-plugins-test-*")

--- a/plugins/manager_test.go
+++ b/plugins/manager_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Plugin managerImpl", func() {
+var _ = Describe("Plugin Manager", func() {
 	var mgr *managerImpl
 	var ctx context.Context
 

--- a/plugins/manifest_permissions_test.go
+++ b/plugins/manifest_permissions_test.go
@@ -47,7 +47,7 @@ func createTestPlugin(tempDir, name string, permissions schema.PluginManifestPer
 
 var _ = Describe("Plugin Permissions", func() {
 	var (
-		mgr     *Manager
+		mgr     *managerImpl
 		tempDir string
 		ctx     context.Context
 	)

--- a/plugins/plugin_lifecycle_manager_test.go
+++ b/plugins/plugin_lifecycle_manager_test.go
@@ -18,7 +18,7 @@ func hasInitService(info *plugin) bool {
 }
 
 var _ = Describe("LifecycleManagement", func() {
-	Describe("Plugin Lifecycle Manager", func() {
+	Describe("Plugin Lifecycle managerImpl", func() {
 		var lifecycleManager *pluginLifecycleManager
 
 		BeforeEach(func() {

--- a/plugins/runtime.go
+++ b/plugins/runtime.go
@@ -41,7 +41,7 @@ var (
 
 // createRuntime returns a function that creates a new wazero runtime and instantiates the required host functions
 // based on the given plugin permissions
-func (m *Manager) createRuntime(pluginID string, permissions schema.PluginManifestPermissions) api.WazeroNewRuntime {
+func (m *managerImpl) createRuntime(pluginID string, permissions schema.PluginManifestPermissions) api.WazeroNewRuntime {
 	return func(ctx context.Context) (wazero.Runtime, error) {
 		// Check if runtime already exists
 		if rt, ok := runtimePool.Load(pluginID); ok {
@@ -70,7 +70,7 @@ func (m *Manager) createRuntime(pluginID string, permissions schema.PluginManife
 }
 
 // createCachingRuntime handles the complex logic of setting up a new cachingRuntime
-func (m *Manager) createCachingRuntime(ctx context.Context, pluginID string, permissions schema.PluginManifestPermissions) (*cachingRuntime, error) {
+func (m *managerImpl) createCachingRuntime(ctx context.Context, pluginID string, permissions schema.PluginManifestPermissions) (*cachingRuntime, error) {
 	// Get compilation cache
 	compCache, err := getCompilationCache()
 	if err != nil {
@@ -94,7 +94,7 @@ func (m *Manager) createCachingRuntime(ctx context.Context, pluginID string, per
 }
 
 // setupHostServices configures all the permitted host services for a plugin
-func (m *Manager) setupHostServices(ctx context.Context, r wazero.Runtime, pluginID string, permissions schema.PluginManifestPermissions) error {
+func (m *managerImpl) setupHostServices(ctx context.Context, r wazero.Runtime, pluginID string, permissions schema.PluginManifestPermissions) error {
 	// Define all available host services
 	type hostService struct {
 		name        string

--- a/plugins/runtime_test.go
+++ b/plugins/runtime_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Runtime", func() {
 var _ = Describe("CachingRuntime", func() {
 	var (
 		ctx    context.Context
-		mgr    *Manager
+		mgr    *managerImpl
 		plugin *wasmScrobblerPlugin
 	)
 


### PR DESCRIPTION
### Description
This PR optimizes the agent loading logic in Navidrome's backend by distinguishing between built-in and plugin agents to avoid unnecessary plugin loader calls, and removes redundant agent-level caching that was over-engineering.

**Key Improvements:**
1. **Enhanced Agent Type Distinction**: Introduced structured data () to track agent names and their types (built-in vs plugin), improving clarity and enabling targeted optimizations.
2. **Removed Redundant Caching**: Eliminated the agent-level cache since the plugin manager already handles plugin adapter caching, and built-in agent constructors are lightweight.
3. **Performance Optimization**: Plugin loading () is now only called for actual plugin agents, not for built-in agents or invalid names.
4. **Comprehensive Testing**: Added tests to verify that plugin loading is not called for built-in agents or invalid agent names, ensuring the optimization works correctly.

### Related Issues
None specified.

### Type of Change
- [x] Refactor

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally  
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Run the agent tests: `make test PKG=./core/agents/...`
2. Verify all tests pass, especially the new tests that ensure plugin loading optimization
3. Test with different agent configurations to ensure built-in and plugin agents work correctly

### Technical Details

**Before**: 
- Used a simple map approach that required plugin loading calls for all agent names
- Had redundant agent-level caching on top of plugin manager caching
- Less clear distinction between built-in and plugin agents

**After**:
- Uses structured `enabledAgent` with name and type information
- Only calls `LoadMediaAgent` for actual plugin agents  
- Removed redundant caching layer, relying on plugin manager's existing adapter cache
- Clear separation of built-in vs plugin agent handling

**Files Changed**:
- `core/agents/agents.go`: Main refactor with structured agent handling and cache removal
- `core/agents/agents_plugin_test.go`: Enhanced tests including verification that plugin loading is not called for built-in/invalid agents
- `core/agents/agents_test.go`: Updated to work with new structured approach
- `plugins/manager.go`: Updated interface and type definitions

### Additional Notes
This change maintains full backward compatibility while improving performance. The plugin manager's existing caching mechanisms are sufficient, making the agent-level cache redundant. The new structured approach makes the codebase more maintainable and provides better optimization opportunities.