### PR TITLE
feat(plugin): add TimeNow function to SchedulerService

### DIFF
--- a/plugins/api/api.pb.go
+++ b/plugins/api/api.pb.go
@@ -903,7 +903,6 @@ type InitRequest struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// Empty for now
 	Config map[string]string `protobuf:"bytes,1,rep,name=config,proto3" json:"config,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"` // Configuration specific to this plugin
 }
 

--- a/plugins/api/api.proto
+++ b/plugins/api/api.proto
@@ -194,7 +194,6 @@ service LifecycleManagement {
 }
 
 message InitRequest {
-  // Empty for now
   map<string, string> config = 1;  // Configuration specific to this plugin
 }
 

--- a/plugins/api/api_plugin_dev_named_registry.go
+++ b/plugins/api/api_plugin_dev_named_registry.go
@@ -88,3 +88,7 @@ func (n *namedSchedulerService) CancelSchedule(ctx context.Context, request *sch
 	request.ScheduleId = key
 	return n.svc.CancelSchedule(ctx, request)
 }
+
+func (n *namedSchedulerService) TimeNow(ctx context.Context, request *scheduler.TimeNowRequest) (*scheduler.TimeNowResponse, error) {
+	return n.svc.TimeNow(ctx, request)
+}

--- a/plugins/host/scheduler/scheduler.pb.go
+++ b/plugins/host/scheduler/scheduler.pb.go
@@ -169,8 +169,9 @@ type TimeNowResponse struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	Rfc3339Nano string `protobuf:"bytes,1,opt,name=rfc3339_nano,json=rfc3339Nano,proto3" json:"rfc3339_nano,omitempty"` // Current time in RFC3339Nano format
-	UnixMilli   int64  `protobuf:"varint,2,opt,name=unix_milli,json=unixMilli,proto3" json:"unix_milli,omitempty"`      // Current time as Unix milliseconds timestamp
+	Rfc3339Nano   string `protobuf:"bytes,1,opt,name=rfc3339_nano,json=rfc3339Nano,proto3" json:"rfc3339_nano,omitempty"`         // Current time in RFC3339Nano format
+	UnixMilli     int64  `protobuf:"varint,2,opt,name=unix_milli,json=unixMilli,proto3" json:"unix_milli,omitempty"`              // Current time as Unix milliseconds timestamp
+	LocalTimeZone string `protobuf:"bytes,3,opt,name=local_time_zone,json=localTimeZone,proto3" json:"local_time_zone,omitempty"` // Local timezone name (e.g., "America/New_York", "UTC")
 }
 
 func (x *TimeNowResponse) ProtoReflect() protoreflect.Message {
@@ -189,6 +190,13 @@ func (x *TimeNowResponse) GetUnixMilli() int64 {
 		return x.UnixMilli
 	}
 	return 0
+}
+
+func (x *TimeNowResponse) GetLocalTimeZone() string {
+	if x != nil {
+		return x.LocalTimeZone
+	}
+	return ""
 }
 
 // go:plugin type=host version=1

--- a/plugins/host/scheduler/scheduler.pb.go
+++ b/plugins/host/scheduler/scheduler.pb.go
@@ -154,6 +154,43 @@ func (x *CancelResponse) GetError() string {
 	return ""
 }
 
