### PR TITLE
chore(plugin): bump plugin compilation timeout for regressions

### DIFF
--- a/plugins/manager_test.go
+++ b/plugins/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/core/agents"
@@ -22,8 +23,11 @@ var _ = Describe("Plugin Manager", func() {
 		// but, as this is an integration test, we can't use configtest.SetupConfig() as it causes
 		// data races.
 		originalPluginsFolder := conf.Server.Plugins.Folder
+		originalTimeout := conf.Server.DevPluginCompilationTimeout
+		conf.Server.DevPluginCompilationTimeout = 2 * time.Minute
 		DeferCleanup(func() {
 			conf.Server.Plugins.Folder = originalPluginsFolder
+			conf.Server.DevPluginCompilationTimeout = originalTimeout
 		})
 		conf.Server.Plugins.Enabled = true
 		conf.Server.Plugins.Folder = testDataDir


### PR DESCRIPTION
### Description
<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Run the regression on github actions. Since 60 seconds appears to be _variably_ clean, 120 seconds should be a comfortable timeout.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->