### PR TITLE
fix(ui): use div for fragment, check lastfm url for artist page

### DIFF
--- a/ui/src/artist/ArtistExternalLink.jsx
+++ b/ui/src/artist/ArtistExternalLink.jsx
@@ -4,7 +4,7 @@ import { IconButton, Tooltip, Link } from '@material-ui/core'
 
 import { ImLastfm2 } from 'react-icons/im'
 import MusicBrainz from '../icons/MusicBrainz'
-import { intersperse } from '../utils'
+import { intersperse, isLastFmURL } from '../utils'
 import config from '../config'
 import { makeStyles } from '@material-ui/core/styles'
 
@@ -13,10 +13,6 @@ const useStyles = makeStyles({
     minHeight: '1.875em',
   },
 })
-
-const isLastFmURL = (url) => {
-  return url?.includes('last.fm/music/')
-}
 
 const ArtistExternalLinks = ({ artistInfo, record }) => {
   const classes = useStyles()

--- a/ui/src/artist/ArtistExternalLink.jsx
+++ b/ui/src/artist/ArtistExternalLink.jsx
@@ -14,6 +14,10 @@ const useStyles = makeStyles({
   },
 })
 
+const isLastFmURL = (url) => {
+  return url?.includes('last.fm/music/')
+}
+
 const ArtistExternalLinks = ({ artistInfo, record }) => {
   const classes = useStyles()
   const translate = useTranslate()
@@ -38,13 +42,13 @@ const ArtistExternalLinks = ({ artistInfo, record }) => {
   }
 
   if (config.lastFMEnabled) {
-    if (lastFMlink) {
+    if (lastFMlink && isLastFmURL(lastFMlink[2])) {
       addLink(
         lastFMlink[2],
         'message.openIn.lastfm',
         <ImLastfm2 className="lastfm-icon" />,
       )
-    } else if (artistInfo?.lastFmUrl) {
+    } else if (isLastFmURL(artistInfo?.lastFmUrl)) {
       addLink(
         artistInfo?.lastFmUrl,
         'message.openIn.lastfm',

--- a/ui/src/common/SafeHTML.jsx
+++ b/ui/src/common/SafeHTML.jsx
@@ -1,5 +1,5 @@
 import DOMPurify from 'dompurify'
-import { Fragment, useMemo } from 'react'
+import { useMemo } from 'react'
 
 export const SafeHTML = ({ children }) => {
   const purified = useMemo(() => {
@@ -23,5 +23,5 @@ export const SafeHTML = ({ children }) => {
     return purify.sanitize(children, { ADD_ATTR: ['referrer-policy'] })
   }, [children])
 
-  return <Fragment dangerouslySetInnerHTML={{ __html: purified }} />
+  return <div dangerouslySetInnerHTML={{ __html: purified }} />
 }

--- a/ui/src/common/SafeHTML.jsx
+++ b/ui/src/common/SafeHTML.jsx
@@ -23,5 +23,5 @@ export const SafeHTML = ({ children }) => {
     return purify.sanitize(children, { ADD_ATTR: ['referrer-policy'] })
   }, [children])
 
-  return <div dangerouslySetInnerHTML={{ __html: purified }} />
+  return <span dangerouslySetInnerHTML={{ __html: purified }} />
 }

--- a/ui/src/utils/urls.js
+++ b/ui/src/utils/urls.js
@@ -44,3 +44,16 @@ export const shareCoverUrl = (id, square) => {
 }
 
 export const docsUrl = (path) => `https://www.navidrome.org${path}`
+
+export const isLastFmURL = (url) => {
+  try {
+    const parsed = new URL(url)
+    return (
+      (parsed.protocol === 'http:' || parsed.protocol === 'https:') &&
+      (parsed.hostname === 'last.fm' || parsed.hostname.endsWith('.last.fm')) &&
+      parsed.pathname.startsWith('/music/')
+    )
+  } catch (e) {
+    return false
+  }
+}

--- a/ui/src/utils/urls.test.js
+++ b/ui/src/utils/urls.test.js
@@ -1,0 +1,25 @@
+import { isLastFmURL } from './urls'
+
+describe('isLastFmURL', () => {
+  it('returns true for valid Last.fm music URLs', () => {
+    expect(isLastFmURL('https://last.fm/music/The+Beatles')).toBe(true)
+    expect(isLastFmURL('http://last.fm/music/Radiohead')).toBe(true)
+    expect(isLastFmURL('https://www.last.fm/music/Daft+Punk')).toBe(true)
+  })
+
+  it('returns false for non-http(s) protocols (XSS prevention)', () => {
+    expect(isLastFmURL('javascript:alert(1)//last.fm/music/')).toBe(false)
+    expect(isLastFmURL('data:text/html,<script>//last.fm/music/')).toBe(false)
+  })
+
+  it('returns false for non-last.fm domains', () => {
+    expect(isLastFmURL('https://example.com/?q=last.fm/music/')).toBe(false)
+    expect(isLastFmURL('https://fake-last.fm/music/Artist')).toBe(false)
+  })
+
+  it('returns false for invalid paths or inputs', () => {
+    expect(isLastFmURL('https://last.fm/user/someone')).toBe(false)
+    expect(isLastFmURL(null)).toBe(false)
+    expect(isLastFmURL('not-a-url')).toBe(false)
+  })
+})


### PR DESCRIPTION
### Description
Fix artist biography display (`Fragment` doesn't exist in the `dom`): use `span` instead (`div` apparently causes nesting warnings).
For artist lastFmUrl, check if it has `last.fm/music` (artist url) instead of automatically assigning it to lastfm icon.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
1. For biography, have anything provide an biography. Make sure that it renders in the DOM.
2. Have a plugin (or some other source) provide artist url. Check that the lastfm icon is not included.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
Instead of just an `include`, a regex might be more appropriate for checking lastfm url?

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->