### PR TITLE
fix: resolve transparent dropdown background in Ligera theme

### DIFF
--- a/ui/src/themes/ligera.js
+++ b/ui/src/themes/ligera.js
@@ -70,7 +70,7 @@ export default {
     },
     background: {
       default: '#f0f2f5',
-      paper: 'inherit',
+      paper: bLight['500'],
     },
     text: {
       secondary: '#232323',


### PR DESCRIPTION
### Description
Fixed the multi-library selector dropdown background in the Ligera theme. The dropdown had a transparent background making it difficult to read when content appeared behind it.

### Related Issues
Closes #4502

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Log in to Navidrome with a user that has access to 2 or more libraries
2. Navigate to Personal settings and change the theme to "Ligera"
3. Click on the "X of Y Libraries" button in the sidebar to open the library selector dropdown
4. Verify the dropdown now has a solid white background and the text is clearly readable

### Screenshots / Demos (if applicable)
**Before:** Dropdown had transparent/inherit background showing content behind it
**After:** Dropdown has solid white background matching the Ligera theme aesthetic

### Additional Notes
The root cause was that `palette.background.paper` was set to `'inherit'` in the Ligera theme, which caused Material-UI Paper components (used for the dropdown) to be transparent. Changed it to `bLight['500']` (white) to match other Ligera theme components. 

Verified that no other themes have this issue - all other themes either set explicit color values or properly inherit from Material-UI defaults.