### PR TITLE
Fix locale-dependent tests without environment variables

### DIFF
--- a/ui/src/utils/formatters.js
+++ b/ui/src/utils/formatters.js
@@ -95,7 +95,7 @@ export const formatFullDate = (date, locale) => {
   return new Date(date).toLocaleDateString(locale, options)
 }
 
-export const formatNumber = (value) => {
+export const formatNumber = (value, locale) => {
   if (value === null || value === undefined) return '0'
-  return value.toLocaleString()
+  return value.toLocaleString(locale)
 }

--- a/ui/src/utils/formatters.test.js
+++ b/ui/src/utils/formatters.test.js
@@ -121,35 +121,35 @@ describe('formatDuration2', () => {
 
 describe('formatNumber', () => {
   it('handles null and undefined values', () => {
-    expect(formatNumber(null)).toEqual('0')
-    expect(formatNumber(undefined)).toEqual('0')
+    expect(formatNumber(null, 'en-CA')).toEqual('0')
+    expect(formatNumber(undefined, 'en-CA')).toEqual('0')
   })
 
   it('formats integers', () => {
-    expect(formatNumber(0)).toEqual('0')
-    expect(formatNumber(1)).toEqual('1')
-    expect(formatNumber(123)).toEqual('123')
-    expect(formatNumber(1000)).toEqual('1,000')
-    expect(formatNumber(1234567)).toEqual('1,234,567')
+    expect(formatNumber(0, 'en-CA')).toEqual('0')
+    expect(formatNumber(1, 'en-CA')).toEqual('1')
+    expect(formatNumber(123, 'en-CA')).toEqual('123')
+    expect(formatNumber(1000, 'en-CA')).toEqual('1,000')
+    expect(formatNumber(1234567, 'en-CA')).toEqual('1,234,567')
   })
 
   it('formats decimal numbers', () => {
-    expect(formatNumber(123.45)).toEqual('123.45')
-    expect(formatNumber(1234.567)).toEqual('1,234.567')
+    expect(formatNumber(123.45, 'en-CA')).toEqual('123.45')
+    expect(formatNumber(1234.567, 'en-CA')).toEqual('1,234.567')
   })
 
   it('formats negative numbers', () => {
-    expect(formatNumber(-123)).toEqual('-123')
-    expect(formatNumber(-1234)).toEqual('-1,234')
-    expect(formatNumber(-123.45)).toEqual('-123.45')
+    expect(formatNumber(-123, 'en-CA')).toEqual('-123')
+    expect(formatNumber(-1234, 'en-CA')).toEqual('-1,234')
+    expect(formatNumber(-123.45, 'en-CA')).toEqual('-123.45')
   })
 })
 
 describe('formatFullDate', () => {
   it('format dates', () => {
-    expect(formatFullDate('2011', 'en-US')).toEqual('2011')
-    expect(formatFullDate('2011-06', 'en-US')).toEqual('Jun 2011')
-    expect(formatFullDate('1985-01-01', 'en-US')).toEqual('Jan 1, 1985')
+    expect(formatFullDate('2011', 'en-CA')).toEqual('2011')
+    expect(formatFullDate('2011-06', 'en-CA')).toEqual('Jun 2011')
+    expect(formatFullDate('1985-01-01', 'en-CA')).toEqual('Jan 1, 1985')
     expect(formatFullDate('199704')).toEqual('')
   })
 })


### PR DESCRIPTION
### Description

This PR provides a cleaner solution to the locale-dependent test failures addressed in #4417, by making the code itself locale-aware instead of relying on environment variables.

The issue occurred when `formatNumber()` used `toLocaleString()` without specifying a locale, causing different output based on system locale settings. Tests expecting en-CA format would fail on systems with different locales (e.g., fr-CH using space separators and commas for decimals).

**Solution:**
- Modified `formatNumber()` to accept an optional `locale` parameter
- Updated tests to explicitly pass `'en-CA'` locale for deterministic results
- Production code continues to use system locale by default (when `locale` parameter is undefined)
- No need for `cross-env` dependency or `LC_ALL` environment variable manipulation

### Related Issues
Related to #4417

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Run `make test-js` on a system with any locale (e.g., fr_CH, de_DE, etc.). Tests should now pass consistently regardless of system locale settings.
