### PR TITLE
fix: preserve created_at when moving songs between libraries

### DIFF
--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -38,7 +38,7 @@ type MediaFile struct {
 	AlbumArtistID string `structs:"album_artist_id" json:"albumArtistId"` // Deprecated: Use Participants instead
 	// AlbumArtist is the display name used for the album artist.
 	AlbumArtist          string   `structs:"album_artist" json:"albumArtist"`
-	AlbumID              string   `structs:"album_id" json:"albumId"`
+	AlbumID              string   `structs:"album_id" json:"albumId" hash:"ignore"`
 	HasCoverArt          bool     `structs:"has_cover_art" json:"hasCoverArt"`
 	TrackNumber          int      `structs:"track_number" json:"trackNumber"`
 	DiscNumber           int      `structs:"disc_number" json:"discNumber"`

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -148,7 +148,9 @@ func (r *mediaFileRepository) Exists(id string) (bool, error) {
 }
 
 func (r *mediaFileRepository) Put(m *model.MediaFile) error {
-	m.CreatedAt = time.Now()
+	if m.CreatedAt.IsZero() {
+		m.CreatedAt = time.Now()
+	}
 	id, err := r.putByMatch(Eq{"path": m.Path, "library_id": m.LibraryID}, m.ID, &dbMediaFile{MediaFile: m})
 	if err != nil {
 		return err

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -104,6 +104,68 @@ var _ = Describe("MediaRepository", func() {
 		}
 	})
 
+	Describe("Put CreatedAt behavior (#5050)", func() {
+		It("sets CreatedAt to now when inserting a new file with zero CreatedAt", func() {
+			before := time.Now().Add(-time.Second)
+			newFile := model.MediaFile{ID: id.NewRandom(), LibraryID: 1, Path: "/test/created-at-zero.mp3"}
+			Expect(mr.Put(&newFile)).To(Succeed())
+
+			retrieved, err := mr.Get(newFile.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retrieved.CreatedAt).To(BeTemporally(">", before))
+
+			_ = mr.Delete(newFile.ID)
+		})
+
+		It("preserves CreatedAt when inserting a new file with non-zero CreatedAt", func() {
+			originalTime := time.Date(2020, 3, 15, 10, 30, 0, 0, time.UTC)
+			newFile := model.MediaFile{
+				ID:        id.NewRandom(),
+				LibraryID: 1,
+				Path:      "/test/created-at-preserved.mp3",
+				CreatedAt: originalTime,
+			}
+			Expect(mr.Put(&newFile)).To(Succeed())
+
+			retrieved, err := mr.Get(newFile.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retrieved.CreatedAt).To(BeTemporally("~", originalTime, time.Second))
+
+			_ = mr.Delete(newFile.ID)
+		})
+
+		It("does not reset CreatedAt when updating an existing file", func() {
+			originalTime := time.Date(2019, 6, 1, 12, 0, 0, 0, time.UTC)
+			fileID := id.NewRandom()
+			newFile := model.MediaFile{
+				ID:        fileID,
+				LibraryID: 1,
+				Path:      "/test/created-at-update.mp3",
+				Title:     "Original Title",
+				CreatedAt: originalTime,
+			}
+			Expect(mr.Put(&newFile)).To(Succeed())
+
+			// Update the file with a new title but zero CreatedAt
+			updatedFile := model.MediaFile{
+				ID:        fileID,
+				LibraryID: 1,
+				Path:      "/test/created-at-update.mp3",
+				Title:     "Updated Title",
+				// CreatedAt is zero - should NOT overwrite the stored value
+			}
+			Expect(mr.Put(&updatedFile)).To(Succeed())
+
+			retrieved, err := mr.Get(fileID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(retrieved.Title).To(Equal("Updated Title"))
+			// CreatedAt should still be the original time (not reset)
+			Expect(retrieved.CreatedAt).To(BeTemporally("~", originalTime, time.Second))
+
+			_ = mr.Delete(fileID)
+		})
+	})
+
 	It("checks existence of mediafiles in the DB", func() {
 		Expect(mr.Exists(songAntenna.ID)).To(BeTrue())
 		Expect(mr.Exists("666")).To(BeFalse())

--- a/scanner/phase_2_missing_tracks_test.go
+++ b/scanner/phase_2_missing_tracks_test.go
@@ -801,6 +801,11 @@ var _ = Describe("phaseMissingTracks", func() {
 
 			// Album's created_at should be copied from old to new
 			Expect(albumRepo.CopyAttributesCalls).To(HaveKeyWithValue("old-album", "new-album"))
+
+			// Verify the new album's CreatedAt was actually updated
+			newAlbum, err := albumRepo.Get("new-album")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newAlbum.CreatedAt).To(Equal(originalTime))
 		})
 
 		It("should not copy album created_at when album ID does not change", func() {

--- a/tests/mock_album_repo.go
+++ b/tests/mock_album_repo.go
@@ -21,6 +21,7 @@ type MockAlbumRepo struct {
 	Err                     bool
 	Options                 model.QueryOptions
 	ReassignAnnotationCalls map[string]string // prevID -> newID
+	CopyAttributesCalls     map[string]string // fromID -> toID
 }
 
 func (m *MockAlbumRepo) SetError(err bool) {
@@ -139,6 +140,32 @@ func (m *MockAlbumRepo) ReassignAnnotation(prevID string, newID string) error {
 		m.ReassignAnnotationCalls = make(map[string]string)
 	}
 	m.ReassignAnnotationCalls[prevID] = newID
+	return nil
+}
+
+// CopyAttributes copies attributes from one album to another
+func (m *MockAlbumRepo) CopyAttributes(fromID, toID string, columns ...string) error {
+	if m.Err {
+		return errors.New("unexpected error")
+	}
+	from, ok := m.Data[fromID]
+	if !ok {
+		return model.ErrNotFound
+	}
+	to, ok := m.Data[toID]
+	if !ok {
+		return model.ErrNotFound
+	}
+	for _, col := range columns {
+		switch col {
+		case "created_at":
+			to.CreatedAt = from.CreatedAt
+		}
+	}
+	if m.CopyAttributesCalls == nil {
+		m.CopyAttributesCalls = make(map[string]string)
+	}
+	m.CopyAttributesCalls[fromID] = toID
 	return nil
 }
 


### PR DESCRIPTION
### Description

When songs are moved between libraries, their `created_at` date was being reset to the current time, causing them to incorrectly appear at the top of "Recently Added". This PR fixes the issue with three targeted changes:

1. **`model/mediafile.go`**: Add `hash:"ignore"` to `AlbumID` so that `Equals()` works correctly for cross-library moves (AlbumID includes a library prefix, making hashes always differ between libraries even when the underlying album is the same).

2. **`scanner/phase_2_missing_tracks.go`**: Preserve the original `created_at` from the missing file when moving tracks, and copy the album's `created_at` via `CopyAttributes` when the album ID changes during a move.

3. **`persistence/mediafile_repository.go`**: Only set `CreatedAt` to `time.Now()` in `Put()` when it's zero (new files), so that an explicitly provided `CreatedAt` is preserved on insert.

### Related Issues

Fixes https://github.com/navidrome/navidrome/discussions/5050

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Set up two libraries in Navidrome
2. Add some music files to library A and let it scan — note the "Recently Added" order
3. Move one or more files from library A to library B
4. Trigger a rescan
5. Verify the moved songs do **not** appear at the top of "Recently Added"
6. Verify the `created_at` timestamp is preserved from the original library entry

### Additional Notes

- The `hash:"ignore"` change to `AlbumID` is necessary because when a track moves between libraries, the album ID changes (it includes a library-specific prefix), which caused the hash comparison to always detect a difference even when the track content was identical.
- Album `created_at` is also preserved via `CopyAttributes` to prevent entire albums from appearing as newly added after a cross-library move.
