### PR TITLE
refactor: use duration as a soft ranking signal instead of hard cutoff in track matching

### DIFF
--- a/core/external/provider_matching.go
+++ b/core/external/provider_matching.go
@@ -312,13 +312,6 @@ func durationMatches(durationMs uint32, mediaFileDurationSec float32) bool {
 // 3. Highest specificity level
 // 4. Highest album similarity (as final tiebreaker)
 func (e *provider) findBestMatch(q songQuery, tracks model.MediaFiles, threshold float64) (model.MediaFile, bool) {
-	return findBestMatchInTracks(q, tracks, threshold)
-}
-
-// findBestMatchInTracks performs the core matching logic on a set of tracks.
-// It finds the track with the best combined score based on title similarity,
-// specificity level, and album similarity.
-func findBestMatchInTracks(q songQuery, tracks model.MediaFiles, threshold float64) (model.MediaFile, bool) {
 	var bestMatch model.MediaFile
 	bestScore := matchScore{titleSimilarity: -1}
 	found := false

--- a/core/external/provider_matching.go
+++ b/core/external/provider_matching.go
@@ -182,10 +182,10 @@ type songQuery struct {
 
 // matchScore combines title/album similarity with metadata specificity for ranking matches
 type matchScore struct {
-	titleSimilarity    float64 // 0.0-1.0 (Jaro-Winkler)
-	durationProximity  float64 // 0.0-1.0 (closer duration = higher, 1.0 if unknown)
-	albumSimilarity    float64 // 0.0-1.0 (Jaro-Winkler), used as tiebreaker
-	specificityLevel   int     // 0-5 (higher = more specific metadata match)
+	titleSimilarity   float64 // 0.0-1.0 (Jaro-Winkler)
+	durationProximity float64 // 0.0-1.0 (closer duration = higher, 1.0 if unknown)
+	albumSimilarity   float64 // 0.0-1.0 (Jaro-Winkler), used as tiebreaker
+	specificityLevel  int     // 0-5 (higher = more specific metadata match)
 }
 
 // betterThan returns true if this score beats another.

--- a/core/external/provider_matching_test.go
+++ b/core/external/provider_matching_test.go
@@ -496,45 +496,45 @@ var _ = Describe("Provider - Song Matching", func() {
 				Expect(songs[0].ID).To(Equal("correct"))
 			})
 
-			It("matches within 3-second tolerance", func() {
+			It("matches tracks with close duration", func() {
 				// Agent returns song with duration 180000ms (180 seconds)
 				returnedSongs := []agents.Song{
 					{Name: "Similar Song", Artist: "Test Artist", Duration: 180000},
 				}
-				// Library has track with 182 seconds (within tolerance)
-				withinTolerance := model.MediaFile{
-					ID: "within-tolerance", Title: "Similar Song", Artist: "Test Artist", Duration: 182.5,
+				// Library has track with 182.5 seconds (close to target)
+				closeDuration := model.MediaFile{
+					ID: "close-duration", Title: "Similar Song", Artist: "Test Artist", Duration: 182.5,
 				}
 
-				setupSimilarSongsExpectations(returnedSongs, model.MediaFiles{withinTolerance})
+				setupSimilarSongsExpectations(returnedSongs, model.MediaFiles{closeDuration})
 
 				songs, err := provider.SimilarSongs(ctx, "track-1", 5)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(songs).To(HaveLen(1))
-				Expect(songs[0].ID).To(Equal("within-tolerance"))
+				Expect(songs[0].ID).To(Equal("close-duration"))
 			})
 
-			It("excludes tracks outside 3-second tolerance when other matches exist", func() {
+			It("prefers closer duration over farther duration", func() {
 				// Agent returns song with duration 180000ms (180 seconds)
 				returnedSongs := []agents.Song{
 					{Name: "Similar Song", Artist: "Test Artist", Duration: 180000},
 				}
-				// Library has one within tolerance, one outside
-				withinTolerance := model.MediaFile{
-					ID: "within", Title: "Similar Song", Artist: "Test Artist", Duration: 181.0,
+				// Library has one close, one far
+				closeDuration := model.MediaFile{
+					ID: "close", Title: "Similar Song", Artist: "Test Artist", Duration: 181.0,
 				}
-				outsideTolerance := model.MediaFile{
-					ID: "outside", Title: "Similar Song", Artist: "Test Artist", Duration: 190.0,
+				farDuration := model.MediaFile{
+					ID: "far", Title: "Similar Song", Artist: "Test Artist", Duration: 190.0,
 				}
 
-				setupSimilarSongsExpectations(returnedSongs, model.MediaFiles{outsideTolerance, withinTolerance})
+				setupSimilarSongsExpectations(returnedSongs, model.MediaFiles{farDuration, closeDuration})
 
 				songs, err := provider.SimilarSongs(ctx, "track-1", 5)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(songs).To(HaveLen(1))
-				Expect(songs[0].ID).To(Equal("within"))
+				Expect(songs[0].ID).To(Equal("close"))
 			})
 
 			It("still matches when no tracks have matching duration", func() {
@@ -605,8 +605,8 @@ var _ = Describe("Provider - Song Matching", func() {
 		})
 
 		Context("edge cases", func() {
-			It("handles very short songs with duration tolerance", func() {
-				// 30-second song with 1-second difference (within 3-second tolerance)
+			It("handles very short songs with close duration", func() {
+				// 30-second song with 1-second difference
 				returnedSongs := []agents.Song{
 					{Name: "Short Song", Artist: "Test Artist", Duration: 30000},
 				}


### PR DESCRIPTION
### Description

Refactors how duration is used in track matching for similar songs. Previously, duration was a binary pre-filter (±3 second tolerance) with a fallback to all tracks when no duration-filtered candidates matched. This two-pass approach was inconsistent with how title, specificity, and album are scored via the hierarchical `matchScore` system.

This PR integrates duration directly into `matchScore` as a continuous value — the absolute difference in seconds between the target and candidate durations. A smaller difference ranks higher. This means:

- Duration no longer acts as a hard cutoff — tracks with slightly longer differences are still considered, just ranked lower
- The separate `findBestMatchInTracks` function and the two-pass filtering logic are removed
- The `durationToleranceSec` constant is no longer needed
- All match criteria now use the same hierarchical comparison in `betterThan`

The ranking order is: title similarity > duration difference > specificity level > album similarity.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run `make test PKG=./core/external/...` — all tests should pass
2. Verify that similar songs matching still works correctly with various duration differences — closer durations should be preferred, but no track is excluded solely due to duration mismatch
