### PR TITLE
fix(ui): prevent "Play Next" from restarting play at top of queue

### DIFF
--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -127,10 +127,12 @@ const reducePlayNext = (state, { data }) => {
   const newQueue = []
   const current = state.current || {}
   let foundPos = false
+  let currentIndex = 0
   state.queue.forEach((item) => {
     newQueue.push(item)
     if (item.uuid === current.uuid) {
       foundPos = true
+      currentIndex = newQueue.length - 1
       Object.keys(data).forEach((id) => {
         newQueue.push(mapToAudioLists(data[id]))
       })
@@ -145,6 +147,7 @@ const reducePlayNext = (state, { data }) => {
   return {
     ...state,
     queue: newQueue,
+    playIndex: foundPos ? currentIndex : undefined,
     clear: true,
   }
 }


### PR DESCRIPTION
### Description
Set playIndex when rebuilding the queue in reducePlayNext so the music player library knows which track is currently playing. Without this, the library's loadNewAudioLists defaults playIndex to 0, causing playback to restart from the top of the queue on rapid "Play Next" actions.

### Related Issues
Fixes #1472 and #1084. #650 is also related

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Play the second song in an album. Then, select "Play Next" on any song. Do this several times. Observe that this no longer interrupts the current song to restart play at the top of the queue (which will be first song in the album that is currently playing).

Before this fix, "Play Next" reliably interrupts playback, typically on the second or third time it's clicked.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->