### PR TITLE
fix: don't expose JWT-related errors from share page

### DIFF
--- a/server/public/handle_images.go
+++ b/server/public/handle_images.go
@@ -35,7 +35,7 @@ func (pub *Router) handleImages(w http.ResponseWriter, r *http.Request) {
 	artId, err := decodeArtworkID(id)
 	if err != nil {
 		log.Error(r, "Error decoding artwork id", "id", id, err)
-		http.Error(w, err.Error(), http.StatusBadRequest)
+		http.Error(w, "invalid request", http.StatusBadRequest)
 		return
 	}
 	size := p.IntOr("size", 0)


### PR DESCRIPTION
### Description

The share / public router would expose the parse error of JWTs when
serving images, leading to unnecessary information disclosure.

Replace any error with a generic "invalid request" as is already done
when serving the streams themselves.

### Related Issues

N/A.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
<!-- Describe the steps to test your changes. Include setup, commands, and expected results. -->

1. On master, enable the sharing feature
2. Try to get an image using an invalid or crafted token

```
http://<navidrome>/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3OTk4NDg0MzAsImlkIjoiSzZ0SEVFSkc3Y05sdklMSlRzYlU5dSIsImlzcyI6Ik5EIn0.e0tzWhuF3n1E-pN7kO6VYlRxQufML42awSMXVmt0FNc&square=true
```

```text
failed to parse jws: failed to decode signature: failed to decode source: illegal base64 data at input byte 43
```

```
http://<navidrome>/share/img/eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3OTk4NDg0MzAsImlkIjoiSzZ0SEVFSkc3Y05sdklMSlRzYlU5dSIsImlzcyI6Ik5EIn0.e0tzWhuF3n1E-pN7kO6VYlRxQufML42awSMXVmt0FNc?square=true
```

```text
could not verify message using any of the signatures or keys
```

3. Use this patch and see that the returned error is instead "invalid request", matching the error returned when the same "trick" is used on other endpoints, like the stream itself.

### Screenshots / Demos (if applicable)

None.

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

None.

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->