### PR TITLE
fix(scanner): Use repeated arg instead of comma split

### DIFF
--- a/cmd/scan.go
+++ b/cmd/scan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/gob"
 	"os"
-	"strings"
 
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/db"
@@ -19,13 +18,13 @@ import (
 var (
 	fullScan   bool
 	subprocess bool
-	targets    string
+	targets    []string
 )
 
 func init() {
 	scanCmd.Flags().BoolVarP(&fullScan, "full", "f", false, "check all subfolders, ignoring timestamps")
 	scanCmd.Flags().BoolVarP(&subprocess, "subprocess", "", false, "run as subprocess (internal use)")
-	scanCmd.Flags().StringVarP(&targets, "targets", "t", "", "comma-separated list of libraryID:folderPath pairs (e.g., \"1:Music/Rock,1:Music/Jazz,2:Classical\")")
+	scanCmd.Flags().StringArrayVarP(&targets, "target", "t", []string{}, "list of libraryID:folderPath pairs, can be repeated (e.g., \"-t 1:Music/Rock -t 1:Music/Jazz -t 2:Classical\")")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -74,9 +73,9 @@ func runScanner(ctx context.Context) {
 
 	// Parse targets if provided
 	var scanTargets []model.ScanTarget
-	if targets != "" {
+	if len(targets) > 0 {
 		var err error
-		scanTargets, err = model.ParseTargets(strings.Split(targets, ","))
+		scanTargets, err = model.ParseTargets(targets)
 		if err != nil {
 			log.Fatal(ctx, "Failed to parse targets", err)
 		}

--- a/scanner/external.go
+++ b/scanner/external.go
@@ -8,12 +8,10 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
-	"github.com/navidrome/navidrome/utils/slice"
 )
 
 // scannerExternal is a scanner that runs an external process to do the scanning. It is used to avoid
@@ -47,9 +45,10 @@ func (s *scannerExternal) scan(ctx context.Context, fullScan bool, targets []mod
 
 	// Add targets if provided
 	if len(targets) > 0 {
-		targetsStr := strings.Join(slice.Map(targets, func(t model.ScanTarget) string { return t.String() }), ",")
-		args = append(args, "--targets", targetsStr)
-		log.Debug(ctx, "Spawning external scanner process with targets", "fullScan", fullScan, "path", exe, "targets", targetsStr)
+		for _, target := range targets {
+			args = append(args, "-t", target.String())
+		}
+		log.Debug(ctx, "Spawning external scanner process with targets", "fullScan", fullScan, "path", exe, "targets", targets)
 	} else {
 		log.Debug(ctx, "Spawning external scanner process", "fullScan", fullScan, "path", exe)
 	}


### PR DESCRIPTION
### Description
Use `StringArrayVarP` (repeatable `-t`) instead of a single string split by `,` for parsing arguments in external scanner. This is important for folders which have `,` in it.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
`touch` (or Windows equivalent) multiple directories with `,` in the filename, make sure external scanner is set, and watcher is enabled. Without this fix, it will fail, with the fix, the scan will complete.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->