### PR TITLE
feat(smart playlist): add explicit status support

### DIFF
--- a/model/criteria/fields.go
+++ b/model/criteria/fields.go
@@ -54,6 +54,7 @@ var fieldMap = map[string]*mappedField{
 	"mbz_release_track_id": {field: "media_file.mbz_release_track_id"},
 	"mbz_release_group_id": {field: "media_file.mbz_release_group_id"},
 	"library_id":           {field: "media_file.library_id", numeric: true},
+	"explicit_status":      {field: "media_file.explicit_status"},
 
 	// Backward compatibility: albumtype is an alias for releasetype tag
 	"albumtype": {field: "releasetype", isTag: true},

--- a/model/criteria/fields.go
+++ b/model/criteria/fields.go
@@ -23,6 +23,7 @@ var fieldMap = map[string]*mappedField{
 	"releasedate":          {field: "media_file.release_date"},
 	"size":                 {field: "media_file.size"},
 	"compilation":          {field: "media_file.compilation"},
+	"explicitstatus":       {field: "media_file.explicit_status"},
 	"dateadded":            {field: "media_file.created_at"},
 	"datemodified":         {field: "media_file.updated_at"},
 	"discsubtitle":         {field: "media_file.disc_subtitle"},
@@ -54,7 +55,6 @@ var fieldMap = map[string]*mappedField{
 	"mbz_release_track_id": {field: "media_file.mbz_release_track_id"},
 	"mbz_release_group_id": {field: "media_file.mbz_release_group_id"},
 	"library_id":           {field: "media_file.library_id", numeric: true},
-	"explicit_status":      {field: "media_file.explicit_status"},
 
 	// Backward compatibility: albumtype is an alias for releasetype tag
 	"albumtype": {field: "releasetype", isTag: true},


### PR DESCRIPTION
### Description
Allow `explicit_status` to be filtered in smart playlists

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Create a smart playlist like
```json
{
  "all": [
    {
      "is": {
        "explicitstatus": "e"
      }
    }
  ],
  "sort": "-playcount"
}
```
Verify that it only has explicit tracks.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->