### PR TITLE
fix(ui): make toggle switches visible in Gruvbox Dark theme

### DIFF
--- a/ui/src/themes/gruvboxDark.js
+++ b/ui/src/themes/gruvboxDark.js
@@ -97,6 +97,16 @@ export default {
         boxShadow: '3px 3px 5px #3c3836',
       },
     },
+    MuiSwitch: {
+      colorSecondary: {
+        '&$checked': {
+          color: '#458588',
+        },
+        '&$checked + $track': {
+          backgroundColor: '#458588',
+        },
+      },
+    },
     NDMobileArtistDetails: {
       bgContainer: {
         background:


### PR DESCRIPTION
### Description

In the Gruvbox Dark theme, the "Public" and "Auto Import" toggle switches in the Playlist list are invisible when checked. The theme's secondary color (`#3c3836`) is identical to the panel/table cell background color, making the checked `MuiSwitch` thumb blend into the background.

This is the same class of bug as #2129 (fixed by PR #2135), which addressed **checkboxes** but not **switches**. This PR adds a `MuiSwitch` override using Gruvbox cyan (`#458588`), which is already used throughout the theme for interactive elements (checkboxes, buttons, slider handles, links).

### Related Issues

Fixes #5063

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No automated tests added — this is a purely visual CSS override in a theme file. Testing is visual/manual.

### Screenshots

#### Before
<img width="1321" height="381" alt="gruvbox-dark-switches-before" src="https://github.com/user-attachments/assets/e59df6f8-5b36-4d6c-a35d-dacb6e6735a2" />

#### After
<img width="1321" height="384" alt="gruvbox-dark-switches-after" src="https://github.com/user-attachments/assets/2ecbaf21-fe9d-4d6b-acbb-90d4575fb6ea" />

### How to Test

1. Start the dev server with `make dev`
2. Open the web UI and select the **Gruvbox Dark** theme
3. Navigate to the Playlists view
4. Toggle the "Public" switch — it should now be visibly **cyan** (`#458588`) when on
5. Toggle the "Auto Import" switch — same check
6. Verify unchecked switches still appear in the default grayish color
7. Verify existing checkboxes (e.g., in column selector menus) still work correctly

### Additional Notes

The fix follows the same pattern used by the Dracula theme's `MuiSwitch` override. Only the Gruvbox Dark theme is affected since it's the only theme where the secondary color matches the background.
