### PR TITLE
feat: add album and artist annotation fields to smart playlists

### DIFF
--- a/model/criteria/criteria.go
+++ b/model/criteria/criteria.go
@@ -95,6 +95,12 @@ func (c Criteria) ToSql() (sql string, args []any, err error) {
 	return c.Expression.ToSql()
 }
 
+// RequiredJoins inspects both the filter expression and sort fields to determine
+// which additional JOINs are needed for the query.
+func (c Criteria) RequiredJoins() JoinType {
+	return requiredJoins(c.Expression) | requiredSortJoins(c.Sort)
+}
+
 func (c Criteria) ChildPlaylistIds() []string {
 	if c.Expression == nil {
 		return nil

--- a/model/criteria/criteria_test.go
+++ b/model/criteria/criteria_test.go
@@ -179,6 +179,46 @@ var _ = Describe("Criteria", func() {
 		})
 	})
 
+	Describe("RequiredJoins", func() {
+		It("returns 0 when no album/artist fields are used", func() {
+			c := Criteria{
+				Expression: All{Is{"title": "test"}, Gt{"rating": 3}},
+				Sort:       "title",
+			}
+			gomega.Expect(c.RequiredJoins()).To(gomega.Equal(JoinType(0)))
+		})
+
+		It("detects album annotation fields in expression", func() {
+			c := Criteria{
+				Expression: All{Gt{"albumRating": 3}},
+			}
+			gomega.Expect(c.RequiredJoins()).To(gomega.Equal(JoinAlbumAnnotation))
+		})
+
+		It("detects artist annotation fields in expression", func() {
+			c := Criteria{
+				Expression: All{Is{"artistLoved": true}},
+			}
+			gomega.Expect(c.RequiredJoins()).To(gomega.Equal(JoinArtistAnnotation))
+		})
+
+		It("detects album fields from sort only", func() {
+			c := Criteria{
+				Expression: All{Is{"title": "test"}},
+				Sort:       "albumRating",
+			}
+			gomega.Expect(c.RequiredJoins()).To(gomega.Equal(JoinAlbumAnnotation))
+		})
+
+		It("combines expression and sort join requirements", func() {
+			c := Criteria{
+				Expression: All{Gt{"albumRating": 3}},
+				Sort:       "artistRating",
+			}
+			gomega.Expect(c.RequiredJoins()).To(gomega.Equal(JoinAlbumAnnotation | JoinArtistAnnotation))
+		})
+	})
+
 	Context("with child playlists", func() {
 		var (
 			topLevelInPlaylistID     string

--- a/model/criteria/fields_test.go
+++ b/model/criteria/fields_test.go
@@ -13,4 +13,74 @@ var _ = Describe("fields", func() {
 			gomega.Expect(m).To(gomega.BeEmpty())
 		})
 	})
+
+	Describe("requiredJoins", func() {
+		It("returns 0 for nil expression", func() {
+			gomega.Expect(requiredJoins(nil)).To(gomega.Equal(JoinType(0)))
+		})
+
+		It("returns 0 for regular fields", func() {
+			expr := All{Is{"title": "test"}, Gt{"playCount": 5}}
+			gomega.Expect(requiredJoins(expr)).To(gomega.Equal(JoinType(0)))
+		})
+
+		It("returns JoinAlbumAnnotation for album annotation fields", func() {
+			expr := All{Gt{"albumRating": 3}}
+			gomega.Expect(requiredJoins(expr)).To(gomega.Equal(JoinAlbumAnnotation))
+		})
+
+		It("returns JoinArtistAnnotation for artist annotation fields", func() {
+			expr := All{Gt{"artistRating": 3}}
+			gomega.Expect(requiredJoins(expr)).To(gomega.Equal(JoinArtistAnnotation))
+		})
+
+		It("returns both join types when both are used", func() {
+			expr := All{Gt{"albumRating": 3}, Is{"artistLoved": true}}
+			gomega.Expect(requiredJoins(expr)).To(gomega.Equal(JoinAlbumAnnotation | JoinArtistAnnotation))
+		})
+
+		It("detects joins in nested Any expressions", func() {
+			expr := All{
+				Any{
+					Gt{"albumRating": 3},
+					Is{"title": "test"},
+				},
+			}
+			gomega.Expect(requiredJoins(expr)).To(gomega.Equal(JoinAlbumAnnotation))
+		})
+
+		It("detects joins in deeply nested expressions", func() {
+			expr := Any{
+				All{
+					Any{
+						Is{"artistPlayCount": 10},
+					},
+				},
+			}
+			gomega.Expect(requiredJoins(expr)).To(gomega.Equal(JoinArtistAnnotation))
+		})
+	})
+
+	Describe("requiredSortJoins", func() {
+		It("returns 0 for regular sort fields", func() {
+			gomega.Expect(requiredSortJoins("title")).To(gomega.Equal(JoinType(0)))
+		})
+
+		It("returns JoinAlbumAnnotation for album annotation sort", func() {
+			gomega.Expect(requiredSortJoins("albumRating")).To(gomega.Equal(JoinAlbumAnnotation))
+		})
+
+		It("returns JoinArtistAnnotation for artist annotation sort", func() {
+			gomega.Expect(requiredSortJoins("-artistRating")).To(gomega.Equal(JoinArtistAnnotation))
+		})
+
+		It("returns both join types for mixed sort fields", func() {
+			gomega.Expect(requiredSortJoins("albumRating,-artistPlayCount")).To(
+				gomega.Equal(JoinAlbumAnnotation | JoinArtistAnnotation))
+		})
+
+		It("returns 0 for empty sort", func() {
+			gomega.Expect(requiredSortJoins("")).To(gomega.Equal(JoinType(0)))
+		})
+	})
 })

