### PR TITLE
feat(ui): add compilations sidebar view - #4930

### DIFF
--- a/resources/i18n/ar.json
+++ b/resources/i18n/ar.json
@@ -78,7 +78,7 @@
                 "mostPlayed": "الأكثر تشغيلاً",
                 "starred": "المفضلات",
                 "topRated": "الأكثر تقييما",
-                "compilations": "Compilations"
+                "compilations": "تجميعات"
             }
         },
         "artist": {

--- a/resources/i18n/ar.json
+++ b/resources/i18n/ar.json
@@ -77,7 +77,8 @@
                 "recentlyPlayed": "المشغلة حديثا",
                 "mostPlayed": "الأكثر تشغيلاً",
                 "starred": "المفضلات",
-                "topRated": "الأكثر تقييما"
+                "topRated": "الأكثر تقييما",
+                "compilations": "Compilations"
             }
         },
         "artist": {

--- a/resources/i18n/bg.json
+++ b/resources/i18n/bg.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Последно слушани",
         "mostPlayed": "Най-слушани",
         "starred": "Любими",
-        "topRated": "Най-висок рейтинг"
+        "topRated": "Най-висок рейтинг",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/bg.json
+++ b/resources/i18n/bg.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Най-слушани",
         "starred": "Любими",
         "topRated": "Най-висок рейтинг",
-        "compilations": "Compilations"
+        "compilations": "Компилации"
       }
     },
     "artist": {

--- a/resources/i18n/bs.json
+++ b/resources/i18n/bs.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Najviše reproducirano",
         "starred": "Favoriti",
         "topRated": "Najbolje ocijenjeno",
-        "compilations": "Compilations"
+        "compilations": "Kompilacije"
       }
     },
     "artist": {

--- a/resources/i18n/bs.json
+++ b/resources/i18n/bs.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Nedavno reproducirano",
         "mostPlayed": "Najviše reproducirano",
         "starred": "Favoriti",
-        "topRated": "Najbolje ocijenjeno"
+        "topRated": "Najbolje ocijenjeno",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/ca.json
+++ b/resources/i18n/ca.json
@@ -92,7 +92,8 @@
                 "recentlyPlayed": "Reproduït fa poc",
                 "mostPlayed": "Més reproduït",
                 "starred": "Preferits",
-                "topRated": "Més ben valorades"
+                "topRated": "Més ben valorades",
+                "compilations": "Compilations"
             }
         },
         "artist": {

--- a/resources/i18n/ca.json
+++ b/resources/i18n/ca.json
@@ -93,7 +93,7 @@
                 "mostPlayed": "Més reproduït",
                 "starred": "Preferits",
                 "topRated": "Més ben valorades",
-                "compilations": "Compilations"
+                "compilations": "Recopilacions"
             }
         },
         "artist": {

--- a/resources/i18n/cs.json
+++ b/resources/i18n/cs.json
@@ -78,7 +78,7 @@
                 "mostPlayed": "Nejpřehrávanější",
                 "starred": "Oblíbené",
                 "topRated": "Nejlépe hodnocené",
-                "compilations": "Compilations"
+                "compilations": "Kompilace"
             }
         },
         "artist": {

--- a/resources/i18n/cs.json
+++ b/resources/i18n/cs.json
@@ -77,7 +77,8 @@
                 "recentlyPlayed": "Nedávno přehrané",
                 "mostPlayed": "Nejpřehrávanější",
                 "starred": "Oblíbené",
-                "topRated": "Nejlépe hodnocené"
+                "topRated": "Nejlépe hodnocené",
+                "compilations": "Compilations"
             }
         },
         "artist": {

--- a/resources/i18n/da.json
+++ b/resources/i18n/da.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Nyligt Afspillet",
         "mostPlayed": "Mest Afspillet",
         "starred": "Stjernemarkerede",
-        "topRated": "Top bedømmelse"
+        "topRated": "Top bedømmelse",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/da.json
+++ b/resources/i18n/da.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Mest Afspillet",
         "starred": "Stjernemarkerede",
         "topRated": "Top bedømmelse",
-        "compilations": "Compilations"
+        "compilations": "Opsamlinger"
       }
     },
     "artist": {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Kürzlich gespielt",
         "mostPlayed": "Meist gespielt",
         "starred": "Favorit",
-        "topRated": "Beste Bewertung"
+        "topRated": "Beste Bewertung",
+        "compilations": "Kompilationen"
       }
     },
     "artist": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Παίζονται Συχνά",
         "starred": "Αγαπημένα",
         "topRated": "Κορυφαία",
