### PR TITLE
fix(scanner): preserve parentheses in lyrics from alias tags

### DIFF
--- a/model/metadata/metadata.go
+++ b/model/metadata/metadata.go
@@ -250,7 +250,15 @@ func processPairMapping(name model.TagName, mapping model.TagConf, lowered model
 	id3Base := parseID3Pairs(name, lowered)
 
 	if len(aliasValues) > 0 {
-		id3Base = append(id3Base, parseVorbisPairs(aliasValues)...)
+		// For lyrics, don't use parseVorbisPairs as parentheses in lyrics content
+		// should not be interpreted as language keys (e.g. "(intro)" is not a language)
+		if name == model.TagLyrics {
+			for _, v := range aliasValues {
+				id3Base = append(id3Base, NewPair("xxx", v))
+			}
+		} else {
+			id3Base = append(id3Base, parseVorbisPairs(aliasValues)...)
+		}
 	}
 	return id3Base
 }

--- a/model/metadata/metadata_test.go
+++ b/model/metadata/metadata_test.go
@@ -246,6 +246,18 @@ var _ = Describe("Metadata", func() {
 					metadata.NewPair("eng", "Lyrics"),
 				))
 			})
+
+			It("should preserve lyrics starting with parentheses from alias tags", func() {
+				props.Tags = model.RawTags{
+					"LYRICS": {"(line one)\nline two\nline three"},
+				}
+				md = metadata.New(filePath, props)
+
+				Expect(md.All()).To(HaveKey(model.TagLyrics))
+				Expect(md.Strings(model.TagLyrics)).To(ContainElements(
+					metadata.NewPair("xxx", "(line one)\nline two\nline three"),
+				))
+			})
 		})
 
 		Describe("ReplayGain", func() {


### PR DESCRIPTION
### Description

Fixes a bug where lyrics starting with text in parentheses (e.g., `(intro)` or `(spoken)`) would have that first line stripped when the lyrics came from alias tags like `LYRICS` or `UNSYNCEDLYRICS`.

**Root Cause:** The `parseVorbisPairs` function was being applied to lyrics from alias tags. This function uses a regex to extract text in parentheses as a "key" (designed for performer tags like `"John Smith (guitar)"`). When lyrics started with `(something)`, it incorrectly interpreted this as a language code and removed it from the lyrics text.

**Fix:** Modified `processPairMapping` to skip `parseVorbisPairs` for lyrics tags, instead treating alias lyrics as plain text with the default `"xxx"` language code.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Have an audio file with embedded unsynced lyrics where the first line starts with parentheses, e.g.:
   ```
   (line one)
   line two
   line three
   ```
2. Rescan the library
3. Query lyrics via Subsonic API (`getLyricsBySongId`) or view in a client
4. Verify the first line `(line one)` is present in the response

### Additional Notes

Users affected by this bug will need to **rescan their library** after updating for the lyrics to be re-parsed correctly.
