### PR TITLE
fix(plugins): correct error handling in plugin initialization

### DIFF
--- a/plugins/base_capability.go
+++ b/plugins/base_capability.go
@@ -78,10 +78,6 @@ type wasmPlugin[S any] interface {
 	getMetrics() metrics.Metrics
 }
 
-type errorMapper interface {
-	mapError(err error) error
-}
-
 func callMethod[S any, R any](ctx context.Context, wp WasmPlugin, methodName string, fn func(inst S) (R, error)) (R, error) {
 	// Add a unique call ID to the context for tracing
 	ctx = log.NewContext(ctx, "callID", id.NewRandom())
@@ -101,10 +97,6 @@ func callMethod[S any, R any](ctx context.Context, wp WasmPlugin, methodName str
 	defer done()
 	r, err = checkErr(fn(inst))
 	elapsed := time.Since(start)
-
-	if em, ok := any(p).(errorMapper); ok {
-		err = em.mapError(err)
-	}
 
 	if !errors.Is(err, api.ErrNotImplemented) {
 		id := p.PluginID()

--- a/plugins/plugin_lifecycle_manager.go
+++ b/plugins/plugin_lifecycle_manager.go
@@ -82,7 +82,7 @@ func (m *pluginLifecycleManager) callOnInit(plugin *plugin) error {
 	// Call OnInit
 	callStart := time.Now()
 	_, err = checkErr(initPlugin.OnInit(ctx, req))
-	m.metrics.RecordPluginRequest(ctx, plugin.ID, "OnInit", err != nil, time.Since(callStart).Milliseconds())
+	m.metrics.RecordPluginRequest(ctx, plugin.ID, "OnInit", err == nil, time.Since(callStart).Milliseconds())
 	if err != nil {
 		log.Error("Error initializing plugin", "plugin", plugin.ID, "elapsed", time.Since(start), err)
 		return err


### PR DESCRIPTION
### Description
This PR fixes a bug in plugin initialization error handling where the success/failure metric was inverted. The fix ensures that plugin initialization metrics correctly reflect the actual success or failure status of the operation.

Additionally, removes the unused `errorMapper` interface and related code that was no longer needed.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Start Navidrome with plugins enabled
2. Monitor plugin initialization metrics
3. Verify that success/failure metrics are correctly recorded
4. Check that plugins initialize without errors

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
The main changes:
- Fixed inverted boolean logic in `plugin_lifecycle_manager.go` where `err != nil` was incorrectly used instead of `err == nil` for the success metric
- Removed unused `errorMapper` interface and related code from `base_capability.go`

These changes ensure that plugin initialization metrics accurately reflect the actual success/failure status, which is important for monitoring and debugging plugin behavior.