### PR TITLE
fix(player-mediasession): manually update playbackState - 4744

### DIFF
--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -243,7 +243,13 @@ const Player = () => {
         }
       }
     },
-    [context, dispatch, showNotifications, startTime, updateMediaSessionPlaybackState],
+    [
+      context,
+      dispatch,
+      showNotifications,
+      startTime,
+      updateMediaSessionPlaybackState,
+    ],
   )
 
   const onAudioPlayTrackChange = useCallback(() => {

--- a/ui/src/share/SharePlayer.jsx
+++ b/ui/src/share/SharePlayer.jsx
@@ -49,21 +49,21 @@ const SharePlayer = () => {
   }, [])
 
   const onAudioPlay = useCallback(
-    (info) => {
+    (_info) => {
       updateMediaSessionPlaybackState('playing')
     },
     [updateMediaSessionPlaybackState],
   )
 
   const onAudioPause = useCallback(
-    (info) => {
+    (_info) => {
       updateMediaSessionPlaybackState('paused')
     },
     [updateMediaSessionPlaybackState],
   )
 
   const onAudioEnded = useCallback(
-    (currentPlayId, audioLists, info) => {
+    (_currentPlayId, _audioLists, _info) => {
       updateMediaSessionPlaybackState('none')
     },
     [updateMediaSessionPlaybackState],

--- a/ui/src/share/SharePlayer.jsx
+++ b/ui/src/share/SharePlayer.jsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react'
 import ReactJkMusicPlayer from 'navidrome-music-player'
 import config, { shareInfo } from '../config'
 import { shareCoverUrl, shareDownloadUrl, shareStreamUrl } from '../utils'
@@ -39,6 +40,35 @@ const SharePlayer = () => {
       src: shareDownloadUrl(shareInfo?.id),
     })
   }
+
+  // ReactJKMusicPlayer doesn't set playbackState, so we do it manually
+  const updateMediaSessionPlaybackState = useCallback((state) => {
+    if ('mediaSession' in navigator) {
+      navigator.mediaSession.playbackState = state
+    }
+  }, [])
+
+  const onAudioPlay = useCallback(
+    (info) => {
+      updateMediaSessionPlaybackState('playing')
+    },
+    [updateMediaSessionPlaybackState],
+  )
+
+  const onAudioPause = useCallback(
+    (info) => {
+      updateMediaSessionPlaybackState('paused')
+    },
+    [updateMediaSessionPlaybackState],
+  )
+
+  const onAudioEnded = useCallback(
+    (currentPlayId, audioLists, info) => {
+      updateMediaSessionPlaybackState('none')
+    },
+    [updateMediaSessionPlaybackState],
+  )
+
   const options = {
     audioLists: list,
     mode: 'full',
@@ -59,6 +89,9 @@ const SharePlayer = () => {
     <ReactJkMusicPlayer
       {...options}
       className={classes.player}
+      onAudioPlay={onAudioPlay}
+      onAudioPause={onAudioPause}
+      onAudioEnded={onAudioEnded}
       onBeforeAudioDownload={onBeforeAudioDownload}
     />
   )


### PR DESCRIPTION

### Description
<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->
This PR introduces the manual configuration of `navigator.mediaSession.playbackState` in both [ui/src/audioplayer/Player.jsx](https://github.com/navidrome/navidrome/blob/master/ui/src/audioplayer/Player.jsx) and [ui/src/share/SharePlayer.jsx](https://github.com/navidrome/navidrome/blob/master/ui/src/share/SharePlayer.jsx),
using [react-music-player](https://github.com/navidrome/react-music-player)'s existing `onAudioPlay`, `onAudioPause` and `onAudioEnded` callback methods.

This change was made because `react-music-player`   itself does not handle the configuration of `mediaSession`'s `playbackState` with [showMediaSession: true](https://github.com/navidrome/navidrome/blob/64a9260174cd7c7c27f2b82c9ebaa4657afaeea6/ui/src/audioplayer/Player.jsx#L114).

I chose not to make a PR to Navidrome's react-music-player, since a UI overhaul is on the way, potentially introducing a new media player that may address this issue.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->
Fixes #4744

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [ ] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
<!-- Describe the steps to test your changes. Include setup, commands, and expected results. -->

 - Play a song in Navidrome, using either the `SharePlayer` or `Player` (the normal one)
 - Open a JS console, and get the value of `navigator.mediaSession.playbackState`
 - Observe that it changes to 'playing', 'paused', and 'none' *(e.g: when an album has played all the way through)* accordingly.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->