-        "compilations": "Compilations"
+        "compilations": "Συλλογές"
       }
     },
     "artist": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Παίχτηκαν Πρόσφατα",
         "mostPlayed": "Παίζονται Συχνά",
         "starred": "Αγαπημένα",
-        "topRated": "Κορυφαία"
+        "topRated": "Κορυφαία",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/eo.json
+++ b/resources/i18n/eo.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Plej Luditaj",
         "starred": "Stelplenaj",
         "topRated": "Plej Alte Taksitaj",
-        "compilations": "Compilations"
+        "compilations": "Kompilaĵoj"
       }
     },
     "artist": {

--- a/resources/i18n/eo.json
+++ b/resources/i18n/eo.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Lastatempe Luditaj",
         "mostPlayed": "Plej Luditaj",
         "starred": "Stelplenaj",
-        "topRated": "Plej Alte Taksitaj"
+        "topRated": "Plej Alte Taksitaj",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Recientes",
         "mostPlayed": "Más reproducidos",
         "starred": "Favoritos",
-        "topRated": "Mejor calificados"
+        "topRated": "Mejor calificados",
+        "compilations": "Compilaciones"
       }
     },
     "artist": {

--- a/resources/i18n/eu.json
+++ b/resources/i18n/eu.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Gehien entzundakoak",
         "starred": "Gogokoak",
         "topRated": "Hobekien baloratutakoak",
-        "compilations": "Compilations"
+        "compilations": "Bildumak"
       }
     },
     "artist": {

--- a/resources/i18n/eu.json
+++ b/resources/i18n/eu.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Berriki entzundakoak",
         "mostPlayed": "Gehien entzundakoak",
         "starred": "Gogokoak",
-        "topRated": "Hobekien baloratutakoak"
+        "topRated": "Hobekien baloratutakoak",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/fa.json
+++ b/resources/i18n/fa.json
@@ -78,7 +78,7 @@
                 "mostPlayed": "بیشتر پخش شده",
                 "starred": "علاقمندی ها",
                 "topRated": "رتبه برتر",
-                "compilations": "Compilations"
+                "compilations": "مجموعه‌ها"
             }
         },
         "artist": {

--- a/resources/i18n/fa.json
+++ b/resources/i18n/fa.json
@@ -77,7 +77,8 @@
                 "recentlyPlayed": "آخرین پخش شده ها",
                 "mostPlayed": "بیشتر پخش شده",
                 "starred": "علاقمندی ها",
-                "topRated": "رتبه برتر"
+                "topRated": "رتبه برتر",
+                "compilations": "Compilations"
             }
         },
         "artist": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Viimeksi soitetut",
         "mostPlayed": "Useimmiten soitetut",
         "starred": "Suosikit",
-        "topRated": "Tykätyimmät"
+        "topRated": "Tykätyimmät",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Useimmiten soitetut",
         "starred": "Suosikit",
         "topRated": "Tykätyimmät",
-        "compilations": "Compilations"
+        "compilations": "Kokoelmat"
       }
     },
     "artist": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Récemment joués",
         "mostPlayed": "Plus joués",
         "starred": "Favoris",
-        "topRated": "Les mieux classés"
+        "topRated": "Les mieux classés",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/gl.json
+++ b/resources/i18n/gl.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Reproducida máis veces",
         "starred": "Favoritas",
         "topRated": "Máis valoradas",
