### PR TITLE
fix(scanner): handle cross-library relative paths in playlists

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -341,17 +341,17 @@ func (r *pathResolver) resolveRelativePath(line string, folder *model.Folder) pa
 
 	// Step 2: Determine which library this absolute path belongs to
 	libID, libPath := r.matcher.findLibraryForPath(absolutePath)
-	if libID != 0 {
-		return pathResolution{
-			absolutePath: absolutePath,
-			libraryPath:  libPath,
-			libraryID:    libID,
-			valid:        true,
-		}
+	if libID == 0 {
+		// Path not found in any library - this should not happen as the playlist's
+		// own library should have been matched above
+		return pathResolution{valid: false}
 	}
-
-	// Fallback: Check if it's in the playlist's own library
-	return r.validatePathInLibrary(absolutePath, folder.LibraryPath, folder.LibraryID)
+	return pathResolution{
+		absolutePath: absolutePath,
+		libraryPath:  libPath,
+		libraryID:    libID,
+		valid:        true,
+	}
 }
 
 // resolveAbsolutePath handles absolute paths by matching them against library paths.
@@ -366,22 +366,6 @@ func (r *pathResolver) resolveAbsolutePath(line string) pathResolution {
 		absolutePath: cleanPath,
 		libraryPath:  libPath,
 		libraryID:    libID,
-		valid:        true,
-	}
-}
-
-// validatePathInLibrary verifies that an absolute path belongs to the specified library.
-// It rejects paths that escape the library using ".." segments.
-func (r *pathResolver) validatePathInLibrary(absolutePath, libraryPath string, libraryID int) pathResolution {
-	rel, err := filepath.Rel(libraryPath, absolutePath)
-	if err != nil || strings.HasPrefix(rel, "..") {
-		return pathResolution{valid: false}
-	}
-
-	return pathResolution{
-		absolutePath: absolutePath,
-		libraryPath:  libraryPath,
-		libraryID:    libraryID,
 		valid:        true,
 	}
 }

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -315,20 +315,12 @@ type pathResolver struct {
 
 // newPathResolver creates a pathResolver with libraries loaded from the datastore.
 func newPathResolver(ctx context.Context, ds model.DataStore) (*pathResolver, error) {
-	matcher, err := buildLibraryMatcher(ctx, ds)
-	if err != nil {
-		return nil, err
-	}
-	return &pathResolver{matcher: matcher}, nil
-}
-
-// buildLibraryMatcher creates a libraryMatcher with libraries sorted by path length (longest first).
-func buildLibraryMatcher(ctx context.Context, ds model.DataStore) (*libraryMatcher, error) {
 	libs, err := ds.Library(ctx).GetAll()
 	if err != nil {
 		return nil, err
 	}
-	return newLibraryMatcher(libs), nil
+	matcher := newLibraryMatcher(libs)
+	return &pathResolver{matcher: matcher}, nil
 }
 
 // resolvePath determines the absolute path and library path for a playlist entry.

--- a/core/playlists_internal_test.go
+++ b/core/playlists_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"golang.org/x/text/unicode/norm"
 )
 
 var _ = Describe("libraryMatcher", func() {
@@ -403,30 +402,5 @@ var _ = Describe("pathResolution", func() {
 
 			Expect(err).To(HaveOccurred())
 		})
-	})
-})
-
-var _ = Describe("normalizePathForComparison", func() {
-	It("normalizes Unicode characters to NFC form and converts to lowercase", func() {
-		// Test with NFD (decomposed) input - as would come from macOS filesystem
-		nfdPath := norm.NFD.String("Michèle") // Explicitly convert to NFD form
-		normalized := normalizePathForComparison(nfdPath)
-		Expect(normalized).To(Equal("michèle"))
-
-		// Test with NFC (composed) input - as would come from Apple Music M3U
-		nfcPath := "Michèle" // This might be in NFC form
-		normalizedNfc := normalizePathForComparison(nfcPath)
-
-		// Ensure the two paths are not equal in their original forms
-		Expect(nfdPath).ToNot(Equal(nfcPath))
-
-		// Both should normalize to the same result
-		Expect(normalized).To(Equal(normalizedNfc))
-	})
-
-	It("handles paths with mixed case and Unicode characters", func() {
-		path := "Artist/Noël Coward/Album/Song.mp3"
-		normalized := normalizePathForComparison(path)
-		Expect(normalized).To(Equal("artist/noël coward/album/song.mp3"))
 	})
 })

