### PR TITLE
Fix replaygain mapping for Subsonic Artist Radio and Top Songs

### DIFF
--- a/ui/src/artist/ArtistActions.test.jsx
+++ b/ui/src/artist/ArtistActions.test.jsx
@@ -53,7 +53,19 @@ describe('ArtistActions', () => {
       json: {
         'subsonic-response': {
           status: 'ok',
-          similarSongs2: { song: [{ id: 'rec1' }] },
+          similarSongs2: {
+            song: [
+              {
+                id: 'rec1',
+                replayGain: {
+                  albumGain: -5,
+                  albumPeak: 1,
+                  trackGain: -6,
+                  trackPeak: 0.8,
+                },
+              },
+            ],
+          },
         },
       },
     })
@@ -61,7 +73,19 @@ describe('ArtistActions', () => {
       json: {
         'subsonic-response': {
           status: 'ok',
-          topSongs: { song: [{ id: 'rec1' }] },
+          topSongs: {
+            song: [
+              {
+                id: 'rec1',
+                replayGain: {
+                  albumGain: -5,
+                  albumPeak: 1,
+                  trackGain: -6,
+                  trackPeak: 0.8,
+                },
+              },
+            ],
+          },
         },
       },
     })
@@ -93,6 +117,20 @@ describe('ArtistActions', () => {
       )
       expect(mockDispatch).toHaveBeenCalled()
     })