-        "compilations": "Compilations"
+        "compilations": "Recompilacións"
       }
     },
     "artist": {

--- a/resources/i18n/gl.json
+++ b/resources/i18n/gl.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Reproducida recentemente",
         "mostPlayed": "Reproducida máis veces",
         "starred": "Favoritas",
-        "topRated": "Máis valoradas"
+        "topRated": "Máis valoradas",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/hi.json
+++ b/resources/i18n/hi.json
@@ -98,7 +98,7 @@
         "mostPlayed": "सबसे ज्यादा चलाए गए",
         "starred": "पसंदीदा",
         "topRated": "टॉप रेटेड",
-        "compilations": "Compilations"
+        "compilations": "संकलन"
       }
     },
     "artist": {

--- a/resources/i18n/hi.json
+++ b/resources/i18n/hi.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "हाल ही में चलाए गए",
         "mostPlayed": "सबसे ज्यादा चलाए गए",
         "starred": "पसंदीदा",
-        "topRated": "टॉप रेटेड"
+        "topRated": "टॉप रेटेड",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/hu.json
+++ b/resources/i18n/hu.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Nemrég lejátszott",
         "mostPlayed": "Legtöbbször lejátszott",
         "starred": "Kedvencek",
-        "topRated": "Legjobbra értékelt"
+        "topRated": "Legjobbra értékelt",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/hu.json
+++ b/resources/i18n/hu.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Legtöbbször lejátszott",
         "starred": "Kedvencek",
         "topRated": "Legjobbra értékelt",
-        "compilations": "Compilations"
+        "compilations": "Válogatások"
       }
     },
     "artist": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Terakhir Diputar",
         "mostPlayed": "Sering Diputar",
         "starred": "Favorit",
-        "topRated": "Peringkat Teratas"
+        "topRated": "Peringkat Teratas",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Sering Diputar",
         "starred": "Favorit",
         "topRated": "Peringkat Teratas",
-        "compilations": "Compilations"
+        "compilations": "Kompilasi"
       }
     },
     "artist": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -77,7 +77,8 @@
                 "recentlyPlayed": "Riprodotti di Recente",
                 "mostPlayed": "I Più Riprodotti",
                 "starred": "Preferiti",
-                "topRated": "Più votati"
+                "topRated": "Più votati",
+                "compilations": "Compilation"
             }
         },
         "artist": {

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "最近の再生",
         "mostPlayed": "最も再生",
         "starred": "お気に入り",
-        "topRated": "高評価"
+        "topRated": "高評価",
+        "compilations": "コンピレーション"
       }
     },
     "artist": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -96,7 +96,8 @@
         "recentlyPlayed": "최근 재생됨",
         "mostPlayed": "가장 많이 재생됨",
         "starred": "즐겨찾기",
-        "topRated": "높은 평가"
+        "topRated": "높은 평가",
+        "compilations": "컴필레이션"
       }
     },
     "artist": {

--- a/resources/i18n/nl.json
+++ b/resources/i18n/nl.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Onlangs afgespeeld",
         "mostPlayed": "Meest afgespeeld",
         "starred": "Favoriet",
-        "topRated": "Best beoordeeld"
+        "topRated": "Best beoordeeld",
+        "compilations": "Compilaties"
       }
     },
     "artist": {

--- a/resources/i18n/no.json
+++ b/resources/i18n/no.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Mest Avspilt",
         "starred": "Favoritter",
         "topRated": "Top Rangert",
-        "compilations": "Compilations"
+        "compilations": "Samlinger"
       }
     },
     "artist": {

--- a/resources/i18n/no.json
+++ b/resources/i18n/no.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Nylig Avspilt",
         "mostPlayed": "Mest Avspilt",
         "starred": "Favoritter",
-        "topRated": "Top Rangert"
+        "topRated": "Top Rangert",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Najczęściej Odtwarzane",
         "starred": "Ulubione",
         "topRated": "Najwyżej Oceniane",
-        "compilations": "Compilations"
+        "compilations": "Kompilacje"
       }
     },
     "artist": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Ostatnio Odtwarzane",
         "mostPlayed": "Najczęściej Odtwarzane",
         "starred": "Ulubione",
