### PR TITLE
feat: add ISRC matching for similar songs

### DIFF
--- a/core/agents/interfaces.go
+++ b/core/agents/interfaces.go
@@ -36,6 +36,7 @@ type Song struct {
 	ID         string
 	Name       string
 	MBID       string
+	ISRC       string
 	Artist     string
 	ArtistMBID string
 	Album      string

--- a/core/external/extdata_helper_test.go
+++ b/core/external/extdata_helper_test.go
@@ -92,6 +92,11 @@ func (m *mockMediaFileRepo) Get(id string) (*model.MediaFile, error) {
 	return args.Get(0).(*model.MediaFile), args.Error(1)
 }
 
+// GetAllByTags implements model.MediaFileRepository.
+func (m *mockMediaFileRepo) GetAllByTags(_ model.TagName, _ []string, options ...model.QueryOptions) (model.MediaFiles, error) {
+	return m.GetAll(options...)
+}
+
 // GetAll implements model.MediaFileRepository.
 func (m *mockMediaFileRepo) GetAll(options ...model.QueryOptions) (model.MediaFiles, error) {
 	argsSlice := make([]interface{}, len(options))

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -359,6 +359,7 @@ type MediaFileRepository interface {
 	Get(id string) (*MediaFile, error)
 	GetWithParticipants(id string) (*MediaFile, error)
 	GetAll(options ...QueryOptions) (MediaFiles, error)
+	GetAllByTags(tag TagName, values []string, options ...QueryOptions) (MediaFiles, error)
 	GetCursor(options ...QueryOptions) (MediaFileCursor, error)
 	Delete(id string) error
 	DeleteMissing(ids []string) error

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -195,6 +195,31 @@ func (r *mediaFileRepository) GetAll(options ...model.QueryOptions) (model.Media
 	return res.toModels(), nil
 }
 
+func (r *mediaFileRepository) GetAllByTags(tag model.TagName, values []string, options ...model.QueryOptions) (model.MediaFiles, error) {
+	placeholders := make([]string, len(values))
+	args := make([]any, len(values))
+	for i, v := range values {
+		placeholders[i] = "?"
+		args[i] = v
+	}
+	tagFilter := Expr(
+		fmt.Sprintf("exists (select 1 from json_tree(media_file.tags, '$.%s') where key='value' and value in (%s))",
+			tag, strings.Join(placeholders, ",")),
+		args...,
+	)
+
+	var opts model.QueryOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	if opts.Filters != nil {
+		opts.Filters = And{tagFilter, opts.Filters}
+	} else {
+		opts.Filters = tagFilter
+	}
+	return r.GetAll(opts)
+}
+
 func (r *mediaFileRepository) GetCursor(options ...model.QueryOptions) (model.MediaFileCursor, error) {
 	sq := r.selectMediaFile(options...)
 	cursor, err := queryWithStableResults[dbMediaFile](r.sqlRepository, sq)

--- a/plugins/capabilities/metadata_agent.go
+++ b/plugins/capabilities/metadata_agent.go
@@ -142,6 +142,8 @@ type SongRef struct {
 	Name string `json:"name"`
 	// MBID is the MusicBrainz ID for the song.
 	MBID string `json:"mbid,omitempty"`
+	// ISRC is the International Standard Recording Code for the song.
+	ISRC string `json:"isrc,omitempty"`
 	// Artist is the artist name.
 	Artist string `json:"artist,omitempty"`
 	// ArtistMBID is the MusicBrainz artist ID.

--- a/plugins/capabilities/metadata_agent.yaml
+++ b/plugins/capabilities/metadata_agent.yaml
@@ -343,6 +343,9 @@ components:
                 mbid:
                     type: string
                     description: MBID is the MusicBrainz ID for the song.
+                isrc:
+                    type: string
+                    description: ISRC is the International Standard Recording Code for the song.
                 artist:
                     type: string
                     description: Artist is the artist name.

--- a/plugins/metadata_agent.go
+++ b/plugins/metadata_agent.go
@@ -230,6 +230,7 @@ func songRefsToAgentSongs(refs []capabilities.SongRef) []agents.Song {
 			ID:         s.ID,
 			Name:       s.Name,
 			MBID:       s.MBID,
+			ISRC:       s.ISRC,
 			Artist:     s.Artist,
 			ArtistMBID: s.ArtistMBID,
 			Album:      s.Album,

--- a/plugins/pdk/go/metadata/metadata.go
+++ b/plugins/pdk/go/metadata/metadata.go
@@ -171,6 +171,8 @@ type SongRef struct {
 	Name string `json:"name"`
 	// MBID is the MusicBrainz ID for the song.
 	MBID string `json:"mbid,omitempty"`
+	// ISRC is the International Standard Recording Code for the song.
+	ISRC string `json:"isrc,omitempty"`
 	// Artist is the artist name.
 	Artist string `json:"artist,omitempty"`
 	// ArtistMBID is the MusicBrainz artist ID.

--- a/plugins/pdk/go/metadata/metadata_stub.go
+++ b/plugins/pdk/go/metadata/metadata_stub.go
@@ -168,6 +168,8 @@ type SongRef struct {
 	Name string `json:"name"`
 	// MBID is the MusicBrainz ID for the song.
 	MBID string `json:"mbid,omitempty"`
+	// ISRC is the International Standard Recording Code for the song.
+	ISRC string `json:"isrc,omitempty"`
 	// Artist is the artist name.
 	Artist string `json:"artist,omitempty"`
 	// ArtistMBID is the MusicBrainz artist ID.

--- a/plugins/pdk/rust/nd-pdk-capabilities/src/metadata.rs
+++ b/plugins/pdk/rust/nd-pdk-capabilities/src/metadata.rs
@@ -242,6 +242,9 @@ pub struct SongRef {
     /// MBID is the MusicBrainz ID for the song.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub mbid: String,
+    /// ISRC is the International Standard Recording Code for the song.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub isrc: String,
     /// Artist is the artist name.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub artist: String,

--- a/plugins/testdata/test-metadata-agent/main.go
+++ b/plugins/testdata/test-metadata-agent/main.go
@@ -134,6 +134,7 @@ func (t *testMetadataAgent) GetSimilarSongsByTrack(input metadata.SimilarSongsBy
 			ID:         "similar-track-id-" + strconv.Itoa(i+1),
 			Name:       "Similar to " + input.Name + " #" + strconv.Itoa(i+1),
 			MBID:       "similar-mbid-" + strconv.Itoa(i+1),
+			ISRC:       "similar-isrc-" + strconv.Itoa(i+1),
 			Artist:     input.Artist,
 			ArtistMBID: "artist-mbid-" + strconv.Itoa(i+1),
 		})

--- a/tests/mock_mediafile_repo.go
+++ b/tests/mock_mediafile_repo.go
@@ -76,6 +76,10 @@ func (m *MockMediaFileRepo) GetWithParticipants(id string) (*model.MediaFile, er
 	return nil, model.ErrNotFound
 }
 
+func (m *MockMediaFileRepo) GetAllByTags(_ model.TagName, _ []string, options ...model.QueryOptions) (model.MediaFiles, error) {
+	return m.GetAll(options...)
+}
+
 func (m *MockMediaFileRepo) GetAll(qo ...model.QueryOptions) (model.MediaFiles, error) {
 	if len(qo) > 0 {
 		m.Options = qo[0]


### PR DESCRIPTION
### Description

Adds ISRC (International Standard Recording Code) as a matching strategy in the provider matching pipeline for similar songs. The matching algorithm now uses four strategies in priority order: **ID > MBID > ISRC > Title+Artist fuzzy match**.

Additionally introduces a `GetAllByTags` method on `MediaFileRepository` to encapsulate tag-based JSON queries (`json_tree`), and optimizes the matching pipeline so each phase skips songs already matched by higher-priority phases.

Key changes:

- Add `ISRC` field to `agents.Song` and plugin `SongRef` structs (Go and Rust PDKs)
- Add `loadTracksByISRC` using the new `GetAllByTags` repository method
- Add `GetAllByTags(tag TagName, values []string, options ...QueryOptions)` to `MediaFileRepository`, moving the `json_tree` SQL logic out of business code and into the persistence layer
- Add `songMatchedIn` helper to avoid redundant DB queries — MBID lookup skips ID-matched songs, ISRC lookup skips ID/MBID-matched songs, and title lookup skips all prior matches
- Integrate ISRC into `selectBestMatchingSongs` priority chain

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run `make test PKG=./core/external/...` — all matching tests should pass
2. Run `make test PKG=./persistence/...` — repository tests should pass
3. Verify similar songs still work correctly with a library that has ISRC tags — tracks with matching ISRCs should be matched with higher priority than title+artist fuzzy matching

### Additional Notes

- The `GetAllByTags` method composes the tag filter with any existing `Filters` in `QueryOptions` using `squirrel.And`, so callers can still add additional constraints (e.g., `missing = false`)
- The `songMatchedIn` helper uses a generic variadic `priorMatches` pattern, making it easy to add future matching phases without changing existing signatures
