### PR TITLE
fix: retry insights collection when no admin user available

### DIFF
--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -113,9 +113,9 @@ func WithAdminUser(ctx context.Context, ds model.DataStore) context.Context {
 	if err != nil {
 		c, err := ds.User(ctx).CountAll()
 		if c == 0 && err == nil {
-			log.Debug(ctx, "Scanner: No admin user yet!", err)
+			log.Debug(ctx, "No admin user yet!", err)
 		} else {
-			log.Error(ctx, "Scanner: No admin user found!", err)
+			log.Error(ctx, "No admin user found!", err)
 		}
 		u = &model.User{}
 	}

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -22,6 +22,7 @@ import (
 	"github.com/navidrome/navidrome/core/metrics/insights"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/plugins/schema"
 	"github.com/navidrome/navidrome/utils/singleton"
 )
@@ -64,9 +65,16 @@ func GetInstance(ds model.DataStore, pluginLoader PluginLoader) Insights {
 }
 
 func (c *insightsCollector) Run(ctx context.Context) {
-	ctx = auth.WithAdminUser(ctx, c.ds)
 	for {
-		c.sendInsights(ctx)
+		// Refresh admin context on each iteration to handle cases where
+		// admin user wasn't available on previous runs
+		insightsCtx := auth.WithAdminUser(ctx, c.ds)
+		u, _ := request.UserFrom(insightsCtx)
+		if !u.IsAdmin {
+			log.Trace(insightsCtx, "No admin user available, skipping insights collection")
+		} else {
+			c.sendInsights(insightsCtx)
+		}
 		select {
 		case <-time.After(consts.InsightsUpdateInterval):
 			continue


### PR DESCRIPTION
### Description
Previously, the insights collector would only try to get an admin user once at startup. If no admin user existed (e.g., fresh database before first user registration), insights collection would silently fail forever.

This change moves the admin context creation inside the collection loop so it retries on each interval. It also updates log messages in `WithAdminUser` to remove the "Scanner:" prefix since this function is now used by other components.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Start Navidrome with a fresh/empty database (no users)
2. Check logs for the message: "No admin user available, skipping insights collection"
3. Create an admin user
4. Observe that on the next insights interval, data is collected and sent successfully