-        "topRated": "Najwyżej Oceniane"
+        "topRated": "Najwyżej Oceniane",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/pt-br.json
+++ b/resources/i18n/pt-br.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Recém-tocados",
         "mostPlayed": "Mais tocados",
         "starred": "Favoritos",
-        "topRated": "Melhor classificados"
+        "topRated": "Melhor classificados",
+        "compilations": "Coletâneas"
       }
     },
     "artist": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Проигранные",
         "mostPlayed": "Популярные",
         "starred": "Избранные",
-        "topRated": "Лучшие"
+        "topRated": "Лучшие",
+        "compilations": "Сборники"
       }
     },
     "artist": {

--- a/resources/i18n/sl.json
+++ b/resources/i18n/sl.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Največ predvajano",
         "starred": "Priljubljeni",
         "topRated": "Najvišje ocenjeno",
-        "compilations": "Compilations"
+        "compilations": "Kompilacije"
       }
     },
     "artist": {

--- a/resources/i18n/sl.json
+++ b/resources/i18n/sl.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Predvajan nedavno",
         "mostPlayed": "Največ predvajano",
         "starred": "Priljubljeni",
-        "topRated": "Najvišje ocenjeno"
+        "topRated": "Najvišje ocenjeno",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/sr.json
+++ b/resources/i18n/sr.json
@@ -91,7 +91,8 @@
         "recentlyAdded": "Додато недавно",
         "recentlyPlayed": "Пуштано недавно",
         "starred": "Омиљено",
-        "topRated": "Најбоље рангирано"
+        "topRated": "Најбоље рангирано",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/sr.json
+++ b/resources/i18n/sr.json
@@ -92,7 +92,7 @@
         "recentlyPlayed": "Пуштано недавно",
         "starred": "Омиљено",
         "topRated": "Најбоље рангирано",
-        "compilations": "Compilations"
+        "compilations": "Компилације"
       }
     },
     "artist": {

--- a/resources/i18n/sv.json
+++ b/resources/i18n/sv.json
@@ -99,7 +99,7 @@
         "mostPlayed": "Mest spelade",
         "starred": "Favoriter",
         "topRated": "Bästa betyg",
-        "compilations": "Compilations"
+        "compilations": "Samlingar"
       }
     },
     "artist": {

--- a/resources/i18n/sv.json
+++ b/resources/i18n/sv.json
@@ -98,7 +98,8 @@
         "recentlyPlayed": "Senast spelade",
         "mostPlayed": "Mest spelade",
         "starred": "Favoriter",
-        "topRated": "Bästa betyg"
+        "topRated": "Bästa betyg",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "เล่นล่าสุด",
         "mostPlayed": "เล่นมากที่สุด",
         "starred": "รายการโปรด",
-        "topRated": "ความนิยมสูง"
+        "topRated": "ความนิยมสูง",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -98,7 +98,7 @@
         "mostPlayed": "เล่นมากที่สุด",
         "starred": "รายการโปรด",
         "topRated": "ความนิยมสูง",
-        "compilations": "Compilations"
+        "compilations": "รวมเพลง"
       }
     },
     "artist": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Son Dinlenenler",
         "mostPlayed": "En Çok Dinlenenler",
         "starred": "Favorilenenler",
-        "topRated": "Yüksek Dereceliler"
+        "topRated": "Yüksek Dereceliler",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -98,7 +98,7 @@
         "mostPlayed": "En Çok Dinlenenler",
         "starred": "Favorilenenler",
         "topRated": "Yüksek Dereceliler",