+type TimeNowRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *TimeNowRequest) ProtoReflect() protoreflect.Message {
+	panic(`not implemented`)
+}
+
+type TimeNowResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Rfc3339Nano string `protobuf:"bytes,1,opt,name=rfc3339_nano,json=rfc3339Nano,proto3" json:"rfc3339_nano,omitempty"` // Current time in RFC3339Nano format
+	UnixMilli   int64  `protobuf:"varint,2,opt,name=unix_milli,json=unixMilli,proto3" json:"unix_milli,omitempty"`      // Current time as Unix milliseconds timestamp
+}
+
+func (x *TimeNowResponse) ProtoReflect() protoreflect.Message {
+	panic(`not implemented`)
+}
+
+func (x *TimeNowResponse) GetRfc3339Nano() string {
+	if x != nil {
+		return x.Rfc3339Nano
+	}
+	return ""
+}
+
+func (x *TimeNowResponse) GetUnixMilli() int64 {
+	if x != nil {
+		return x.UnixMilli
+	}
+	return 0
+}
+
 // go:plugin type=host version=1
 type SchedulerService interface {
 	// One-time event scheduling
@@ -162,4 +199,6 @@ type SchedulerService interface {
 	ScheduleRecurring(context.Context, *ScheduleRecurringRequest) (*ScheduleResponse, error)
 	// Cancel any scheduled job
 	CancelSchedule(context.Context, *CancelRequest) (*CancelResponse, error)
+	// Get current time in multiple formats
+	TimeNow(context.Context, *TimeNowRequest) (*TimeNowResponse, error)
 }

--- a/plugins/host/scheduler/scheduler.proto
+++ b/plugins/host/scheduler/scheduler.proto
@@ -51,4 +51,5 @@ message TimeNowRequest {
 message TimeNowResponse {
     string rfc3339_nano = 1;       // Current time in RFC3339Nano format
     int64 unix_milli = 2;          // Current time as Unix milliseconds timestamp
+    string local_time_zone = 3;    // Local timezone name (e.g., "America/New_York", "UTC")
 } 

--- a/plugins/host/scheduler/scheduler.proto
+++ b/plugins/host/scheduler/scheduler.proto
@@ -14,6 +14,9 @@ service SchedulerService {
     
     // Cancel any scheduled job
     rpc CancelSchedule(CancelRequest) returns (CancelResponse);
+    
+    // Get current time in multiple formats
+    rpc TimeNow(TimeNowRequest) returns (TimeNowResponse);
 }
 
 message ScheduleOneTimeRequest {
@@ -39,4 +42,13 @@ message CancelRequest {
 message CancelResponse {
     bool success = 1;              // Whether cancellation was successful
     string error = 2;              // Error message if cancellation failed
+}
+
+message TimeNowRequest {
+    // Empty request - no parameters needed
+}
+
+message TimeNowResponse {
+    string rfc3339_nano = 1;       // Current time in RFC3339Nano format
+    int64 unix_milli = 2;          // Current time as Unix milliseconds timestamp
 } 

--- a/plugins/host/scheduler/scheduler_plugin.pb.go
+++ b/plugins/host/scheduler/scheduler_plugin.pb.go
@@ -88,3 +88,26 @@ func (h schedulerService) CancelSchedule(ctx context.Context, request *CancelReq
 	}
 	return response, nil
 }
+
+//go:wasmimport env time_now
+func _time_now(ptr uint32, size uint32) uint64
+
+func (h schedulerService) TimeNow(ctx context.Context, request *TimeNowRequest) (*TimeNowResponse, error) {
+	buf, err := request.MarshalVT()
+	if err != nil {
+		return nil, err
+	}
+	ptr, size := wasm.ByteToPtr(buf)
+	ptrSize := _time_now(ptr, size)
+	wasm.Free(ptr)
+
+	ptr = uint32(ptrSize >> 32)
+	size = uint32(ptrSize)
+	buf = wasm.PtrToByte(ptr, size)
+
+	response := new(TimeNowResponse)
+	if err = response.UnmarshalVT(buf); err != nil {
+		return nil, err
+	}
+	return response, nil
+}

--- a/plugins/host/scheduler/scheduler_vtproto.pb.go
+++ b/plugins/host/scheduler/scheduler_vtproto.pb.go
@@ -319,6 +319,13 @@ func (m *TimeNowResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 		i -= len(m.unknownFields)
 		copy(dAtA[i:], m.unknownFields)
 	}
+	if len(m.LocalTimeZone) > 0 {
+		i -= len(m.LocalTimeZone)
+		copy(dAtA[i:], m.LocalTimeZone)
+		i = encodeVarint(dAtA, i, uint64(len(m.LocalTimeZone)))
+		i--
+		dAtA[i] = 0x1a
+	}
 	if m.UnixMilli != 0 {
 		i = encodeVarint(dAtA, i, uint64(m.UnixMilli))
 		i--
@@ -455,6 +462,10 @@ func (m *TimeNowResponse) SizeVT() (n int) {
 	}
 	if m.UnixMilli != 0 {
 		n += 1 + sov(uint64(m.UnixMilli))
+	}
+	l = len(m.LocalTimeZone)
+	if l > 0 {
+		n += 1 + l + sov(uint64(l))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -1151,6 +1162,38 @@ func (m *TimeNowResponse) UnmarshalVT(dAtA []byte) error {
 					break
 				}
 			}
+		case 3:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field LocalTimeZone", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.LocalTimeZone = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
 		default:
 			iNdEx = preIndex
 			skippy, err := skip(dAtA[iNdEx:])

--- a/plugins/host/scheduler/scheduler_vtproto.pb.go
+++ b/plugins/host/scheduler/scheduler_vtproto.pb.go
@@ -256,6 +256,84 @@ func (m *CancelResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *TimeNowRequest) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TimeNowRequest) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *TimeNowRequest) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *TimeNowResponse) MarshalVT() (dAtA []byte, err error) {
+	if m == nil {
+		return nil, nil
+	}
+	size := m.SizeVT()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBufferVT(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *TimeNowResponse) MarshalToVT(dAtA []byte) (int, error) {
+	size := m.SizeVT()
+	return m.MarshalToSizedBufferVT(dAtA[:size])
+}
+
+func (m *TimeNowResponse) MarshalToSizedBufferVT(dAtA []byte) (int, error) {
+	if m == nil {
+		return 0, nil
+	}
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.unknownFields != nil {
+		i -= len(m.unknownFields)
+		copy(dAtA[i:], m.unknownFields)
+	}
+	if m.UnixMilli != 0 {
+		i = encodeVarint(dAtA, i, uint64(m.UnixMilli))
+		i--
+		dAtA[i] = 0x10
+	}
+	if len(m.Rfc3339Nano) > 0 {
+		i -= len(m.Rfc3339Nano)
+		copy(dAtA[i:], m.Rfc3339Nano)
+		i = encodeVarint(dAtA, i, uint64(len(m.Rfc3339Nano)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarint(dAtA []byte, offset int, v uint64) int {
 	offset -= sov(v)
 	base := offset
@@ -350,6 +428,33 @@ func (m *CancelResponse) SizeVT() (n int) {
 	l = len(m.Error)
 	if l > 0 {
 		n += 1 + l + sov(uint64(l))
+	}
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *TimeNowRequest) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	n += len(m.unknownFields)
+	return n
+}
+
+func (m *TimeNowResponse) SizeVT() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Rfc3339Nano)
+	if l > 0 {
+		n += 1 + l + sov(uint64(l))
+	}
+	if m.UnixMilli != 0 {
+		n += 1 + sov(uint64(m.UnixMilli))
 	}
 	n += len(m.unknownFields)
 	return n
@@ -893,6 +998,159 @@ func (m *CancelResponse) UnmarshalVT(dAtA []byte) error {
 			}
 			m.Error = string(dAtA[iNdEx:postIndex])
 			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TimeNowRequest) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TimeNowRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TimeNowRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skip(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLength
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.unknownFields = append(m.unknownFields, dAtA[iNdEx:iNdEx+skippy]...)
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *TimeNowResponse) UnmarshalVT(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflow
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: TimeNowResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: TimeNowResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Rfc3339Nano", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLength
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLength
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Rfc3339Nano = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		case 2:
+			if wireType != 0 {
+				return fmt.Errorf("proto: wrong wireType = %d for field UnixMilli", wireType)
+			}
+			m.UnixMilli = 0
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflow
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				m.UnixMilli |= int64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
 		default:
 			iNdEx = preIndex
 			skippy, err := skip(dAtA[iNdEx:])

--- a/plugins/host_scheduler.go
+++ b/plugins/host_scheduler.go
@@ -45,6 +45,10 @@ func (s SchedulerHostFunctions) CancelSchedule(ctx context.Context, req *schedul
 	return s.ss.cancelSchedule(ctx, s.pluginID, req)
 }
 
+func (s SchedulerHostFunctions) TimeNow(ctx context.Context, req *scheduler.TimeNowRequest) (*scheduler.TimeNowResponse, error) {
+	return s.ss.timeNow(ctx, req)
+}
+
 type schedulerService struct {
 	// Map of schedule IDs to their callback info
 	schedules  map[string]*ScheduledCallback
@@ -257,6 +261,16 @@ func (s *schedulerService) cancelSchedule(_ context.Context, pluginID string, re
 
 	return &scheduler.CancelResponse{
 		Success: true,
+	}, nil
+}
+
+// timeNow returns the current time in multiple formats
+func (s *schedulerService) timeNow(_ context.Context, req *scheduler.TimeNowRequest) (*scheduler.TimeNowResponse, error) {
+	now := time.Now()
+
+	return &scheduler.TimeNowResponse{
+		Rfc3339Nano: now.Format(time.RFC3339Nano),
+		UnixMilli:   now.UnixMilli(),
 	}, nil
 }
 

--- a/plugins/host_scheduler.go
+++ b/plugins/host_scheduler.go
@@ -269,8 +269,9 @@ func (s *schedulerService) timeNow(_ context.Context, req *scheduler.TimeNowRequ
 	now := time.Now()
 
 	return &scheduler.TimeNowResponse{
-		Rfc3339Nano: now.Format(time.RFC3339Nano),
-		UnixMilli:   now.UnixMilli(),
+		Rfc3339Nano:   now.Format(time.RFC3339Nano),
+		UnixMilli:     now.UnixMilli(),
+		LocalTimeZone: now.Location().String(),
 	}, nil
 }
 

--- a/plugins/host_scheduler_test.go
+++ b/plugins/host_scheduler_test.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"context"
+	"time"
 
 	"github.com/navidrome/navidrome/core/metrics"
 	"github.com/navidrome/navidrome/plugins/host/scheduler"
@@ -162,6 +163,25 @@ var _ = Describe("SchedulerService", func() {
 				return ss.hasSchedule(pluginName + ":" + "replace-cron")
 			}).Should(BeTrue(), "Schedule should exist after replacement")
 			Expect(ss.scheduleCount()).To(Equal(beforeCount), "Job count should remain the same after replacement")
+		})
+	})
+
+	Describe("TimeNow", func() {
+		It("returns current time in RFC3339Nano and Unix milliseconds", func() {
+			now := time.Now()
+			req := &scheduler.TimeNowRequest{}
+			resp, err := ss.timeNow(context.Background(), req)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(resp.UnixMilli).To(BeNumerically(">=", now.UnixMilli()))
+
+			// Validate RFC3339Nano format can be parsed
+			parsedTime, parseErr := time.Parse(time.RFC3339Nano, resp.Rfc3339Nano)
+			Expect(parseErr).ToNot(HaveOccurred())
+
+			// Validate that Unix milliseconds is reasonably close to the RFC3339Nano time
+			expectedMillis := parsedTime.UnixMilli()
+			Expect(resp.UnixMilli).To(Equal(expectedMillis))
 		})
 	})
 })

