### PR TITLE
fix(ui): allow scrolling in play queue by adding delay

### DIFF
--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -127,6 +127,7 @@ const Player = () => {
         />
       ),
       locale: locale(translate),
+      sortableOptions: { delay: 200, delayOnTouchOnly: true },
     }),
     [gainInfo, isDesktop, playerTheme, translate, playerState.mode],
   )


### PR DESCRIPTION
### Description

Allows scrolling in the play queue for touchscreen users by adding a delay for sortablejs.

Users now have to touch the row for 200ms before they can drag on it for reordering. This may be slightly annoying, but it's still better than not being able to scroll the play queue.

There are multiple ways to fix the issue below. The best way will be to add a marker in the row for dragging, which sortablejs also supports. However, that requires modifying the [react music player](https://github.com/navidrome/react-music-player), which seems to be abandoned now. If the devs are willing to change it, let me know and I can probably implement a better solution.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

Fixes #4062.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [ ] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Have a long enough play queue on mobile, and try to scroll and reorder it.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->