--- a/core/playlists_internal_test.go
+++ b/core/playlists_internal_test.go
@@ -1,0 +1,186 @@
+package core
+
+import (
+	"context"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("compileLibraryPaths", func() {
+	var ds *tests.MockDataStore
+	var mockLibRepo *tests.MockLibraryRepo
+	var ps *playlists
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		mockLibRepo = &tests.MockLibraryRepo{}
+		ds = &tests.MockDataStore{
+			MockedLibrary: mockLibRepo,
+		}
+		ps = &playlists{ds: ds}
+	})
+
+	Describe("Longest library path matching", func() {
+		It("matches the longest library path when multiple libraries share a prefix", func() {
+			// Setup libraries with prefix conflicts
+			mockLibRepo.SetData([]model.Library{
+				{ID: 1, Path: "/music"},
+				{ID: 2, Path: "/music-classical"},
+				{ID: 3, Path: "/music-classical/opera"},
+			})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Test that longest path matches first
+			// Note: The regex pattern ^path(?:/|$) will match the path plus the trailing /
+			testCases := []struct {
+				path     string
+				expected string
+			}{
+				{"/music-classical/opera/track.mp3", "/music-classical/opera/"},
+				{"/music-classical/track.mp3", "/music-classical/"},
+				{"/music/track.mp3", "/music/"},
+				{"/music-classical/opera/", "/music-classical/opera/"}, // Trailing slash
+				{"/music-classical/opera", "/music-classical/opera"},   // Exact match (no trailing /)
+			}
+
+			for _, tc := range testCases {
+				matched := libRegex.FindString(tc.path)
+				Expect(matched).To(Equal(tc.expected), "Path %s should match %s, but got %s", tc.path, tc.expected, matched)
+			}
+		})
+
+		It("handles libraries with similar prefixes but different structures", func() {
+			mockLibRepo.SetData([]model.Library{
+				{ID: 1, Path: "/home/user/music"},
+				{ID: 2, Path: "/home/user/music-backup"},
+			})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Test that music-backup library is matched correctly
+			matched := libRegex.FindString("/home/user/music-backup/track.mp3")
+			Expect(matched).To(Equal("/home/user/music-backup/"))
+
+			// Test that music library is still matched correctly
+			matched = libRegex.FindString("/home/user/music/track.mp3")
+			Expect(matched).To(Equal("/home/user/music/"))
+		})
+
+		It("matches path that is exactly the library root", func() {
+			mockLibRepo.SetData([]model.Library{
+				{ID: 1, Path: "/music"},
+				{ID: 2, Path: "/music-classical"},
+			})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Exact library path should match (no trailing /)
+			matched := libRegex.FindString("/music-classical")
+			Expect(matched).To(Equal("/music-classical"))
+		})
+
+		It("handles complex nested library structures", func() {
+			mockLibRepo.SetData([]model.Library{
+				{ID: 1, Path: "/media"},
+				{ID: 2, Path: "/media/audio"},
+				{ID: 3, Path: "/media/audio/classical"},
+				{ID: 4, Path: "/media/audio/classical/baroque"},
+			})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			testCases := []struct {
+				path     string
+				expected string
+			}{
+				{"/media/audio/classical/baroque/bach/track.mp3", "/media/audio/classical/baroque/"},
+				{"/media/audio/classical/mozart/track.mp3", "/media/audio/classical/"},
+				{"/media/audio/rock/track.mp3", "/media/audio/"},
+				{"/media/video/movie.mp4", "/media/"},
+			}
+
+			for _, tc := range testCases {
+				matched := libRegex.FindString(tc.path)
+				Expect(matched).To(Equal(tc.expected), "Path %s should match %s, but got %s", tc.path, tc.expected, matched)
+			}
+		})
+	})
+
+	Describe("Edge cases", func() {
+		It("handles empty library list", func() {
+			mockLibRepo.SetData([]model.Library{})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(libRegex).ToNot(BeNil())
+
+			// Should not match anything
+			matched := libRegex.FindString("/music/track.mp3")
+			Expect(matched).To(BeEmpty())
+		})
+
+		It("handles single library", func() {
+			mockLibRepo.SetData([]model.Library{
+				{ID: 1, Path: "/music"},
+			})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			matched := libRegex.FindString("/music/track.mp3")
+			Expect(matched).To(Equal("/music/"))
+		})
+
+		It("handles libraries with special regex characters", func() {
+			mockLibRepo.SetData([]model.Library{
+				{ID: 1, Path: "/music[test]"},
+				{ID: 2, Path: "/music(backup)"},
+			})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(libRegex).ToNot(BeNil())
+
+			// Special characters should be escaped and match literally
+			matched := libRegex.FindString("/music[test]/track.mp3")
+			Expect(matched).To(Equal("/music[test]/"))
+		})
+	})
+
+	Describe("Regex pattern validation", func() {
+		It("ensures regex alternation respects order by testing actual matching behavior", func() {
+			mockLibRepo.SetData([]model.Library{
+				{ID: 1, Path: "/a"},
+				{ID: 2, Path: "/ab"},
+				{ID: 3, Path: "/abc"},
+			})
+
+			libRegex, err := ps.compileLibraryPaths(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Verify that longer paths match correctly (not cut off by shorter prefix)
+			// If ordering is wrong, /ab would match before /abc for path "/abc/file"
+			testCases := []struct {
+				path     string
+				expected string
+			}{
+				{"/abc/file.mp3", "/abc/"},
+				{"/ab/file.mp3", "/ab/"},
+				{"/a/file.mp3", "/a/"},
+			}
+
+			for _, tc := range testCases {
+				matched := libRegex.FindString(tc.path)
+				Expect(matched).To(Equal(tc.expected), "Path %s should match %s", tc.path, tc.expected)
+			}
+		})
+	})
+})