--- a/plugins/host_scheduler_test.go
+++ b/plugins/host_scheduler_test.go
@@ -167,13 +167,14 @@ var _ = Describe("SchedulerService", func() {
 	})
 
 	Describe("TimeNow", func() {
-		It("returns current time in RFC3339Nano and Unix milliseconds", func() {
+		It("returns current time in RFC3339Nano, Unix milliseconds, and local timezone", func() {
 			now := time.Now()
 			req := &scheduler.TimeNowRequest{}
 			resp, err := ss.timeNow(context.Background(), req)
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(resp.UnixMilli).To(BeNumerically(">=", now.UnixMilli()))
+			Expect(resp.LocalTimeZone).ToNot(BeEmpty())
 
 			// Validate RFC3339Nano format can be parsed
 			parsedTime, parseErr := time.Parse(time.RFC3339Nano, resp.Rfc3339Nano)
@@ -182,6 +183,10 @@ var _ = Describe("SchedulerService", func() {
 			// Validate that Unix milliseconds is reasonably close to the RFC3339Nano time
 			expectedMillis := parsedTime.UnixMilli()
 			Expect(resp.UnixMilli).To(Equal(expectedMillis))
+
+			// Validate local timezone matches the current system timezone
+			expectedTimezone := now.Location().String()
+			Expect(resp.LocalTimeZone).To(Equal(expectedTimezone))
 		})
 	})
 })


### PR DESCRIPTION
### Description
This PR adds a new `TimeNow` function to the SchedulerService plugin system that returns the current time in multiple formats for plugin use. This enhancement allows plugins to access current time information in standardized formats without requiring additional host services.

### Related Issues

### Type of Change
- [x] New feature

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### Changes Made

#### 1. Enhanced SchedulerService Plugin API
- Added `TimeNow` RPC method to scheduler.proto
- Returns current time in three formats:
  - `rfc3339_nano`: RFC3339 format with nanosecond precision
  - `unix_milli`: Unix timestamp in milliseconds
  - `local_time_zone`: Local timezone name (e.g., "UTC", "America/New_York")

#### 2. Implementation Details
- **Protocol Buffer Definition**: Added `TimeNowRequest` (empty) and `TimeNowResponse` messages
- **Go Implementation**: Added `TimeNow` method to `SchedulerHostFunctions` interface and `schedulerService` implementation
- **Generated Code**: Updated all protobuf bindings for Go and WebAssembly interfaces

#### 3. Testing
- Added comprehensive test coverage in `host_scheduler_test.go`
- Tests validate RFC3339 format parsing, Unix milliseconds accuracy, and timezone matching
- All existing tests continue to pass

### How to Test
1. Run the scheduler tests: `make test PKG=./plugins/host/scheduler/...`
2. Build the project: `make build`
3. All tests should pass and the new TimeNow functionality should be available to plugins

### Technical Implementation
```go
// Example usage from plugin perspective
timeResponse := scheduler.TimeNow()
// timeResponse.Rfc3339Nano = "2024-01-15T10:30:45.123456789Z"
// timeResponse.UnixMilli = 1705312245123
// timeResponse.LocalTimeZone = "UTC"
```

The implementation uses Go's `time.Now()` with:
- `Format(time.RFC3339Nano)` for high-precision string representation
- `UnixMilli()` for efficient numeric timestamp
- `Location().String()` for timezone information

### Additional Notes
This enhancement maintains backward compatibility with existing scheduler functionality while adding new time access capabilities for plugins. The implementation follows existing patterns in the Navidrome plugin system and includes proper error handling and testing.