### PR TITLE
fix(docker): use standalone wget instead of the busybox one

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,9 @@ ARG TARGETPLATFORM
 ARG CROSS_TAGLIB_VERSION=2.1.1-1
 ENV CROSS_TAGLIB_RELEASES_URL=https://github.com/navidrome/cross-taglib/releases/download/v${CROSS_TAGLIB_VERSION}/
 
+# wget in busybox can't follow redirects
 RUN <<EOT
+    apk add --no-cache wget
     PLATFORM=$(echo ${TARGETPLATFORM} | tr '/' '-')
     FILE=taglib-${PLATFORM}.tar.gz
 


### PR DESCRIPTION
### Description
This fixes an issue for local development environments of the Docker build: the wget provided by busybox doesn't support redirects. So downloading taglib returns an error later from tar (because wget previously downloaded the HTML content of the redirect). I fixed that by installing the wget package.

### Related Issues
Fixes #3738.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] ~~I have added or updated documentation as needed~~
- [ ] ~~I have added tests that prove my fix/feature works (or explain why not)~~
- [x] All existing and new tests pass

### How to Test
Just run the Docker build process.

### Additional Notes
I can't explain why the bug doesn't happen on GitHub Actions. Here is a log from https://github.com/navidrome/navidrome/actions/runs/16577552503/job/46885668061

```
#12 [taglib-build 2/2] RUN <<EOT (PLATFORM=$(echo windows/amd64 | tr '/' '-')...)
#12 0.221 Connecting to github.com (140.82.112.3:443)
#12 0.443 Connecting to release-assets.githubusercontent.com (185.199.108.133:443)
#12 0.544 saving to 'taglib-windows-amd64.tar.gz'
#12 0.580 taglib-windows-amd64 100% |********************************|  810k  0:00:00 ETA
#12 0.580 'taglib-windows-amd64.tar.gz' saved
#12 DONE 1.6s
```

I'm using different Docker versions, but I doubt it makes a difference:

```
Client: Docker Engine - Community
 Version:           28.3.3
 API version:       1.51
 Go version:        go1.24.5
 Git commit:        980b856
 Built:             Fri Jul 25 11:34:10 2025
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          28.3.3
  API version:      1.51 (minimum version 1.24)
  Go version:       go1.24.5
  Git commit:       bea959c
  Built:            Fri Jul 25 11:34:10 2025
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.7.27
  GitCommit:        05044ec0a9a75232cad458027ca83437aae3f4da
 runc:
  Version:          1.2.5
  GitCommit:        v1.2.5-0-g59923ef
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```

```
github.com/docker/buildx v0.26.1 1a8287f
```
