### PR TITLE
feat(subsonic): Add avgRating from subsonic spec

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -152,6 +152,7 @@ type subsonicOptions struct {
 	AppendSubtitle        bool
 	ArtistParticipations  bool
 	DefaultReportRealPath bool
+	EnableAverageRating   bool
 	LegacyClients         string
 	MinimalClients        string
 }
@@ -609,6 +610,7 @@ func setViperDefaults() {
 	viper.SetDefault("subsonic.appendsubtitle", true)
 	viper.SetDefault("subsonic.artistparticipations", false)
 	viper.SetDefault("subsonic.defaultreportrealpath", false)
+	viper.SetDefault("subsonic.enableaveragerating", true)
 	viper.SetDefault("subsonic.legacyclients", "DSub,SubMusic")
 	viper.SetDefault("agents", "lastfm,spotify,deezer")
 	viper.SetDefault("lastfm.enabled", true)

--- a/db/migrations/20260117104231_add_annotation_avg_rating_index.sql
+++ b/db/migrations/20260117104231_add_annotation_avg_rating_index.sql
@@ -1,0 +1,6 @@
+-- +goose Up
+CREATE INDEX IF NOT EXISTS annotation_item_type_rating
+    ON annotation (item_id, item_type, rating);
+
+-- +goose Down
+DROP INDEX IF EXISTS annotation_item_type_rating;

--- a/db/migrations/20260117104231_add_annotation_avg_rating_index.sql
+++ b/db/migrations/20260117104231_add_annotation_avg_rating_index.sql
@@ -1,6 +1,0 @@
--- +goose Up
-CREATE INDEX IF NOT EXISTS annotation_item_type_rating
-    ON annotation (item_id, item_type, rating);
-
--- +goose Down
-DROP INDEX IF EXISTS annotation_item_type_rating;

--- a/db/migrations/20260117201522_add_avg_rating_column.sql
+++ b/db/migrations/20260117201522_add_avg_rating_column.sql
@@ -1,23 +1,23 @@
 -- +goose Up
-ALTER TABLE album ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
-ALTER TABLE media_file ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
-ALTER TABLE artist ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
+ALTER TABLE album ADD COLUMN average_rating REAL NOT NULL DEFAULT 0;
+ALTER TABLE media_file ADD COLUMN average_rating REAL NOT NULL DEFAULT 0;
+ALTER TABLE artist ADD COLUMN average_rating REAL NOT NULL DEFAULT 0;
 
--- Populate avg_rating from existing ratings
-UPDATE album SET avg_rating = coalesce(
+-- Populate average_rating from existing ratings
+UPDATE album SET average_rating = coalesce(
     (SELECT round(avg(rating), 2) FROM annotation WHERE item_id = album.id AND item_type = 'album' AND rating > 0),
     0
 );
-UPDATE media_file SET avg_rating = coalesce(
+UPDATE media_file SET average_rating = coalesce(
     (SELECT round(avg(rating), 2) FROM annotation WHERE item_id = media_file.id AND item_type = 'media_file' AND rating > 0),
     0
 );
-UPDATE artist SET avg_rating = coalesce(
+UPDATE artist SET average_rating = coalesce(
     (SELECT round(avg(rating), 2) FROM annotation WHERE item_id = artist.id AND item_type = 'artist' AND rating > 0),
     0
 );
 
 -- +goose Down
-ALTER TABLE artist DROP COLUMN avg_rating;
-ALTER TABLE media_file DROP COLUMN avg_rating;
-ALTER TABLE album DROP COLUMN avg_rating;
+ALTER TABLE artist DROP COLUMN average_rating;
+ALTER TABLE media_file DROP COLUMN average_rating;
+ALTER TABLE album DROP COLUMN average_rating;

--- a/db/migrations/20260117201522_add_avg_rating_column.sql
+++ b/db/migrations/20260117201522_add_avg_rating_column.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+ALTER TABLE album ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
+ALTER TABLE media_file ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
+ALTER TABLE artist ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS album_avg_rating ON album(avg_rating);
+CREATE INDEX IF NOT EXISTS media_file_avg_rating ON media_file(avg_rating);
+CREATE INDEX IF NOT EXISTS artist_avg_rating ON artist(avg_rating);
+
+-- +goose Down
+DROP INDEX IF EXISTS artist_avg_rating;
+DROP INDEX IF EXISTS media_file_avg_rating;
+DROP INDEX IF EXISTS album_avg_rating;
+
+ALTER TABLE artist DROP COLUMN avg_rating;
+ALTER TABLE media_file DROP COLUMN avg_rating;
+ALTER TABLE album DROP COLUMN avg_rating;

--- a/db/migrations/20260117201522_add_avg_rating_column.sql
+++ b/db/migrations/20260117201522_add_avg_rating_column.sql
@@ -3,15 +3,21 @@ ALTER TABLE album ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
 ALTER TABLE media_file ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
 ALTER TABLE artist ADD COLUMN avg_rating REAL NOT NULL DEFAULT 0;
 
-CREATE INDEX IF NOT EXISTS album_avg_rating ON album(avg_rating);
-CREATE INDEX IF NOT EXISTS media_file_avg_rating ON media_file(avg_rating);
-CREATE INDEX IF NOT EXISTS artist_avg_rating ON artist(avg_rating);
+-- Populate avg_rating from existing ratings
+UPDATE album SET avg_rating = coalesce(
+    (SELECT round(avg(rating), 2) FROM annotation WHERE item_id = album.id AND item_type = 'album' AND rating > 0),
+    0
+);
+UPDATE media_file SET avg_rating = coalesce(
+    (SELECT round(avg(rating), 2) FROM annotation WHERE item_id = media_file.id AND item_type = 'media_file' AND rating > 0),
+    0
+);
+UPDATE artist SET avg_rating = coalesce(
+    (SELECT round(avg(rating), 2) FROM annotation WHERE item_id = artist.id AND item_type = 'artist' AND rating > 0),
+    0
+);
 
 -- +goose Down
-DROP INDEX IF EXISTS artist_avg_rating;
-DROP INDEX IF EXISTS media_file_avg_rating;
-DROP INDEX IF EXISTS album_avg_rating;
-
 ALTER TABLE artist DROP COLUMN avg_rating;
 ALTER TABLE media_file DROP COLUMN avg_rating;
 ALTER TABLE album DROP COLUMN avg_rating;

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -3,12 +3,13 @@ package model
 import "time"
 
 type Annotations struct {
-	PlayCount int64      `structs:"play_count" json:"playCount,omitempty"`
-	PlayDate  *time.Time `structs:"play_date"  json:"playDate,omitempty" `
-	Rating    int        `structs:"rating"     json:"rating,omitempty"   `
-	RatedAt   *time.Time `structs:"rated_at"   json:"ratedAt,omitempty"  `
-	Starred   bool       `structs:"starred"    json:"starred,omitempty"  `
-	StarredAt *time.Time `structs:"starred_at" json:"starredAt,omitempty"`
+	PlayCount     int64      `structs:"play_count"     json:"playCount,omitempty"`
+	PlayDate      *time.Time `structs:"play_date"      json:"playDate,omitempty" `
+	Rating        int        `structs:"rating"         json:"rating,omitempty"   `
+	RatedAt       *time.Time `structs:"rated_at"       json:"ratedAt,omitempty"  `
+	Starred       bool       `structs:"starred"        json:"starred,omitempty"  `
+	StarredAt     *time.Time `structs:"starred_at"     json:"starredAt,omitempty"`
+	AverageRating float64    `structs:"average_rating" json:"averageRating,omitempty"`
 }
 
 type AnnotatedRepository interface {

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -9,7 +9,7 @@ type Annotations struct {
 	RatedAt       *time.Time `structs:"rated_at"       json:"ratedAt,omitempty"  `
 	Starred       bool       `structs:"starred"        json:"starred,omitempty"  `
 	StarredAt     *time.Time `structs:"starred_at"     json:"starredAt,omitempty"`
-	AverageRating float64    `structs:"avg_rating"     json:"averageRating,omitempty" db:"avg_rating"`
+	AverageRating float64    `structs:"average_rating" json:"averageRating,omitempty"`
 }
 
 type AnnotatedRepository interface {

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -9,7 +9,7 @@ type Annotations struct {
 	RatedAt       *time.Time `structs:"rated_at"       json:"ratedAt,omitempty"  `
 	Starred       bool       `structs:"starred"        json:"starred,omitempty"  `
 	StarredAt     *time.Time `structs:"starred_at"     json:"starredAt,omitempty"`
-	AverageRating float64    `structs:"average_rating" json:"averageRating,omitempty"`
+	AverageRating float64    `structs:"avg_rating" json:"averageRating,omitempty" db:"avg_rating"`
 }
 
 type AnnotatedRepository interface {

--- a/model/annotation.go
+++ b/model/annotation.go
@@ -9,7 +9,7 @@ type Annotations struct {
 	RatedAt       *time.Time `structs:"rated_at"       json:"ratedAt,omitempty"  `
 	Starred       bool       `structs:"starred"        json:"starred,omitempty"  `
 	StarredAt     *time.Time `structs:"starred_at"     json:"starredAt,omitempty"`
-	AverageRating float64    `structs:"avg_rating" json:"averageRating,omitempty" db:"avg_rating"`
+	AverageRating float64    `structs:"avg_rating"     json:"averageRating,omitempty" db:"avg_rating"`
 }
 
 type AnnotatedRepository interface {

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -157,13 +157,9 @@ var _ = Describe("AlbumRepository", func() {
 
 			Expect(albumRepo.SetRating(4, newID)).To(Succeed())
 
-			_, err := albumRepo.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
-				"user_id":   "2222",
-				"item_id":   newID,
-				"item_type": "album",
-				"rating":    5,
-			}))
-			Expect(err).ToNot(HaveOccurred())
+			user2Ctx := request.WithUser(GinkgoT().Context(), regularUser)
+			user2Repo := NewAlbumRepository(user2Ctx, GetDBXBuilder()).(*albumRepository)
+			Expect(user2Repo.SetRating(5, newID)).To(Succeed())
 
 			album, err := albumRepo.Get(newID)
 			Expect(err).ToNot(HaveOccurred())
@@ -178,13 +174,9 @@ var _ = Describe("AlbumRepository", func() {
 			Expect(albumRepo.Put(&model.Album{LibraryID: 1, ID: newID, Name: "zero rating excluded album"})).To(Succeed())
 			Expect(albumRepo.SetRating(3, newID)).To(Succeed())
 
-			_, err := albumRepo.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
-				"user_id":   "2222",
-				"item_id":   newID,
-				"item_type": "album",
-				"rating":    0,
-			}))
-			Expect(err).ToNot(HaveOccurred())
+			user2Ctx := request.WithUser(GinkgoT().Context(), regularUser)
+			user2Repo := NewAlbumRepository(user2Ctx, GetDBXBuilder()).(*albumRepository)
+			Expect(user2Repo.SetRating(0, newID)).To(Succeed())
 
 			album, err := albumRepo.Get(newID)
 			Expect(err).ToNot(HaveOccurred())
@@ -200,27 +192,18 @@ var _ = Describe("AlbumRepository", func() {
 
 			Expect(albumRepo.SetRating(5, newID)).To(Succeed())
 
-			_, err := albumRepo.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
-				"user_id":   "2222",
-				"item_id":   newID,
-				"item_type": "album",
-				"rating":    4,
-			}))
-			Expect(err).ToNot(HaveOccurred())
+			user2Ctx := request.WithUser(GinkgoT().Context(), regularUser)
+			user2Repo := NewAlbumRepository(user2Ctx, GetDBXBuilder()).(*albumRepository)
+			Expect(user2Repo.SetRating(4, newID)).To(Succeed())
 
-			_, err = albumRepo.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
-				"user_id":   "3333",
-				"item_id":   newID,
-				"item_type": "album",
-				"rating":    4,
-			}))
-			Expect(err).ToNot(HaveOccurred())
+			user3Ctx := request.WithUser(GinkgoT().Context(), thirdUser)
+			user3Repo := NewAlbumRepository(user3Ctx, GetDBXBuilder()).(*albumRepository)
+			Expect(user3Repo.SetRating(4, newID)).To(Succeed())
 
 			album, err := albumRepo.Get(newID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(album.AverageRating).To(Equal(4.33)) // (5 + 4 + 4) / 3 = 4.333...
 
-			// Cleanup
 			_, _ = albumRepo.executeSQL(squirrel.Delete("annotation").Where(squirrel.Eq{"item_id": newID}))
 			_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": newID}))
 		})

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -119,6 +119,82 @@ var _ = Describe("MediaRepository", func() {
 			Expect(mf.PlayCount).To(Equal(int64(1)))
 		})
 
+		Describe("AverageRating", func() {
+			var raw *mediaFileRepository
+
+			BeforeEach(func() {
+				raw = mr.(*mediaFileRepository)
+			})
+
+			It("returns 0 when no ratings exist", func() {
+				newID := id.NewRandom()
+				Expect(mr.Put(&model.MediaFile{LibraryID: 1, ID: newID, Path: "/test/no-rating.mp3"})).To(Succeed())
+
+				mf, err := mr.Get(newID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mf.AverageRating).To(Equal(0.0))
+
+				_, _ = raw.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": newID}))
+			})
+
+			It("returns the user's rating as average when only one user rated", func() {
+				newID := id.NewRandom()
+				Expect(mr.Put(&model.MediaFile{LibraryID: 1, ID: newID, Path: "/test/single-rating.mp3"})).To(Succeed())
+				Expect(mr.SetRating(5, newID)).To(Succeed())
+
+				mf, err := mr.Get(newID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mf.AverageRating).To(Equal(5.0))
+
+				_, _ = raw.executeSQL(squirrel.Delete("annotation").Where(squirrel.Eq{"item_id": newID}))
+				_, _ = raw.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": newID}))
+			})
+
+			It("calculates average across multiple users", func() {
+				newID := id.NewRandom()
+				Expect(mr.Put(&model.MediaFile{LibraryID: 1, ID: newID, Path: "/test/multi-rating.mp3"})).To(Succeed())
+
+				Expect(mr.SetRating(3, newID)).To(Succeed())
+
+				_, err := raw.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
+					"user_id":   "2222", // regularUser from test fixtures
+					"item_id":   newID,
+					"item_type": "media_file",
+					"rating":    5,
+				}))
+				Expect(err).ToNot(HaveOccurred())
+
+				mf, err := mr.Get(newID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mf.AverageRating).To(Equal(4.0))
+
+				_, _ = raw.executeSQL(squirrel.Delete("annotation").Where(squirrel.Eq{"item_id": newID}))
+				_, _ = raw.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": newID}))
+			})
+
+			It("excludes zero ratings from average calculation", func() {
+				newID := id.NewRandom()
+				Expect(mr.Put(&model.MediaFile{LibraryID: 1, ID: newID, Path: "/test/zero-excluded.mp3"})).To(Succeed())
+
+				Expect(mr.SetRating(4, newID)).To(Succeed())
+
+				_, err := raw.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
+					"user_id":   "2222",
+					"item_id":   newID,
+					"item_type": "media_file",
+					"rating":    0,
+				}))
+				Expect(err).ToNot(HaveOccurred())
+
+				mf, err := mr.Get(newID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mf.AverageRating).To(Equal(4.0))
+
+				_, _ = raw.executeSQL(squirrel.Delete("annotation").Where(squirrel.Eq{"item_id": newID}))
+				_, _ = raw.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": newID}))
+			})
+		})
+
 		It("preserves play date if and only if provided date is older", func() {
 			id := "incplay.playdate"
 			Expect(mr.Put(&model.MediaFile{LibraryID: 1, ID: id})).To(BeNil())

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -156,13 +156,9 @@ var _ = Describe("MediaRepository", func() {
 
 				Expect(mr.SetRating(3, newID)).To(Succeed())
 
-				_, err := raw.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
-					"user_id":   "2222", // regularUser from test fixtures
-					"item_id":   newID,
-					"item_type": "media_file",
-					"rating":    5,
-				}))
-				Expect(err).ToNot(HaveOccurred())
+				user2Ctx := request.WithUser(GinkgoT().Context(), regularUser)
+				user2Repo := NewMediaFileRepository(user2Ctx, GetDBXBuilder())
+				Expect(user2Repo.SetRating(5, newID)).To(Succeed())
 
 				mf, err := mr.Get(newID)
 				Expect(err).ToNot(HaveOccurred())
@@ -178,13 +174,9 @@ var _ = Describe("MediaRepository", func() {
 
 				Expect(mr.SetRating(4, newID)).To(Succeed())
 
-				_, err := raw.executeSQL(squirrel.Insert("annotation").SetMap(map[string]interface{}{
-					"user_id":   "2222",
-					"item_id":   newID,
-					"item_type": "media_file",
-					"rating":    0,
-				}))
-				Expect(err).ToNot(HaveOccurred())
+				user2Ctx := request.WithUser(GinkgoT().Context(), regularUser)
+				user2Repo := NewMediaFileRepository(user2Ctx, GetDBXBuilder())
+				Expect(user2Repo.SetRating(0, newID)).To(Succeed())
 
 				mf, err := mr.Get(newID)
 				Expect(err).ToNot(HaveOccurred())

--- a/persistence/persistence_suite_test.go
+++ b/persistence/persistence_suite_test.go
@@ -130,7 +130,8 @@ var (
 var (
 	adminUser   = model.User{ID: "userid", UserName: "userid", Name: "admin", Email: "admin@email.com", IsAdmin: true}
 	regularUser = model.User{ID: "2222", UserName: "regular-user", Name: "Regular User", Email: "regular@example.com"}
-	testUsers   = model.Users{adminUser, regularUser}
+	thirdUser   = model.User{ID: "3333", UserName: "third-user", Name: "Third User", Email: "third@example.com"}
+	testUsers   = model.Users{adminUser, regularUser, thirdUser}
 )
 
 func p(path string) string {

--- a/persistence/sql_annotations.go
+++ b/persistence/sql_annotations.go
@@ -17,7 +17,7 @@ const annotationTable = "annotation"
 func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) SelectBuilder {
 	userID := loggedUser(r.ctx).ID
 	if userID == invalidUserId {
-		return query.Columns(fmt.Sprintf("%s.avg_rating", r.tableName))
+		return query.Columns(fmt.Sprintf("%s.average_rating", r.tableName))
 	}
 	query = query.
 		LeftJoin("annotation on ("+
@@ -38,7 +38,7 @@ func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) Selec
 		query = query.Columns("coalesce(play_count, 0) as play_count")
 	}
 
-	query = query.Columns(fmt.Sprintf("%s.avg_rating", r.tableName))
+	query = query.Columns(fmt.Sprintf("%s.average_rating", r.tableName))
 
 	return query
 }
@@ -91,7 +91,7 @@ func (r sqlRepository) SetRating(rating int, itemID string) error {
 func (r sqlRepository) updateAvgRating(itemID string) error {
 	upd := Update(r.tableName).
 		Where(Eq{"id": itemID}).
-		Set("avg_rating", Expr(
+		Set("average_rating", Expr(
 			"coalesce((select round(avg(rating), 2) from annotation where item_id = ? and item_type = ? and rating > 0), 0)",
 			itemID, r.tableName,
 		))

--- a/persistence/sql_annotations.go
+++ b/persistence/sql_annotations.go
@@ -38,6 +38,10 @@ func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) Selec
 		query = query.Columns("coalesce(play_count, 0) as play_count")
 	}
 
+	query = query.Columns(
+		fmt.Sprintf("coalesce((select round(avg(rating), 2) from annotation where annotation.item_id = %s and annotation.item_type = '%s' and annotation.rating > 0), 0) as average_rating", idField, r.tableName),
+	)
+
 	return query
 }
 

--- a/persistence/sql_annotations.go
+++ b/persistence/sql_annotations.go
@@ -17,7 +17,7 @@ const annotationTable = "annotation"
 func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) SelectBuilder {
 	userID := loggedUser(r.ctx).ID
 	if userID == invalidUserId {
-		return query
+		return query.Columns(fmt.Sprintf("%s.avg_rating as average_rating", r.tableName))
 	}
 	query = query.
 		LeftJoin("annotation on ("+
@@ -38,9 +38,7 @@ func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) Selec
 		query = query.Columns("coalesce(play_count, 0) as play_count")
 	}
 
-	query = query.Columns(
-		fmt.Sprintf("coalesce((select round(avg(rating), 2) from annotation where annotation.item_id = %s and annotation.item_type = '%s' and annotation.rating > 0), 0) as average_rating", idField, r.tableName),
-	)
+	query = query.Columns(fmt.Sprintf("%s.avg_rating as average_rating", r.tableName))
 
 	return query
 }
@@ -83,7 +81,22 @@ func (r sqlRepository) SetStar(starred bool, ids ...string) error {
 
 func (r sqlRepository) SetRating(rating int, itemID string) error {
 	ratedAt := time.Now()
-	return r.annUpsert(map[string]interface{}{"rating": rating, "rated_at": ratedAt}, itemID)
+	err := r.annUpsert(map[string]interface{}{"rating": rating, "rated_at": ratedAt}, itemID)
+	if err != nil {
+		return err
+	}
+	return r.updateAvgRating(itemID)
+}
+
+func (r sqlRepository) updateAvgRating(itemID string) error {
+	upd := Update(r.tableName).
+		Where(Eq{"id": itemID}).
+		Set("avg_rating", Expr(
+			"coalesce((select round(avg(rating), 2) from annotation where item_id = ? and item_type = ? and rating > 0), 0)",
+			itemID, r.tableName,
+		))
+	_, err := r.executeSQL(upd)
+	return err
 }
 
 func (r sqlRepository) IncPlayCount(itemID string, ts time.Time) error {

--- a/persistence/sql_annotations.go
+++ b/persistence/sql_annotations.go
@@ -17,7 +17,7 @@ const annotationTable = "annotation"
 func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) SelectBuilder {
 	userID := loggedUser(r.ctx).ID
 	if userID == invalidUserId {
-		return query.Columns(fmt.Sprintf("%s.avg_rating as average_rating", r.tableName))
+		return query.Columns(fmt.Sprintf("%s.avg_rating", r.tableName))
 	}
 	query = query.
 		LeftJoin("annotation on ("+
@@ -38,7 +38,7 @@ func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) Selec
 		query = query.Columns("coalesce(play_count, 0) as play_count")
 	}
 
-	query = query.Columns(fmt.Sprintf("%s.avg_rating as average_rating", r.tableName))
+	query = query.Columns(fmt.Sprintf("%s.avg_rating", r.tableName))
 
 	return query
 }

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -410,6 +410,7 @@ func (api *Router) buildArtistDirectory(ctx context.Context, artist *model.Artis
 	}
 	dir.AlbumCount = getArtistAlbumCount(artist)
 	dir.UserRating = int32(artist.Rating)
+	dir.AverageRating = artist.AverageRating
 	if artist.Starred {
 		dir.Starred = artist.StarredAt
 	}
@@ -447,6 +448,7 @@ func (api *Router) buildAlbumDirectory(ctx context.Context, album *model.Album) 
 		dir.Played = album.PlayDate
 	}
 	dir.UserRating = int32(album.Rating)
+	dir.AverageRating = album.AverageRating
 	dir.SongCount = int32(album.SongCount)
 	dir.CoverArt = album.CoverArtID().String()
 	if album.Starred {

--- a/server/subsonic/browsing.go
+++ b/server/subsonic/browsing.go
@@ -410,7 +410,9 @@ func (api *Router) buildArtistDirectory(ctx context.Context, artist *model.Artis
 	}
 	dir.AlbumCount = getArtistAlbumCount(artist)
 	dir.UserRating = int32(artist.Rating)
-	dir.AverageRating = artist.AverageRating
+	if conf.Server.Subsonic.EnableAverageRating {
+		dir.AverageRating = artist.AverageRating
+	}
 	if artist.Starred {
 		dir.Starred = artist.StarredAt
 	}
@@ -448,7 +450,9 @@ func (api *Router) buildAlbumDirectory(ctx context.Context, album *model.Album) 
 		dir.Played = album.PlayDate
 	}
 	dir.UserRating = int32(album.Rating)
-	dir.AverageRating = album.AverageRating
+	if conf.Server.Subsonic.EnableAverageRating {
+		dir.AverageRating = album.AverageRating
+	}
 	dir.SongCount = int32(album.SongCount)
 	dir.CoverArt = album.CoverArtID().String()
 	if album.Starred {

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -98,9 +98,11 @@ func toArtist(r *http.Request, a model.Artist) responses.Artist {
 		Id:             a.ID,
 		Name:           a.Name,
 		UserRating:     int32(a.Rating),
-		AverageRating:  a.AverageRating,
 		CoverArt:       a.CoverArtID().String(),
 		ArtistImageUrl: publicurl.ImageURL(r, a.CoverArtID(), 600),
+	}
+	if conf.Server.Subsonic.EnableAverageRating {
+		artist.AverageRating = a.AverageRating
 	}
 	if a.Starred {
 		artist.Starred = a.StarredAt
@@ -116,7 +118,9 @@ func toArtistID3(r *http.Request, a model.Artist) responses.ArtistID3 {
 		CoverArt:       a.CoverArtID().String(),
 		ArtistImageUrl: publicurl.ImageURL(r, a.CoverArtID(), 600),
 		UserRating:     int32(a.Rating),
-		AverageRating:  a.AverageRating,
+	}
+	if conf.Server.Subsonic.EnableAverageRating {
+		artist.AverageRating = a.AverageRating
 	}
 	if a.Starred {
 		artist.Starred = a.StarredAt
@@ -220,7 +224,9 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 		child.Starred = mf.StarredAt
 	}
 	child.UserRating = int32(mf.Rating)
-	child.AverageRating = mf.AverageRating
+	if conf.Server.Subsonic.EnableAverageRating {
+		child.AverageRating = mf.AverageRating
+	}
 
 	format, _ := getTranscoding(ctx)
 	if mf.Suffix != "" && format != "" && mf.Suffix != format {
@@ -332,7 +338,9 @@ func childFromAlbum(ctx context.Context, al model.Album) responses.Child {
 	}
 	child.PlayCount = al.PlayCount
 	child.UserRating = int32(al.Rating)
-	child.AverageRating = al.AverageRating
+	if conf.Server.Subsonic.EnableAverageRating {
+		child.AverageRating = al.AverageRating
+	}
 	child.OpenSubsonicChild = osChildFromAlbum(ctx, al)
 	return child
 }
@@ -426,7 +434,9 @@ func buildOSAlbumID3(ctx context.Context, album model.Album) *responses.OpenSubs
 		dir.Played = album.PlayDate
 	}
 	dir.UserRating = int32(album.Rating)
-	dir.AverageRating = album.AverageRating
+	if conf.Server.Subsonic.EnableAverageRating {
+		dir.AverageRating = album.AverageRating
+	}
 	dir.RecordLabels = slice.Map(album.Tags.Values(model.TagRecordLabel), func(s string) responses.RecordLabel {
 		return responses.RecordLabel{Name: s}
 	})

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -98,6 +98,7 @@ func toArtist(r *http.Request, a model.Artist) responses.Artist {
 		Id:             a.ID,
 		Name:           a.Name,
 		UserRating:     int32(a.Rating),
+		AverageRating:  a.AverageRating,
 		CoverArt:       a.CoverArtID().String(),
 		ArtistImageUrl: publicurl.ImageURL(r, a.CoverArtID(), 600),
 	}
@@ -115,6 +116,7 @@ func toArtistID3(r *http.Request, a model.Artist) responses.ArtistID3 {
 		CoverArt:       a.CoverArtID().String(),
 		ArtistImageUrl: publicurl.ImageURL(r, a.CoverArtID(), 600),
 		UserRating:     int32(a.Rating),
+		AverageRating:  a.AverageRating,
 	}
 	if a.Starred {
 		artist.Starred = a.StarredAt
@@ -218,6 +220,7 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 		child.Starred = mf.StarredAt
 	}
 	child.UserRating = int32(mf.Rating)
+	child.AverageRating = mf.AverageRating
 
 	format, _ := getTranscoding(ctx)
 	if mf.Suffix != "" && format != "" && mf.Suffix != format {
@@ -329,6 +332,7 @@ func childFromAlbum(ctx context.Context, al model.Album) responses.Child {
 	}
 	child.PlayCount = al.PlayCount
 	child.UserRating = int32(al.Rating)
+	child.AverageRating = al.AverageRating
 	child.OpenSubsonicChild = osChildFromAlbum(ctx, al)
 	return child
 }
@@ -422,6 +426,7 @@ func buildOSAlbumID3(ctx context.Context, album model.Album) *responses.OpenSubs
 		dir.Played = album.PlayDate
 	}
 	dir.UserRating = int32(album.Rating)
+	dir.AverageRating = album.AverageRating
 	dir.RecordLabels = slice.Map(album.Tags.Values(model.TagRecordLabel), func(s string) responses.RecordLabel {
 		return responses.RecordLabel{Name: s}
 	})

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -456,4 +456,88 @@ var _ = Describe("helpers", func() {
 			})
 		})
 	})
