### PR TITLE
fix(playlists): match M3U paths across NFC/NFD normalization

### DIFF
--- a/core/playlists.go
+++ b/core/playlists.go
@@ -174,7 +174,9 @@ func (s *playlists) parseNSP(_ context.Context, pls *model.Playlist, reader io.R
 func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *model.Folder, reader io.Reader) error {
 	mediaFileRepository := s.ds.MediaFile(ctx)
 	var mfs model.MediaFiles
-	for lines := range slice.CollectChunks(slice.LinesFrom(reader), 400) {
+	// Chunk size of 100 lines, as each line can generate up to 4 lookup candidates
+	// (NFC/NFD × raw/lowercase), and SQLite has a max expression tree depth of 1000.
+	for lines := range slice.CollectChunks(slice.LinesFrom(reader), 100) {
 		filteredLines := make([]string, 0, len(lines))
 		for _, line := range lines {
 			line := strings.TrimSpace(line)

--- a/core/playlists.go
+++ b/core/playlists.go
@@ -243,7 +243,7 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 			} else {
 				// Prefer logging a composed representation when possible to avoid confusing output
 				// with decomposed combining marks.
-				log.Warn(ctx, "Path in playlist not found", "playlist", pls.Name, "path", path)
+				log.Warn(ctx, "Path in playlist not found", "playlist", pls.Name, "path", norm.NFC.String(path))
 			}
 		}
 	}

--- a/core/playlists_test.go
+++ b/core/playlists_test.go
@@ -474,6 +474,21 @@ var _ = Describe("Playlists", func() {
 			Expect(pls.Tracks[0].Path).To(Equal("abc/tEsT1.Mp3"))
 		})
 
+		// Fullwidth characters (e.g., ＡＢＣＤ) are not handled by SQLite's NOCASE collation,
+		// so we need exact matching for non-ASCII characters.
+		It("matches fullwidth characters exactly (SQLite NOCASE limitation)", func() {
+			// Fullwidth uppercase ＡＣＲＯＳＳ (U+FF21, U+FF23, U+FF32, U+FF2F, U+FF33, U+FF33)
+			repo.data = []string{
+				"plex/02 - ＡＣＲＯＳＳ.flac",
+			}
+			m3u := "/music/plex/02 - ＡＣＲＯＳＳ.flac\n"
+			f := strings.NewReader(m3u)
+			pls, err := ps.ImportM3U(ctx, f)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pls.Tracks).To(HaveLen(1))
+			Expect(pls.Tracks[0].Path).To(Equal("plex/02 - ＡＣＲＯＳＳ.flac"))
+		})
+
 		// Unicode normalization tests: NFC (composed) vs NFD (decomposed) forms
 		// macOS stores paths in NFD, Linux/Windows use NFC. Playlists may use either form.
 		DescribeTable("matches paths across Unicode NFC/NFD normalization",

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -410,4 +410,92 @@ var _ = Describe("MediaRepository", func() {
 			})
 		})
 	})
