### PR TITLE
feat: added the possibility to ignore a library completely

### DIFF
--- a/db/migrations/20260128132617_add_library_ignored_column.sql
+++ b/db/migrations/20260128132617_add_library_ignored_column.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE library ADD COLUMN ignored BOOLEAN NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE library DROP COLUMN ignored;

--- a/model/library.go
+++ b/model/library.go
@@ -25,6 +25,7 @@ type Library struct {
 	TotalSize          int64     `json:"totalSize" db:"total_size"`
 	TotalDuration      float64   `json:"totalDuration" db:"total_duration"`
 	DefaultNewUsers    bool      `json:"defaultNewUsers" db:"default_new_users"`
+	Ignored            bool      `json:"ignored" db:"ignored"`
 }
 
 const (

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -81,7 +81,7 @@ func (r *userRepository) selectUserWithLibraries(options ...model.QueryOptions) 
 				'full_scan_in_progress', library.full_scan_in_progress,
 				'updated_at', library.updated_at,
 				'created_at', library.created_at
-			)) FILTER (WHERE library.id IS NOT NULL), '[]') AS libraries_json`).
+			)) FILTER (WHERE library.id IS NOT NULL AND library.ignored = false), '[]') AS libraries_json`).
 		LeftJoin("user_library ul ON user.id = ul.user_id").
 		LeftJoin("library ON ul.library_id = library.id").
 		GroupBy("user.id")
@@ -451,7 +451,7 @@ func (r *userRepository) GetUserLibraries(userID string) (model.Libraries, error
 	sel := Select("l.*").
 		From("library l").
 		Join("user_library ul ON l.id = ul.library_id").
-		Where(Eq{"ul.user_id": userID}).
+		Where(And{Eq{"ul.user_id": userID}, Eq{"l.ignored": false}}).
 		OrderBy("l.name")
 
 	var res model.Libraries

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -295,6 +295,7 @@
         "totalSize": "Total Size",
         "totalDuration": "Duration",
         "defaultNewUsers": "Default for New Users",
+        "ignored": "Ignored",
         "createdAt": "Created",
         "updatedAt": "Updated"
       },

--- a/ui/src/library/LibraryCreate.jsx
+++ b/ui/src/library/LibraryCreate.jsx
@@ -76,6 +76,7 @@ const LibraryCreate = (props) => {
         <TextInput source="name" validate={[required()]} />
         <TextInput source="path" validate={[required()]} fullWidth />
         <BooleanInput source="defaultNewUsers" />
+        <BooleanInput source="ignored" />
       </SimpleForm>
     </Create>
   )

--- a/ui/src/library/LibraryEdit.jsx
+++ b/ui/src/library/LibraryEdit.jsx
@@ -117,6 +117,11 @@ const LibraryEdit = (props) => {
                     )}
                     variant="outlined"
                   />
+                  <BooleanInput
+                    source="ignored"
+                    label={translate('resources.library.fields.ignored')}
+                    variant="outlined"
+                  />
 
                   <Box mt="2em" />
 

--- a/ui/src/library/LibraryList.jsx
+++ b/ui/src/library/LibraryList.jsx
@@ -35,13 +35,16 @@ const LibraryList = (props) => {
       {isXsmall ? (
         <SimpleList
           primaryText={(record) => record.name}
-          secondaryText={(record) => record.path}
+          secondaryText={(record) =>
+            `${record.path}${record.ignored ? ' (Ignored)' : ''}`
+          }
         />
       ) : (
         <Datagrid rowClick="edit">
           <TextField source="name" />
           <TextField source="path" />
           <BooleanField source="defaultNewUsers" />
+          <BooleanField source="ignored" />
           <NumberField source="totalSongs" />
           <NumberField source="totalAlbums" />
           <NumberField source="totalMissingFiles" />


### PR DESCRIPTION
### Description
This adds the possibility to totally ignore a library. It  can be set through the library admin settings.

The use case for me is that when setting up navidrome with docker i have to set a root folder which will be added as a default library which cant be removed.
But what i wanted was multiple libraries from subfolders of that root folder.
Without ignoring it i was ending with duplicates for all albums.

It was implemented with the help of Claude Sonnet 4.5

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Disable a library and see it is not shown anymore nor returned by the API

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->