### PR TITLE
fix: qualify user id filter to avoid ambiguous column

### DIFF
--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -57,6 +57,7 @@ func NewUserRepository(ctx context.Context, db dbx.Builder) model.UserRepository
 	r.db = db
 	r.tableName = "user"
 	r.registerModel(&model.User{}, map[string]filterFunc{
+		"id":       idFilter(r.tableName),
 		"password": invalidFilter(ctx),
 		"name":     r.withTableName(startsWithFilter),
 	})

--- a/persistence/user_repository_test.go
+++ b/persistence/user_repository_test.go
@@ -559,4 +559,15 @@ var _ = Describe("UserRepository", func() {
 			Expect(user.Libraries[0].ID).To(Equal(1))
 		})
 	})
+
+	Describe("filters", func() {
+		It("qualifies id filter with table name", func() {
+			r := repo.(*userRepository)
+			qo := r.parseRestOptions(r.ctx, rest.QueryOptions{Filters: map[string]any{"id": "123"}})
+			sel := r.selectUserWithLibraries(qo)
+			query, _, err := r.toSQL(sel)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(query).To(ContainSubstring("user.id = {:p0}"))
+		})
+	})
 })


### PR DESCRIPTION
## Summary
- ensure REST id filters are qualified for users
- cover user id filter behaviour with tests

## Testing
- `make lint`
- `make test PKG=./persistence/...`


------
https://chatgpt.com/codex/tasks/task_b_68b76c1af54c832e8014a4364c07c599