### PR TITLE
add download toml link, disable copy when clipboard mostly not available

### DIFF
--- a/ui/src/dialogs/AboutDialog.jsx
+++ b/ui/src/dialogs/AboutDialog.jsx
@@ -9,6 +9,7 @@ import TableBody from '@material-ui/core/TableBody'
 import TableRow from '@material-ui/core/TableRow'
 import TableCell from '@material-ui/core/TableCell'
 import Paper from '@material-ui/core/Paper'
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
 import FileCopyIcon from '@material-ui/icons/FileCopy'
 import Button from '@material-ui/core/Button'
@@ -245,6 +246,21 @@ const ConfigTabContent = ({ configData }) => {
     }
   }
 
+  const handleDownloadToml = () => {
+    const tomlContent = configToToml(configData, translate)
+    const tomlFile = new File([tomlContent], 'navidrome.toml', {
+      type: 'text/plain',
+    })
+
+    const tomlFileLink = document.createElement('a')
+    const tomlFileUrl = URL.createObjectURL(tomlFile)
+    tomlFileLink.href = tomlFileUrl
+    tomlFileLink.download = tomlFile.name
+    tomlFileLink.click()
+
+    URL.revokeObjectURL(tomlFileUrl)
+  }
+
   return (
     <div className={classes.configContainer}>
       <Button
@@ -252,10 +268,22 @@ const ConfigTabContent = ({ configData }) => {
         startIcon={<FileCopyIcon />}
         onClick={handleCopyToml}
         className={classes.copyButton}
-        disabled={!configData}
+        disabled={
+          !configData || !navigator.clipboard || !window.isSecureContext
+        }
         size="small"
       >
         {translate('about.config.exportToml')}
+      </Button>
+      <Button
+        variant="outlined"
+        startIcon={<CloudDownloadIcon />}
+        onClick={handleDownloadToml}
+        className={classes.copyButton}
+        disabled={!configData}
+        size="small"
+      >
+        {translate('about.config.downloadToml')}
       </Button>
       <TableContainer className={classes.tableContainer}>
         <Table size="small" stickyHeader>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -673,6 +673,7 @@
       "currentValue": "Current Value",
       "configurationFile": "Configuration File",
       "exportToml": "Export Configuration (TOML)",
+      "downloadToml": "Download Configuration (TOML)",
       "exportSuccess": "Configuration exported to clipboard in TOML format",
       "exportFailed": "Failed to copy configuration",
       "devFlagsHeader": "Development Flags (subject to change/removal)",


### PR DESCRIPTION
### Description
When clipboard is not available, disable copying to clipboard.
Add a "download file" button that will be enabled when the data is available.

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Test in a non-secure context (http with an IP address. For example, your LAN IP). Export configuration (TOML) should be disabled.
Click download configuration, config should be downloaded as a file `navidrome.toml`

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->