### PR TITLE
Improve the AMusic theme

### DIFF
--- a/ui/src/themes/amusic.css.js
+++ b/ui/src/themes/amusic.css.js
@@ -1,4 +1,10 @@
 const stylesheet = `
+.react-jinke-music-player-main .music-player-panel svg {
+    color: #eee
+}
+.react-jinke-music-player-main .music-player-panel button:disabled svg {
+    opacity: 0.3
+}
 .react-jinke-music-player-main svg:active, .react-jinke-music-player-main svg:hover {
     color: #D60017
 }


### PR DESCRIPTION
### Description

Improve the lyric button of the AMusic theme.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### Additional Notes

The current AMusic theme keeps the button color fixed at `#ff4e6b` both before and after the lyrics activate.

![before](https://github.com/user-attachments/assets/795e50d7-2b13-456b-a673-03e5876d61eb)

This improvement allows the lyric button to have a significant difference before and after activation.

![after](https://github.com/user-attachments/assets/d72dee76-1d7c-4f48-9b2b-8ae8ea5daf85)
