### PR TITLE
fix: headless library access improvements

### DIFF
--- a/core/share.go
+++ b/core/share.go
@@ -149,7 +149,7 @@ func (r *shareRepositoryWrapper) contentsLabelFromArtist(shareID string, ids str
 
 func (r *shareRepositoryWrapper) contentsLabelFromAlbums(shareID string, ids string) string {
 	idList := strings.Split(ids, ",")
-	all, err := r.ds.Album(r.ctx).GetAll(model.QueryOptions{Filters: squirrel.Eq{"id": idList}})
+	all, err := r.ds.Album(r.ctx).GetAll(model.QueryOptions{Filters: squirrel.Eq{"album.id": idList}})
 	if err != nil {
 		log.Error(r.ctx, "Error retrieving album names for share", "share", shareID, err)
 		return ""

--- a/model/tag.go
+++ b/model/tag.go
@@ -12,11 +12,11 @@ import (
 )
 
 type Tag struct {
-	ID             string  `json:"id,omitempty"`
-	TagName        TagName `json:"tagName,omitempty"`
-	TagValue       string  `json:"tagValue,omitempty"`
-	AlbumCount     int     `json:"albumCount,omitempty"`
-	MediaFileCount int     `json:"songCount,omitempty"`
+	ID         string  `json:"id,omitempty"`
+	TagName    TagName `json:"tagName,omitempty"`
+	TagValue   string  `json:"tagValue,omitempty"`
+	AlbumCount int     `json:"albumCount,omitempty"`
+	SongCount  int     `json:"songCount,omitempty"`
 }
 
 type TagList []Tag

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -171,8 +171,8 @@ func artistLibraryIdFilter(_ string, value interface{}) Sqlizer {
 func (r *artistRepository) applyLibraryFilterToArtistQuery(query SelectBuilder) SelectBuilder {
 	user := loggedUser(r.ctx)
 	if user.ID == invalidUserId {
-		// No user context - return empty result set
-		return query.Where(Eq{"1": "0"})
+		// No user context - skip library filtering
+		return query
 	}
 
 	// Apply library filtering by joining only with accessible libraries

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -174,8 +174,9 @@ func (r *artistRepository) applyLibraryFilterToArtistQuery(query SelectBuilder) 
 	// Exclude artists with empty stats (no actual content in the library)
 	query = query.Join("library_artist on library_artist.artist_id = artist.id AND library_artist.stats != '{}'")
 
-	if user.ID != invalidUserId {
-		// Apply library filtering by joining only with accessible libraries
+	// Admin users see all artists from all libraries, no additional filtering needed
+	if user.ID != invalidUserId && !user.IsAdmin {
+		// Apply library filtering only for non-admin users by joining with their accessible libraries
 		query = query.Join("user_library on user_library.library_id = library_artist.library_id AND user_library.user_id = ?", user.ID)
 	}
 

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -170,14 +170,11 @@ func artistLibraryIdFilter(_ string, value interface{}) Sqlizer {
 // applyLibraryFilterToArtistQuery applies library filtering to artist queries through the library_artist junction table
 func (r *artistRepository) applyLibraryFilterToArtistQuery(query SelectBuilder) SelectBuilder {
 	user := loggedUser(r.ctx)
-	if user.ID == invalidUserId {
-		// No user context - skip library filtering
-		return query
+	if user.ID != invalidUserId {
+		// Apply library filtering by joining only with accessible libraries
+		query = query.Join("user_library on user_library.library_id = library_artist.library_id AND user_library.user_id = ?", user.ID)
 	}
-
-	// Apply library filtering by joining only with accessible libraries
-	query = query.LeftJoin("library_artist on library_artist.artist_id = artist.id").
-		Join("user_library on user_library.library_id = library_artist.library_id AND user_library.user_id = ?", user.ID)
+	query = query.LeftJoin("library_artist on library_artist.artist_id = artist.id")
 
 	return query
 }

--- a/persistence/artist_repository_test.go
+++ b/persistence/artist_repository_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/navidrome/navidrome/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/pocketbase/dbx"
 )
 
 var _ = Describe("ArtistRepository", func() {
@@ -293,13 +292,12 @@ var _ = Describe("ArtistRepository", func() {
 				})
 
 				AfterEach(func() {
-					// Restore original stats for library_artist table - tests expect non-empty stats
-					defaultStats := `{"albumartist":{"albumCount":1,"songCount":1}}`
+					// Clean up stats from library_artist table
 					_, _ = raw.executeSQL(squirrel.Update("library_artist").
-						Set("stats", defaultStats).
+						Set("stats", "{}").
 						Where(squirrel.Eq{"artist_id": artistBeatles.ID, "library_id": 1}))
 					_, _ = raw.executeSQL(squirrel.Update("library_artist").
-						Set("stats", defaultStats).
+						Set("stats", "{}").
 						Where(squirrel.Eq{"artist_id": artistKraftwerk.ID, "library_id": 1}))
 				})
 
@@ -596,12 +594,6 @@ var _ = Describe("ArtistRepository", func() {
 				err = lr.AddArtist(1, missing.ID)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Populate stats for the missing artist so it can be found by library filtering
-				_, err = raw.executeSQL(squirrel.Update("library_artist").
-					Set("stats", `{"albumartist":{"albumCount":1,"songCount":1}}`).
-					Where(squirrel.Eq{"library_id": 1, "artist_id": missing.ID}))
-				Expect(err).ToNot(HaveOccurred())
-
 				// Ensure the test user exists and has library access
 				ur := NewUserRepository(request.WithUser(GinkgoT().Context(), adminUser), GetDBXBuilder())
 				currentUser, ok := request.UserFrom(repo.(*artistRepository).ctx)
@@ -891,14 +883,8 @@ var _ = Describe("ArtistRepository", func() {
 				})
 
 				It("should allow headless processes to apply explicit library_id filters", func() {
-					// Add artists to different libraries with stats
+					// Add artists to different libraries
 					err := lr.AddArtist(lib2.ID, artistBeatles.ID)
-					Expect(err).ToNot(HaveOccurred())
-
-					// Populate stats for the new library association so artist is visible with filtering
-					conn := GetDBXBuilder()
-					_, err = conn.NewQuery("UPDATE library_artist SET stats = '{\"albumartist\":{\"albumCount\":1,\"songCount\":1}}' WHERE artist_id = {:artist_id} AND library_id = {:library_id}").
-						Bind(dbx.Params{"artist_id": artistBeatles.ID, "library_id": lib2.ID}).Execute()
 					Expect(err).ToNot(HaveOccurred())
 
 					// Filter by specific library
@@ -917,14 +903,8 @@ var _ = Describe("ArtistRepository", func() {
 				})
 
 				It("should get individual artists when no user is in context", func() {
-					// Add artist to a library with stats
+					// Add artist to a library
 					err := lr.AddArtist(lib2.ID, artistBeatles.ID)
-					Expect(err).ToNot(HaveOccurred())
-
-					// Populate stats for the new library association so artist is visible with filtering
-					conn := GetDBXBuilder()
-					_, err = conn.NewQuery("UPDATE library_artist SET stats = '{\"albumartist\":{\"albumCount\":1,\"songCount\":1}}' WHERE artist_id = {:artist_id} AND library_id = {:library_id}").
-						Bind(dbx.Params{"artist_id": artistBeatles.ID, "library_id": lib2.ID}).Execute()
 					Expect(err).ToNot(HaveOccurred())
 
 					// Headless process should be able to get the artist
@@ -947,15 +927,5 @@ func createArtistWithLibrary(repo model.ArtistRepository, artist *model.Artist, 
 
 	// Add the artist to the specified library
 	lr := NewLibraryRepository(request.WithUser(GinkgoT().Context(), adminUser), GetDBXBuilder())
-	err = lr.AddArtist(libraryID, artist.ID)
-	if err != nil {
-		return err
-	}
-
-	// Populate stats for the artist to make it visible with new filtering logic
-	// The new filtering requires stats to be non-empty
-	conn := GetDBXBuilder()
-	_, err = conn.NewQuery("UPDATE library_artist SET stats = '{\"albumartist\":{\"albumCount\":1,\"songCount\":1}}' WHERE artist_id = {:artist_id} AND library_id = {:library_id}").
-		Bind(dbx.Params{"artist_id": artist.ID, "library_id": libraryID}).Execute()
-	return err
+	return lr.AddArtist(libraryID, artist.ID)
 }

--- a/persistence/genre_repository.go
+++ b/persistence/genre_repository.go
@@ -21,7 +21,9 @@ func NewGenreRepository(ctx context.Context, db dbx.Builder) model.GenreReposito
 }
 
 func (r *genreRepository) selectGenre(opt ...model.QueryOptions) SelectBuilder {
-	return r.newSelect(opt...)
+	sq := r.newSelect(opt...).Columns("tag.tag_value as name")
+
+	return sq
 }
 
 func (r *genreRepository) GetAll(opt ...model.QueryOptions) (model.Genres, error) {

--- a/persistence/genre_repository.go
+++ b/persistence/genre_repository.go
@@ -21,9 +21,7 @@ func NewGenreRepository(ctx context.Context, db dbx.Builder) model.GenreReposito
 }
 
 func (r *genreRepository) selectGenre(opt ...model.QueryOptions) SelectBuilder {
-	sq := r.newSelect(opt...).Columns("tag.tag_value as name")
-
-	return sq
+	return r.newSelect(opt...).Columns("tag.tag_value as name")
 }
 
 func (r *genreRepository) GetAll(opt ...model.QueryOptions) (model.Genres, error) {

--- a/persistence/persistence_suite_test.go
+++ b/persistence/persistence_suite_test.go
@@ -176,16 +176,6 @@ var _ = BeforeSuite(func() {
 		}
 	}
 
-	// Populate stats for library_artist to make artists visible with new filtering
-	// The new filtering logic requires stats to be non-empty
-	for i := range testArtists {
-		_, err := conn.NewQuery("UPDATE library_artist SET stats = '{\"albumartist\":{\"albumCount\":1,\"songCount\":1}}' WHERE artist_id = {:artist_id} AND library_id = 1").
-			Bind(dbx.Params{"artist_id": testArtists[i].ID}).Execute()
-		if err != nil {
-			panic(err)
-		}
-	}
-
 	mr := NewMediaFileRepository(ctx, conn)
 	for i := range testSongs {
 		err := mr.Put(&testSongs[i])

--- a/persistence/scrobble_buffer_repository.go
+++ b/persistence/scrobble_buffer_repository.go
@@ -8,7 +8,6 @@ import (
 	. "github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
-	"github.com/navidrome/navidrome/model/request"
 	"github.com/pocketbase/dbx"
 )
 
@@ -83,20 +82,7 @@ func (r *scrobbleBufferRepository) Next(service string, userId string) (*model.S
 	if err != nil {
 		return nil, err
 	}
-
-	// Create context with user information for getParticipants call
-	// This is needed because the artist repository requires user context for multi-library support
-	userRepo := NewUserRepository(r.ctx, r.db)
-	user, err := userRepo.Get(res.ScrobbleEntry.UserID)
-	if err != nil {
-		return nil, err
-	}
-	// Temporarily use user context for getParticipants
-	originalCtx := r.ctx
-	r.ctx = request.WithUser(r.ctx, *user)
 	res.ScrobbleEntry.Participants, err = r.getParticipants(&res.ScrobbleEntry.MediaFile)
-	r.ctx = originalCtx // Restore original context
-
 	if err != nil {
 		return nil, err
 	}

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -95,7 +95,7 @@ func (r *shareRepository) loadMedia(share *model.Share) error {
 		return err
 	case "album":
 		albumRepo := NewAlbumRepository(r.ctx, r.db)
-		share.Albums, err = albumRepo.GetAll(model.QueryOptions{Filters: noMissing(Eq{"id": ids})})
+		share.Albums, err = albumRepo.GetAll(model.QueryOptions{Filters: noMissing(Eq{"album.id": ids})})
 		if err != nil {
 			return err
 		}

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -1,0 +1,128 @@
+package persistence
+
+import (
+	"context"
+	"time"
+
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ShareRepository", func() {
+	var repo model.ShareRepository
+	var ctx context.Context
+	var adminUser = model.User{ID: "admin", UserName: "admin", IsAdmin: true}
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		ctx = request.WithUser(log.NewContext(context.TODO()), adminUser)
+		repo = NewShareRepository(ctx, GetDBXBuilder())
+
+		// Clean up shares
+		db := GetDBXBuilder()
+		_, err := db.NewQuery("DELETE FROM share").Execute()
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	Describe("Headless Access", func() {
+		Context("Repository creation and basic operations", func() {
+			It("should create repository successfully with no user context", func() {
+				// Create repository with no user context (headless)
+				headlessRepo := NewShareRepository(context.Background(), GetDBXBuilder())
+				Expect(headlessRepo).ToNot(BeNil())
+			})
+
+			It("should handle GetAll for headless processes", func() {
+				// Create a simple share directly in database
+				shareID := "headless-test-share"
+				_, err := GetDBXBuilder().NewQuery(`
+					INSERT INTO share (id, user_id, description, resource_type, resource_ids, created_at, updated_at) 
+					VALUES ({:id}, {:user}, {:desc}, {:type}, {:ids}, {:created}, {:updated})
+				`).Bind(map[string]interface{}{
+					"id":      shareID,
+					"user":    adminUser.ID,
+					"desc":    "Headless Test Share",
+					"type":    "song",
+					"ids":     "song-1",
+					"created": time.Now(),
+					"updated": time.Now(),
+				}).Execute()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Headless process should see all shares
+				headlessRepo := NewShareRepository(context.Background(), GetDBXBuilder())
+				shares, err := headlessRepo.GetAll()
+				Expect(err).ToNot(HaveOccurred())
+
+				found := false
+				for _, s := range shares {
+					if s.ID == shareID {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(), "Headless process should see all shares")
+			})
+
+			It("should handle individual share retrieval for headless processes", func() {
+				// Create a simple share
+				shareID := "headless-get-share"
+				_, err := GetDBXBuilder().NewQuery(`
+					INSERT INTO share (id, user_id, description, resource_type, resource_ids, created_at, updated_at) 
+					VALUES ({:id}, {:user}, {:desc}, {:type}, {:ids}, {:created}, {:updated})
+				`).Bind(map[string]interface{}{
+					"id":      shareID,
+					"user":    adminUser.ID,
+					"desc":    "Headless Get Share",
+					"type":    "song",
+					"ids":     "song-2",
+					"created": time.Now(),
+					"updated": time.Now(),
+				}).Execute()
+				Expect(err).ToNot(HaveOccurred())
+
+				// Headless process should be able to get the share
+				headlessRepo := NewShareRepository(context.Background(), GetDBXBuilder())
+				share, err := headlessRepo.Get(shareID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(share.ID).To(Equal(shareID))
+				Expect(share.Description).To(Equal("Headless Get Share"))
+			})
+		})
+	})
+
+	Describe("SQL ambiguity fix verification", func() {
+		It("should handle share operations without SQL ambiguity errors", func() {
+			// This test verifies that the loadMedia function doesn't cause SQL ambiguity
+			// The key fix was using "album.id" instead of "id" in the album query filters
+
+			// Create a share that would trigger the loadMedia function
+			shareID := "sql-test-share"
+			_, err := GetDBXBuilder().NewQuery(`
+				INSERT INTO share (id, user_id, description, resource_type, resource_ids, created_at, updated_at) 
+				VALUES ({:id}, {:user}, {:desc}, {:type}, {:ids}, {:created}, {:updated})
+			`).Bind(map[string]interface{}{
+				"id":      shareID,
+				"user":    adminUser.ID,
+				"desc":    "SQL Test Share",
+				"type":    "album",
+				"ids":     "non-existent-album", // Won't find albums, but shouldn't cause SQL errors
+				"created": time.Now(),
+				"updated": time.Now(),
+			}).Execute()
+			Expect(err).ToNot(HaveOccurred())
+
+			// The Get operation should work without SQL ambiguity errors
+			// even if no albums are found
+			share, err := repo.Get(shareID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(share.ID).To(Equal(shareID))
+			// Albums array should be empty since we used non-existent album ID
+			Expect(share.Albums).To(BeEmpty())
+		})
+	})
+})

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -22,9 +22,14 @@ var _ = Describe("ShareRepository", func() {
 		ctx = request.WithUser(log.NewContext(context.TODO()), adminUser)
 		repo = NewShareRepository(ctx, GetDBXBuilder())
 
+		// Insert the admin user into the database (required for foreign key constraint)
+		ur := NewUserRepository(ctx, GetDBXBuilder())
+		err := ur.Put(&adminUser)
+		Expect(err).ToNot(HaveOccurred())
+
 		// Clean up shares
 		db := GetDBXBuilder()
-		_, err := db.NewQuery("DELETE FROM share").Execute()
+		_, err = db.NewQuery("DELETE FROM share").Execute()
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/persistence/sql_participations.go
+++ b/persistence/sql_participations.go
@@ -68,7 +68,7 @@ func (r sqlRepository) updateParticipants(itemID string, participants model.Part
 func (r *sqlRepository) getParticipants(m *model.MediaFile) (model.Participants, error) {
 	ar := NewArtistRepository(r.ctx, r.db)
 	ids := m.Participants.AllIDs()
-	artists, err := ar.GetAll(model.QueryOptions{Filters: Eq{"id": ids}})
+	artists, err := ar.GetAll(model.QueryOptions{Filters: Eq{"artist.id": ids}})
 	if err != nil {
 		return nil, fmt.Errorf("getting participants: %w", err)
 	}

--- a/persistence/tag_library_filtering_test.go
+++ b/persistence/tag_library_filtering_test.go
@@ -14,225 +14,199 @@ import (
 	"github.com/pocketbase/dbx"
 )
 
+const (
+	adminUserID   = "userid"
+	regularUserID = "2222"
+	libraryID1    = 1
+	libraryID2    = 2
+	libraryID3    = 3
+
+	tagNameGenre = "genre"
+	tagValueRock = "rock"
+	tagValuePop  = "pop"
+	tagValueJazz = "jazz"
+)
+
 var _ = Describe("Tag Library Filtering", func() {
+	var (
+		tagRockID = id.NewTagID(tagNameGenre, tagValueRock)
+		tagPopID  = id.NewTagID(tagNameGenre, tagValuePop)
+		tagJazzID = id.NewTagID(tagNameGenre, tagValueJazz)
+	)
+
+	expectTagValues := func(tagList model.TagList, expected []string) {
+		tagValues := make([]string, len(tagList))
+		for i, tag := range tagList {
+			tagValues[i] = tag.TagValue
+		}
+		Expect(tagValues).To(ContainElements(expected))
+	}
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
 
-		// Clean up all relevant tables
+		// Clean up database
 		db := GetDBXBuilder()
 		_, err := db.NewQuery("DELETE FROM library_tag").Execute()
 		Expect(err).ToNot(HaveOccurred())
 		_, err = db.NewQuery("DELETE FROM tag").Execute()
 		Expect(err).ToNot(HaveOccurred())
-		_, err = db.NewQuery("DELETE FROM user_library WHERE user_id != 'userid' AND user_id != '2222'").Execute()
+		_, err = db.NewQuery("DELETE FROM user_library WHERE user_id != {:admin} AND user_id != {:regular}").
+			Bind(dbx.Params{"admin": adminUserID, "regular": regularUserID}).Execute()
 		Expect(err).ToNot(HaveOccurred())
 		_, err = db.NewQuery("DELETE FROM library WHERE id > 1").Execute()
 		Expect(err).ToNot(HaveOccurred())
 
 		// Create test libraries
-		_, err = db.NewQuery("INSERT INTO library (id, name, path) VALUES (2, 'Library 2', '/music/lib2')").Execute()
+		_, err = db.NewQuery("INSERT INTO library (id, name, path) VALUES ({:id}, {:name}, {:path})").
+			Bind(dbx.Params{"id": libraryID2, "name": "Library 2", "path": "/music/lib2"}).Execute()
 		Expect(err).ToNot(HaveOccurred())
-		_, err = db.NewQuery("INSERT INTO library (id, name, path) VALUES (3, 'Library 3', '/music/lib3')").Execute()
-		Expect(err).ToNot(HaveOccurred())
-
-		// Ensure admin user has access to all libraries (since admin users should have access to all libraries)
-		_, err = db.NewQuery("INSERT OR IGNORE INTO user_library (user_id, library_id) VALUES ('userid', 1)").Execute()
-		Expect(err).ToNot(HaveOccurred())
-		_, err = db.NewQuery("INSERT OR IGNORE INTO user_library (user_id, library_id) VALUES ('userid', 2)").Execute()
-		Expect(err).ToNot(HaveOccurred())
-		_, err = db.NewQuery("INSERT OR IGNORE INTO user_library (user_id, library_id) VALUES ('userid', 3)").Execute()
+		_, err = db.NewQuery("INSERT INTO library (id, name, path) VALUES ({:id}, {:name}, {:path})").
+			Bind(dbx.Params{"id": libraryID3, "name": "Library 3", "path": "/music/lib3"}).Execute()
 		Expect(err).ToNot(HaveOccurred())
 
-		// Set up test tags
-		newTag := func(name, value string) model.Tag {
-			return model.Tag{ID: id.NewTagID(name, value), TagName: model.TagName(name), TagValue: value}
+		// Give admin access to all libraries
+		for _, libID := range []int{libraryID1, libraryID2, libraryID3} {
+			_, err = db.NewQuery("INSERT OR IGNORE INTO user_library (user_id, library_id) VALUES ({:user}, {:lib})").
+				Bind(dbx.Params{"user": adminUserID, "lib": libID}).Execute()
+			Expect(err).ToNot(HaveOccurred())
 		}
 
-		// Create tags in admin context
+		// Create test tags
 		adminCtx := request.WithUser(log.NewContext(context.TODO()), adminUser)
 		tagRepo := NewTagRepository(adminCtx, GetDBXBuilder())
 
-		// Add tags to different libraries
-		err = tagRepo.Add(1, newTag("genre", "rock"))
-		Expect(err).ToNot(HaveOccurred())
-		err = tagRepo.Add(2, newTag("genre", "pop"))
-		Expect(err).ToNot(HaveOccurred())
-		err = tagRepo.Add(3, newTag("genre", "jazz"))
-		Expect(err).ToNot(HaveOccurred())
-		err = tagRepo.Add(2, newTag("genre", "rock"))
-		Expect(err).ToNot(HaveOccurred())
+		createTag := func(libraryID int, name, value string) {
+			tag := model.Tag{ID: id.NewTagID(name, value), TagName: model.TagName(name), TagValue: value}
+			err := tagRepo.Add(libraryID, tag)
+			Expect(err).ToNot(HaveOccurred())
+		}
 
-		// Update counts manually for testing
-		_, err = db.NewQuery("UPDATE library_tag SET album_count = 5, media_file_count = 20 WHERE tag_id = {:tagId} AND library_id = 1").Bind(dbx.Params{"tagId": id.NewTagID("genre", "rock")}).Execute()
-		Expect(err).ToNot(HaveOccurred())
-		_, err = db.NewQuery("UPDATE library_tag SET album_count = 3, media_file_count = 10 WHERE tag_id = {:tagId} AND library_id = 2").Bind(dbx.Params{"tagId": id.NewTagID("genre", "pop")}).Execute()
-		Expect(err).ToNot(HaveOccurred())
-		_, err = db.NewQuery("UPDATE library_tag SET album_count = 2, media_file_count = 8 WHERE tag_id = {:tagId} AND library_id = 3").Bind(dbx.Params{"tagId": id.NewTagID("genre", "jazz")}).Execute()
-		Expect(err).ToNot(HaveOccurred())
-		_, err = db.NewQuery("UPDATE library_tag SET album_count = 1, media_file_count = 4 WHERE tag_id = {:tagId} AND library_id = 2").Bind(dbx.Params{"tagId": id.NewTagID("genre", "rock")}).Execute()
-		Expect(err).ToNot(HaveOccurred())
+		createTag(libraryID1, tagNameGenre, tagValueRock)
+		createTag(libraryID2, tagNameGenre, tagValuePop)
+		createTag(libraryID3, tagNameGenre, tagValueJazz)
+		createTag(libraryID2, tagNameGenre, tagValueRock) // Rock appears in both lib1 and lib2
 
-		// Set up user library access - Regular user has access to libraries 1 and 2 only
-		_, err = db.NewQuery("INSERT INTO user_library (user_id, library_id) VALUES ('2222', 2)").Execute()
+		// Set tag counts (manually for testing)
+		setCounts := func(tagID string, libID, albums, songs int) {
+			_, err := db.NewQuery("UPDATE library_tag SET album_count = {:albums}, media_file_count = {:songs} WHERE tag_id = {:tag} AND library_id = {:lib}").
+				Bind(dbx.Params{"albums": albums, "songs": songs, "tag": tagID, "lib": libID}).Execute()
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		setCounts(tagRockID, libraryID1, 5, 20)
+		setCounts(tagPopID, libraryID2, 3, 10)
+		setCounts(tagJazzID, libraryID3, 2, 8)
+		setCounts(tagRockID, libraryID2, 1, 4)
+
+		// Give regular user access to library 2 only
+		_, err = db.NewQuery("INSERT INTO user_library (user_id, library_id) VALUES ({:user}, {:lib})").
+			Bind(dbx.Params{"user": regularUserID, "lib": libraryID2}).Execute()
 		Expect(err).ToNot(HaveOccurred())
 	})
 
 	Describe("TagRepository Library Filtering", func() {
+		// Helper to create repository and read all tags
+		readAllTags := func(user *model.User, filters ...rest.QueryOptions) model.TagList {
+			var ctx context.Context
+			if user != nil {
+				ctx = request.WithUser(log.NewContext(context.TODO()), *user)
+			} else {
+				ctx = context.Background() // Headless context
+			}
+
+			tagRepo := NewTagRepository(ctx, GetDBXBuilder())
+			repo := tagRepo.(model.ResourceRepository)
+
+			var opts rest.QueryOptions
+			if len(filters) > 0 {
+				opts = filters[0]
+			}
+
+			tags, err := repo.ReadAll(opts)
+			Expect(err).ToNot(HaveOccurred())
+			return tags.(model.TagList)
+		}
+
+		// Helper to count tags
+		countTags := func(user *model.User) int64 {
+			var ctx context.Context
+			if user != nil {
+				ctx = request.WithUser(log.NewContext(context.TODO()), *user)
+			} else {
+				ctx = context.Background()
+			}
+
+			tagRepo := NewTagRepository(ctx, GetDBXBuilder())
+			repo := tagRepo.(model.ResourceRepository)
+
+			count, err := repo.Count()
+			Expect(err).ToNot(HaveOccurred())
+			return count
+		}
+
 		Context("Admin User", func() {
 			It("should see all tags regardless of library", func() {
-				ctx := request.WithUser(log.NewContext(context.TODO()), adminUser)
-				tagRepo := NewTagRepository(ctx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				tags, err := repo.ReadAll()
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-				Expect(tagList).To(HaveLen(3))
+				tags := readAllTags(&adminUser)
+				Expect(tags).To(HaveLen(3))
 			})
 		})
 
 		Context("Regular User with Limited Library Access", func() {
 			It("should only see tags from accessible libraries", func() {
-				ctx := request.WithUser(log.NewContext(context.TODO()), regularUser)
-				tagRepo := NewTagRepository(ctx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				tags, err := repo.ReadAll()
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
+				tags := readAllTags(&regularUser)
 				// Should see rock (libraries 1,2) and pop (library 2), but not jazz (library 3)
-				Expect(tagList).To(HaveLen(2))
+				Expect(tags).To(HaveLen(2))
 			})
 
 			It("should respect explicit library_id filters within accessible libraries", func() {
-				ctx := request.WithUser(log.NewContext(context.TODO()), regularUser)
-				tagRepo := NewTagRepository(ctx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				// Filter by library 2 (user has access to libraries 1 and 2)
-				tags, err := repo.ReadAll(rest.QueryOptions{
-					Filters: map[string]interface{}{
-						"library_id": 2,
-					},
+				tags := readAllTags(&regularUser, rest.QueryOptions{
+					Filters: map[string]interface{}{"library_id": libraryID2},
 				})
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
 				// Should see only tags from library 2: pop and rock(lib2)
-				Expect(tagList).To(HaveLen(2))
-
-				// Verify the tags are correct
-				tagValues := make([]string, len(tagList))
-				for i, tag := range tagList {
-					tagValues[i] = tag.TagValue
-				}
-				Expect(tagValues).To(ContainElements("pop", "rock"))
+				Expect(tags).To(HaveLen(2))
+				expectTagValues(tags, []string{tagValuePop, tagValueRock})
 			})
 
 			It("should not return tags when filtering by inaccessible library", func() {
-				ctx := request.WithUser(log.NewContext(context.TODO()), regularUser)
-				tagRepo := NewTagRepository(ctx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				// Try to filter by library 3 (user doesn't have access)
-				tags, err := repo.ReadAll(rest.QueryOptions{
-					Filters: map[string]interface{}{
-						"library_id": 3,
-					},
+				tags := readAllTags(&regularUser, rest.QueryOptions{
+					Filters: map[string]interface{}{"library_id": libraryID3},
 				})
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
 				// Should return no tags since user can't access library 3
-				Expect(tagList).To(HaveLen(0))
+				Expect(tags).To(HaveLen(0))
 			})
 
 			It("should filter by library 1 correctly", func() {
-				ctx := request.WithUser(log.NewContext(context.TODO()), regularUser)
-				tagRepo := NewTagRepository(ctx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				// Filter by library 1 (user has access)
-				tags, err := repo.ReadAll(rest.QueryOptions{
-					Filters: map[string]interface{}{
-						"library_id": 1,
-					},
+				tags := readAllTags(&regularUser, rest.QueryOptions{
+					Filters: map[string]interface{}{"library_id": libraryID1},
 				})
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
 				// Should see only rock from library 1
-				Expect(tagList).To(HaveLen(1))
-				Expect(tagList[0].TagValue).To(Equal("rock"))
+				Expect(tags).To(HaveLen(1))
+				Expect(tags[0].TagValue).To(Equal(tagValueRock))
 			})
 		})
 
 		Context("Headless Processes (No User Context)", func() {
 			It("should see all tags from all libraries when no user is in context", func() {
-				// Create context without user (simulates headless processes like shares, providers, etc.)
-				headlessCtx := context.Background() // No user in context
-				tagRepo := NewTagRepository(headlessCtx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				tags, err := repo.ReadAll()
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
+				tags := readAllTags(nil) // nil = headless context
 				// Should see all tags from all libraries (no filtering applied)
-				Expect(tagList).To(HaveLen(3))
-
-				// Verify we can see tags from all libraries
-				tagValues := make([]string, len(tagList))
-				for i, tag := range tagList {
-					tagValues[i] = tag.TagValue
-				}
-				Expect(tagValues).To(ContainElements("rock", "pop", "jazz"))
+				Expect(tags).To(HaveLen(3))
+				expectTagValues(tags, []string{tagValueRock, tagValuePop, tagValueJazz})
 			})
 
 			It("should count all tags from all libraries when no user is in context", func() {
-				// Create context without user
-				headlessCtx := context.Background()
-				tagRepo := NewTagRepository(headlessCtx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				count, err := repo.Count()
-				Expect(err).ToNot(HaveOccurred())
-
+				count := countTags(nil)
 				// Should count all tags from all libraries
 				Expect(count).To(Equal(int64(3)))
 			})
 
 			It("should calculate proper statistics from all libraries for headless processes", func() {
-				// Create context without user
-				headlessCtx := context.Background()
-				tagRepo := NewTagRepository(headlessCtx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				// Debug: Check what's in the library_tag table for rock
-				db := GetDBXBuilder()
-				rockTagId := id.NewTagID("genre", "rock")
-
-				type libraryTagRow struct {
-					LibraryId      int `db:"library_id"`
-					AlbumCount     int `db:"album_count"`
-					MediaFileCount int `db:"media_file_count"`
-				}
-				var rows []libraryTagRow
-				err := db.NewQuery("SELECT library_id, album_count, media_file_count FROM library_tag WHERE tag_id = {:tagId}").
-					Bind(dbx.Params{"tagId": rockTagId}).
-					All(&rows)
-				Expect(err).ToNot(HaveOccurred())
-
-				tags, err := repo.ReadAll()
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
+				tags := readAllTags(nil)
 
 				// Find the rock tag (appears in libraries 1 and 2)
 				var rockTag *model.Tag
-				for _, tag := range tagList {
-					if tag.TagValue == "rock" {
+				for _, tag := range tags {
+					if tag.TagValue == tagValueRock {
 						rockTag = &tag
 						break
 					}
@@ -248,79 +222,37 @@ var _ = Describe("Tag Library Filtering", func() {
 			})
 
 			It("should allow headless processes to apply explicit library_id filters", func() {
-				// Create context without user
-				headlessCtx := context.Background()
-				tagRepo := NewTagRepository(headlessCtx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				// Filter by library 3 (even without user context)
-				tags, err := repo.ReadAll(rest.QueryOptions{
-					Filters: map[string]interface{}{
-						"library_id": 3,
-					},
+				tags := readAllTags(nil, rest.QueryOptions{
+					Filters: map[string]interface{}{"library_id": libraryID3},
 				})
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
 				// Should see only jazz from library 3
-				Expect(tagList).To(HaveLen(1))
-				Expect(tagList[0].TagValue).To(Equal("jazz"))
+				Expect(tags).To(HaveLen(1))
+				Expect(tags[0].TagValue).To(Equal(tagValueJazz))
 			})
 		})
 
 		Context("Admin User with Explicit Library Filtering", func() {
 			It("should see all tags when no filter is applied", func() {
-				adminCtx := request.WithUser(log.NewContext(context.TODO()), adminUser)
-				tagRepo := NewTagRepository(adminCtx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				tags, err := repo.ReadAll()
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-				Expect(tagList).To(HaveLen(3))
+				tags := readAllTags(&adminUser)
+				Expect(tags).To(HaveLen(3))
 			})
 
 			It("should respect explicit library_id filters", func() {
-				adminCtx := request.WithUser(log.NewContext(context.TODO()), adminUser)
-				tagRepo := NewTagRepository(adminCtx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				// Filter by library 3
-				tags, err := repo.ReadAll(rest.QueryOptions{
-					Filters: map[string]interface{}{
-						"library_id": 3,
-					},
+				tags := readAllTags(&adminUser, rest.QueryOptions{
+					Filters: map[string]interface{}{"library_id": libraryID3},
 				})
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
 				// Should see only jazz from library 3
-				Expect(tagList).To(HaveLen(1))
-				Expect(tagList[0].TagValue).To(Equal("jazz"))
+				Expect(tags).To(HaveLen(1))
+				Expect(tags[0].TagValue).To(Equal(tagValueJazz))
 			})
 
 			It("should filter by library 2 correctly", func() {
-				adminCtx := request.WithUser(log.NewContext(context.TODO()), adminUser)
-				tagRepo := NewTagRepository(adminCtx, GetDBXBuilder())
-				repo := tagRepo.(model.ResourceRepository)
-
-				// Filter by library 2
-				tags, err := repo.ReadAll(rest.QueryOptions{
-					Filters: map[string]interface{}{
-						"library_id": 2,
-					},
+				tags := readAllTags(&adminUser, rest.QueryOptions{
+					Filters: map[string]interface{}{"library_id": libraryID2},
 				})
-				Expect(err).ToNot(HaveOccurred())
-				tagList := tags.(model.TagList)
-
 				// Should see pop and rock from library 2
-				Expect(tagList).To(HaveLen(2))
-
-				tagValues := make([]string, len(tagList))
-				for i, tag := range tagList {
-					tagValues[i] = tag.TagValue
-				}
-				Expect(tagValues).To(ContainElements("pop", "rock"))
+				Expect(tags).To(HaveLen(2))
+				expectTagValues(tags, []string{tagValuePop, tagValueRock})
 			})
 		})
 	})

--- a/ui/src/artist/ArtistList.jsx
+++ b/ui/src/artist/ArtistList.jsx
@@ -132,8 +132,10 @@ const ArtistListView = ({ hasShow, hasEdit, hasList, width, ...rest }) => {
   useResourceRefresh('artist')
 
   const role = filterValues?.role
-  const getCounter = (record, counter) =>
-    role ? record?.stats[role]?.[counter] : record?.[counter]
+  const getCounter = (record, counter) => {
+    if (!record) return undefined
+    return role ? record?.stats?.[role]?.[counter] : record?.[counter]
+  }
   const getAlbumCount = (record) => getCounter(record, 'albumCount')
   const getSongCount = (record) => getCounter(record, 'songCount')
   const getSize = (record) => {


### PR DESCRIPTION
### Description
Fixes headless library access issues in Navidrome by improving library filtering logic and resolving SQL ambiguity errors in share queries.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Set up a Navidrome instance with multiple libraries
2. Test library access with both authenticated and headless operations
3. Verify that share queries execute without SQL ambiguity errors
4. Confirm that library filtering is applied correctly in all scenarios

### Changes Made
- Fixed user context validation in `applyLibraryFilterToArtistQuery`
- Improved join order and conditional logic for library filtering
- Resolved SQL ambiguity errors in share queries
- Ensured library access works correctly for both authenticated and headless operations

### Key Commits
- `fe2a2204c`: Enable library access for headless processes
- `946265823`: Resolve SQL ambiguity errors in share queries  
- `a28c6965b`: Remove overly restrictive headless library access guard
- `b06d86987`: Improve headless library access with proper user context validation