+
+	Describe("FindByPaths", func() {
+		// Test fixtures for Unicode and case-sensitivity tests
+		var testFiles []model.MediaFile
+
+		BeforeEach(func() {
+			testFiles = []model.MediaFile{
+				{ID: "findpath-1", LibraryID: 1, Path: "artist/Album/track.mp3", Title: "Track"},
+				{ID: "findpath-2", LibraryID: 1, Path: "artist/Album/UPPER.mp3", Title: "Upper"},
+				// Fullwidth uppercase: ＡＣＲＯＳＳ (U+FF21 U+FF23 U+FF32 U+FF2F U+FF33 U+FF33)
+				{ID: "findpath-3", LibraryID: 1, Path: "plex/02 - ＡＣＲＯＳＳ.flac", Title: "Fullwidth"},
+				// French diacritic: è (U+00E8, can decompose to e + combining grave)
+				{ID: "findpath-4", LibraryID: 1, Path: "artist/Michèle/song.mp3", Title: "French"},
+			}
+			for _, mf := range testFiles {
+				Expect(mr.Put(&mf)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			for _, mf := range testFiles {
+				_ = mr.Delete(mf.ID)
+			}
+		})
+
+		It("finds files by exact path", func() {
+			results, err := mr.FindByPaths([]string{"1:artist/Album/track.mp3"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].ID).To(Equal("findpath-1"))
+		})
+
+		It("finds files case-insensitively for ASCII characters (NOCASE)", func() {
+			// SQLite's COLLATE NOCASE handles ASCII case-insensitivity
+			results, err := mr.FindByPaths([]string{"1:ARTIST/ALBUM/TRACK.MP3"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].ID).To(Equal("findpath-1"))
+		})
+
+		It("finds fullwidth characters only with exact case match (SQLite NOCASE limitation)", func() {
+			// SQLite's NOCASE does NOT handle fullwidth uppercase/lowercase equivalence
+			// The DB has fullwidth uppercase ＡＣＲＯＳＳ, searching with exact match should work
+			results, err := mr.FindByPaths([]string{"1:plex/02 - ＡＣＲＯＳＳ.flac"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results[0].ID).To(Equal("findpath-3"))
+
+			// Searching with fullwidth lowercase ａｃｒｏｓｓ should NOT match
+			// (this is the SQLite limitation that requires exact matching for non-ASCII)
+			results, err = mr.FindByPaths([]string{"1:plex/02 - ａｃｒｏｓｓ.flac"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+
+		It("returns multiple files when querying multiple paths", func() {
+			results, err := mr.FindByPaths([]string{
+				"1:artist/Album/track.mp3",
+				"1:artist/Album/UPPER.mp3",
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(2))
+		})
+
+		It("returns empty slice for non-existent paths", func() {
+			results, err := mr.FindByPaths([]string{"1:nonexistent/path.mp3"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+
+		It("returns empty slice for empty input", func() {
+			results, err := mr.FindByPaths([]string{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+
+		It("handles library-qualified paths correctly", func() {
+			// Library 1 should find the file
+			results, err := mr.FindByPaths([]string{"1:artist/Album/track.mp3"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+
+			// Library 2 should NOT find it (file is in library 1)
+			results, err = mr.FindByPaths([]string{"2:artist/Album/track.mp3"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(results).To(BeEmpty())
+		})
+	})
 })

--- a/ui/src/dialogs/SelectPlaylistInput.jsx
+++ b/ui/src/dialogs/SelectPlaylistInput.jsx
@@ -318,11 +318,10 @@ export const SelectPlaylistInput = ({ onChange }) => {
 
   const canCreateNew = Boolean(
     searchText.trim() &&
-      !filteredOptions.some(
-        (option) =>
-          option.name.toLowerCase() === searchText.toLowerCase().trim(),
-      ) &&
-      !selectedPlaylists.some((p) => p.name === searchText.trim()),
+    !filteredOptions.some(
+      (option) => option.name.toLowerCase() === searchText.toLowerCase().trim(),
+    ) &&
+    !selectedPlaylists.some((p) => p.name === searchText.trim()),
   )
 
   return (


### PR DESCRIPTION
### Description
Fixes M3U import path matching across Unicode normalization forms (NFC vs NFD).

Navidrome currently normalizes playlist entry paths to NFD before querying the database. This helps macOS cases where scanned file paths are often NFD, but it regresses Linux/Windows where paths are typically NFC (e.g. Japanese Katakana with dakuten like `ド`), causing playlist entries to not resolve.

This change generates NFC+NFD lookup candidates for each library-qualified playlist entry and matches results back to the original playlist order using an NFC-canonical comparison key. It also logs missing paths using a composed (NFC) representation to avoid confusing combining-mark output.

### Related Issues
Fixes #4884, #4791, #4789, #4659, #4663, #4677

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Create an M3U with a path containing Japanese Katakana + dakuten (e.g. `.../ドリームソング.mp3`).
2. Import it via playlist scan or the M3U import endpoint.
3. Confirm tracks are found regardless of whether the playlist path is NFC/NFD.

### Screenshots / Demos (if applicable)

### Additional Notes
None.
