### PR TITLE
fix: silence plugin warnings and folder creation when plugins disabled

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -175,7 +175,7 @@ func GetPlaybackServer() playback.PlaybackServer {
 	return playbackServer
 }
 
-func getPluginManager() *plugins.Manager {
+func getPluginManager() plugins.Manager {
 	sqlDB := db.Db()
 	dataStore := persistence.New(sqlDB)
 	metricsMetrics := metrics.GetPrometheusInstance(dataStore)
@@ -185,9 +185,9 @@ func getPluginManager() *plugins.Manager {
 
 // wire_injectors.go:
 
-var allProviders = wire.NewSet(core.Set, artwork.Set, server.New, subsonic.New, nativeapi.New, public.New, persistence.New, lastfm.NewRouter, listenbrainz.NewRouter, events.GetBroker, scanner.New, scanner.NewWatcher, plugins.GetManager, metrics.GetPrometheusInstance, db.Db, wire.Bind(new(agents.PluginLoader), new(*plugins.Manager)), wire.Bind(new(scrobbler.PluginLoader), new(*plugins.Manager)))
+var allProviders = wire.NewSet(core.Set, artwork.Set, server.New, subsonic.New, nativeapi.New, public.New, persistence.New, lastfm.NewRouter, listenbrainz.NewRouter, events.GetBroker, scanner.New, scanner.NewWatcher, plugins.GetManager, metrics.GetPrometheusInstance, db.Db, wire.Bind(new(agents.PluginLoader), new(plugins.Manager)), wire.Bind(new(scrobbler.PluginLoader), new(plugins.Manager)))
 
-func GetPluginManager(ctx context.Context) *plugins.Manager {
+func GetPluginManager(ctx context.Context) plugins.Manager {
 	manager := getPluginManager()
 	manager.SetSubsonicRouter(CreateSubsonicAPIRouter(ctx))
 	return manager

--- a/cmd/wire_injectors.go
+++ b/cmd/wire_injectors.go
@@ -42,8 +42,8 @@ var allProviders = wire.NewSet(
 	plugins.GetManager,
 	metrics.GetPrometheusInstance,
 	db.Db,
-	wire.Bind(new(agents.PluginLoader), new(*plugins.Manager)),
-	wire.Bind(new(scrobbler.PluginLoader), new(*plugins.Manager)),
+	wire.Bind(new(agents.PluginLoader), new(plugins.Manager)),
+	wire.Bind(new(scrobbler.PluginLoader), new(plugins.Manager)),
 )
 
 func CreateDataStore() model.DataStore {
@@ -118,13 +118,13 @@ func GetPlaybackServer() playback.PlaybackServer {
 	))
 }
 
-func getPluginManager() *plugins.Manager {
+func getPluginManager() plugins.Manager {
 	panic(wire.Build(
 		allProviders,
 	))
 }
 
-func GetPluginManager(ctx context.Context) *plugins.Manager {
+func GetPluginManager(ctx context.Context) plugins.Manager {
 	manager := getPluginManager()
 	manager.SetSubsonicRouter(CreateSubsonicAPIRouter(ctx))
 	return manager

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -264,13 +264,15 @@ func Load(noConfigDump bool) {
 		os.Exit(1)
 	}
 
-	if Server.Plugins.Folder == "" {
-		Server.Plugins.Folder = filepath.Join(Server.DataFolder, "plugins")
-	}
-	err = os.MkdirAll(Server.Plugins.Folder, 0700)
-	if err != nil {
-		_, _ = fmt.Fprintln(os.Stderr, "FATAL: Error creating plugins path:", err)
-		os.Exit(1)
+	if Server.Plugins.Enabled {
+		if Server.Plugins.Folder == "" {
+			Server.Plugins.Folder = filepath.Join(Server.DataFolder, "plugins")
+		}
+		err = os.MkdirAll(Server.Plugins.Folder, 0700)
+		if err != nil {
+			_, _ = fmt.Fprintln(os.Stderr, "FATAL: Error creating plugins path:", err)
+			os.Exit(1)
+		}
 	}
 
 	Server.ConfigFile = viper.GetViper().ConfigFileUsed()

--- a/plugins/adapter_media_agent.go
+++ b/plugins/adapter_media_agent.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewWasmMediaAgent creates a new adapter for a MetadataAgent plugin
-func newWasmMediaAgent(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmMediaAgent(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewMetadataAgentPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating media metadata service plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/adapter_media_agent_test.go
+++ b/plugins/adapter_media_agent_test.go
@@ -14,7 +14,7 @@ import (
 
 var _ = Describe("Adapter Media Agent", func() {
 	var ctx context.Context
-	var mgr *Manager
+	var mgr *managerImpl
 
 	BeforeEach(func() {
 		ctx = GinkgoT().Context()

--- a/plugins/adapter_scheduler_callback.go
+++ b/plugins/adapter_scheduler_callback.go
@@ -9,7 +9,7 @@ import (
 )
 
 // newWasmSchedulerCallback creates a new adapter for a SchedulerCallback plugin
-func newWasmSchedulerCallback(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmSchedulerCallback(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewSchedulerCallbackPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating scheduler callback plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/adapter_scrobbler.go
+++ b/plugins/adapter_scrobbler.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tetratelabs/wazero"
 )
 
-func newWasmScrobblerPlugin(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmScrobblerPlugin(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewScrobblerPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating scrobbler service plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/adapter_websocket_callback.go
+++ b/plugins/adapter_websocket_callback.go
@@ -9,7 +9,7 @@ import (
 )
 
 // newWasmWebSocketCallback creates a new adapter for a WebSocketCallback plugin
-func newWasmWebSocketCallback(wasmPath, pluginID string, m *Manager, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
+func newWasmWebSocketCallback(wasmPath, pluginID string, m *managerImpl, runtime api.WazeroNewRuntime, mc wazero.ModuleConfig) WasmPlugin {
 	loader, err := api.NewWebSocketCallbackPlugin(context.Background(), api.WazeroRuntime(runtime), api.WazeroModuleConfig(mc))
 	if err != nil {
 		log.Error("Error creating WebSocket callback plugin", "plugin", pluginID, "path", wasmPath, err)

--- a/plugins/host_scheduler.go
+++ b/plugins/host_scheduler.go
@@ -49,13 +49,13 @@ func (s SchedulerHostFunctions) CancelSchedule(ctx context.Context, req *schedul
 type schedulerService struct {
 	// Map of schedule IDs to their callback info
 	schedules  map[string]*ScheduledCallback
-	manager    *Manager
+	manager    *managerImpl
 	navidSched navidsched.Scheduler // Navidrome scheduler for recurring jobs
 	mu         sync.Mutex
 }
 
 // newSchedulerService creates a new schedulerService instance
-func newSchedulerService(manager *Manager) *schedulerService {
+func newSchedulerService(manager *managerImpl) *schedulerService {
 	return &schedulerService{
 		schedules:  make(map[string]*ScheduledCallback),
 		manager:    manager,

--- a/plugins/host_scheduler_test.go
+++ b/plugins/host_scheduler_test.go
@@ -11,7 +11,7 @@ import (
 var _ = Describe("SchedulerService", func() {
 	var (
 		ss         *schedulerService
-		manager    *Manager
+		manager    *managerImpl
 		pluginName = "test_plugin"
 	)
 

--- a/plugins/host_websocket.go
+++ b/plugins/host_websocket.go
@@ -50,12 +50,12 @@ func (s WebSocketHostFunctions) Close(ctx context.Context, req *websocket.CloseR
 // websocketService implements the WebSocket service functionality
 type websocketService struct {
 	connections map[string]*WebSocketConnection
-	manager     *Manager
+	manager     *managerImpl
 	mu          sync.RWMutex
 }
 
 // newWebsocketService creates a new websocketService instance
-func newWebsocketService(manager *Manager) *websocketService {
+func newWebsocketService(manager *managerImpl) *websocketService {
 	return &websocketService{
 		connections: make(map[string]*WebSocketConnection),
 		manager:     manager,

--- a/plugins/host_websocket_test.go
+++ b/plugins/host_websocket_test.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("WebSocket Host Service", func() {
 	var (
 		wsService      *websocketService
-		manager        *Manager
+		manager        *managerImpl
 		ctx            context.Context
 		server         *httptest.Server
 		upgrader       gorillaws.Upgrader

--- a/plugins/manager_test.go
+++ b/plugins/manager_test.go
@@ -11,8 +11,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Plugin Manager", func() {
-	var mgr *Manager
+var _ = Describe("Plugin managerImpl", func() {
+	var mgr *managerImpl
 	var ctx context.Context
 
 	BeforeEach(func() {
@@ -76,7 +76,7 @@ var _ = Describe("Plugin Manager", func() {
 
 	Describe("ScanPlugins", func() {
 		var tempPluginsDir string
-		var m *Manager
+		var m *managerImpl
 
 		BeforeEach(func() {
 			tempPluginsDir, _ = os.MkdirTemp("", "navidrome-plugins-test-*")

--- a/plugins/manager_test.go
+++ b/plugins/manager_test.go
@@ -11,7 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Plugin managerImpl", func() {
+var _ = Describe("Plugin Manager", func() {
 	var mgr *managerImpl
 	var ctx context.Context
 

--- a/plugins/manifest_permissions_test.go
+++ b/plugins/manifest_permissions_test.go
@@ -47,7 +47,7 @@ func createTestPlugin(tempDir, name string, permissions schema.PluginManifestPer
 
 var _ = Describe("Plugin Permissions", func() {
 	var (
-		mgr     *Manager
+		mgr     *managerImpl
 		tempDir string
 		ctx     context.Context
 	)

--- a/plugins/plugin_lifecycle_manager_test.go
+++ b/plugins/plugin_lifecycle_manager_test.go
@@ -18,7 +18,7 @@ func hasInitService(info *plugin) bool {
 }
 
 var _ = Describe("LifecycleManagement", func() {
-	Describe("Plugin Lifecycle Manager", func() {
+	Describe("Plugin Lifecycle managerImpl", func() {
 		var lifecycleManager *pluginLifecycleManager
 
 		BeforeEach(func() {

--- a/plugins/runtime.go
+++ b/plugins/runtime.go
@@ -41,7 +41,7 @@ var (
 
 // createRuntime returns a function that creates a new wazero runtime and instantiates the required host functions
 // based on the given plugin permissions
-func (m *Manager) createRuntime(pluginID string, permissions schema.PluginManifestPermissions) api.WazeroNewRuntime {
+func (m *managerImpl) createRuntime(pluginID string, permissions schema.PluginManifestPermissions) api.WazeroNewRuntime {
 	return func(ctx context.Context) (wazero.Runtime, error) {
 		// Check if runtime already exists
 		if rt, ok := runtimePool.Load(pluginID); ok {
@@ -70,7 +70,7 @@ func (m *Manager) createRuntime(pluginID string, permissions schema.PluginManife
 }
 
 // createCachingRuntime handles the complex logic of setting up a new cachingRuntime
-func (m *Manager) createCachingRuntime(ctx context.Context, pluginID string, permissions schema.PluginManifestPermissions) (*cachingRuntime, error) {
+func (m *managerImpl) createCachingRuntime(ctx context.Context, pluginID string, permissions schema.PluginManifestPermissions) (*cachingRuntime, error) {
 	// Get compilation cache
 	compCache, err := getCompilationCache()
 	if err != nil {
@@ -94,7 +94,7 @@ func (m *Manager) createCachingRuntime(ctx context.Context, pluginID string, per
 }
 
 // setupHostServices configures all the permitted host services for a plugin
-func (m *Manager) setupHostServices(ctx context.Context, r wazero.Runtime, pluginID string, permissions schema.PluginManifestPermissions) error {
+func (m *managerImpl) setupHostServices(ctx context.Context, r wazero.Runtime, pluginID string, permissions schema.PluginManifestPermissions) error {
 	// Define all available host services
 	type hostService struct {
 		name        string

--- a/plugins/runtime_test.go
+++ b/plugins/runtime_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Runtime", func() {
 var _ = Describe("CachingRuntime", func() {
 	var (
 		ctx    context.Context
-		mgr    *Manager
+		mgr    *managerImpl
 		plugin *wasmScrobblerPlugin
 	)
 


### PR DESCRIPTION
### Description
This PR fixes issues with plugin-related warnings and directory creation that were impacting users when plugins are disabled. The changes ensure that plugin operations are only performed when plugins are actually enabled.

**Key Changes:**
1. **Silenced repeated "Plugin not found" warnings**: Eliminated spam warnings for inactive Spotify/Last.fm agents when plugins are disabled
2. **Fixed plugin folder creation**: Ensured the plugin folder is only created when plugins are enabled, preventing permission errors in restrictive environments
3. **Improved plugin system efficiency**: Plugin loading operations are now completely bypassed when `Plugins.Enabled = false`

### Related Issues
Fixes #4292 - This PR addresses the "permission denied" error when creating the plugins directory in environments where plugins are disabled.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Set `Plugins.Enabled = false` in configuration
2. Verify no "Plugin not found" warnings appear in logs for Spotify/Last.fm agents
3. Verify the `/data/plugins` directory is not created when plugins are disabled
4. Test in Docker environments with restrictive permissions to ensure no permission errors occur

### Screenshots / Demos (if applicable)
**Before**: Logs filled with warnings like:
```
level=warning msg="Plugin not found" capability=MetadataAgent name=spotify
```

**After**: Clean logs with no plugin-related warnings when plugins are disabled _and_ no builtin agents are configured.

### Additional Notes
This fix is particularly important for Docker deployments and environments with restrictive file permissions, where the automatic creation of plugin directories can cause startup failures.