### PR TITLE
fix(ui): Show all participating albums

### DIFF
--- a/ui/src/artist/ArtistShow.jsx
+++ b/ui/src/artist/ArtistShow.jsx
@@ -123,9 +123,9 @@ const ArtistShowLayout = (props) => {
           {...showContext}
           addLabel={false}
           reference="album"
-          target="artist_id"
+          target="role_total_id"
           sort={{ field: 'max_year', order: 'ASC' }}
-          filter={{ artist_id: record?.id }}
+          filter={{ role_total_id: record?.id }}
           perPage={perPage}
           pagination={pagination}
         >


### PR DESCRIPTION
### Description

Navidrome indexes all types of participants of an album and the UI
exposes these as artists, which can be filtered by role (e.g. composer).

However, when entering a participant's artist page, nothing is shown.

This PR fixes that by showing all albums the "artist" participated to.
Doing so followings other music apps like Spotify and allows for
Navidrome to work better with classical music where composers rarely
have aritst credits on the work they've composed.

### Related Issues

- #4853

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
<!-- Describe the steps to test your changes. Include setup, commands, and expected results. -->

Go to the artist page and select a role which is not the main artist role (e.g. composer). Go to the artist's page and expect albums to show where there previously were none.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

I'm treating this as a fix, but due to lack of context it might have been an explicit decision to only show main credit albums. So I am open to changes, but the way this PR works does fix the issues I have.

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->