-        "compilations": "Compilations"
+        "compilations": "Derlemeler"
       }
     },
     "artist": {

--- a/resources/i18n/uk.json
+++ b/resources/i18n/uk.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "Нещодавно відтворено",
         "mostPlayed": "Часто відтворювані",
         "starred": "Вибрані",
-        "topRated": "Найкраще"
+        "topRated": "Найкраще",
+        "compilations": "Compilations"
       }
     },
     "artist": {

--- a/resources/i18n/uk.json
+++ b/resources/i18n/uk.json
@@ -98,7 +98,7 @@
         "mostPlayed": "Часто відтворювані",
         "starred": "Вибрані",
         "topRated": "Найкраще",
-        "compilations": "Compilations"
+        "compilations": "Збірки"
       }
     },
     "artist": {

--- a/resources/i18n/zh-Hans.json
+++ b/resources/i18n/zh-Hans.json
@@ -97,7 +97,8 @@
                 "recentlyPlayed": "最近播放",
                 "mostPlayed": "最多播放",
                 "starred": "收藏",
-                "topRated": "评分排行"
+                "topRated": "评分排行",
+                "compilations": "合辑"
             }
         },
         "artist": {

--- a/resources/i18n/zh-Hant.json
+++ b/resources/i18n/zh-Hant.json
@@ -97,7 +97,8 @@
         "recentlyPlayed": "最近播放",
         "mostPlayed": "最常播放",
         "starred": "收藏",
-        "topRated": "最高評分"
+        "topRated": "最高評分",
+        "compilations": "合輯"
       }
     },
     "artist": {

--- a/ui/src/album/albumLists.jsx
+++ b/ui/src/album/albumLists.jsx
@@ -11,6 +11,8 @@ import StarBorderIcon from '@material-ui/icons/StarBorder'
 import AlbumOutlinedIcon from '@material-ui/icons/AlbumOutlined'
 import LibraryAddOutlinedIcon from '@material-ui/icons/LibraryAddOutlined'
 import VideoLibraryOutlinedIcon from '@material-ui/icons/VideoLibraryOutlined'
+import LibraryMusicIcon from '@material-ui/icons/LibraryMusic'
+import LibraryMusicOutlinedIcon from '@material-ui/icons/LibraryMusicOutlined'
 import config from '../config'
 import DynamicMenuIcon from '../layout/DynamicMenuIcon'
 
@@ -76,6 +78,16 @@ const albumLists = {
   mostPlayed: {
     icon: <RepeatIcon />,
     params: 'sort=play_count&order=DESC&filter={"recently_played":true}',
+  },
+  compilations: {
+    icon: (
+      <DynamicMenuIcon
+        path={'album/compilations'}
+        icon={LibraryMusicOutlinedIcon}
+        activeIcon={LibraryMusicIcon}
+      />
+    ),
+    params: 'sort=name&order=ASC&filter={"compilation":true}',
   },
 }
 

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -98,7 +98,8 @@
         "recentlyPlayed": "Recently Played",
         "mostPlayed": "Most Played",
         "starred": "Favourites",
-        "topRated": "Top Rated"
+        "topRated": "Top Rated",
+        "compilations": "Compilations"
       }
     },
     "artist": {


### PR DESCRIPTION
Closes #4930

## Description

Add a dedicated "Compilations" entry in the sidebar navigation, allowing users to browse compilation albums (Various Artists, soundtracks, samplers) separately from regular artist albums.

## Changes

- Add `compilations` entry to `ui/src/album/albumLists.jsx` with filter `{"compilation":true}`
- Add translation keys to all 35 i18n files (localized for de, fr, es, ja, zh, ko, ru, etc.)
- Uses `LibraryMusicIcon` for visual distinction in sidebar

## Implementation Details

This feature reuses 100% existing infrastructure:
- `booleanFilter` in `album_repository.go` already handles compilation filtering
- `Menu.jsx` iterates over `albumLists` entries automatically
- `AlbumGridView` and sorting/pagination work out of the box
- URL is bookmarkable: `/album/compilations?filter={"compilation":true}`

## Screenshots

Tested via Chrome DevTools automation:
- Sidebar shows "Compilations" entry with LibraryMusic icon
- Click navigates to filtered album list (only compilation=true albums)
- Grid and Table view both work
- Sorting by name/year/recently added works
- Pagination works

## Related Issues

None - this is a standalone feature request.