--- a/core/playlists_internal_test.go
+++ b/core/playlists_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/text/unicode/norm"
 )
 
 var _ = Describe("compileLibraryPaths", func() {
@@ -182,5 +183,30 @@ var _ = Describe("compileLibraryPaths", func() {
 				Expect(matched).To(Equal(tc.expected), "Path %s should match %s", tc.path, tc.expected)
 			}
 		})
+	})
+})
+
+var _ = Describe("normalizePathForComparison", func() {
+	It("normalizes Unicode characters to NFC form and converts to lowercase", func() {
+		// Test with NFD (decomposed) input - as would come from macOS filesystem
+		nfdPath := norm.NFD.String("Michèle") // Explicitly convert to NFD form
+		normalized := normalizePathForComparison(nfdPath)
+		Expect(normalized).To(Equal("michèle"))
+
+		// Test with NFC (composed) input - as would come from Apple Music M3U
+		nfcPath := "Michèle" // This might be in NFC form
+		normalizedNfc := normalizePathForComparison(nfcPath)
+
+		// Ensure the two paths are not equal in their original forms
+		Expect(nfdPath).ToNot(Equal(nfcPath))
+
+		// Both should normalize to the same result
+		Expect(normalized).To(Equal(normalizedNfc))
+	})
+
+	It("handles paths with mixed case and Unicode characters", func() {
+		path := "Artist/Noël Coward/Album/Song.mp3"
+		normalized := normalizePathForComparison(path)
+		Expect(normalized).To(Equal("artist/noël coward/album/song.mp3"))
 	})
 })

--- a/core/playlists_internal_test.go
+++ b/core/playlists_internal_test.go
@@ -335,34 +335,6 @@ var _ = Describe("pathResolver", func() {
 		})
 	})
 
