### PR TITLE
fix(plugins): avoid Chi RouteContext pollution in SubsonicAPI host service

### DIFF
--- a/plugins/host_subsonicapi.go
+++ b/plugins/host_subsonicapi.go
@@ -93,8 +93,12 @@ func (s *subsonicAPIServiceImpl) Call(ctx context.Context, req *subsonicapi.Call
 		RawQuery: query.Encode(),
 	}
 
-	// Create HTTP request with internal authentication
-	httpReq, err := http.NewRequestWithContext(ctx, "GET", finalURL.String(), nil)
+	// Create HTTP request with a fresh context to avoid Chi RouteContext pollution.
+	// Using http.NewRequest (instead of http.NewRequestWithContext) ensures the internal
+	// SubsonicAPI call doesn't inherit routing information from the parent handler,
+	// which would cause Chi to invoke the wrong handler. Authentication context is
+	// explicitly added in the next step via request.WithInternalAuth.
+	httpReq, err := http.NewRequest("GET", finalURL.String(), nil)
 	if err != nil {
 		return &subsonicapi.CallResponse{
 			Error: fmt.Sprintf("failed to create HTTP request: %v", err),


### PR DESCRIPTION
### Description
This PR fixes a critical bug where internal SubsonicAPI calls made from plugins were failing due to Chi RouteContext pollution. When plugins called SubsonicAPI endpoints (e.g., `getNowPlaying`), the internal HTTP requests inherited routing information from their parent handlers, causing Chi to invoke the wrong handler and resulting in errors like "missing parameter: 'id'".

The fix ensures that internal SubsonicAPI calls use a fresh context by switching from `http.NewRequestWithContext` to `http.NewRequest`. This prevents the parent handler's routing context from interfering with the internal call, while still maintaining proper authentication by explicitly adding the auth context in a subsequent step.

Additionally, the PR includes a minor refactoring of the SubsonicAPI host service initialization logic in `plugins/runtime.go` for improved clarity and error handling.

### Related Issues
Fixes #4710

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Create a plugin with the Scrobbler capability enabled
2. In the plugin's `NowPlaying` function, make a SubsonicAPI call:
   ```go
   resp, err := subsonicService.Call(ctx, &subsonicapi.CallRequest{
       Url: "/rest/getNowPlaying?f=json&u=username",
   })
   ```
3. Start playing something in Navidrome
4. Verify that the SubsonicAPI call succeeds without "missing parameter" errors
5. Check logs to ensure no warning messages about missing parameters

