### PR TITLE
fix(ui): update Deutsch, Galego, Italiano translations

### DIFF
--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -273,7 +273,7 @@
       "empty": "keine fehlenden Dateien"
     },
     "library": {
-      "name": "Bibliothek ||| Bibliotheken",
+      "name": "Bibliothek |||| Bibliotheken",
       "fields": {
         "name": "Name",
         "path": "Pfad",

--- a/resources/i18n/gl.json
+++ b/resources/i18n/gl.json
@@ -63,7 +63,7 @@
         "size": "Tamaño",
         "originalDate": "Orixinal",
         "releaseDate": "Publicado",
-        "releases": "Publicación ||| Publicacións",
+        "releases": "Publicación |||| Publicacións",
         "released": "Publicado",
         "recordLabel": "Editorial",
         "catalogNum": "Número de catálogo",

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -232,7 +232,7 @@
             "add_filter": "Aggiungi un filtro",
             "add": "Aggiungi",
             "back": "Indietro",
-            "bulk_actions": "Un elemento selezionato ||| %{smart_count} elementi selezionati",
+            "bulk_actions": "Un elemento selezionato |||| %{smart_count} elementi selezionati",
             "cancel": "Annulla",
             "clear_input_value": "Cancella",
             "clone": "Duplica",


### PR DESCRIPTION
Corrects pluralization syntax in i18n translation files by adding the missing pipe character.