### PR TITLE
fix: make playlist name sorting case-insensitive

### DIFF
--- a/db/migrations/20260104203627_playlist_case_insensitive_name.sql
+++ b/db/migrations/20260104203627_playlist_case_insensitive_name.sql
@@ -1,0 +1,99 @@
+-- +goose Up
+-- Fix case-insensitive sorting for playlist names
+create table playlist_dg_tmp
+(
+    id           varchar(255)                              not null
+        primary key,
+    name         varchar(255) collate NOCASE default ''    not null,
+    comment      varchar(255)                default ''    not null,
+    duration     real                        default 0     not null,
+    song_count   integer                     default 0     not null,
+    public       bool                        default FALSE not null,
+    created_at   datetime,
+    updated_at   datetime,
+    path         string                      default ''    not null,
+    sync         bool                        default false not null,
+    size         integer                     default 0     not null,
+    rules        varchar,
+    evaluated_at datetime,
+    owner_id     varchar(255)                              not null
+        constraint playlist_user_user_id_fk
+            references user
+            on update cascade on delete cascade
+);
+
+insert into playlist_dg_tmp(id, name, comment, duration, song_count, public, created_at, updated_at, path, sync, size,
+                            rules, evaluated_at, owner_id)
+select id, name, comment, duration, song_count, public, created_at, updated_at, path, sync, size, rules, evaluated_at,
+       owner_id
+from playlist;
+
+drop table playlist;
+
+alter table playlist_dg_tmp
+    rename to playlist;
+
+create index playlist_name
+    on playlist (name);
+
+create index playlist_created_at
+    on playlist (created_at);
+
+create index playlist_updated_at
+    on playlist (updated_at);
+
+create index playlist_evaluated_at
+    on playlist (evaluated_at);
+
+create index playlist_size
+    on playlist (size);
+
+-- +goose Down
+-- Note: Downgrade loses the collation but preserves data
+create table playlist_dg_tmp
+(
+    id           varchar(255)              not null
+        primary key,
+    name         varchar(255) default ''   not null,
+    comment      varchar(255) default ''   not null,
+    duration     real         default 0    not null,
+    song_count   integer      default 0    not null,
+    public       bool         default FALSE not null,
+    created_at   datetime,
+    updated_at   datetime,
+    path         string       default ''   not null,
+    sync         bool         default false not null,
+    size         integer      default 0    not null,
+    rules        varchar,
+    evaluated_at datetime,
+    owner_id     varchar(255)              not null
+        constraint playlist_user_user_id_fk
+            references user
+            on update cascade on delete cascade
+);
+
+insert into playlist_dg_tmp(id, name, comment, duration, song_count, public, created_at, updated_at, path, sync, size,
+                            rules, evaluated_at, owner_id)
+select id, name, comment, duration, song_count, public, created_at, updated_at, path, sync, size, rules, evaluated_at,
+       owner_id
+from playlist;
+
+drop table playlist;
+
+alter table playlist_dg_tmp
+    rename to playlist;
+
+create index playlist_name
+    on playlist (name);
+
+create index playlist_created_at
+    on playlist (created_at);
+
+create index playlist_updated_at
+    on playlist (updated_at);
+
+create index playlist_evaluated_at
+    on playlist (evaluated_at);
+
+create index playlist_size
+    on playlist (size);

--- a/persistence/collation_test.go
+++ b/persistence/collation_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Collation", func() {
 		Entry("media_file.sort_title", "media_file", "sort_title"),
 		Entry("media_file.sort_album_name", "media_file", "sort_album_name"),
 		Entry("media_file.sort_artist_name", "media_file", "sort_artist_name"),
+		Entry("playlist.name", "playlist", "name"),
 		Entry("radio.name", "radio", "name"),
 		Entry("user.name", "user", "name"),
 	)
@@ -53,6 +54,7 @@ var _ = Describe("Collation", func() {
 		Entry("media_file.sort_album_name", "media_file", "coalesce(nullif(sort_album_name,''),order_album_name) collate nocase"),
 		Entry("media_file.sort_artist_name", "media_file", "coalesce(nullif(sort_artist_name,''),order_artist_name) collate nocase"),
 		Entry("media_file.path", "media_file", "path collate nocase"),
+		Entry("playlist.name", "playlist", "name collate nocase"),
 		Entry("radio.name", "radio", "name collate nocase"),
 		Entry("user.user_name", "user", "user_name collate nocase"),
 	)

--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -170,6 +170,7 @@ const PlaylistList = (props) => {
     <List
       {...props}
       exporter={false}
+      sort={{ field: 'name', order: 'ASC' }}
       filters={<PlaylistFilter />}
       actions={<PlaylistListActions />}
       bulkActionButtons={!isXsmall && <PlaylistListBulkActions />}


### PR DESCRIPTION
## Description
Add collation NOCASE to playlist.name column to ensure case-insensitive sorting, matching the behavior of other tables like radio and user. This fixes the issue where uppercase playlist names would appear before lowercase names regardless of alphabetical order.

## Related Issues
Fixes #4838

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

## How to Test
1. Run collation tests: `go run github.com/onsi/ginkgo/v2/ginkgo -v --focus "Collation" ./persistence/...`
2. All collation tests should pass, including the new playlist.name entries

## Additional Notes
The migration recreates the playlist table with proper collation (NOCASE) and recreates all associated indexes. This follows the same pattern used for the radio and user tables. All collation tests pass.