### PR TITLE
fix(sse): increase the writeTimeout to be more than the keepAlive period (#5053)

### DIFF
--- a/server/events/sse.go
+++ b/server/events/sse.go
@@ -24,8 +24,9 @@ type Broker interface {
 
 const (
 	keepAliveFrequency = 15 * time.Second
-	writeTimeOut       = 5 * time.Second
-	bufferSize         = 1
+	// The timeout must be higher than the keepAliveFrequency, or the lack of activity will cause the channel to close.
+	writeTimeOut = keepAliveFrequency + 5*time.Second
+	bufferSize   = 1
 )
 
 type (


### PR DESCRIPTION
### Description

When using HTTP2, setting the writeTimeout too low causes the channel to close before the keepAlive event has a chance of beeing sent.

### Related Issues
Fixes #5053 

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Start navidrome in dev mode with a TLS cert/key
2. Open a HTTP2 channel with `curl --cacert cert.pem -H "Remote-User: admin" -v -N https://localhost:4533/api/events` 
3. wait 15 seconds to see if the channel stays alive
