### PR TITLE
Fix for the Italian translation: from "Scalette" to "Playlist"

### DIFF
--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -400,8 +400,8 @@
         },
         "albumList": "Album",
         "about": "Info",
-        "playlists": "Scalette",
-        "sharedPlaylists": "Scalette Condivise"
+        "playlists": "Playlist",
+        "sharedPlaylists": "Playlist Condivise"
     },
     "player": {
         "playListsText": "Coda",


### PR DESCRIPTION
In Italian, we usually use "Playlist" rather than "Scaletta" (or "Scalette" plural). 

The word Scaletta/e can refer to physical objects, such as a small ladder, or to other types of functions.