### PR TITLE
fix(db): Include items with no annotation for starred=false, handle has_rating=false

### DIFF
--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -119,7 +119,7 @@ var albumFilters = sync.OnceValue(func() map[string]filterFunc {
 		"artist_id":       artistFilter,
 		"year":            yearFilter,
 		"recently_played": recentlyPlayedFilter,
-		"starred":         optionalBoolFilter,
+		"starred":         starredFilter,
 		"has_rating":      hasRatingFilter,
 		"missing":         booleanFilter,
 		"genre_id":        tagIDFilter,

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -119,7 +119,7 @@ var albumFilters = sync.OnceValue(func() map[string]filterFunc {
 		"artist_id":       artistFilter,
 		"year":            yearFilter,
 		"recently_played": recentlyPlayedFilter,
-		"starred":         booleanFilter,
+		"starred":         optionalBoolFilter,
 		"has_rating":      hasRatingFilter,
 		"missing":         booleanFilter,
 		"genre_id":        tagIDFilter,
@@ -149,7 +149,11 @@ func recentlyPlayedFilter(string, interface{}) Sqlizer {
 	return Gt{"play_count": 0}
 }
 
-func hasRatingFilter(string, interface{}) Sqlizer {
+func hasRatingFilter(field string, value any) Sqlizer {
+	v := strings.ToLower(value.(string))
+	if v == "false" {
+		return Expr("COALESCE(rating, 0) = ?", 0)
+	}
 	return Gt{"rating": 0}
 }
 

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -150,7 +150,11 @@ func recentlyPlayedFilter(string, interface{}) Sqlizer {
 }
 
 func hasRatingFilter(field string, value any) Sqlizer {
-	v := strings.ToLower(value.(string))
+	v, ok := value.(string)
+	if !ok {
+		return nil
+	}
+	v = strings.ToLower(v)
 	if v == "false" {
 		return Expr("COALESCE(rating, 0) = ?", 0)
 	}

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -119,8 +119,8 @@ var albumFilters = sync.OnceValue(func() map[string]filterFunc {
 		"artist_id":       artistFilter,
 		"year":            yearFilter,
 		"recently_played": recentlyPlayedFilter,
-		"starred":         starredFilter,
-		"has_rating":      hasRatingFilter,
+		"starred":         annotationBoolFilter("starred"),
+		"has_rating":      annotationBoolFilter("rating"),
 		"missing":         booleanFilter,
 		"genre_id":        tagIDFilter,
 		"role_total_id":   allRolesFilter,
@@ -147,18 +147,6 @@ func recentlyAddedSort() string {
 
 func recentlyPlayedFilter(string, interface{}) Sqlizer {
 	return Gt{"play_count": 0}
-}
-
-func hasRatingFilter(field string, value any) Sqlizer {
-	v, ok := value.(string)
-	if !ok {
-		return nil
-	}
-	v = strings.ToLower(v)
-	if v == "false" {
-		return Expr("COALESCE(rating, 0) = ?", 0)
-	}
-	return Gt{"rating": 0}
 }
 
 func yearFilter(_ string, value interface{}) Sqlizer {

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -133,7 +133,7 @@ func NewArtistRepository(ctx context.Context, db dbx.Builder) model.ArtistReposi
 	r.registerModel(&model.Artist{}, map[string]filterFunc{
 		"id":         idFilter(r.tableName),
 		"name":       fullTextFilter(r.tableName, "mbz_artist_id"),
-		"starred":    optionalBoolFilter,
+		"starred":    starredFilter,
 		"role":       roleFilter,
 		"missing":    booleanFilter,
 		"library_id": artistLibraryIdFilter,

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -133,7 +133,7 @@ func NewArtistRepository(ctx context.Context, db dbx.Builder) model.ArtistReposi
 	r.registerModel(&model.Artist{}, map[string]filterFunc{
 		"id":         idFilter(r.tableName),
 		"name":       fullTextFilter(r.tableName, "mbz_artist_id"),
-		"starred":    booleanFilter,
+		"starred":    optionalBoolFilter,
 		"role":       roleFilter,
 		"missing":    booleanFilter,
 		"library_id": artistLibraryIdFilter,

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -133,7 +133,7 @@ func NewArtistRepository(ctx context.Context, db dbx.Builder) model.ArtistReposi
 	r.registerModel(&model.Artist{}, map[string]filterFunc{
 		"id":         idFilter(r.tableName),
 		"name":       fullTextFilter(r.tableName, "mbz_artist_id"),
-		"starred":    starredFilter,
+		"starred":    annotationBoolFilter("starred"),
 		"role":       roleFilter,
 		"missing":    booleanFilter,
 		"library_id": artistLibraryIdFilter,

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -95,7 +95,7 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
 		"id":         idFilter("media_file"),
 		"title":      fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
-		"starred":    booleanFilter,
+		"starred":    optionalBoolFilter,
 		"genre_id":   tagIDFilter,
 		"missing":    booleanFilter,
 		"artists_id": artistFilter,

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -95,7 +95,7 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
 		"id":         idFilter("media_file"),
 		"title":      fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
-		"starred":    starredFilter,
+		"starred":    annotationBoolFilter("starred"),
 		"genre_id":   tagIDFilter,
 		"missing":    booleanFilter,
 		"artists_id": artistFilter,

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -95,7 +95,7 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 	filters := map[string]filterFunc{
 		"id":         idFilter("media_file"),
 		"title":      fullTextFilter("media_file", "mbz_recording_id", "mbz_release_track_id"),
-		"starred":    optionalBoolFilter,
+		"starred":    starredFilter,
 		"genre_id":   tagIDFilter,
 		"missing":    booleanFilter,
 		"artists_id": artistFilter,

--- a/persistence/sql_annotations.go
+++ b/persistence/sql_annotations.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/Masterminds/squirrel"
@@ -41,6 +42,17 @@ func (r sqlRepository) withAnnotation(query SelectBuilder, idField string) Selec
 	query = query.Columns(fmt.Sprintf("%s.average_rating", r.tableName))
 
 	return query
+}
+
+func annotationBoolFilter(field string) func(string, any) Sqlizer {
+	return func(_ string, value any) Sqlizer {
+		v, ok := value.(string)
+		if !ok {
+			return nil
+		}
+		v = strings.ToLower(v)
+		return Expr(fmt.Sprintf("COALESCE(%s, 0) = ?", field), v == "true")
+	}
 }
 
 func (r sqlRepository) annId(itemID ...string) And {

--- a/persistence/sql_annotations.go
+++ b/persistence/sql_annotations.go
@@ -50,8 +50,10 @@ func annotationBoolFilter(field string) func(string, any) Sqlizer {
 		if !ok {
 			return nil
 		}
-		v = strings.ToLower(v)
-		return Expr(fmt.Sprintf("COALESCE(%s, 0) = ?", field), v == "true")
+		if strings.ToLower(v) == "true" {
+			return Expr(fmt.Sprintf("COALESCE(%s, 0) > 0", field))
+		}
+		return Expr(fmt.Sprintf("COALESCE(%s, 0) = 0", field))
 	}
 }
 

--- a/persistence/sql_annotations_test.go
+++ b/persistence/sql_annotations_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Annotation Filters", func() {
 	Describe("starredFilter", func() {
 		It("false includes items without annotations", func() {
 			albums, err := albumRepo.GetAll(model.QueryOptions{
-				Filters: starredFilter("starred", "false"),
+				Filters: annotationBoolFilter("starred")("starred", "false"),
 			})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -48,7 +48,7 @@ var _ = Describe("Annotation Filters", func() {
 
 		It("true excludes items without annotations", func() {
 			albums, err := albumRepo.GetAll(model.QueryOptions{
-				Filters: starredFilter("starred", "true"),
+				Filters: annotationBoolFilter("starred")("starred", "true"),
 			})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -61,7 +61,7 @@ var _ = Describe("Annotation Filters", func() {
 	Describe("hasRatingFilter", func() {
 		It("false includes items without annotations", func() {
 			albums, err := albumRepo.GetAll(model.QueryOptions{
-				Filters: hasRatingFilter("has_rating", "false"),
+				Filters: annotationBoolFilter("rating")("rating", "false"),
 			})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -77,7 +77,7 @@ var _ = Describe("Annotation Filters", func() {
 
 		It("true excludes items without annotations", func() {
 			albums, err := albumRepo.GetAll(model.QueryOptions{
-				Filters: hasRatingFilter("has_rating", "true"),
+				Filters: annotationBoolFilter("rating")("rating", "true"),
 			})
 			Expect(err).ToNot(HaveOccurred())
 

--- a/persistence/sql_annotations_test.go
+++ b/persistence/sql_annotations_test.go
@@ -1,0 +1,89 @@
+package persistence
+
+import (
+	"context"
+
+	"github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Annotation Filters", func() {
+	var (
+		albumRepo              *albumRepository
+		albumWithoutAnnotation model.Album
+	)
+
+	BeforeEach(func() {
+		ctx := request.WithUser(context.Background(), model.User{ID: "userid", UserName: "johndoe"})
+		albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
+
+		// Create album without any annotation (no star, no rating)
+		albumWithoutAnnotation = model.Album{ID: "no-annotation-album", Name: "No Annotation", LibraryID: 1}
+		Expect(albumRepo.Put(&albumWithoutAnnotation)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": albumWithoutAnnotation.ID}))
+	})
+
+	Describe("starredFilter", func() {
+		It("false includes items without annotations", func() {
+			albums, err := albumRepo.GetAll(model.QueryOptions{
+				Filters: starredFilter("starred", "false"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			var found bool
+			for _, a := range albums {
+				if a.ID == albumWithoutAnnotation.ID {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "Item without annotation should be included in starred=false filter")
+		})
+
+		It("true excludes items without annotations", func() {
+			albums, err := albumRepo.GetAll(model.QueryOptions{
+				Filters: starredFilter("starred", "true"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, a := range albums {
+				Expect(a.ID).ToNot(Equal(albumWithoutAnnotation.ID))
+			}
+		})
+	})
+
+	Describe("hasRatingFilter", func() {
+		It("false includes items without annotations", func() {
+			albums, err := albumRepo.GetAll(model.QueryOptions{
+				Filters: hasRatingFilter("has_rating", "false"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			var found bool
+			for _, a := range albums {
+				if a.ID == albumWithoutAnnotation.ID {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(), "Item without annotation should be included in has_rating=false filter")
+		})
+
+		It("true excludes items without annotations", func() {
+			albums, err := albumRepo.GetAll(model.QueryOptions{
+				Filters: hasRatingFilter("has_rating", "true"),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			for _, a := range albums {
+				Expect(a.ID).ToNot(Equal(albumWithoutAnnotation.ID))
+			}
+		})
+	})
+})

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -106,6 +106,11 @@ func booleanFilter(field string, value any) Sqlizer {
 	return Eq{field: v == "true"}
 }
 
+func optionalBoolFilter(field string, value any) Sqlizer {
+	v := strings.ToLower(value.(string))
+	return Expr("COALESCE("+field+", 0) = ?", v == "true")
+}
+
 func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {
 	return func(field string, value any) Sqlizer {
 		v := strings.ToLower(value.(string))

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -106,15 +106,6 @@ func booleanFilter(field string, value any) Sqlizer {
 	return Eq{field: v == "true"}
 }
 
-func starredFilter(_ string, value any) Sqlizer {
-	v, ok := value.(string)
-	if !ok {
-		return nil
-	}
-	v = strings.ToLower(v)
-	return Expr("COALESCE(starred, 0) = ?", v == "true")
-}
-
 func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {
 	return func(field string, value any) Sqlizer {
 		v := strings.ToLower(value.(string))

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -106,9 +106,9 @@ func booleanFilter(field string, value any) Sqlizer {
 	return Eq{field: v == "true"}
 }
 
-func optionalBoolFilter(field string, value any) Sqlizer {
+func starredFilter(_ string, value any) Sqlizer {
 	v := strings.ToLower(value.(string))
-	return Expr("COALESCE("+field+", 0) = ?", v == "true")
+	return Expr("COALESCE(starred, 0) = ?", v == "true")
 }
 
 func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -107,7 +107,11 @@ func booleanFilter(field string, value any) Sqlizer {
 }
 
 func starredFilter(_ string, value any) Sqlizer {
-	v := strings.ToLower(value.(string))
+	v, ok := value.(string)
+	if !ok {
+		return nil
+	}
+	v = strings.ToLower(v)
 	return Expr("COALESCE(starred, 0) = ?", v == "true")
 }
 


### PR DESCRIPTION
### Description
If an item has _no_ annotation, then certain fields in the query (`starred`, `rating`) will be null. 
Even though the query has `coalesce(starred, 0) as starred`, the _original_ value is taken, not the alias.
Fix this to use coalesce in the filter as well.
Additionally, handle `has_rating=false` for albums

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [X] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Have one or more items (album, artist, track) with no annotation. Filter by `starred=false`.
For album, test `has_rating=false` does what's expected

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->