-	Describe("validatePathInLibrary", func() {
-		It("validates path within library", func() {
-			resolution := resolver.validatePathInLibrary("/music/artist/track.mp3", "/music", 1)
-
-			Expect(resolution.valid).To(BeTrue())
-			Expect(resolution.libraryID).To(Equal(1))
-			Expect(resolution.libraryPath).To(Equal("/music"))
-		})
-
-		It("rejects path that escapes library using ..", func() {
-			resolution := resolver.validatePathInLibrary("/music/../etc/passwd", "/music", 1)
-
-			Expect(resolution.valid).To(BeFalse())
-		})
-
-		It("rejects path outside library", func() {
-			resolution := resolver.validatePathInLibrary("/podcasts/track.mp3", "/music", 1)
-
-			Expect(resolution.valid).To(BeFalse())
-		})
-
-		It("accepts path exactly at library root", func() {
-			resolution := resolver.validatePathInLibrary("/music", "/music", 1)
-
-			Expect(resolution.valid).To(BeTrue())
-		})
-	})
-
 	Describe("Cross-library resolution scenarios", func() {
 		It("handles playlist in library A referencing file in library B", func() {
 			// Playlist is in /music/playlists

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -33,8 +33,6 @@ var _ = Describe("Playlists", func() {
 			MockedLibrary:  mockLibRepo,
 		}
 		ctx = request.WithUser(ctx, model.User{ID: "123"})
-		// Path should be libPath, but we want to match the root folder referenced in the m3u, which is `/`
-		mockLibRepo.SetData([]model.Library{{ID: 1, Path: "/"}})
 	})
 
 	Describe("ImportFile", func() {
@@ -43,6 +41,8 @@ var _ = Describe("Playlists", func() {
 			ps = core.NewPlaylists(ds)
 			ds.MockedMediaFile = &mockedMediaFileRepo{}
 			libPath, _ := os.Getwd()
+			// Set up library with the actual library path that matches the folder
+			mockLibRepo.SetData([]model.Library{{ID: 1, Path: libPath}})
 			folder = &model.Folder{
 				ID:          "1",
 				LibraryID:   1,

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -194,9 +194,11 @@ func (r *mediaFileRepository) GetCursor(options ...model.QueryOptions) (model.Me
 	}, nil
 }
 
+// FindByPaths finds media files by their paths.
+// The paths can be library-qualified (format: "libraryID:path") or unqualified ("path").
+// Library-qualified paths search within the specified library, while unqualified paths
+// search across all libraries for backward compatibility.
 func (r *mediaFileRepository) FindByPaths(paths []string) (model.MediaFiles, error) {
-	// Parse library-qualified paths and build query
-	// Format: "libraryID:path" or just "path" (backward compatibility)
 	query := Or{}
 
 	for _, path := range paths {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -193,11 +195,40 @@ func (r *mediaFileRepository) GetCursor(options ...model.QueryOptions) (model.Me
 }
 
 func (r *mediaFileRepository) FindByPaths(paths []string) (model.MediaFiles, error) {
-	sel := r.newSelect().Columns("*").Where(Eq{"path collate nocase": paths})
+	// Parse library-qualified paths and build query
+	// Format: "libraryID:path" or just "path" (backward compatibility)
+	query := Or{}
+
+	for _, path := range paths {
+		parts := strings.SplitN(path, ":", 2)
+		if len(parts) == 2 {
+			// Library-qualified path: "libraryID:path"
+			libraryID, err := strconv.Atoi(parts[0])
+			if err != nil {
+				// Invalid format, skip
+				continue
+			}
+			relativePath := parts[1]
+			query = append(query, And{
+				Eq{"path collate nocase": relativePath},
+				Eq{"library_id": libraryID},
+			})
+		} else {
+			// Unqualified path: search across all libraries
+			query = append(query, Eq{"path collate nocase": path})
+		}
+	}
+
+	if len(query) == 0 {
+		return model.MediaFiles{}, nil
+	}
+
+	sel := r.newSelect().Columns("*").Where(query)
 	var res dbMediaFiles
 	if err := r.queryAll(sel, &res); err != nil {
 		return nil, err
 	}
+
 	return res.toModels(), nil
 }
 


### PR DESCRIPTION
### Description
Fixes playlist path resolution to support relative paths that reference songs across library boundaries. Previously, relative paths like `../Songs/abc.mp3` would fail when pointing to files in a different library than the playlist file.

### Related Issues
Fixes #4617, #4663 

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Changes Made

**Core Implementation:**
- Introduced `pathResolver`, `libraryMatcher`, and `pathResolution` components for proper path resolution
- Modified `resolvePaths` in `core/playlists.go` to resolve relative paths to absolute, then map to correct library using library-qualified format (`libraryID:relativePath`)
- Updated `FindByPaths` in `persistence/mediafile_repository.go` to handle library-qualified paths while maintaining backward compatibility
- Implemented longest-path-first matching to handle library path prefixes correctly (e.g., `/music-classical/opera` vs `/music-classical` vs `/music`)

**Testing:**
- Added 432 lines of unit tests in `core/playlists_internal_test.go` covering path matching, prefix conflicts, and edge cases
- Enhanced integration tests in `core/playlists_test.go` with cross-library scenarios
- All existing and new tests pass

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Create two libraries (e.g., `/music/Playlists/` and `/music/Songs/`)
2. Add a song to the second library (`abc.mp3`)
3. Create a playlist in the first library with relative path: `../Songs/abc.mp3`
4. Verify the playlist correctly finds and plays the song from the other library

**Automated:** `go test ./core/... -race -count=1`

### Additional Notes

- Uses two-step resolution: relative → absolute → library-qualified
- Library-qualified format ensures correct matching when multiple libraries have files at the same relative path
- Maintains backward compatibility with existing playlists
- Handles edge cases: library path prefixes, special characters, paths outside libraries
