### PR TITLE
feat: add EnableNowPlayingForAllUsers config option

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -83,6 +83,7 @@ type configOptions struct {
 	EnableReplayGain                bool
 	EnableCoverAnimation            bool
 	EnableNowPlaying                bool
+	EnableNowPlayingForAllUsers     bool
 	GATrackingID                    string
 	EnableLogRedacting              bool
 	AuthRequestLimit                int
@@ -577,6 +578,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablereplaygain", true)
 	viper.SetDefault("enablecoveranimation", true)
 	viper.SetDefault("enablenowplaying", true)
+	viper.SetDefault("enablenowplayingforallusers", false)
 	viper.SetDefault("enablesharing", false)
 	viper.SetDefault("shareurl", "")
 	viper.SetDefault("defaultshareexpiration", 8760*time.Hour)

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -56,6 +56,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"defaultUIVolume":           conf.Server.DefaultUIVolume,
 			"enableCoverAnimation":      conf.Server.EnableCoverAnimation,
 			"enableNowPlaying":          conf.Server.EnableNowPlaying,
+			"enableNowPlayingForAllUsers": conf.Server.EnableNowPlayingForAllUsers,
 			"gaTrackingId":              conf.Server.GATrackingID,
 			"losslessFormats":           strings.ToUpper(strings.Join(mime.LosslessFormats, ",")),
 			"devActivityPanel":          conf.Server.DevActivityPanel,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -87,6 +87,7 @@ var _ = Describe("serveIndex", func() {
 		Entry("defaultUIVolume", func() { conf.Server.DefaultUIVolume = 45 }, "defaultUIVolume", float64(45)),
 		Entry("enableCoverAnimation", func() { conf.Server.EnableCoverAnimation = true }, "enableCoverAnimation", true),
 		Entry("enableNowPlaying", func() { conf.Server.EnableNowPlaying = true }, "enableNowPlaying", true),
+		Entry("enableNowPlayingForAllUsers", func() { conf.Server.EnableNowPlayingForAllUsers = true }, "enableNowPlayingForAllUsers", true),
 		Entry("gaTrackingId", func() { conf.Server.GATrackingID = "UA-12345" }, "gaTrackingId", "UA-12345"),
 		Entry("defaultDownloadableShare", func() { conf.Server.DefaultDownloadableShare = true }, "defaultDownloadableShare", true),
 		Entry("devSidebarPlaylists", func() { conf.Server.DevSidebarPlaylists = true }, "devSidebarPlaylists", true),

--- a/server/subsonic/album_lists.go
+++ b/server/subsonic/album_lists.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/core/scrobbler"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -203,6 +204,10 @@ func (api *Router) GetStarred2(r *http.Request) (*responses.Subsonic, error) {
 
 func (api *Router) GetNowPlaying(r *http.Request) (*responses.Subsonic, error) {
 	ctx := r.Context()
+	user := getUser(ctx)
+	if !conf.Server.EnableNowPlayingForAllUsers && !user.IsAdmin {
+		return nil, newError(responses.ErrorAuthorizationFail, "Now playing is admin only")
+	}
 	npInfo, err := api.scrobbler.GetNowPlaying(ctx)
 	if err != nil {
 		log.Error(r, "Error retrieving now playing list", err)

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -30,6 +30,7 @@ const defaultConfig = {
   enableExternalServices: true,
   enableCoverAnimation: true,
   enableNowPlaying: true,
+  enableNowPlayingForAllUsers: false,
   devShowArtistPage: true,
   devUIShowConfig: true,
   devNewEventStream: false,

--- a/ui/src/layout/AppBar.jsx
+++ b/ui/src/layout/AppBar.jsx
@@ -121,7 +121,7 @@ const CustomUserMenu = ({ onClick, ...rest }) => {
   return (
     <>
       {config.devActivityPanel &&
-        permissions === 'admin' &&
+        (permissions === 'admin' || config.enableNowPlayingForAllUsers) &&
         config.enableNowPlaying && <NowPlayingPanel />}
       {config.devActivityPanel && permissions === 'admin' && <ActivityPanel />}
       <UserMenu {...rest}>

--- a/ui/src/layout/AppBar.test.jsx
+++ b/ui/src/layout/AppBar.test.jsx
@@ -8,11 +8,12 @@ import AppBar from './AppBar'
 import config from '../config'
 
 let store
+let mockPermissions = 'admin'
 
 vi.mock('react-admin', () => ({
   AppBar: ({ userMenu }) => <div data-testid="appbar">{userMenu}</div>,
   useTranslate: () => (x) => x,
-  usePermissions: () => ({ permissions: 'admin' }),
+  usePermissions: () => ({ permissions: mockPermissions }),
   getResources: () => [],
 }))
 
@@ -39,6 +40,8 @@ describe('<AppBar />', () => {
   beforeEach(() => {
     config.devActivityPanel = true
     config.enableNowPlaying = true
+    config.enableNowPlayingForAllUsers = false
+    mockPermissions = 'admin'
     store = createStore(combineReducers({ activity: activityReducer }), {
       activity: { nowPlayingCount: 0 },
     })
@@ -61,5 +64,26 @@ describe('<AppBar />', () => {
       </Provider>,
     )
     expect(screen.queryByTestId('now-playing-panel')).toBeNull()
+  })
+
+  it('hides NowPlayingPanel for non-admin users by default', () => {
+    mockPermissions = 'regular'
+    render(
+      <Provider store={store}>
+        <AppBar />
+      </Provider>,
+    )
+    expect(screen.queryByTestId('now-playing-panel')).toBeNull()
+  })
+
+  it('renders NowPlayingPanel for non-admin users when enableNowPlayingForAllUsers is true', () => {
+    mockPermissions = 'regular'
+    config.enableNowPlayingForAllUsers = true
+    render(
+      <Provider store={store}>
+        <AppBar />
+      </Provider>,
+    )
+    expect(screen.getByTestId('now-playing-panel')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
### Description

**Update:**
Hm, I just noticed this branch:
https://github.com/navidrome/navidrome/compare/master...feat/now-playing-visibility-control

Perhaps I should close this PR?

---

Allow non-admin users to see the Now Playing panel in the web UI when the new EnableNowPlayingForAllUsers config option is set to true. The default remains false, preserving existing behavior.

Before this change, the logic to show or hide the Now Playing panel was implemented on the frontend. That means it was essentially a cosmetic indicator. This PR includes logic that adds an auth check to the backend, operating under the assumption that said logic should have been there the whole time. LMK if I'm misunderstanding something.

### Related Issues
Closes #4312
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [ ] My code follows the project’s coding style
- [ ] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [ ] All existing and new tests pass

### How to Test

Create two non-admin users, User A and User B. Loop a track as User A. View the navidrome UI as user B. When the new flag flag is false, User B should not see a now playing UI. When the flag is true, they should see it.
