### PR TITLE
fix(plugin): enable http response headers

### DIFF
--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -334,8 +334,9 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 	}
 
 	extismConfig := extism.PluginConfig{
-		EnableWasi:    true,
-		RuntimeConfig: runtimeConfig,
+		EnableWasi:                true,
+		RuntimeConfig:             runtimeConfig,
+		EnableHttpResponseHeaders: true,
 	}
 	compiled, err := extism.NewCompiledPlugin(m.ctx, pluginManifest, extismConfig, hostFunctions)
 	if err != nil {


### PR DESCRIPTION
### Description
Enable HTTP responses for plugins (useful for parsing rate limits and other fields).

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Have a plugin make an HTTP request. Call `resp.Headers()`, confirm that it is not empty.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->