### PR TITLE
Handle plugin over reverse proxy auth

### DIFF
--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -91,10 +91,19 @@ func authenticate(ds model.DataStore) func(next http.Handler) http.Handler {
 			var usr *model.User
 			var err error
 
-			internalAuth := server.InternalAuth(r)
-			proxyAuth := server.UsernameFromReverseProxyHeader(r)
-			if username := cmp.Or(internalAuth, proxyAuth); username != "" {
-				authType := If(internalAuth != "", "internal", "reverse-proxy")
+			isInternalAuth := false
+
+			username := server.InternalAuth(r)
+			// If the username comes from internal auth, do not also do reverse proxy auth, as
+			// the request will have no reverse proxy IP
+			if username == "" {
+				username = server.UsernameFromReverseProxyHeader(r)
+			} else {
+				isInternalAuth = true
+			}
+
+			if username != "" {
+				authType := If(isInternalAuth, "internal", "reverse-proxy")
 				usr, err = ds.User(ctx).FindByUsername(username)
 				if errors.Is(err, context.Canceled) {
 					log.Debug(ctx, "API: Request canceled when authenticating", "auth", authType, "username", username, "remoteAddr", r.RemoteAddr, err)

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -51,7 +51,13 @@ func checkRequiredParameters(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var requiredParameters []string
 
-		username := cmp.Or(server.InternalAuth(r), server.UsernameFromReverseProxyHeader(r))
+		username := server.InternalAuth(r)
+		// If the username comes from internal auth, do not also do reverse proxy auth, as
+		// the request will have no reverse proxy IP
+		if username == "" {
+			username = server.UsernameFromReverseProxyHeader(r)
+		}
+
 		if username != "" {
 			requiredParameters = []string{"v", "c"}
 		} else {


### PR DESCRIPTION
### Description
When reverse proxy authentication is enabled (`ReverseProxyWhitelist` is nonempty), if a subsonic plugin request is made, Navidrome will still try check the reverse proxy authentication.

This is a problem, because the internal authentication does not provide a reverse proxy IP, so every request results in error log `ReverseProxyWhitelist enabled but no proxy IP found in request context. Please report this error.` being present.

This PR fixes the order, by _first_ checking internal authentication, and only if empty fallback to reverse proxy.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
I don't think there's an authentication test for this specifically.

I tested this by enabling `ReverseProxyWhitelist = "@"` and then using a plugin which makes Subsonic requests, and verifying that the error goes away with the PR.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->