+
+	Describe("AverageRating in responses", func() {
+		var ctx context.Context
+
+		BeforeEach(func() {
+			ctx = context.Background()
+		})
+
+		Describe("childFromMediaFile", func() {
+			It("includes averageRating when set", func() {
+				mf := model.MediaFile{
+					ID:    "mf-avg-1",
+					Title: "Test Song",
+					Annotations: model.Annotations{
+						AverageRating: 4.5,
+					},
+				}
+				child := childFromMediaFile(ctx, mf)
+				Expect(child.AverageRating).To(Equal(4.5))
+			})
+
+			It("returns 0 for averageRating when not set", func() {
+				mf := model.MediaFile{
+					ID:    "mf-avg-2",
+					Title: "Test Song No Rating",
+				}
+				child := childFromMediaFile(ctx, mf)
+				Expect(child.AverageRating).To(Equal(0.0))
+			})
+		})
+
+		Describe("childFromAlbum", func() {
+			It("includes averageRating when set", func() {
+				al := model.Album{
+					ID:   "al-avg-1",
+					Name: "Test Album",
+					Annotations: model.Annotations{
+						AverageRating: 3.75,
+					},
+				}
+				child := childFromAlbum(ctx, al)
+				Expect(child.AverageRating).To(Equal(3.75))
+			})
+
+			It("returns 0 for averageRating when not set", func() {
+				al := model.Album{
+					ID:   "al-avg-2",
+					Name: "Test Album No Rating",
+				}
+				child := childFromAlbum(ctx, al)
+				Expect(child.AverageRating).To(Equal(0.0))
+			})
+		})
+
+		Describe("toArtist", func() {
+			It("includes averageRating when set", func() {
+				r := httptest.NewRequest("GET", "/test", nil)
+				a := model.Artist{
+					ID:   "ar-avg-1",
+					Name: "Test Artist",
+					Annotations: model.Annotations{
+						AverageRating: 5.0,
+					},
+				}
+				artist := toArtist(r, a)
+				Expect(artist.AverageRating).To(Equal(5.0))
+			})
+		})
+
+		Describe("toArtistID3", func() {
+			It("includes averageRating when set", func() {
+				r := httptest.NewRequest("GET", "/test", nil)
+				a := model.Artist{
+					ID:   "ar-avg-2",
+					Name: "Test Artist ID3",
+					Annotations: model.Annotations{
+						AverageRating: 2.5,
+					},
+				}
+				artist := toArtistID3(r, a)
+				Expect(artist.AverageRating).To(Equal(2.5))
+			})
+		})
+	})
 })

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -95,11 +95,9 @@ type Artist struct {
 	Name           string     `xml:"name,attr"                         json:"name"`
 	Starred        *time.Time `xml:"starred,attr,omitempty"            json:"starred,omitempty"`
 	UserRating     int32      `xml:"userRating,attr,omitempty"         json:"userRating,omitempty"`
+	AverageRating  float64    `xml:"averageRating,attr,omitempty"      json:"averageRating,omitempty"`
 	CoverArt       string     `xml:"coverArt,attr,omitempty"           json:"coverArt,omitempty"`
 	ArtistImageUrl string     `xml:"artistImageUrl,attr,omitempty"     json:"artistImageUrl,omitempty"`
-	/* TODO:
-	<xs:attribute name="averageRating" type="sub:AverageRating" use="optional"/>  <!-- Added in 1.13.0 -->
-	*/
 }
 
 type Index struct {
@@ -160,13 +158,11 @@ type Child struct {
 	ArtistId              string     `xml:"artistId,attr,omitempty"                 json:"artistId,omitempty"`
 	Type                  string     `xml:"type,attr,omitempty"                     json:"type,omitempty"`
 	UserRating            int32      `xml:"userRating,attr,omitempty"               json:"userRating,omitempty"`
+	AverageRating         float64    `xml:"averageRating,attr,omitempty"            json:"averageRating,omitempty"`
 	SongCount             int32      `xml:"songCount,attr,omitempty"                json:"songCount,omitempty"`
 	IsVideo               bool       `xml:"isVideo,attr,omitempty"                  json:"isVideo,omitempty"`
 	BookmarkPosition      int64      `xml:"bookmarkPosition,attr,omitempty"         json:"bookmarkPosition,omitempty"`
-	/*
-	   <xs:attribute name="averageRating" type="sub:AverageRating" use="optional"/>  <!-- Added in 1.6.0 -->
-	*/
-	*OpenSubsonicChild `xml:",omitempty" json:",omitempty"`
+	*OpenSubsonicChild    `xml:",omitempty" json:",omitempty"`
 }
 
 type OpenSubsonicChild struct {
@@ -198,14 +194,15 @@ type Songs struct {
 }
 
 type Directory struct {
-	Child      []Child    `xml:"child"                              json:"child,omitempty"`
-	Id         string     `xml:"id,attr"                            json:"id"`
-	Name       string     `xml:"name,attr"                          json:"name"`
-	Parent     string     `xml:"parent,attr,omitempty"              json:"parent,omitempty"`
-	Starred    *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
-	PlayCount  int64      `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
-	Played     *time.Time `xml:"played,attr,omitempty"              json:"played,omitempty"`
-	UserRating int32      `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	Child         []Child    `xml:"child"                              json:"child,omitempty"`
+	Id            string     `xml:"id,attr"                            json:"id"`
+	Name          string     `xml:"name,attr"                          json:"name"`
+	Parent        string     `xml:"parent,attr,omitempty"              json:"parent,omitempty"`
+	Starred       *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
+	PlayCount     int64      `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
+	Played        *time.Time `xml:"played,attr,omitempty"              json:"played,omitempty"`
+	UserRating    int32      `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	AverageRating float64    `xml:"averageRating,attr,omitempty"       json:"averageRating,omitempty"`
 
 	// ID3
 	Artist     string     `xml:"artist,attr,omitempty"              json:"artist,omitempty"`
@@ -217,10 +214,6 @@ type Directory struct {
 	Created    *time.Time `xml:"created,attr,omitempty"             json:"created,omitempty"`
 	Year       int32      `xml:"year,attr,omitempty"                json:"year,omitempty"`
 	Genre      string     `xml:"genre,attr,omitempty"               json:"genre,omitempty"`
-
-	/*
-	   <xs:attribute name="averageRating" type="sub:AverageRating" use="optional"/>  <!-- Added in 1.13.0 -->
-	*/
 }
 
 // ArtistID3Ref is a reference to an artist, a simplified version of ArtistID3. This is used to resolve the
@@ -237,6 +230,7 @@ type ArtistID3 struct {
 	AlbumCount             int32      `xml:"albumCount,attr"                    json:"albumCount"`
 	Starred                *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`
 	UserRating             int32      `xml:"userRating,attr,omitempty"          json:"userRating,omitempty"`
+	AverageRating          float64    `xml:"averageRating,attr,omitempty"       json:"averageRating,omitempty"`
 	ArtistImageUrl         string     `xml:"artistImageUrl,attr,omitempty"      json:"artistImageUrl,omitempty"`
 	*OpenSubsonicArtistID3 `xml:",omitempty" json:",omitempty"`
 }
@@ -268,6 +262,7 @@ type OpenSubsonicAlbumID3 struct {
 	// OpenSubsonic extensions
 	Played              *time.Time          `xml:"played,attr,omitempty"         json:"played,omitempty"`
 	UserRating          int32               `xml:"userRating,attr,omitempty"     json:"userRating"`
+	AverageRating       float64             `xml:"averageRating,attr,omitempty"  json:"averageRating,omitempty"`
 	Genres              Array[ItemGenre]    `xml:"genres,omitempty"              json:"genres"`
 	MusicBrainzId       string              `xml:"musicBrainzId,attr,omitempty"  json:"musicBrainzId"`
 	IsCompilation       bool                `xml:"isCompilation,attr,omitempty"  json:"isCompilation"`


### PR DESCRIPTION
### Description
Add support for the `averageRating` attribute in Subsonic API responses. This implements a feature from the Subsonic API specification (v1.6.0 for songs, v1.13.0 for albums/artists) that calculates the average rating across all users who have rated an item.

**Changes:**
- Added `AverageRating` field to the `Annotations` model
- Added `avg_rating` column to `album`, `media_file`, and `artist` tables to store pre-computed averages
- Modified `SetRating()` to recalculate and store the average when any user rates an item
- Modified `withAnnotation()` to read the stored average directly (no subquery on reads)
- Added `AverageRating` to Subsonic response structs: `Artist`, `ArtistID3`, `Child`, `Directory`, `OpenSubsonicAlbumID3`
- Wired up average rating in browsing and helper response builders

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Rate an album/artist/song with multiple user accounts (different ratings)
2. Query the Subsonic API (e.g., `getAlbum`, `getArtist`, `getSong`)
3. Verify the `averageRating` attribute is present in the response
4. Verify the value is the average of all non-zero user ratings (rounded to 2 decimal places)

Example: If User A rates an album 4 stars and User B rates it 5 stars, `averageRating` should be `4.5`.

### Screenshots / Demos (if applicable)
N/A - API-only change, no UI modifications.

### Additional Notes
- The average rating is pre-computed and stored on the entity tables (`album`, `media_file`, `artist`) when ratings change, avoiding subqueries on read operations for better performance
- Only non-zero ratings are included in the average calculation
- Returns `0` (omitted in JSON/XML due to `omitempty`) when no ratings exist

### Important

Add to documentation:

**`ND_SUBSONIC_ENABLEAVERAGERATING`** (default: `true`) - When set to `true`, includes the `averageRating` attribute in Subsonic API responses. Set to `false` to hide other users' rating data from API responses. The average rating is still calculated and stored internally regardless of this setting.