### PR TITLE
Fix playlist import for songs with accented characters

### DIFF
--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -192,12 +192,14 @@ var _ = Describe("Playlists", func() {
 			// Test case for Apple Music playlists that use NFC encoding vs macOS filesystem NFD
 			// The character "è" can be represented as NFC (single codepoint) or NFD (e + combining accent)
 
+			const pathWithAccents = "artist/Michèle Desrosiers/album/Noël.m4a"
+
 			// Simulate a database entry with NFD encoding (as stored by macOS filesystem)
-			nfdPath := "artist/Michèle Desrosiers/album/Noël.m4a" // NFD form
+			nfdPath := norm.NFD.String(pathWithAccents)
 			repo.data = []string{nfdPath}
 
 			// Simulate an Apple Music M3U playlist entry with NFC encoding
-			nfcPath := "/music/artist/Michèle Desrosiers/album/Noël.m4a" // NFC form
+			nfcPath := norm.NFC.String("/music/" + pathWithAccents)
 			m3u := strings.Join([]string{
 				nfcPath,
 			}, "\n")

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -223,6 +223,9 @@ var _ = Describe("Playlists", func() {
 			nfcPath := "Michèle" // This might be in NFC form
 			normalizedNfc := normalizePathForComparison(nfcPath)
 
+			// Ensure the two paths are not equal in their original forms
+			Expect(nfdPath).ToNot(Equal(nfcPath))
+
 			// Both should normalize to the same result
 			Expect(normalized).To(Equal(normalizedNfc))
 		})

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/text/unicode/norm"
 )
 
 var _ = Describe("Playlists", func() {
@@ -185,6 +186,49 @@ var _ = Describe("Playlists", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(pls.Tracks).To(HaveLen(1))
 			Expect(pls.Tracks[0].Path).To(Equal("abc/tEsT1.Mp3"))
+		})
+
+		It("handles Unicode normalization when comparing paths", func() {
+			// Test case for Apple Music playlists that use NFC encoding vs macOS filesystem NFD
+			// The character "è" can be represented as NFC (single codepoint) or NFD (e + combining accent)
+
+			// Simulate a database entry with NFD encoding (as stored by macOS filesystem)
+			nfdPath := "artist/Michèle Desrosiers/album/Noël.m4a" // NFD form
+			repo.data = []string{nfdPath}
+
+			// Simulate an Apple Music M3U playlist entry with NFC encoding
+			nfcPath := "/music/artist/Michèle Desrosiers/album/Noël.m4a" // NFC form
+			m3u := strings.Join([]string{
+				nfcPath,
+			}, "\n")
+			f := strings.NewReader(m3u)
+
+			pls, err := ps.ImportM3U(ctx, f)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pls.Tracks).To(HaveLen(1), "Should find the track despite Unicode normalization differences")
+			Expect(pls.Tracks[0].Path).To(Equal(nfdPath))
+		})
+	})
+
+	Describe("normalizePathForComparison", func() {
+		It("normalizes Unicode characters to NFC form and converts to lowercase", func() {
+			// Test with NFD (decomposed) input - as would come from macOS filesystem
+			nfdPath := norm.NFD.String("Michèle") // Explicitly convert to NFD form
+			normalized := normalizePathForComparison(nfdPath)
+			Expect(normalized).To(Equal("michèle"))
+
+			// Test with NFC (composed) input - as would come from Apple Music M3U
+			nfcPath := "Michèle" // This might be in NFC form
+			normalizedNfc := normalizePathForComparison(nfcPath)
+
+			// Both should normalize to the same result
+			Expect(normalized).To(Equal(normalizedNfc))
+		})
+
+		It("handles paths with mixed case and Unicode characters", func() {
+			path := "Artist/Noël Coward/Album/Song.mp3"
+			normalized := normalizePathForComparison(path)
+			Expect(normalized).To(Equal("artist/noël coward/album/song.mp3"))
 		})
 	})
 


### PR DESCRIPTION
### Description
Fixes playlist import issues for songs with accented characters from Apple Music M3U playlists. The problem occurred because Apple Music exports M3U playlists with Unicode NFC (Canonical Composed) encoding while macOS filesystem normalizes paths to NFD (Canonical Decomposed) encoding, causing path mismatches during playlist import.

### Related Issues
Fixes #3332

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. **Run specific Unicode tests**: Use `go test -v ./core -ginkgo.focus "normalizePathForComparison|Unicode normalization"` to run only the Unicode-related tests
2. **Integration testing** (optional): 
   - Create a test M3U file with paths containing accented characters (both NFC and NFD encoded)
   - Place it in a monitored playlist directory 
   - Verify that songs are correctly matched during playlist sync

### Screenshots / Demos (if applicable)
N/A - This is a backend fix for Unicode path handling.

### Additional Notes
**Technical Details:**
- Added `normalizePathForComparison()` helper function that normalizes paths to NFC form using `golang.org/x/text/unicode/norm`
- Updated `parseM3U()` to normalize both filesystem paths and M3U playlist paths before comparison
- Added comprehensive test coverage for Unicode normalization scenarios including both NFC and NFD character representations

**Root Cause:**
Apple Music exports M3U playlists with Unicode characters in NFC (Canonical Composed) form, while macOS filesystem stores file paths in NFD (Canonical Decomposed) form. For example:
- M3U path: `Noël` (NFC: é as single character U+00E9)
- Filesystem path: `Noël` (NFD: e + combining acute accent U+0065 U+0301)

These look identical but have different byte representations, causing the path matching to fail during playlist import.

**Impact:**
This fix resolves the issue for all users on macOS who import playlists from Apple Music containing songs with accented characters, diacritics, or other Unicode combining characters.