--- a/model/criteria/operators_test.go
+++ b/model/criteria/operators_test.go
@@ -54,6 +54,22 @@ var _ = Describe("Operators", func() {
 		Entry("inTheLast", InTheLast{"lastPlayed": 30}, "annotation.play_date > ?", StartOfPeriod(30, time.Now())),
 		Entry("notInTheLast", NotInTheLast{"lastPlayed": 30}, "(annotation.play_date < ? OR annotation.play_date IS NULL)", StartOfPeriod(30, time.Now())),
 
+		// Album annotation tests
+		Entry("albumrating [gt]", Gt{"albumRating": 3}, "COALESCE(album_annotation.rating, 0) > ?", 3),
+		Entry("albumloved [is]", Is{"albumLoved": true}, "COALESCE(album_annotation.starred, false) = ?", true),
+		Entry("albumplaycount [gt]", Gt{"albumPlayCount": 10}, "COALESCE(album_annotation.play_count, 0) > ?", 10),
+		Entry("albumlastplayed [after]", After{"albumLastPlayed": rangeStart}, "album_annotation.play_date > ?", rangeStart),
+		Entry("albumdaterated [before]", Before{"albumDateRated": rangeStart}, "album_annotation.rated_at < ?", rangeStart),
+		Entry("albumdateloved [after]", After{"albumDateLoved": rangeStart}, "album_annotation.starred_at > ?", rangeStart),
+
+		// Artist annotation tests
+		Entry("artistrating [gt]", Gt{"artistRating": 3}, "COALESCE(artist_annotation.rating, 0) > ?", 3),
+		Entry("artistloved [is]", Is{"artistLoved": true}, "COALESCE(artist_annotation.starred, false) = ?", true),
+		Entry("artistplaycount [gt]", Gt{"artistPlayCount": 10}, "COALESCE(artist_annotation.play_count, 0) > ?", 10),
+		Entry("artistlastplayed [after]", After{"artistLastPlayed": rangeStart}, "artist_annotation.play_date > ?", rangeStart),
+		Entry("artistdaterated [before]", Before{"artistDateRated": rangeStart}, "artist_annotation.rated_at < ?", rangeStart),
+		Entry("artistdateloved [after]", After{"artistDateLoved": rangeStart}, "artist_annotation.starred_at > ?", rangeStart),
+
 		// Tag tests
 		Entry("tag is [string]", Is{"genre": "Rock"}, "exists (select 1 from json_tree(tags, '$.genre') where key='value' and value = ?)", "Rock"),
 		Entry("tag isNot [string]", IsNot{"genre": "Rock"}, "not exists (select 1 from json_tree(tags, '$.genre') where key='value' and value = ?)", "Rock"),

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -260,10 +260,28 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 	}
 
 	sq := Select("row_number() over (order by "+rules.OrderBy()+") as id", "'"+pls.ID+"' as playlist_id", "media_file.id as media_file_id").
-		From("media_file").LeftJoin("annotation on (" +
-		"annotation.item_id = media_file.id" +
-		" AND annotation.item_type = 'media_file'" +
-		" AND annotation.user_id = '" + usr.ID + "')")
+		From("media_file").
+		LeftJoin("annotation on ("+
+			"annotation.item_id = media_file.id"+
+			" AND annotation.item_type = 'media_file'"+
+			" AND annotation.user_id = ?)", usr.ID)
+
+	// Conditionally add album/artist joins only when the criteria references those fields
+	joins := rules.RequiredJoins()
+	if joins&criteria.JoinAlbumAnnotation != 0 {
+		sq = sq.
+			LeftJoin("annotation album_annotation on ("+
+				"album_annotation.item_id = media_file.album_id"+
+				" AND album_annotation.item_type = 'album'"+
+				" AND album_annotation.user_id = ?)", usr.ID)
+	}
+	if joins&criteria.JoinArtistAnnotation != 0 {
+		sq = sq.
+			LeftJoin("annotation artist_annotation on ("+
+				"artist_annotation.item_id = media_file.artist_id"+
+				" AND artist_annotation.item_type = 'artist'"+
+				" AND artist_annotation.user_id = ?)", usr.ID)
+	}
 
 	// Only include media files from libraries the user has access to
 	sq = r.applyLibraryFilter(sq, "media_file")


### PR DESCRIPTION
Add support for filtering and sorting smart playlists by album and
artist annotation attributes (rating, loved, playcount, lastplayed,
dateloved, daterated). The album and artist annotation JOINs are
only added to the query when those fields are actually referenced
in the criteria or sort, avoiding unnecessary joins for regular
smart playlists.

Also switches the existing annotation JOIN to use parameterized
queries instead of string concatenation for the user ID.
