### PR TITLE
fix(taglib): read cover art from dsf, wavpak, fix wma test

### DIFF
--- a/adapters/taglib/taglib_test.go
+++ b/adapters/taglib/taglib_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Extractor", func() {
 			Entry("correctly parses wma/asf tags", "test.wma", "1.02s", 1, 44100, 16, "3.27 dB", "0.132914", "3.27 dB", "0.132914", false, true),
 
 			// ffmpeg -f lavfi -i "sine=frequency=800:duration=1" test.wv
-			Entry("correctly parses wv (wavpak) tags", "test.wv", "1s", 1, 44100, 16, "3.43 dB", "0.125061", "3.43 dB", "0.125061", false, false),
+			Entry("correctly parses wv (wavpak) tags", "test.wv", "1s", 1, 44100, 16, "3.43 dB", "0.125061", "3.43 dB", "0.125061", false, true),
 
 			// ffmpeg -f lavfi -i "sine=frequency=1000:duration=1" test.wav
 			Entry("correctly parses wav tags", "test.wav", "1s", 1, 44100, 16, "3.06 dB", "0.125056", "3.06 dB", "0.125056", true, true),

--- a/adapters/taglib/taglib_wrapper.cpp
+++ b/adapters/taglib/taglib_wrapper.cpp
@@ -160,9 +160,9 @@ int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id) {
   if (m4afile != NULL) {
     const auto itemListMap = m4afile->tag()->itemMap();
     for (const auto item: itemListMap) {
-      char *key = (char *)item.first.toCString(true);
+      char *key = const_cast<char*>(item.first.toCString(true));
       for (const auto value: item.second.toStringList()) {
-        char *val = (char *)value.toCString(true);
+        char *val = const_cast<char*>(value.toCString(true));
         goPutM4AStr(id, key, val);
       }
     }

--- a/adapters/taglib/taglib_wrapper.cpp
+++ b/adapters/taglib/taglib_wrapper.cpp
@@ -244,6 +244,11 @@ char has_cover(const TagLib::FileRef f) {
     const TagLib::ASF::Tag *tag{ asfFile->tag() };
     hasCover = tag && asfFile->tag()->attributeListMap().contains("WM/Picture");
   }
+  // ----- DSF
+  else if (TagLib::DSF::File * dsffile{ dynamic_cast<TagLib::DSF::File *>(f.file())}) {
+    const auto& frameListMap = dsffile->tag()->frameListMap();
+    hasCover = !frameListMap["APIC"].isEmpty();
+  }
 
   return hasCover;
 }

--- a/adapters/taglib/taglib_wrapper.cpp
+++ b/adapters/taglib/taglib_wrapper.cpp
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <string.h>
-#include <typeinfo>
 
 #define TAGLIB_STATIC
 #include <apeproperties.h>
@@ -113,7 +112,7 @@ int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id) {
             strncpy(language, bv.data(), 3);
           }
 
-          char *val = (char *)frame->text().toCString(true);
+          char *val = const_cast<char*>(frame->text().toCString(true));
 
           goPutLyrics(id, language, val);
         }
@@ -132,7 +131,7 @@ int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id) {
           if (format == TagLib::ID3v2::SynchronizedLyricsFrame::AbsoluteMilliseconds) {
 
             for (const auto &line: frame->synchedText()) {
-              char *text = (char *)line.text.toCString(true);
+              char *text = const_cast<char*>(line.text.toCString(true));
               goPutLyricLine(id, language, text, line.time);
             }
           } else if (format == TagLib::ID3v2::SynchronizedLyricsFrame::AbsoluteMpegFrames) {
@@ -141,7 +140,7 @@ int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id) {
             if (sampleRate != 0) {
               for (const auto &line: frame->synchedText()) {
                 const int timeInMs = (line.time * 1000) / sampleRate;
-                char *text = (char *)line.text.toCString(true);
+                char *text = const_cast<char*>(line.text.toCString(true));
                 goPutLyricLine(id, language, text, timeInMs);
               }
             }
@@ -174,12 +173,12 @@ int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id) {
     const TagLib::ASF::Tag *asfTags{asfFile->tag()};
     const auto itemListMap = asfTags->attributeListMap();
     for (const auto item : itemListMap) {
-      char *key = (char *)item.first.toCString(true);
+      char *key = const_cast<char*>(item.first.toCString(true));
 
       for (auto j = item.second.begin();
            j != item.second.end(); ++j) {
 
-        char *val = (char *) j->toString().toCString(true);
+        char *val = const_cast<char*>(j->toString().toCString(true));
         goPutStr(id, key, val);
       }
     }
@@ -188,10 +187,10 @@ int taglib_read(const FILENAME_CHAR_T *filename, unsigned long id) {
   // Send all collected tags to the Go map
   for (TagLib::PropertyMap::ConstIterator i = tags.begin(); i != tags.end();
        ++i) {
-    char *key = (char *)i->first.toCString(true);
+    char *key = const_cast<char*>(i->first.toCString(true));
     for (TagLib::StringList::ConstIterator j = i->second.begin();
          j != i->second.end(); ++j) {
-      char *val = (char *)(*j).toCString(true);
+      char *val = const_cast<char*>((*j).toCString(true));
       goPutStr(id, key, val);
     }
   }


### PR DESCRIPTION
### Description
DSF/DSD (or, at least Picard) appears to store cover art in APIC field (ID3). Extract this in taglib for `has_cover`

Also make reading from wma a bit safer, fix the tests, and read from WavPack (APE tags only, not ID3v1).

### Related Issues
Fixes #4278 

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [X] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
I could not for the life of me figure out how to trim a DSF file to 1 second. So, to test:
1. Get a DSD file from https://www.oppodigital.com/hra/dsd-by-davidelias.aspx
2. Use Picard to embed cover art
3. Verify `navidrome inspect $file` shows `"hasCoverArt": true,`
4. Verify that Navidrome, with `Agents` set to an empty string, shows the embedded cover art for the album and song

For the other formats, just `make test PKG=./adapters/taglib`

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->
Inspect output:

[inspect_output.json](https://github.com/user-attachments/files/21020746/inspect_output.json)

Embedding a completely unrelated screenshot into the album:
![image](https://github.com/user-attachments/assets/8f420c5a-7690-4b2b-9d5b-e74dc82ce811)


### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->