### PR TITLE
feat(search): add BM25 relevance ranking to FTS5 search

### DIFF
--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -110,9 +110,10 @@ func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sq
 	return func(field string, value any) Sqlizer {
 		v := strings.ToLower(value.(string))
 		searchExpr := getSearchExpr()
+		filter := searchExpr(tableName, v)
 		cond := cmp.Or(
 			mbidExpr(tableName, v, mbidFields...),
-			searchExpr(tableName, v),
+			filter.AsSqlizer(),
 		)
 		return cond
 	}

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -109,13 +109,10 @@ func booleanFilter(field string, value any) Sqlizer {
 func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {
 	return func(field string, value any) Sqlizer {
 		v := strings.ToLower(value.(string))
-		searchExpr := getSearchExpr()
-		filter := searchExpr(tableName, v)
-		cond := cmp.Or(
+		return cmp.Or(
 			mbidExpr(tableName, v, mbidFields...),
-			filter.AsSqlizer(),
+			getSearchFilter(tableName, v),
 		)
-		return cond
 	}
 }
 

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -16,8 +16,27 @@ func formatFullText(text ...string) string {
 	return " " + fullText
 }
 
+// searchFilter carries the result of a search expression builder.
+// For WHERE-based filters (legacy LIKE, CJK LIKE), only Where is set.
+// For FTS5 ranked search, Where contains a rowid IN subquery for filtering,
+// and RankOrder contains a correlated subquery for BM25 relevance ordering.
+type searchFilter struct {
+	Where     Sqlizer // WHERE clause (LIKE/legacy/FTS5 rowid IN)
+	RankOrder string  // ORDER BY expression for relevance (correlated bm25 subquery)
+	RankArgs  []any   // Args for the rank ORDER BY expression
+}
+
+// AsSqlizer returns a Sqlizer suitable for use in a WHERE clause.
+// This is used in contexts like fullTextFilter where only filtering is needed, not ranking.
+func (sf *searchFilter) AsSqlizer() Sqlizer {
+	if sf == nil {
+		return nil
+	}
+	return sf.Where
+}
+
 // searchExprFunc is the function signature for search expression builders.
-type searchExprFunc func(tableName string, query string) Sqlizer
+type searchExprFunc func(tableName string, query string) *searchFilter
 
 // getSearchExpr returns the active search expression function based on config.
 // It falls back to legacySearchExpr when Search.FullString is enabled, because
@@ -28,7 +47,7 @@ func getSearchExpr() searchExprFunc {
 	if conf.Server.Search.Backend == "legacy" || conf.Server.Search.FullString {
 		return legacySearchExpr
 	}
-	return func(tableName, query string) Sqlizer {
+	return func(tableName, query string) *searchFilter {
 		if containsCJK(query) {
 			return likeSearchExpr(tableName, query)
 		}
@@ -50,8 +69,18 @@ func (r sqlRepository) doSearch(sq SelectBuilder, q string, offset, size int, re
 	searchExpr := getSearchExpr()
 	filter := searchExpr(r.tableName, q)
 	if filter != nil {
-		sq = sq.Where(filter)
-		sq = sq.OrderBy(orderBys...)
+		sq = sq.Where(filter.Where)
+		if filter.RankOrder != "" {
+			// FTS5 ranked search: use correlated subquery for BM25 relevance ordering.
+			// OrderByClause supports parameterized args (unlike OrderBy).
+			rankArgs := make([]interface{}, len(filter.RankArgs))
+			copy(rankArgs, filter.RankArgs)
+			sq = sq.OrderByClause(filter.RankOrder, rankArgs...)
+			sq = sq.OrderBy(orderBys...)
+		} else {
+			// WHERE-based search (legacy LIKE, CJK LIKE): no ranking
+			sq = sq.OrderBy(orderBys...)
+		}
 	} else {
 		// This is to speed up the results of `search3?query=""`, for OpenSubsonic
 		// If the filter is empty, we sort by the specified natural order.
@@ -83,7 +112,7 @@ func mbidExpr(tableName, mbid string, mbidFields ...string) Sqlizer {
 
 // legacySearchExpr generates LIKE-based search filters against the full_text column.
 // This is the original search implementation, used when Search.Backend="legacy".
-func legacySearchExpr(tableName string, s string) Sqlizer {
+func legacySearchExpr(tableName string, s string) *searchFilter {
 	q := str.SanitizeStrings(s)
 	if q == "" {
 		log.Trace("Search using legacy backend, query is empty", "table", tableName)
@@ -99,5 +128,5 @@ func legacySearchExpr(tableName string, s string) Sqlizer {
 		filters = append(filters, Like{tableName + ".full_text": "%" + sep + part + "%"})
 	}
 	log.Trace("Search using legacy backend", "query", filters, "table", tableName)
-	return filters
+	return &searchFilter{Where: filters}
 }

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -56,9 +56,7 @@ func applySearchFilter(sq SelectBuilder, tableName, query, naturalOrder string, 
 	}
 	sq = sq.Where(filter.where)
 	if filter.rankOrder != "" {
-		rankArgs := make([]interface{}, len(filter.rankArgs))
-		copy(rankArgs, filter.rankArgs)
-		sq = sq.OrderByClause(filter.rankOrder, rankArgs...)
+		sq = sq.OrderByClause(filter.rankOrder, filter.rankArgs...)
 	}
 	return sq.OrderBy(orderBys...)
 }

--- a/persistence/sql_search_fts.go
+++ b/persistence/sql_search_fts.go
@@ -221,7 +221,7 @@ func likeSearchExpr(tableName string, s string) *searchFilter {
 		wordFilters = append(wordFilters, colFilters)
 	}
 	log.Trace("Search using LIKE backend", "query", wordFilters, "table", tableName)
-	return &searchFilter{Where: wordFilters}
+	return &searchFilter{where: wordFilters}
 }
 
 // ftsSearchColumns defines which FTS5 columns are included in general search.
@@ -282,7 +282,7 @@ func ftsSearchExpr(tableName string, s string) *searchFilter {
 	if !ok {
 		// Fallback: no weights available, filter only (no ranking)
 		log.Trace("Search using FTS5 backend (no ranking)", "table", tableName, "query", q)
-		return &searchFilter{Where: whereFilter}
+		return &searchFilter{where: whereFilter}
 	}
 
 	// Build bm25 weight args string: "10, 5, 5, ..."
@@ -306,8 +306,8 @@ func ftsSearchExpr(tableName string, s string) *searchFilter {
 
 	log.Trace("Search using FTS5 backend with BM25 ranking", "table", tableName, "query", q, "weights", bm25Args)
 	return &searchFilter{
-		Where:     whereFilter,
-		RankOrder: rankOrder,
-		RankArgs:  []any{matchExpr},
+		where:     whereFilter,
+		rankOrder: rankOrder,
+		rankArgs:  []any{matchExpr},
 	}
 }

--- a/persistence/sql_search_fts_test.go
+++ b/persistence/sql_search_fts_test.go
@@ -90,9 +90,16 @@ var _ = Describe("likeSearchExpr", func() {
 		Expect(likeSearchExpr("media_file", "   ")).To(BeNil())
 	})
 
+	It("returns a searchFilter with Where set and no ranking", func() {
+		filter := likeSearchExpr("media_file", "周杰伦")
+		Expect(filter).ToNot(BeNil())
+		Expect(filter.Where).ToNot(BeNil())
+		Expect(filter.RankOrder).To(BeEmpty())
+	})
+
 	It("generates LIKE filters against core columns for single CJK word", func() {
-		expr := likeSearchExpr("media_file", "周杰伦")
-		sql, args, err := expr.ToSql()
+		filter := likeSearchExpr("media_file", "周杰伦")
+		sql, args, err := filter.Where.ToSql()
 		Expect(err).ToNot(HaveOccurred())
 		// Should have OR between columns for the single word
 		Expect(sql).To(ContainSubstring("OR"))
@@ -107,8 +114,8 @@ var _ = Describe("likeSearchExpr", func() {
 	})
 
 	It("generates AND of OR groups for multi-word query", func() {
-		expr := likeSearchExpr("media_file", "周杰伦 greatest")
-		sql, args, err := expr.ToSql()
+		filter := likeSearchExpr("media_file", "周杰伦 greatest")
+		sql, args, err := filter.Where.ToSql()
 		Expect(err).ToNot(HaveOccurred())
 		// Two groups AND'd together, each with 4 columns OR'd
 		Expect(sql).To(ContainSubstring("AND"))
@@ -116,8 +123,8 @@ var _ = Describe("likeSearchExpr", func() {
 	})
 
 	It("uses correct columns for album table", func() {
-		expr := likeSearchExpr("album", "周杰伦")
-		sql, args, err := expr.ToSql()
+		filter := likeSearchExpr("album", "周杰伦")
+		sql, args, err := filter.Where.ToSql()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sql).To(ContainSubstring("album.name LIKE"))
 		Expect(sql).To(ContainSubstring("album.album_artist LIKE"))
@@ -125,8 +132,8 @@ var _ = Describe("likeSearchExpr", func() {
 	})
 
 	It("uses correct columns for artist table", func() {
-		expr := likeSearchExpr("artist", "周杰伦")
-		sql, args, err := expr.ToSql()
+		filter := likeSearchExpr("artist", "周杰伦")
+		sql, args, err := filter.Where.ToSql()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sql).To(ContainSubstring("artist.name LIKE"))
 		Expect(args).To(HaveLen(1))
@@ -142,60 +149,91 @@ var _ = Describe("ftsSearchExpr", func() {
 		Expect(ftsSearchExpr("media_file", "")).To(BeNil())
 	})
 
-	It("generates rowid IN subquery with MATCH and column filter", func() {
-		expr := ftsSearchExpr("media_file", "beatles")
-		sql, args, err := expr.ToSql()
+	It("generates WHERE IN filter with correlated bm25 ranking for known tables", func() {
+		filter := ftsSearchExpr("media_file", "beatles")
+		Expect(filter).ToNot(BeNil())
+		// WHERE clause should use rowid IN subquery
+		sql, args, err := filter.Where.ToSql()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sql).To(ContainSubstring("media_file.rowid IN"))
 		Expect(sql).To(ContainSubstring("media_file_fts"))
 		Expect(sql).To(ContainSubstring("MATCH"))
 		Expect(args).To(HaveLen(1))
-		Expect(args[0]).To(HavePrefix("{title album artist album_artist"))
-		Expect(args[0]).To(ContainSubstring("beatles*"))
+		matchExpr, ok := args[0].(string)
+		Expect(ok).To(BeTrue())
+		Expect(matchExpr).To(HavePrefix("{title album artist album_artist"))
+		Expect(matchExpr).To(ContainSubstring("beatles*"))
+		// RankOrder should contain correlated bm25 subquery
+		Expect(filter.RankOrder).To(ContainSubstring("bm25(media_file_fts"))
+		Expect(filter.RankOrder).To(ContainSubstring("MATCH"))
+		Expect(filter.RankArgs).To(HaveLen(1))
+	})
+
+	It("includes correct BM25 weights for media_file", func() {
+		filter := ftsSearchExpr("media_file", "test")
+		Expect(filter.RankOrder).To(ContainSubstring("bm25(media_file_fts, 10, 5, 5, 5, 1, 1, 1, 1, 2, 3, 1)"))
+	})
+
+	It("includes correct BM25 weights for album", func() {
+		filter := ftsSearchExpr("album", "test")
+		Expect(filter.RankOrder).To(ContainSubstring("bm25(album_fts, 10, 1, 5, 3, 1, 2, 2, 1)"))
+	})
+
+	It("includes correct BM25 weights for artist", func() {
+		filter := ftsSearchExpr("artist", "test")
+		Expect(filter.RankOrder).To(ContainSubstring("bm25(artist_fts, 10, 1, 1)"))
 	})
 
 	It("generates correct FTS table name per entity", func() {
 		for _, table := range []string{"media_file", "album", "artist"} {
-			expr := ftsSearchExpr(table, "test")
-			sql, _, err := expr.ToSql()
+			filter := ftsSearchExpr(table, "test")
+			Expect(filter).ToNot(BeNil())
+			sql, _, err := filter.Where.ToSql()
 			Expect(err).ToNot(HaveOccurred())
-			Expect(sql).To(ContainSubstring(table + ".rowid IN"))
 			Expect(sql).To(ContainSubstring(table + "_fts"))
+			Expect(sql).To(ContainSubstring(table + ".rowid"))
 		}
 	})
 
 	It("wraps query with column filter for known tables", func() {
-		expr := ftsSearchExpr("artist", "Beatles")
-		_, args, err := expr.ToSql()
-		Expect(err).ToNot(HaveOccurred())
+		filter := ftsSearchExpr("artist", "Beatles")
+		sql, args, _ := filter.Where.ToSql()
+		Expect(sql).To(ContainSubstring("MATCH"))
 		Expect(args[0]).To(Equal("{name sort_artist_name search_normalized} : (Beatles*)"))
 	})
 
-	It("passes query without column filter for unknown tables", func() {
-		expr := ftsSearchExpr("unknown_table", "test")
-		_, args, err := expr.ToSql()
+	It("passes query without column filter for unknown tables (WHERE IN fallback)", func() {
+		filter := ftsSearchExpr("unknown_table", "test")
+		Expect(filter).ToNot(BeNil())
+		// Unknown tables have no BM25 weights, so they fall back to WHERE IN without ranking
+		Expect(filter.Where).ToNot(BeNil())
+		Expect(filter.RankOrder).To(BeEmpty())
+		sql, args, err := filter.Where.ToSql()
 		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("MATCH"))
 		Expect(args[0]).To(Equal("test*"))
 	})
 
 	It("preserves phrase queries inside column filter", func() {
-		expr := ftsSearchExpr("media_file", `"the beatles"`)
-		_, args, err := expr.ToSql()
-		Expect(err).ToNot(HaveOccurred())
+		filter := ftsSearchExpr("media_file", `"the beatles"`)
+		sql, args, _ := filter.Where.ToSql()
+		Expect(sql).To(ContainSubstring("MATCH"))
 		Expect(args[0]).To(ContainSubstring(`"the beatles"`))
 	})
 
 	It("preserves prefix queries inside column filter", func() {
-		expr := ftsSearchExpr("media_file", "beat*")
-		_, args, err := expr.ToSql()
-		Expect(err).ToNot(HaveOccurred())
+		filter := ftsSearchExpr("media_file", "beat*")
+		sql, args, _ := filter.Where.ToSql()
+		Expect(sql).To(ContainSubstring("MATCH"))
 		Expect(args[0]).To(ContainSubstring("beat*"))
 	})
 
 	It("falls back to LIKE search for punctuation-only query", func() {
-		expr := ftsSearchExpr("media_file", "!!!!!!!")
-		Expect(expr).ToNot(BeNil())
-		sql, args, err := expr.ToSql()
+		filter := ftsSearchExpr("media_file", "!!!!!!!")
+		Expect(filter).ToNot(BeNil())
+		Expect(filter.Where).ToNot(BeNil())
+		Expect(filter.RankOrder).To(BeEmpty())
+		sql, args, err := filter.Where.ToSql()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sql).To(ContainSubstring("LIKE"))
 		Expect(args).To(ContainElement("%!!!!!!!%"))
@@ -208,6 +246,35 @@ var _ = Describe("ftsSearchExpr", func() {
 
 	It("returns nil for empty quoted phrase", func() {
 		Expect(ftsSearchExpr("media_file", `""`)).To(BeNil())
+	})
+
+	It("AsSqlizer returns Where for FTS5 filter", func() {
+		filter := ftsSearchExpr("media_file", "beatles")
+		Expect(filter).ToNot(BeNil())
+		sqlizer := filter.AsSqlizer()
+		Expect(sqlizer).ToNot(BeNil())
+		sql, args, err := sqlizer.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("media_file.rowid IN"))
+		Expect(sql).To(ContainSubstring("media_file_fts"))
+		Expect(sql).To(ContainSubstring("MATCH"))
+		Expect(args).To(HaveLen(1))
+		Expect(args[0]).To(ContainSubstring("beatles*"))
+	})
+
+	It("AsSqlizer returns Where directly for LIKE-based filter", func() {
+		filter := likeSearchExpr("media_file", "周杰伦")
+		Expect(filter).ToNot(BeNil())
+		sqlizer := filter.AsSqlizer()
+		Expect(sqlizer).ToNot(BeNil())
+		sql, _, err := sqlizer.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("LIKE"))
+	})
+
+	It("AsSqlizer returns nil for nil filter", func() {
+		var filter *searchFilter
+		Expect(filter.AsSqlizer()).To(BeNil())
 	})
 })
 

--- a/server/e2e/subsonic_searching_test.go
+++ b/server/e2e/subsonic_searching_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -145,6 +146,76 @@ var _ = Describe("Search Endpoints", func() {
 				Expect(s.Id).ToNot(BeEmpty())
 				Expect(s.Title).ToNot(BeEmpty())
 			}
+		})
+
+		Describe("MBID search", func() {
+			It("finds songs by mbz_recording_id", func() {
+				resp := doReq("search3", "query", mbidComeTogetherRec)
+
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				Expect(resp.SearchResult3).ToNot(BeNil())
+				Expect(resp.SearchResult3.Song).To(HaveLen(1))
+				Expect(resp.SearchResult3.Song[0].Title).To(Equal("Come Together"))
+			})
+
+			It("finds songs by mbz_release_track_id", func() {
+				resp := doReq("search3", "query", mbidSomething)
+
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				Expect(resp.SearchResult3).ToNot(BeNil())
+				Expect(resp.SearchResult3.Song).To(HaveLen(1))
+				Expect(resp.SearchResult3.Song[0].Title).To(Equal("Something"))
+			})
+
+			It("finds albums by mbz_album_id", func() {
+				resp := doReq("search3", "query", mbidAbbeyRoadAlbum)
+
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				Expect(resp.SearchResult3).ToNot(BeNil())
+				Expect(resp.SearchResult3.Album).To(HaveLen(1))
+				Expect(resp.SearchResult3.Album[0].Name).To(Equal("Abbey Road"))
+			})
+
+			It("finds albums by mbz_release_group_id", func() {
+				resp := doReq("search3", "query", mbidAbbeyRoadRelGroup)
+
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				Expect(resp.SearchResult3).ToNot(BeNil())
+				Expect(resp.SearchResult3.Album).To(HaveLen(1))
+				Expect(resp.SearchResult3.Album[0].Name).To(Equal("Abbey Road"))
+			})
+
+			It("finds artists by mbz_artist_id", func() {
+				resp := doReq("search3", "query", mbidBeatlesArtist)
+
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				Expect(resp.SearchResult3).ToNot(BeNil())
+				Expect(resp.SearchResult3.Artist).To(HaveLen(1))
+				Expect(resp.SearchResult3.Artist[0].Name).To(Equal("The Beatles"))
+			})
+
+			It("returns empty results for non-matching UUID", func() {
+				nonMatchingUUID := uuid.NewString()
+				resp := doReq("search3", "query", nonMatchingUUID)
+
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				Expect(resp.SearchResult3).ToNot(BeNil())
+				Expect(resp.SearchResult3.Artist).To(BeEmpty())
+				Expect(resp.SearchResult3.Album).To(BeEmpty())
+				Expect(resp.SearchResult3.Song).To(BeEmpty())
+			})
+
+			It("does not return songs for artist MBID", func() {
+				// media_file MBID search only checks mbz_recording_id and mbz_release_track_id,
+				// so an artist MBID should return only the artist, not songs
+				resp := doReq("search3", "query", mbidBeatlesArtist)
+
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				Expect(resp.SearchResult3).ToNot(BeNil())
+				Expect(resp.SearchResult3.Artist).To(HaveLen(1))
+				Expect(resp.SearchResult3.Artist[0].Name).To(Equal("The Beatles"))
+				Expect(resp.SearchResult3.Song).To(BeEmpty())
+			})
 		})
 	})
 })


### PR DESCRIPTION
### Description

Add BM25 relevance ranking to FTS5 search results so that matches in more important fields (e.g., title, artist) rank higher than matches in less important fields (e.g., sort columns, normalized search text).

The implementation introduces per-table BM25 column weights and uses a correlated subquery to compute BM25 scores. The correlated subquery approach is necessary because SQLite's `bm25()` function cannot be referenced from an outer query that has `GROUP BY` (it silently returns 0 rows).

As part of this change, the internal search expression functions (`ftsSearchExpr`, `likeSearchExpr`, `legacySearchExpr`) now return a `searchFilter` struct containing the WHERE clause, optional rank ORDER BY expression, and rank args — instead of a bare `Sqlizer`. This allows `applySearchFilter` to handle both filtering and ordering in one place, keeping the calling code (`doSearch`, `fullTextFilter`) clean and simple.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run the persistence tests: `make test PKG=./persistence`
2. Start the dev server: `make dev`
3. Search for a term that appears in multiple fields (e.g., an artist name that also appears in album names) — results where the term matches the title or artist should rank higher than results where it only matches sort or normalized columns.
4. Verify that CJK search, legacy search backend, and punctuation-only queries continue to work as before (these paths are unaffected by BM25 ranking).

### Additional Notes

- **BM25 weights** are defined in `ftsColumnWeights` and can be tuned independently per FTS table (media_file, album, artist). Current weights prioritize title/name (10), then artist/album_artist (5), then search_participants (3), then other fields (1-2).
- **Unknown tables** (if any future FTS table lacks weights) fall back to filter-only mode without ranking.
- The `searchFilter` struct is unexported and never exposed to callers — they use `getSearchFilter` (WHERE-only) or `applySearchFilter` (WHERE + ORDER BY).