+
+    it('maps replaygain info', async () => {
+      renderArtistActions()
+      clickActionButton('radio')
+
+      await waitFor(() =>
+        expect(subsonic.getSimilarSongs2).toHaveBeenCalledWith('ar1', 100),
+      )
+      const action = mockDispatch.mock.calls[0][0]
+      expect(action.data.rec1.rgAlbumGain).toBe(-5)
+      expect(action.data.rec1.rgAlbumPeak).toBe(1)
+      expect(action.data.rec1.rgTrackGain).toBe(-6)
+      expect(action.data.rec1.rgTrackPeak).toBe(0.8)
+    })
   })
 
   describe('Play action', () => {
@@ -104,6 +142,20 @@ describe('ArtistActions', () => {
         expect(subsonic.getTopSongs).toHaveBeenCalledWith('Artist', 100),
       )
       expect(mockDispatch).toHaveBeenCalled()
+    })
+
+    it('maps replaygain info for top songs', async () => {
+      renderArtistActions()
+      clickActionButton('topSongs')
+
+      await waitFor(() =>
+        expect(subsonic.getTopSongs).toHaveBeenCalledWith('Artist', 100),
+      )
+      const action = mockDispatch.mock.calls[0][0]
+      expect(action.data.rec1.rgAlbumGain).toBe(-5)
+      expect(action.data.rec1.rgAlbumPeak).toBe(1)
+      expect(action.data.rec1.rgTrackGain).toBe(-6)
+      expect(action.data.rec1.rgTrackPeak).toBe(0.8)
     })
 
     it('handles API rejection', async () => {

--- a/ui/src/artist/ArtistActions.test.jsx
+++ b/ui/src/artist/ArtistActions.test.jsx
@@ -49,23 +49,21 @@ describe('ArtistActions', () => {
     // Mock console.error to suppress error logging in tests
     vi.spyOn(console, 'error').mockImplementation(() => {})
 
+    const songWithReplayGain = {
+      id: 'rec1',
+      replayGain: {
+        albumGain: -5,
+        albumPeak: 1,
+        trackGain: -6,
+        trackPeak: 0.8,
+      },
+    }
+
     subsonic.getSimilarSongs2.mockResolvedValue({
       json: {
         'subsonic-response': {
           status: 'ok',
-          similarSongs2: {
-            song: [
-              {
-                id: 'rec1',
-                replayGain: {
-                  albumGain: -5,
-                  albumPeak: 1,
-                  trackGain: -6,
-                  trackPeak: 0.8,
-                },
-              },
-            ],
-          },
+          similarSongs2: { song: [songWithReplayGain] },
         },
       },
     })
@@ -73,19 +71,7 @@ describe('ArtistActions', () => {
       json: {
         'subsonic-response': {
           status: 'ok',
-          topSongs: {
-            song: [
-              {
-                id: 'rec1',
-                replayGain: {
-                  albumGain: -5,
-                  albumPeak: 1,
-                  trackGain: -6,
-                  trackPeak: 0.8,
-                },
-              },
-            ],
-          },
+          topSongs: { song: [songWithReplayGain] },
         },
       },
     })
@@ -126,10 +112,12 @@ describe('ArtistActions', () => {
         expect(subsonic.getSimilarSongs2).toHaveBeenCalledWith('ar1', 100),
       )
       const action = mockDispatch.mock.calls[0][0]
-      expect(action.data.rec1.rgAlbumGain).toBe(-5)
-      expect(action.data.rec1.rgAlbumPeak).toBe(1)
-      expect(action.data.rec1.rgTrackGain).toBe(-6)
-      expect(action.data.rec1.rgTrackPeak).toBe(0.8)
+      expect(action.data.rec1).toMatchObject({
+        rgAlbumGain: -5,
+        rgAlbumPeak: 1,
+        rgTrackGain: -6,
+        rgTrackPeak: 0.8,
+      })
     })
   })
 
@@ -152,10 +140,12 @@ describe('ArtistActions', () => {
         expect(subsonic.getTopSongs).toHaveBeenCalledWith('Artist', 100),
       )
       const action = mockDispatch.mock.calls[0][0]
-      expect(action.data.rec1.rgAlbumGain).toBe(-5)
-      expect(action.data.rec1.rgAlbumPeak).toBe(1)
-      expect(action.data.rec1.rgTrackGain).toBe(-6)
-      expect(action.data.rec1.rgTrackPeak).toBe(0.8)
+      expect(action.data.rec1).toMatchObject({
+        rgAlbumGain: -5,
+        rgAlbumPeak: 1,
+        rgTrackGain: -6,
+        rgTrackPeak: 0.8,
+      })
     })
 
     it('handles API rejection', async () => {

--- a/ui/src/artist/actions.js
+++ b/ui/src/artist/actions.js
@@ -1,15 +1,30 @@
 import subsonic from '../subsonic/index.js'
 import { playTracks } from '../actions/index.js'
 
-const mapSubsonicSong = (song) => {
-  const rg = song.replayGain
-  if (rg) {
-    if (rg.albumGain !== undefined) song.rgAlbumGain = rg.albumGain
-    if (rg.albumPeak !== undefined) song.rgAlbumPeak = rg.albumPeak
-    if (rg.trackGain !== undefined) song.rgTrackGain = rg.trackGain
-    if (rg.trackPeak !== undefined) song.rgTrackPeak = rg.trackPeak
+const mapReplayGain = (song) => {
+  const { replayGain: rg } = song
+  if (!rg) {
+    return song
   }
-  return song
+
+  return {
+    ...song,
+    ...(rg.albumGain !== undefined && { rgAlbumGain: rg.albumGain }),
+    ...(rg.albumPeak !== undefined && { rgAlbumPeak: rg.albumPeak }),
+    ...(rg.trackGain !== undefined && { rgTrackGain: rg.trackGain }),
+    ...(rg.trackPeak !== undefined && { rgTrackPeak: rg.trackPeak }),
+  }
+}
+
+const processSongsForPlayback = (songs) => {
+  const songData = {}
+  const ids = []
+  songs.forEach((s) => {
+    const song = mapReplayGain(s)
+    songData[song.id] = song
+    ids.push(song.id)
+  })
+  return { songData, ids }
 }
 
 export const playTopSongs = async (dispatch, notify, artistName) => {
@@ -28,13 +43,7 @@ export const playTopSongs = async (dispatch, notify, artistName) => {
     return
   }
 
-  const songData = {}
-  const ids = []
-  songs.forEach((s) => {
-    const song = mapSubsonicSong(s)
-    songData[song.id] = song
-    ids.push(song.id)
-  })
+  const { songData, ids } = processSongsForPlayback(songs)
   dispatch(playTracks(songData, ids))
 }
 
@@ -54,13 +63,7 @@ export const playSimilar = async (dispatch, notify, id) => {
     return
   }
 
-  const songData = {}
-  const ids = []
-  songs.forEach((s) => {
-    const song = mapSubsonicSong(s)
-    songData[song.id] = song
-    ids.push(song.id)
-  })
+  const { songData, ids } = processSongsForPlayback(songs)
   dispatch(playTracks(songData, ids))
 }
 

--- a/ui/src/artist/actions.js
+++ b/ui/src/artist/actions.js
@@ -1,7 +1,7 @@
 import subsonic from '../subsonic/index.js'
 import { playTracks } from '../actions/index.js'
 
-const mapReplayGain = (song) => {
+const mapSubsonicSong = (song) => {
   const rg = song.replayGain
   if (rg) {
     if (rg.albumGain !== undefined) song.rgAlbumGain = rg.albumGain
@@ -31,7 +31,7 @@ export const playTopSongs = async (dispatch, notify, artistName) => {
   const songData = {}
   const ids = []
   songs.forEach((s) => {
-    const song = mapReplayGain(s)
+    const song = mapSubsonicSong(s)
     songData[song.id] = song
     ids.push(song.id)
   })
@@ -57,7 +57,7 @@ export const playSimilar = async (dispatch, notify, id) => {
   const songData = {}
   const ids = []
   songs.forEach((s) => {
-    const song = mapReplayGain(s)
+    const song = mapSubsonicSong(s)
     songData[song.id] = song
     ids.push(song.id)
   })

--- a/ui/src/artist/actions.js
+++ b/ui/src/artist/actions.js
@@ -1,6 +1,17 @@
 import subsonic from '../subsonic/index.js'
 import { playTracks } from '../actions/index.js'
 
+const mapReplayGain = (song) => {
+  const rg = song.replayGain
+  if (rg) {
+    if (rg.albumGain !== undefined) song.rgAlbumGain = rg.albumGain
+    if (rg.albumPeak !== undefined) song.rgAlbumPeak = rg.albumPeak
+    if (rg.trackGain !== undefined) song.rgTrackGain = rg.trackGain
+    if (rg.trackPeak !== undefined) song.rgTrackPeak = rg.trackPeak
+  }
+  return song
+}
+
 export const playTopSongs = async (dispatch, notify, artistName) => {
   const res = await subsonic.getTopSongs(artistName, 100)
   const data = res.json['subsonic-response']
@@ -20,8 +31,9 @@ export const playTopSongs = async (dispatch, notify, artistName) => {
   const songData = {}
   const ids = []
   songs.forEach((s) => {
-    songData[s.id] = s
-    ids.push(s.id)
+    const song = mapReplayGain(s)
+    songData[song.id] = song
+    ids.push(song.id)
   })
   dispatch(playTracks(songData, ids))
 }
@@ -45,8 +57,9 @@ export const playSimilar = async (dispatch, notify, id) => {
   const songData = {}
   const ids = []
   songs.forEach((s) => {
-    songData[s.id] = s
-    ids.push(s.id)
+    const song = mapReplayGain(s)
+    songData[song.id] = song
+    ids.push(song.id)
   })
   dispatch(playTracks(songData, ids))
 }


### PR DESCRIPTION
### Description
This PR fixes the bug where artist radios (similar songs) were ignoring replaygain information, causing songs to be played at much louder volumes than when played manually.

The issue was that the `getSimilarSongs2` and `getTopSongs` Subsonic API endpoints return replaygain data in a different format (`replayGain` object) than what the frontend expects (`rgAlbumGain`, `rgAlbumPeak`, `rgTrackGain`, `rgTrackPeak` fields). This PR adds proper mapping between these formats to ensure replaygain information is correctly passed to the playback system.

### Related Issues
Fixes #4299

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Enable replaygain in Navidrome settings
2. Ensure your music library has files with replaygain tags
3. Start an artist radio from any artist page
4. Verify that songs play at the expected volume level (consistent with manual playback)
5. Test both "Play top songs" and "Play similar songs" functions
6. Compare the perceived volume with manually playing the same songs

### Screenshots / Demos (if applicable)
N/A - This is an audio-related bug fix with no visual changes.

### Additional Notes
- The fix adds a `mapSubsonicSong` function that maps the `replayGain` object from Subsonic API responses to the expected frontend format
- Comprehensive test coverage has been added to verify the mapping works correctly for both radio and top songs functionality
- This change only affects the artist actions (radio and top songs) - other playback methods were already working correctly
- The mapping is defensive and only adds the replaygain fields if they exist in the source data

This PR addresses the volume inconsistency issue reported in #4299 by ensuring replaygain information is properly preserved when starting artist radios.