### PR TITLE
fix(db): Make playqueue position field an integer

### DIFF
--- a/db/migrations/20250823142158_make_playqueue_position_int.sql
+++ b/db/migrations/20250823142158_make_playqueue_position_int.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE playqueue ADD COLUMN position_int integer;
+UPDATE playqueue SET position_int = CAST(position as INTEGER) ;
+ALTER TABLE playqueue DROP COLUMN position;
+ALTER TABLE playqueue RENAME COLUMN position_int TO position;
+-- +goose StatementEnd
+
+-- +goose Down


### PR DESCRIPTION
### Description
For some reason, the `position` column for `playqueue` is a real, but the datatype is int64. Make it an int.

### Related Issues
Should reduce the risk of #4479

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Manually call `savePlayQueue`, make sure the datatype in the database makes sense. Call `getPlayQueue` to get the value.

### Screenshots / Demos (if applicable)

### Additional Notes

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->