### PR TITLE
test(fix): Use /bin/sh as interpreter for mock_mpv.sh - 4301

### DIFF
--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -372,7 +372,7 @@ goto loop
 `
 	} else {
 		scriptExt = ".sh"
-		scriptContent = `#!/bin/bash
+		scriptContent = `#!/bin/sh
 echo "$0"
 for arg in "$@"; do
     echo "$arg"


### PR DESCRIPTION
### Description

Not all systems have bash at `/bin/bash`. `/bin/sh` is POSIX and we can trust it to be present. We don't use any bash features in this simple script so should should be an easy, portable change.

### Related Issues

Fixes #4301

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

In an environment without /bin/bash attempt to run the mpv tests and note the
ones that execute the test sh script fail.

`go test -tags=netgo -count=1 ./core/playback/mpv`

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->
