### PR TITLE
fix(subsonic): return error 70 when scrobble contains invalid IDs

### DIFF
--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -354,7 +354,7 @@ type MediaFileCursor iter.Seq2[MediaFile, error]
 type MediaFileRepository interface {
 	CountAll(options ...QueryOptions) (int64, error)
 	CountBySuffix(options ...QueryOptions) (map[string]int64, error)
-	Exists(id string) (bool, error)
+	Exists(ids ...string) (bool, error)
 	Put(m *MediaFile) error
 	Get(id string) (*MediaFile, error)
 	GetWithParticipants(id string) (*MediaFile, error)

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -143,8 +143,19 @@ func (r *mediaFileRepository) CountBySuffix(options ...model.QueryOptions) (map[
 	return counts, nil
 }
 
-func (r *mediaFileRepository) Exists(id string) (bool, error) {
-	return r.exists(Eq{"media_file.id": id})
+// Exists checks if all given media file IDs exist in the database. If no IDs are provided, it returns true.
+// If any of the IDs do not exist, it returns false. It returns an error if the database query fails.
+func (r *mediaFileRepository) Exists(ids ...string) (bool, error) {
+	if len(ids) == 0 {
+		return true, nil
+	}
+	existsQuery := Select("count(*) as exist").From("media_file").Where(Eq{"media_file.id": ids})
+	var res struct{ Exist int64 }
+	err := r.queryOne(existsQuery, &res)
+	if err != nil {
+		return false, err
+	}
+	return res.Exist == int64(len(ids)), nil
 }
 
 func (r *mediaFileRepository) Put(m *model.MediaFile) error {

--- a/tests/mock_mediafile_repo.go
+++ b/tests/mock_mediafile_repo.go
@@ -44,12 +44,16 @@ func (m *MockMediaFileRepo) SetData(mfs model.MediaFiles) {
 	}
 }
 
-func (m *MockMediaFileRepo) Exists(id string) (bool, error) {
+func (m *MockMediaFileRepo) Exists(ids ...string) (bool, error) {
 	if m.Err {
 		return false, errors.New("error")
 	}
-	_, found := m.Data[id]
-	return found, nil
+	for _, id := range ids {
+		if _, found := m.Data[id]; !found {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 func (m *MockMediaFileRepo) Get(id string) (*model.MediaFile, error) {


### PR DESCRIPTION
### Description

Implements the OpenSubsonic API clarification from [opensubsonic/open-subsonic-api#202](https://github.com/opensubsonic/open-subsonic-api/pull/202): the scrobble endpoint now validates all media file IDs before processing and returns error code 70 (data not found) if any ID is invalid.

This ensures the entire operation fails atomically - no scrobbles are submitted when any ID in the batch is invalid, matching the OpenSubsonic specification.

### Related Issues

Implements [opensubsonic/open-subsonic-api#202](https://github.com/opensubsonic/open-subsonic-api/pull/202)

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Start Navidrome
2. Send a scrobble request with an invalid media file ID:
   ```
   GET /rest/scrobble?id=invalid-id&u=user&p=pass&c=test&v=1.16.1
   ```
3. Verify the response contains error code 70 (data not found)
4. Send a scrobble request with a mix of valid and invalid IDs - verify all are rejected

### Additional Notes

- Updated `MediaFileRepository.Exists()` to accept variadic IDs for efficient batch validation via a single COUNT query
- This is a behavioral change: previously, errors during scrobbling were logged but the endpoint always returned success
