### PR TITLE
bugfix(scanner): Specify exact table to use for missing mediafile filter

### DIFF
--- a/core/maintenance.go
+++ b/core/maintenance.go
@@ -166,7 +166,7 @@ func (s *maintenanceService) getAffectedAlbumIDs(ctx context.Context, ids []stri
 	if len(ids) > 0 {
 		filters = squirrel.And{
 			squirrel.Eq{"missing": true},
-			squirrel.Eq{"id": ids},
+			squirrel.Eq{"media_file.id": ids},
 		}
 	}
 


### PR DESCRIPTION
### Description
In `getAffectedAlbumIDs`, when one or more IDs is added, it adds a filter `"id": ids`. This filter is ambiguous though, because the `getAll` query joins with library table, which _also_ has an `id` field. Clarify this by adding the table name to the filter.

Note that this was not caught in testing, as it only uses mock db.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
If this should be tested in regressions, it would be necessary to use a real database (not mock).
To reproduce the error at runtime (and verify it is fixed), add a new file/album to the library, remove the file, and then from the missing tab delete that single item.
In the failing case, there will be an SQL error `ambiguous column name: id`, and in the working case there will be no error.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->