### PR TITLE
limit the concurrency of transcoding for every login token

### DIFF
--- a/server/subsonic/stream.go
+++ b/server/subsonic/stream.go
@@ -56,6 +56,10 @@ func (api *Router) Stream(w http.ResponseWriter, r *http.Request) (*responses.Su
 	if err != nil {
 		return nil, err
 	}
+	// Save the token to the context, which will be used later to limit the concurrency of transcoding for a single token.
+	token, _ := p.String("t")
+	ctx = context.WithValue(ctx, "token", token)
+
 	maxBitRate := p.IntOr("maxBitRate", 0)
 	format, _ := p.String("format")
 	timeOffset := p.IntOr("timeOffset", 0)


### PR DESCRIPTION
### Description
On low-power servers with only 2 or less cores , 3 or 4 transcoding would keep cpu 100% for a long time.
Limit each logged-in user (token) to running only one transcoding task concurrently. Each time a new transcoding request is initiated, the previous transcoding task under the same token will be automatically terminated to ensure that resources are not occupied by multiple concurrent transcoding tasks. This change helps improve system stability and resource utilization.
At the mean time, when a song is fully played (or listened to for 6, 7 seconds), meaning transcoding process is done, the transcoded cache is also saved to disk for future streaming.

### Related Issues
https://github.com/navidrome/navidrome/discussions/4398

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Play in transcoding mode, and switch 3 or 4 songs consecutively and quickly, 
Use `ps -ef|grep ffmpeg` to see how many transcoding task is running

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->