### PR TITLE
fix: Nautiline theme font path

### DIFF
--- a/ui/src/themes/nautiline.js
+++ b/ui/src/themes/nautiline.js
@@ -8,6 +8,7 @@
 // ============================================
 
 const ACCENT_COLOR = '#009688' // Material teal
+const UNBOUNDED_FONT_PATH = 'fonts/Unbounded-Variable.woff2'
 
 // ============================================
 // DESIGN TOKENS
@@ -69,7 +70,7 @@ const tokens = {
         font-style: normal;
         font-weight: 300 800;
         font-display: swap;
-        src: url('fonts/Unbounded-Variable.woff2') format('woff2');
+        src: url('${UNBOUNDED_FONT_PATH}') format('woff2');
       }
     `,
   },
@@ -275,7 +276,7 @@ const NautilineTheme = {
           fontStyle: 'normal',
           fontWeight: '300 800',
           fontDisplay: 'swap',
-          src: "url('fonts/Unbounded-Variable.woff2') format('woff2')",
+          src: `url('${UNBOUNDED_FONT_PATH}') format('woff2')`,
         },
         body: {
           backgroundColor: colors.background.primary,
@@ -794,7 +795,7 @@ const NautilineTheme = {
         font-style: normal;
         font-weight: 300 800;
         font-display: swap;
-        src: url('fonts/Unbounded-Variable.woff2') format('woff2');
+        src: url('${UNBOUNDED_FONT_PATH}') format('woff2');
       }
 
       .react-jinke-music-player-main {

--- a/ui/src/themes/nautiline.js
+++ b/ui/src/themes/nautiline.js
@@ -69,7 +69,7 @@ const tokens = {
         font-style: normal;
         font-weight: 300 800;
         font-display: swap;
-        src: url('/fonts/Unbounded-Variable.woff2') format('woff2');
+        src: url('fonts/Unbounded-Variable.woff2') format('woff2');
       }
     `,
   },
@@ -275,7 +275,7 @@ const NautilineTheme = {
           fontStyle: 'normal',
           fontWeight: '300 800',
           fontDisplay: 'swap',
-          src: "url('/fonts/Unbounded-Variable.woff2') format('woff2')",
+          src: "url('fonts/Unbounded-Variable.woff2') format('woff2')",
         },
         body: {
           backgroundColor: colors.background.primary,
@@ -794,7 +794,7 @@ const NautilineTheme = {
         font-style: normal;
         font-weight: 300 800;
         font-display: swap;
-        src: url('/fonts/Unbounded-Variable.woff2') format('woff2');
+        src: url('fonts/Unbounded-Variable.woff2') format('woff2');
       }
 
       .react-jinke-music-player-main {


### PR DESCRIPTION
### Description

  Fix Unbounded font failing to load in production for the Nautiline theme. The
  `@font-face` declarations used absolute URLs (`/fonts/Unbounded-Variable.woff2`),
  which resolve to the domain root. Since the UI is served at `/app/`, the font file
  lives at `/app/fonts/...`. The mismatched path causes the server's catch-all to
  redirect to `/app/` (returning HTML), which the browser fails to decode as a font.

  Fixed by making the URLs relative (`fonts/...`), which resolve correctly against the
  document location.

  ### Related Issues

  <!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

  ### Type of Change
  - [x] Bug fix
  - [ ] New feature
  - [ ] Documentation update
  - [ ] Refactor
  - [ ] Other (please describe):

  ### Checklist

  - [x] My code follows the project's coding style
  - [x] I have tested the changes locally
  - [ ] I have added or updated documentation as needed
  - [ ] I have added tests that prove my fix/feature works (or explain why not)
  - [x] All existing and new tests pass

  ### How to Test

  1. Enable the Nautiline theme in Settings
  2. Open browser DevTools Network tab, filter by "Font"
  3. Verify `Unbounded-Variable.woff2` loads with HTTP 200 (not a redirect to HTML)
  4. Verify headings render in the Unbounded font
  5. Optionally test with a custom `BasePath` server configuration

  ### Screenshots / Demos (if applicable)

  N/A

  ### Additional Notes

  All 3 `@font-face` declarations in `ui/src/themes/nautiline.js` (lines 72, 278, 797)
  were affected. The fix relies on the fact that CSS in `<style>` tags resolves relative
   URLs against the document's base URL (`/app/`), which correctly maps to where the
  font file is served.