### PR TITLE
feat(ui): prompt before closing window if music is playing - #4898

### DIFF
--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -97,13 +97,10 @@ const Player = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
-      // Check if there's a current track and audio is actually playing
-      if (playerState.current && Object.keys(playerState.current).length > 0) {
-        // Check if audio is actually playing (not paused)
-        if (audioInstance && !audioInstance.paused) {
-          e.preventDefault()
-          e.returnValue = '' // Chrome requires returnValue to be set
-        }
+      // Check there's a current track and is actually playing/not paused
+      if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
+        e.preventDefault()
+        e.returnValue = '' // Chrome requires returnValue to be set
       }
     }
 

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -95,6 +95,22 @@ const Player = () => {
     }
   }, [audioInstance, context, gainNode, playerState, gainInfo])
 
+  useEffect(() => {
+    const handleBeforeUnload = (e) => {
+      // Check if there's a current track and audio is actually playing
+      if (playerState.current && Object.keys(playerState.current).length > 0) {
+        // Check if audio is actually playing (not paused)
+        if (audioInstance && !audioInstance.paused) {
+          e.preventDefault()
+          e.returnValue = '' // Chrome requires returnValue to be set
+        }
+      }
+    }
+
+    window.addEventListener('beforeunload', handleBeforeUnload)
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [playerState, audioInstance])
+
   const defaultOptions = useMemo(
     () => ({
       theme: playerTheme,


### PR DESCRIPTION
### Description
This adds a small feature where if music is currently playing, closing the browser window/tab will result in a browser prompt. If there's no music playing, it has no effect.

### Related Issues
Fixes #4898

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
- Play a song
- Try to close the window
- Observe pop-up

### Screenshots / Demos (if applicable)
![prompt to close](https://github.com/user-attachments/assets/e85052ad-ebea-48d8-a4a8-eaafdafe54f5)

### Additional Notes