### PR TITLE
chore(plugins): allow using defaults form manifset

### DIFF
--- a/ui/src/plugin/SchemaConfigEditor.jsx
+++ b/ui/src/plugin/SchemaConfigEditor.jsx
@@ -42,7 +42,7 @@ SchemaErrorBoundary.propTypes = {
 // params.missingProperty. We transform them to point to the field directly
 // (e.g., "/users/1/username") so JSONForms displays them under the correct input.
 const ajv = new Ajv({
-  useDefaults: false,
+  useDefaults: true,
   allErrors: true,
   verbose: true,
   jsonPointers: true,


### PR DESCRIPTION
### Description
<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->

### Related Issues
`useDefaults: true` is required for JSONForm to pick up `defaults` from the manifest. 

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Install a plugin which has defaults. Verify that the defaults are picked up in the UI.

### Screenshots / Demos (if applicable)


### Additional Notes


<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->