### PR TITLE
fix(search): two-phase FTS queries with BM25 ranking for search3

### DIFF
--- a/model/searchable.go
+++ b/model/searchable.go
@@ -1,5 +1,5 @@
 package model
 
 type SearchableRepository[T any] interface {
-	Search(q string, offset, size int, options ...QueryOptions) (T, error)
+	Search(q string, options ...QueryOptions) (T, error)
 }

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -361,7 +361,7 @@ func (r *albumRepository) Search(q string, offset int, size int, options ...mode
 			return nil, fmt.Errorf("searching album by MBID %q: %w", q, err)
 		}
 	} else {
-		err := r.doSearch(r.selectAlbum(options...), q, offset, size, &res, "album.rowid", "name")
+		err := r.doSearch(r.selectAlbum(options...), q, offset, size, &res, "album.rowid", "rank", "name")
 		if err != nil {
 			return nil, fmt.Errorf("searching album by query %q: %w", q, err)
 		}

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -361,7 +361,7 @@ func (r *albumRepository) Search(q string, offset int, size int, options ...mode
 			return nil, fmt.Errorf("searching album by MBID %q: %w", q, err)
 		}
 	} else {
-		err := r.doSearch(r.selectAlbum(options...), q, offset, size, &res, "album.rowid", "rank", "name")
+		err := r.doSearch(r.selectAlbum(options...), q, offset, size, &res, "album.rowid", "name")
 		if err != nil {
 			return nil, fmt.Errorf("searching album by query %q: %w", q, err)
 		}

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -523,7 +523,7 @@ func (r *artistRepository) Search(q string, offset int, size int, options ...mod
 	} else {
 		// Natural order for artists is more performant by ID, due to GROUP BY clause in selectArtist
 		err := r.doSearch(r.selectArtist(options...), q, offset, size, &res, "artist.id",
-			"rank", "name")
+			"sum(json_extract(stats, '$.total.m')) desc", "name")
 		if err != nil {
 			return nil, fmt.Errorf("searching artist by query %q: %w", q, err)
 		}

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -523,7 +523,7 @@ func (r *artistRepository) Search(q string, offset int, size int, options ...mod
 	} else {
 		// Natural order for artists is more performant by ID, due to GROUP BY clause in selectArtist
 		err := r.doSearch(r.selectArtist(options...), q, offset, size, &res, "artist.id",
-			"sum(json_extract(stats, '$.total.m')) desc", "name")
+			"rank", "name")
 		if err != nil {
 			return nil, fmt.Errorf("searching artist by query %q: %w", q, err)
 		}

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
-	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -513,20 +512,25 @@ func (r *artistRepository) RefreshStats(allArtists bool) (int64, error) {
 	return totalRowsAffected, nil
 }
 
-func (r *artistRepository) Search(q string, offset int, size int, options ...model.QueryOptions) (model.Artists, error) {
-	var res dbArtists
-	if uuid.Validate(q) == nil {
-		err := r.searchByMBID(r.selectArtist(options...), q, []string{"mbz_artist_id"}, &res)
-		if err != nil {
-			return nil, fmt.Errorf("searching artist by MBID %q: %w", q, err)
-		}
-	} else {
+func (r *artistRepository) searchCfg() searchConfig {
+	return searchConfig{
 		// Natural order for artists is more performant by ID, due to GROUP BY clause in selectArtist
-		err := r.doSearch(r.selectArtist(options...), q, offset, size, &res, "artist.id",
-			"sum(json_extract(stats, '$.total.m')) desc", "name")
-		if err != nil {
-			return nil, fmt.Errorf("searching artist by query %q: %w", q, err)
-		}
+		NaturalOrder:  "artist.id",
+		OrderBy:       []string{"sum(json_extract(stats, '$.total.m')) desc", "name"},
+		MBIDFields:    []string{"mbz_artist_id"},
+		LibraryFilter: r.applyLibraryFilterToArtistQuery,
+	}
+}
+
+func (r *artistRepository) Search(q string, options ...model.QueryOptions) (model.Artists, error) {
+	var opts model.QueryOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
+	var res dbArtists
+	err := r.doSearch(r.selectArtist(options...), q, &res, r.searchCfg(), opts)
+	if err != nil {
+		return nil, fmt.Errorf("searching artist %q: %w", q, err)
 	}
 	return res.toModels(), nil
 }

--- a/persistence/artist_repository_test.go
+++ b/persistence/artist_repository_test.go
@@ -512,7 +512,7 @@ var _ = Describe("ArtistRepository", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// Test the search
-					results, err := (*testRepo).Search("550e8400-e29b-41d4-a716-446655440010", 0, 10)
+					results, err := (*testRepo).Search("550e8400-e29b-41d4-a716-446655440010", model.QueryOptions{Max: 10})
 					Expect(err).ToNot(HaveOccurred())
 
 					if shouldFind {
@@ -543,12 +543,12 @@ var _ = Describe("ArtistRepository", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Restricted user should not find this artist
-				results, err := restrictedRepo.Search("a74b1b7f-71a5-4011-9441-d0b5e4122711", 0, 10)
+				results, err := restrictedRepo.Search("a74b1b7f-71a5-4011-9441-d0b5e4122711", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(BeEmpty())
 
 				// But admin should find it
-				results, err = repo.Search("a74b1b7f-71a5-4011-9441-d0b5e4122711", 0, 10)
+				results, err = repo.Search("a74b1b7f-71a5-4011-9441-d0b5e4122711", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(HaveLen(1))
 
@@ -560,7 +560,7 @@ var _ = Describe("ArtistRepository", func() {
 
 			Context("Text Search", func() {
 				It("allows admin to find artists by name regardless of library", func() {
-					results, err := repo.Search("Beatles", 0, 10)
+					results, err := repo.Search("Beatles", model.QueryOptions{Max: 10})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(results).To(HaveLen(1))
 					Expect(results[0].Name).To(Equal("The Beatles"))
@@ -580,7 +580,7 @@ var _ = Describe("ArtistRepository", func() {
 					Expect(err).ToNot(HaveOccurred())
 
 					// Restricted user should not find this artist
-					results, err := restrictedRepo.Search("Unique Search Name", 0, 10)
+					results, err := restrictedRepo.Search("Unique Search Name", model.QueryOptions{Max: 10})
 					Expect(err).ToNot(HaveOccurred())
 					Expect(results).To(BeEmpty(), "Text search should respect library filtering")
 
@@ -688,7 +688,7 @@ var _ = Describe("ArtistRepository", func() {
 				Expect(artists).To(HaveLen(5)) // Including the missing artist
 
 				// Search never returns missing artists (hardcoded behavior)
-				results, err := repo.Search("Missing Artist", 0, 10)
+				results, err := repo.Search("Missing Artist", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(BeEmpty())
 			})
@@ -742,11 +742,11 @@ var _ = Describe("ArtistRepository", func() {
 			})
 
 			It("Search returns empty results for users without library access", func() {
-				results, err := restrictedRepo.Search("Beatles", 0, 10)
+				results, err := restrictedRepo.Search("Beatles", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(BeEmpty())
 
-				results, err = restrictedRepo.Search("Kraftwerk", 0, 10)
+				results, err = restrictedRepo.Search("Kraftwerk", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(BeEmpty())
 			})

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -436,7 +436,7 @@ func (r *mediaFileRepository) Search(q string, offset int, size int, options ...
 			return nil, fmt.Errorf("searching media_file by MBID %q: %w", q, err)
 		}
 	} else {
-		err := r.doSearch(r.selectMediaFile(options...), q, offset, size, &res, "media_file.rowid", "title")
+		err := r.doSearch(r.selectMediaFile(options...), q, offset, size, &res, "media_file.rowid", "rank", "title")
 		if err != nil {
 			return nil, fmt.Errorf("searching media_file by query %q: %w", q, err)
 		}

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -11,7 +11,6 @@ import (
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
-	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -428,18 +427,21 @@ func (r *mediaFileRepository) FindRecentFilesByProperties(missing model.MediaFil
 	return res.toModels(), nil
 }
 
-func (r *mediaFileRepository) Search(q string, offset int, size int, options ...model.QueryOptions) (model.MediaFiles, error) {
+var mediaFileSearchConfig = searchConfig{
+	NaturalOrder: "media_file.rowid",
+	OrderBy:      []string{"title"},
+	MBIDFields:   []string{"mbz_recording_id", "mbz_release_track_id"},
+}
+
+func (r *mediaFileRepository) Search(q string, options ...model.QueryOptions) (model.MediaFiles, error) {
+	var opts model.QueryOptions
+	if len(options) > 0 {
+		opts = options[0]
+	}
 	var res dbMediaFiles
-	if uuid.Validate(q) == nil {
-		err := r.searchByMBID(r.selectMediaFile(options...), q, []string{"mbz_recording_id", "mbz_release_track_id"}, &res)
-		if err != nil {
-			return nil, fmt.Errorf("searching media_file by MBID %q: %w", q, err)
-		}
-	} else {
-		err := r.doSearch(r.selectMediaFile(options...), q, offset, size, &res, "media_file.rowid", "title")
-		if err != nil {
-			return nil, fmt.Errorf("searching media_file by query %q: %w", q, err)
-		}
+	err := r.doSearch(r.selectMediaFile(options...), q, &res, mediaFileSearchConfig, opts)
+	if err != nil {
+		return nil, fmt.Errorf("searching media_file %q: %w", q, err)
 	}
 	return res.toModels(), nil
 }

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -436,7 +436,7 @@ func (r *mediaFileRepository) Search(q string, offset int, size int, options ...
 			return nil, fmt.Errorf("searching media_file by MBID %q: %w", q, err)
 		}
 	} else {
-		err := r.doSearch(r.selectMediaFile(options...), q, offset, size, &res, "media_file.rowid", "rank", "title")
+		err := r.doSearch(r.selectMediaFile(options...), q, offset, size, &res, "media_file.rowid", "title")
 		if err != nil {
 			return nil, fmt.Errorf("searching media_file by query %q: %w", q, err)
 		}

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -527,7 +527,7 @@ var _ = Describe("MediaRepository", func() {
 	Describe("Search", func() {
 		Context("text search", func() {
 			It("finds media files by title", func() {
-				results, err := mr.Search("Antenna", 0, 10)
+				results, err := mr.Search("Antenna", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(HaveLen(3)) // songAntenna, songAntennaWithLyrics, songAntenna2
 				for _, result := range results {
@@ -536,7 +536,7 @@ var _ = Describe("MediaRepository", func() {
 			})
 
 			It("finds media files case insensitively", func() {
-				results, err := mr.Search("antenna", 0, 10)
+				results, err := mr.Search("antenna", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(HaveLen(3))
 				for _, result := range results {
@@ -545,7 +545,7 @@ var _ = Describe("MediaRepository", func() {
 			})
 
 			It("returns empty result when no matches found", func() {
-				results, err := mr.Search("nonexistent", 0, 10)
+				results, err := mr.Search("nonexistent", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(BeEmpty())
 			})
@@ -578,7 +578,7 @@ var _ = Describe("MediaRepository", func() {
 			})
 
 			It("finds media file by mbz_recording_id", func() {
-				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440020", 0, 10)
+				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440020", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(HaveLen(1))
 				Expect(results[0].ID).To(Equal("test-mbid-mediafile"))
@@ -586,7 +586,7 @@ var _ = Describe("MediaRepository", func() {
 			})
 
 			It("finds media file by mbz_release_track_id", func() {
-				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440021", 0, 10)
+				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440021", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(HaveLen(1))
 				Expect(results[0].ID).To(Equal("test-mbid-mediafile"))
@@ -594,7 +594,7 @@ var _ = Describe("MediaRepository", func() {
 			})
 
 			It("returns empty result when MBID is not found", func() {
-				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440099", 0, 10)
+				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440099", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(BeEmpty())
 			})
@@ -614,7 +614,7 @@ var _ = Describe("MediaRepository", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// Search never returns missing media files (hardcoded behavior)
-				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440022", 0, 10)
+				results, err := mr.Search("550e8400-e29b-41d4-a716-446655440022", model.QueryOptions{Max: 10})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(results).To(BeEmpty())
 

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -109,12 +109,10 @@ func booleanFilter(field string, value any) Sqlizer {
 func fullTextFilter(tableName string, mbidFields ...string) func(string, any) Sqlizer {
 	return func(field string, value any) Sqlizer {
 		v := strings.ToLower(value.(string))
-		searchExpr := getSearchExpr()
-		cond := cmp.Or(
+		return cmp.Or[Sqlizer](
 			mbidExpr(tableName, v, mbidFields...),
-			searchExpr(tableName, v),
+			getSearchStrategy(tableName, v),
 		)
-		return cond
 	}
 }
 

--- a/persistence/sql_restful_test.go
+++ b/persistence/sql_restful_test.go
@@ -102,11 +102,11 @@ var _ = Describe("sqlRestful", func() {
 				uuid := "550e8400-e29b-41d4-a716-446655440000"
 				result := noMbidFilter("search", uuid)
 
-				// mbidExpr with no fields returns nil, so cmp.Or falls back to fullTextExpr
-				expected := squirrel.And{
-					squirrel.Like{"test_table.full_text": "% 550e8400-e29b-41d4-a716-446655440000%"},
-				}
-				Expect(result).To(Equal(expected))
+				// mbidExpr with no fields returns nil, so cmp.Or falls back to search strategy
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(ContainElement("% 550e8400-e29b-41d4-a716-446655440000%"))
 			})
 		})
 
@@ -114,26 +114,25 @@ var _ = Describe("sqlRestful", func() {
 			It("returns full text search condition only", func() {
 				result := filter("search", "beatles")
 
-				// mbidExpr returns nil for non-UUIDs, so fullTextExpr result is returned directly
-				expected := squirrel.And{
-					squirrel.Like{"test_table.full_text": "% beatles%"},
-				}
-				Expect(result).To(Equal(expected))
+				// mbidExpr returns nil for non-UUIDs, so search strategy result is returned directly
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(ContainElement("% beatles%"))
 			})
 
 			It("handles multi-word search terms", func() {
 				result := filter("search", "the beatles abbey road")
 
-				// Should return And condition directly
-				andCondition, ok := result.(squirrel.And)
-				Expect(ok).To(BeTrue())
-				Expect(andCondition).To(HaveLen(4))
-
-				// Check that all words are present (order may vary)
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% the%"}))
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% beatles%"}))
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% abbey%"}))
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% road%"}))
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				// All words should be present as LIKE conditions
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(HaveLen(4))
+				Expect(args).To(ContainElement("% the%"))
+				Expect(args).To(ContainElement("% beatles%"))
+				Expect(args).To(ContainElement("% abbey%"))
+				Expect(args).To(ContainElement("% road%"))
 			})
 		})
 
@@ -142,26 +141,24 @@ var _ = Describe("sqlRestful", func() {
 				conf.Server.Search.FullString = false
 				result := filter("search", "test query")
 
-				andCondition, ok := result.(squirrel.And)
-				Expect(ok).To(BeTrue())
-				Expect(andCondition).To(HaveLen(2))
-
-				// Check that all words are present with leading space (order may vary)
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% test%"}))
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "% query%"}))
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(HaveLen(2))
+				Expect(args).To(ContainElement("% test%"))
+				Expect(args).To(ContainElement("% query%"))
 			})
 
 			It("uses no separator with SearchFullString=true", func() {
 				conf.Server.Search.FullString = true
 				result := filter("search", "test query")
 
-				andCondition, ok := result.(squirrel.And)
-				Expect(ok).To(BeTrue())
-				Expect(andCondition).To(HaveLen(2))
-
-				// Check that all words are present without leading space (order may vary)
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "%test%"}))
-				Expect(andCondition).To(ContainElement(squirrel.Like{"test_table.full_text": "%query%"}))
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(HaveLen(2))
+				Expect(args).To(ContainElement("%test%"))
+				Expect(args).To(ContainElement("%query%"))
 			})
 		})
 
@@ -179,10 +176,10 @@ var _ = Describe("sqlRestful", func() {
 			It("handles special characters that are sanitized", func() {
 				result := filter("search", "don't")
 
-				expected := squirrel.And{
-					squirrel.Like{"test_table.full_text": "% dont%"}, // str.SanitizeStrings removes quotes
-				}
-				Expect(result).To(Equal(expected))
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(ContainElement("% dont%"))
 			})
 
 			It("returns nil for single quote (SQL injection protection)", func() {
@@ -206,31 +203,30 @@ var _ = Describe("sqlRestful", func() {
 				result := filter("search", "550e8400-invalid-uuid")
 
 				// Should return full text filter since UUID is invalid
-				expected := squirrel.And{
-					squirrel.Like{"test_table.full_text": "% 550e8400-invalid-uuid%"},
-				}
-				Expect(result).To(Equal(expected))
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(ContainElement("% 550e8400-invalid-uuid%"))
 			})
 
 			It("handles empty mbid fields array", func() {
 				emptyMbidFilter := fullTextFilter(tableName, []string{}...)
 				result := emptyMbidFilter("search", "test")
 
-				// mbidExpr with empty fields returns nil, so cmp.Or falls back to fullTextExpr
-				expected := squirrel.And{
-					squirrel.Like{"test_table.full_text": "% test%"},
-				}
-				Expect(result).To(Equal(expected))
+				// mbidExpr with empty fields returns nil, so search strategy result is returned directly
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(ContainElement("% test%"))
 			})
 
 			It("converts value to lowercase before processing", func() {
 				result := filter("search", "TEST")
 
-				// The function converts to lowercase internally
-				expected := squirrel.And{
-					squirrel.Like{"test_table.full_text": "% test%"},
-				}
-				Expect(result).To(Equal(expected))
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("test_table.full_text LIKE"))
+				Expect(args).To(ContainElement("% test%"))
 			})
 		})
 	})

--- a/persistence/sql_restful_test.go
+++ b/persistence/sql_restful_test.go
@@ -162,6 +162,30 @@ var _ = Describe("sqlRestful", func() {
 			})
 		})
 
+		Context("single-character queries (regression: must not be rejected)", func() {
+			It("returns valid filter for single-char query with legacy backend", func() {
+				conf.Server.Search.Backend = "legacy"
+				result := filter("search", "a")
+				Expect(result).ToNot(BeNil(), "single-char REST filter must not be dropped")
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("LIKE"))
+				Expect(args).ToNot(BeEmpty())
+			})
+
+			It("returns valid filter for single-char query with FTS backend", func() {
+				conf.Server.Search.Backend = "fts"
+				conf.Server.Search.FullString = false
+				ftsFilter := fullTextFilter(tableName, mbidFields...)
+				result := ftsFilter("search", "a")
+				Expect(result).ToNot(BeNil(), "single-char REST filter must not be dropped")
+				sql, args, err := result.ToSql()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sql).To(ContainSubstring("MATCH"))
+				Expect(args).ToNot(BeEmpty())
+			})
+		})
+
 		Context("edge cases", func() {
 			It("returns nil for empty string", func() {
 				result := filter("search", "")

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -1,13 +1,11 @@
 package persistence
 
 import (
-	"fmt"
 	"strings"
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/conf"
-	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/str"
 )
@@ -17,105 +15,49 @@ func formatFullText(text ...string) string {
 	return " " + fullText
 }
 
-// searchExprFunc is the function signature for search expression builders.
-type searchExprFunc func(tableName string, query string) Sqlizer
+// searchStrategy defines how to execute a text search against a repository table.
+// ToSql() (from embedded Sqlizer) is used by the REST filter path as a WHERE clause.
+// execute() is used by the Search endpoints for full search with pagination and ordering.
+type searchStrategy interface {
+	Sqlizer
+	execute(r sqlRepository, sq SelectBuilder, offset, size int, dest any, orderBys ...string) error
+}
 
-// getSearchExpr returns the active search expression function based on config.
-func getSearchExpr() searchExprFunc {
+// getSearchStrategy returns the appropriate search strategy based on config and query content.
+// Returns nil when the query is too short for the selected strategy or produces no searchable tokens.
+func getSearchStrategy(tableName, query string) searchStrategy {
 	if conf.Server.Search.Backend == "legacy" || conf.Server.Search.FullString {
-		return legacySearchExpr
+		return newLegacySearch(tableName, query)
 	}
-	return func(tableName, query string) Sqlizer {
-		if containsCJK(query) {
-			return likeSearchExpr(tableName, query)
-		}
-		return ftsSearchExpr(tableName, query)
+	if containsCJK(query) {
+		return newLikeSearch(tableName, query)
 	}
+	return newFTSSearch(tableName, query)
 }
 
 // doSearch performs a full-text search with the specified parameters.
-// The naturalOrder is used when no filter is applied (e.g. OpenSubsonic `search3?query=""`).
-// Normally it should be `tableName + ".rowid"`, but some repositories (e.g. artist) may differ.
+// Empty queries return all results in natural order (OpenSubsonic `search3?query=""`).
+// The naturalOrder column should normally be `tableName + ".rowid"`, but some repositories
+// (e.g. artist) may differ. Minimum query length is enforced by each strategy individually.
 func (r sqlRepository) doSearch(sq SelectBuilder, q string, offset, size int, results any, naturalOrder string, orderBys ...string) error {
 	q = strings.TrimSpace(q)
 	q = strings.TrimSuffix(q, "*")
-	if len(q) < 2 {
-		return nil
-	}
 
 	sq = sq.Where(Eq{r.tableName + ".missing": false})
 
-	filter := getSearchExpr()(r.tableName, q)
-	if filter == nil {
-		// No search tokens; sort by natural order.
+	// Empty or quoted-empty query (OpenSubsonic `search3?query=""`) — return all results in natural order.
+	if q == "" || q == `""` {
 		sq = sq.OrderBy(naturalOrder)
 		sq = sq.Limit(uint64(size)).Offset(uint64(offset))
 		return r.queryAll(sq, results, model.QueryOptions{Offset: offset})
 	}
 
-	// Two-phase query for FTS5 to avoid expensive JOINs on high-cardinality results.
-	if fts, ok := filter.(*ftsFilter); ok {
-		return r.doFTSSearch(sq, fts, offset, size, results, orderBys...)
+	strategy := getSearchStrategy(r.tableName, q)
+	if strategy == nil {
+		return nil
 	}
 
-	// LIKE/legacy: single-query approach.
-	sq = sq.Where(filter)
-	sq = sq.OrderBy(orderBys...)
-	sq = sq.Limit(uint64(size)).Offset(uint64(offset))
-	return r.queryAll(sq, results, model.QueryOptions{Offset: offset})
-}
-
-// doFTSSearch implements a two-phase FTS5 search to avoid expensive LEFT JOINs on
-// high-cardinality FTS results.
-//
-// Phase 1: lightweight query (main table + FTS only) to get sorted, paginated rowids.
-// Phase 2: full SELECT with all JOINs, filtered by the small set of Phase 1 rowids.
-//
-// Complex ORDER BY expressions (function calls, aggregations) are dropped from Phase 1;
-// only FTS rank + simple columns are used.
-func (r sqlRepository) doFTSSearch(sq SelectBuilder, fts *ftsFilter, offset, size int, results any, orderBys ...string) error {
-	qualifiedOrderBys := []string{fts.rankExpr}
-	for _, ob := range orderBys {
-		if qualified := qualifyOrderBy(r.tableName, ob); qualified != "" {
-			qualifiedOrderBys = append(qualifiedOrderBys, qualified)
-		}
-	}
-
-	// Phase 1: only main table + FTS index, no annotation/bookmark/library JOINs.
-	rowidQuery := Select(r.tableName+".rowid").
-		From(r.tableName).
-		Join(fts.ftsTable+" ON "+fts.ftsTable+".rowid = "+r.tableName+".rowid AND "+fts.ftsTable+" MATCH ?", fts.matchExpr).
-		Where(Eq{r.tableName + ".missing": false}).
-		OrderBy(qualifiedOrderBys...).
-		Limit(uint64(size)).Offset(uint64(offset))
-
-	rowidSQL, rowidArgs, err := rowidQuery.ToSql()
-	if err != nil {
-		return fmt.Errorf("building FTS rowid query: %w", err)
-	}
-
-	// Phase 2: hydrate with full JOINs, preserving Phase 1's ordering via row_number.
-	rankedSubquery := fmt.Sprintf(
-		"(SELECT rowid as _rid, row_number() OVER () AS _rn FROM (%s)) AS _ranked",
-		rowidSQL,
-	)
-	sq = sq.Join(rankedSubquery+" ON "+r.tableName+".rowid = _ranked._rid", rowidArgs...)
-	sq = sq.OrderBy("_ranked._rn")
-	return r.queryAll(sq, results)
-}
-
-// qualifyOrderBy prepends tableName to a simple column name. Returns empty string for
-// complex expressions (function calls, aggregations) that can't be used in Phase 1.
-func qualifyOrderBy(tableName, orderBy string) string {
-	orderBy = strings.TrimSpace(orderBy)
-	if orderBy == "" || strings.ContainsAny(orderBy, "(,") {
-		return ""
-	}
-	parts := strings.Fields(orderBy)
-	if !strings.Contains(parts[0], ".") {
-		parts[0] = tableName + "." + parts[0]
-	}
-	return strings.Join(parts, " ")
+	return strategy.execute(r, sq, offset, size, results, orderBys...)
 }
 
 func (r sqlRepository) searchByMBID(sq SelectBuilder, mbid string, mbidFields []string, results any) error {
@@ -135,25 +77,4 @@ func mbidExpr(tableName, mbid string, mbidFields ...string) Sqlizer {
 		cond = append(cond, Eq{tableName + "." + mbidField: mbid})
 	}
 	return Or(cond)
-}
-
-// legacySearchExpr generates LIKE-based search filters against the full_text column.
-// This is the original search implementation, used when Search.Backend="legacy".
-func legacySearchExpr(tableName string, s string) Sqlizer {
-	q := str.SanitizeStrings(s)
-	if q == "" {
-		log.Trace("Search using legacy backend, query is empty", "table", tableName)
-		return nil
-	}
-	var sep string
-	if !conf.Server.Search.FullString {
-		sep = " "
-	}
-	parts := strings.Split(q, " ")
-	filters := And{}
-	for _, part := range parts {
-		filters = append(filters, Like{tableName + ".full_text": "%" + sep + part + "%"})
-	}
-	log.Trace("Search using legacy backend", "query", filters, "table", tableName)
-	return filters
 }

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -15,12 +15,22 @@ func formatFullText(text ...string) string {
 	return " " + fullText
 }
 
+// searchConfig holds per-repository constants for doSearch.
+type searchConfig struct {
+	NaturalOrder string   // ORDER BY for empty-query results (e.g. "album.rowid")
+	OrderBy      []string // ORDER BY for text search results (e.g. ["name"])
+	MBIDFields   []string // columns to match when query is a UUID
+	// LibraryFilter overrides the default applyLibraryFilter for FTS Phase 1.
+	// Needed when library access requires a junction table (e.g. artist → library_artist).
+	LibraryFilter func(sq SelectBuilder) SelectBuilder
+}
+
 // searchStrategy defines how to execute a text search against a repository table.
-// ToSql() (from embedded Sqlizer) is used by the REST filter path as a WHERE clause.
-// execute() is used by the Search endpoints for full search with pagination and ordering.
+// options carries filters and pagination that must reach all query phases,
+// including FTS Phase 1 which builds its own query outside sq.
 type searchStrategy interface {
 	Sqlizer
-	execute(r sqlRepository, sq SelectBuilder, offset, size int, dest any, orderBys ...string) error
+	execute(r sqlRepository, sq SelectBuilder, dest any, cfg searchConfig, options model.QueryOptions) error
 }
 
 // getSearchStrategy returns the appropriate search strategy based on config and query content.
@@ -35,21 +45,26 @@ func getSearchStrategy(tableName, query string) searchStrategy {
 	return newFTSSearch(tableName, query)
 }
 
-// doSearch performs a full-text search with the specified parameters.
-// Empty queries return all results in natural order (OpenSubsonic `search3?query=""`).
-// The naturalOrder column should normally be `tableName + ".rowid"`, but some repositories
-// (e.g. artist) may differ. Minimum query length is enforced by each strategy individually.
-func (r sqlRepository) doSearch(sq SelectBuilder, q string, offset, size int, results any, naturalOrder string, orderBys ...string) error {
+// doSearch dispatches a search query: empty → natural order, UUID → MBID match,
+// otherwise delegates to getSearchStrategy. sq must already have LIMIT/OFFSET set
+// via newSelect(options...). options is forwarded so FTS Phase 1 can apply the same
+// filters and pagination independently.
+func (r sqlRepository) doSearch(sq SelectBuilder, q string, results any, cfg searchConfig, options model.QueryOptions) error {
 	q = strings.TrimSpace(q)
 	q = strings.TrimSuffix(q, "*")
 
 	sq = sq.Where(Eq{r.tableName + ".missing": false})
 
-	// Empty or quoted-empty query (OpenSubsonic `search3?query=""`) — return all results in natural order.
+	// Empty query (OpenSubsonic `search3?query=""`) — return all in natural order.
 	if q == "" || q == `""` {
-		sq = sq.OrderBy(naturalOrder)
-		sq = sq.Limit(uint64(size)).Offset(uint64(offset))
-		return r.queryAll(sq, results, model.QueryOptions{Offset: offset})
+		sq = sq.OrderBy(cfg.NaturalOrder)
+		return r.queryAll(sq, results, options)
+	}
+
+	// MBID search: if query is a valid UUID, search by MBID fields instead
+	if uuid.Validate(q) == nil && len(cfg.MBIDFields) > 0 {
+		sq = sq.Where(mbidExpr(r.tableName, q, cfg.MBIDFields...))
+		return r.queryAll(sq, results)
 	}
 
 	strategy := getSearchStrategy(r.tableName, q)
@@ -57,14 +72,7 @@ func (r sqlRepository) doSearch(sq SelectBuilder, q string, offset, size int, re
 		return nil
 	}
 
-	return strategy.execute(r, sq, offset, size, results, orderBys...)
-}
-
-func (r sqlRepository) searchByMBID(sq SelectBuilder, mbid string, mbidFields []string, results any) error {
-	sq = sq.Where(mbidExpr(r.tableName, mbid, mbidFields...))
-	sq = sq.Where(Eq{r.tableName + ".missing": false})
-
-	return r.queryAll(sq, results)
+	return strategy.execute(r, sq, results, cfg, options)
 }
 
 func mbidExpr(tableName, mbid string, mbidFields ...string) Sqlizer {

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/Masterminds/squirrel"
@@ -49,17 +50,104 @@ func (r sqlRepository) doSearch(sq SelectBuilder, q string, offset, size int, re
 
 	searchExpr := getSearchExpr()
 	filter := searchExpr(r.tableName, q)
-	if filter != nil {
-		sq = sq.Where(filter)
-		sq = sq.OrderBy(orderBys...)
-	} else {
+	if filter == nil {
 		// This is to speed up the results of `search3?query=""`, for OpenSubsonic
 		// If the filter is empty, we sort by the specified natural order.
 		sq = sq.OrderBy(naturalOrder)
+		sq = sq.Where(Eq{r.tableName + ".missing": false})
+		sq = sq.Limit(uint64(size)).Offset(uint64(offset))
+		return r.queryAll(sq, results, model.QueryOptions{Offset: offset})
 	}
+
+	// For FTS5 filters, use a two-phase query to avoid expensive JOINs on high-cardinality results.
+	if fts, ok := filter.(*ftsFilter); ok {
+		return r.doFTSSearch(sq, fts, offset, size, results, orderBys...)
+	}
+
+	// For non-FTS filters (LIKE, legacy), use the original single-query approach.
+	sq = sq.Where(filter)
+	sq = sq.OrderBy(orderBys...)
 	sq = sq.Where(Eq{r.tableName + ".missing": false})
 	sq = sq.Limit(uint64(size)).Offset(uint64(offset))
 	return r.queryAll(sq, results, model.QueryOptions{Offset: offset})
+}
+
+// doFTSSearch implements a two-phase FTS5 search to avoid the performance penalty of
+// expensive LEFT JOINs (annotation, bookmark, library) on high-cardinality FTS results.
+//
+// Phase 1 builds a lightweight query that only touches the main table + FTS index to get
+// the sorted, paginated rowids.
+//
+// Phase 2 uses the full SelectBuilder (with all JOINs) but
+// filters by the small set of rowids from Phase 1, making the JOINs nearly free.
+//
+// If the ORDER BY references columns from other tables (e.g. aggregated stats), the two-phase
+// approach is skipped and the original single-query approach is used instead.
+func (r sqlRepository) doFTSSearch(sq SelectBuilder, fts *ftsFilter, offset, size int, results any, orderBys ...string) error {
+	// Qualify ORDER BY columns for the lightweight query to avoid ambiguity between
+	// the main table and the FTS table. Only simple column names (no expressions with
+	// parens or commas) can be safely qualified; complex expressions indicate
+	// the sort depends on JOINed tables, so we fall back to the single-query approach.
+	qualifiedOrderBys := make([]string, 0, len(orderBys))
+	for _, ob := range orderBys {
+		qualified := qualifyOrderBy(r.tableName, ob)
+		if qualified == "" {
+			// Complex expression that can't be used in the lightweight query — fall back.
+			sq = sq.Where(fts)
+			sq = sq.OrderBy(orderBys...)
+			sq = sq.Where(Eq{r.tableName + ".missing": false})
+			sq = sq.Limit(uint64(size)).Offset(uint64(offset))
+			return r.queryAll(sq, results, model.QueryOptions{Offset: offset})
+		}
+		qualifiedOrderBys = append(qualifiedOrderBys, qualified)
+	}
+
+	// Phase 1: Lightweight rowid query — only main table + FTS, no annotation/bookmark/library JOINs.
+	rowidQuery := Select(r.tableName+".rowid").
+		From(r.tableName).
+		Join(fts.ftsTable+" ON "+fts.ftsTable+".rowid = "+r.tableName+".rowid AND "+fts.ftsTable+" MATCH ?", fts.matchExpr).
+		Where(Eq{r.tableName + ".missing": false}).
+		OrderBy(qualifiedOrderBys...).
+		Limit(uint64(size)).Offset(uint64(offset))
+
+	rowidSQL, rowidArgs, err := rowidQuery.ToSql()
+	if err != nil {
+		return fmt.Errorf("building FTS rowid query: %w", err)
+	}
+
+	// Phase 2: Hydrate the rowids with the full SelectBuilder (all JOINs included).
+	sq = sq.Where(r.tableName+".rowid IN ("+rowidSQL+")", rowidArgs...)
+	sq = sq.OrderBy(orderBys...)
+	return r.queryAll(sq, results)
+}
+
+// qualifyOrderBy prepends tableName to a simple ORDER BY column name if it's not already
+// qualified. Returns empty string for complex expressions (containing parens, commas, or
+// function calls) that can't be safely used in a lightweight query without extra JOINs.
+func qualifyOrderBy(tableName, orderBy string) string {
+	orderBy = strings.TrimSpace(orderBy)
+	if orderBy == "" {
+		return ""
+	}
+
+	// If the expression contains parens (function calls like sum(...)) or commas,
+	// it's too complex for the lightweight rowid query.
+	if strings.ContainsAny(orderBy, "(,") {
+		return ""
+	}
+
+	// Split into column and optional direction (e.g., "title" or "name desc")
+	parts := strings.Fields(orderBy)
+	col := parts[0]
+
+	// Already qualified (contains a dot)
+	if strings.Contains(col, ".") {
+		return orderBy
+	}
+
+	// Qualify with table name
+	parts[0] = tableName + "." + col
+	return strings.Join(parts, " ")
 }
 
 func (r sqlRepository) searchByMBID(sq SelectBuilder, mbid string, mbidFields []string, results any) error {

--- a/persistence/sql_search_fts.go
+++ b/persistence/sql_search_fts.go
@@ -329,13 +329,8 @@ func qualifyOrderBy(tableName, orderBy string) string {
 
 // newFTSSearch creates an FTS5 search strategy. Falls back to LIKE search if the
 // query produces no FTS tokens (e.g., punctuation-only like "!!!!!!!").
-// Returns nil when the query is too short or produces no searchable tokens at all.
-// Single-character queries are rejected because prefix matching (e.g., "a*") would
-// match most rows in the index.
+// Returns nil when the query produces no searchable tokens at all.
 func newFTSSearch(tableName, query string) searchStrategy {
-	if len(query) < 2 {
-		return nil
-	}
 	q := buildFTS5Query(query)
 	if q == "" {
 		// Punctuation-only fallback: try LIKE search with the raw query

--- a/persistence/sql_search_fts.go
+++ b/persistence/sql_search_fts.go
@@ -234,31 +234,24 @@ var ftsSearchColumns = map[string]string{
 }
 
 // ftsBM25Weights defines BM25 column weights for relevance ranking.
-// Higher weights make matches in that column score higher. The order must match
-// the column order in the FTS5 table definition (not ftsSearchColumns).
-// Columns like title/name get the highest weight so exact title matches rank above
-// matches in secondary fields like artist name or sort columns.
+// The order must match the column order in the FTS5 table definition.
 var ftsBM25Weights = map[string]string{
-	// media_file_fts columns: title, album, artist, album_artist, sort_title, sort_album_name, sort_artist_name, sort_album_artist_name, disc_subtitle, search_participants, search_normalized
 	"media_file": "10.0, 5.0, 3.0, 3.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0",
-	// album_fts columns: name, sort_album_name, album_artist, search_participants, discs, catalog_num, album_version, search_normalized
-	"album": "10.0, 1.0, 3.0, 2.0, 1.0, 1.0, 1.0, 1.0",
-	// artist_fts columns: name, sort_artist_name, search_normalized
-	"artist": "10.0, 1.0, 1.0",
+	"album":      "10.0, 1.0, 3.0, 2.0, 1.0, 1.0, 1.0, 1.0",
+	"artist":     "10.0, 1.0, 1.0",
 }
 
 // ftsFilter holds the information needed for a two-phase FTS5 search query.
-// It implements Sqlizer so it can be used as a WHERE clause fallback, but doSearch
-// detects this type and uses a more efficient two-phase approach instead.
+// It implements Sqlizer so it can be returned through the searchExprFunc interface;
+// doSearch type-asserts it to use the more efficient two-phase approach.
 type ftsFilter struct {
 	tableName string
 	ftsTable  string
 	matchExpr string
-	rankExpr  string // bm25() expression with column weights for ORDER BY
+	rankExpr  string
 }
 
-// ToSql implements Sqlizer. This is only used as a fallback when doSearch doesn't
-// handle ftsFilter specially (shouldn't happen in practice).
+// ToSql implements Sqlizer as a single-query fallback (rowid IN subquery).
 func (f *ftsFilter) ToSql() (string, []interface{}, error) {
 	sql := f.tableName + ".rowid IN (SELECT rowid FROM " + f.ftsTable + " WHERE " + f.ftsTable + " MATCH ?)"
 	return sql, []interface{}{f.matchExpr}, nil
@@ -283,8 +276,6 @@ func ftsSearchExpr(tableName string, s string) Sqlizer {
 		matchExpr = cols + " : (" + q + ")"
 	}
 
-	// Build bm25() ranking expression with column weights.
-	// Falls back to the built-in rank column if no weights are defined.
 	rankExpr := ftsTable + ".rank"
 	if weights, ok := ftsBM25Weights[tableName]; ok {
 		rankExpr = "bm25(" + ftsTable + ", " + weights + ")"

--- a/persistence/sql_search_fts_test.go
+++ b/persistence/sql_search_fts_test.go
@@ -3,8 +3,6 @@ package persistence
 import (
 	"context"
 
-	"github.com/navidrome/navidrome/conf"
-	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
@@ -392,34 +390,18 @@ var _ = Describe("FTS5 Integration Search", func() {
 	})
 
 	Describe("Single-character search (doSearch min-length guard)", func() {
-		It("returns empty results for single-char query via Search (FTS backend)", func() {
-			DeferCleanup(configtest.SetupConfig())
-			conf.Server.Search.Backend = "fts"
-
-			results, err := mr.Search("a", model.QueryOptions{Max: 10})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(results).To(BeEmpty(), "doSearch should reject single-char queries")
-		})
-
-		It("returns empty results for single-char query via Search (legacy backend)", func() {
-			DeferCleanup(configtest.SetupConfig())
-			conf.Server.Search.Backend = "legacy"
-
+		It("returns empty results for single-char query via Search", func() {
 			results, err := mr.Search("a", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(BeEmpty(), "doSearch should reject single-char queries")
 		})
 	})
 
-	Describe("Legacy backend fallback", func() {
-		It("returns results using legacy LIKE-based search when configured", func() {
-			DeferCleanup(configtest.SetupConfig())
-			conf.Server.Search.Backend = "legacy"
-
-			results, err := mr.Search("Radioactivity", model.QueryOptions{Max: 10})
+	Describe("Max=0 means no limit (regression: must not produce LIMIT 0)", func() {
+		It("returns results with Max=0", func() {
+			results, err := mr.Search("Beatles", model.QueryOptions{Max: 0})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(results).To(HaveLen(1))
-			Expect(results[0].Title).To(Equal("Radioactivity"))
+			Expect(results).ToNot(BeEmpty(), "Max=0 should mean no limit, not LIMIT 0")
 		})
 	})
 })

--- a/persistence/sql_search_fts_test.go
+++ b/persistence/sql_search_fts_test.go
@@ -142,7 +142,17 @@ var _ = Describe("ftsSearchExpr", func() {
 		Expect(ftsSearchExpr("media_file", "")).To(BeNil())
 	})
 
-	It("generates rowid IN subquery with MATCH and column filter", func() {
+	It("returns ftsFilter with correct table names and MATCH expression", func() {
+		expr := ftsSearchExpr("media_file", "beatles")
+		fts, ok := expr.(*ftsFilter)
+		Expect(ok).To(BeTrue())
+		Expect(fts.tableName).To(Equal("media_file"))
+		Expect(fts.ftsTable).To(Equal("media_file_fts"))
+		Expect(fts.matchExpr).To(HavePrefix("{title album artist album_artist"))
+		Expect(fts.matchExpr).To(ContainSubstring("beatles*"))
+	})
+
+	It("ToSql generates rowid IN subquery with MATCH (fallback path)", func() {
 		expr := ftsSearchExpr("media_file", "beatles")
 		sql, args, err := expr.ToSql()
 		Expect(err).ToNot(HaveOccurred())
@@ -150,51 +160,51 @@ var _ = Describe("ftsSearchExpr", func() {
 		Expect(sql).To(ContainSubstring("media_file_fts"))
 		Expect(sql).To(ContainSubstring("MATCH"))
 		Expect(args).To(HaveLen(1))
-		Expect(args[0]).To(HavePrefix("{title album artist album_artist"))
-		Expect(args[0]).To(ContainSubstring("beatles*"))
 	})
 
 	It("generates correct FTS table name per entity", func() {
 		for _, table := range []string{"media_file", "album", "artist"} {
 			expr := ftsSearchExpr(table, "test")
-			sql, _, err := expr.ToSql()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sql).To(ContainSubstring(table + ".rowid IN"))
-			Expect(sql).To(ContainSubstring(table + "_fts"))
+			fts, ok := expr.(*ftsFilter)
+			Expect(ok).To(BeTrue())
+			Expect(fts.tableName).To(Equal(table))
+			Expect(fts.ftsTable).To(Equal(table + "_fts"))
 		}
 	})
 
 	It("wraps query with column filter for known tables", func() {
 		expr := ftsSearchExpr("artist", "Beatles")
-		_, args, err := expr.ToSql()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(args[0]).To(Equal("{name sort_artist_name search_normalized} : (Beatles*)"))
+		fts, ok := expr.(*ftsFilter)
+		Expect(ok).To(BeTrue())
+		Expect(fts.matchExpr).To(Equal("{name sort_artist_name search_normalized} : (Beatles*)"))
 	})
 
 	It("passes query without column filter for unknown tables", func() {
 		expr := ftsSearchExpr("unknown_table", "test")
-		_, args, err := expr.ToSql()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(args[0]).To(Equal("test*"))
+		fts, ok := expr.(*ftsFilter)
+		Expect(ok).To(BeTrue())
+		Expect(fts.matchExpr).To(Equal("test*"))
 	})
 
 	It("preserves phrase queries inside column filter", func() {
 		expr := ftsSearchExpr("media_file", `"the beatles"`)
-		_, args, err := expr.ToSql()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(args[0]).To(ContainSubstring(`"the beatles"`))
+		fts, ok := expr.(*ftsFilter)
+		Expect(ok).To(BeTrue())
+		Expect(fts.matchExpr).To(ContainSubstring(`"the beatles"`))
 	})
 
 	It("preserves prefix queries inside column filter", func() {
 		expr := ftsSearchExpr("media_file", "beat*")
-		_, args, err := expr.ToSql()
-		Expect(err).ToNot(HaveOccurred())
-		Expect(args[0]).To(ContainSubstring("beat*"))
+		fts, ok := expr.(*ftsFilter)
+		Expect(ok).To(BeTrue())
+		Expect(fts.matchExpr).To(ContainSubstring("beat*"))
 	})
 
 	It("falls back to LIKE search for punctuation-only query", func() {
 		expr := ftsSearchExpr("media_file", "!!!!!!!")
 		Expect(expr).ToNot(BeNil())
+		_, ok := expr.(*ftsFilter)
+		Expect(ok).To(BeFalse(), "punctuation-only should fall back to LIKE, not FTS")
 		sql, args, err := expr.ToSql()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(sql).To(ContainSubstring("LIKE"))

--- a/persistence/sql_search_fts_test.go
+++ b/persistence/sql_search_fts_test.go
@@ -137,6 +137,23 @@ var _ = Describe("likeSearchExpr", func() {
 	})
 })
 
+var _ = DescribeTable("qualifyOrderBy",
+	func(tableName, ftsTable, orderBy, expected string) {
+		Expect(qualifyOrderBy(tableName, ftsTable, orderBy)).To(Equal(expected))
+	},
+	Entry("returns empty string for empty input", "artist", "artist_fts", "", ""),
+	Entry("qualifies simple column with table name", "artist", "artist_fts", "name", "artist.name"),
+	Entry("qualifies column with direction", "artist", "artist_fts", "name desc", "artist.name desc"),
+	Entry("qualifies rank with FTS table name", "artist", "artist_fts", "rank", "artist_fts.rank"),
+	Entry("qualifies rank with direction using FTS table name", "artist", "artist_fts", "rank asc", "artist_fts.rank asc"),
+	Entry("preserves already-qualified column", "artist", "artist_fts", "artist.name", "artist.name"),
+	Entry("preserves already-qualified column with direction", "artist", "artist_fts", "artist.name desc", "artist.name desc"),
+	Entry("returns empty for function call expression", "artist", "artist_fts", "sum(json_extract(stats, '$.total.m')) desc", ""),
+	Entry("returns empty for expression with comma", "artist", "artist_fts", "a, b", ""),
+	Entry("qualifies media_file column", "media_file", "media_file_fts", "title", "media_file.title"),
+	Entry("qualifies rank for media_file FTS table", "media_file", "media_file_fts", "rank", "media_file_fts.rank"),
+)
+
 var _ = Describe("ftsSearchExpr", func() {
 	It("returns nil for empty query", func() {
 		Expect(ftsSearchExpr("media_file", "")).To(BeNil())

--- a/persistence/sql_search_fts_test.go
+++ b/persistence/sql_search_fts_test.go
@@ -288,7 +288,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 
 	Describe("MediaFile search", func() {
 		It("finds media files by title", func() {
-			results, err := mr.Search("Radioactivity", 0, 10)
+			results, err := mr.Search("Radioactivity", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Title).To(Equal("Radioactivity"))
@@ -296,7 +296,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 		})
 
 		It("finds media files by artist name", func() {
-			results, err := mr.Search("Beatles", 0, 10)
+			results, err := mr.Search("Beatles", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(3))
 			for _, r := range results {
@@ -307,7 +307,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 
 	Describe("Album search", func() {
 		It("finds albums by name", func() {
-			results, err := alr.Search("Sgt Peppers", 0, 10)
+			results, err := alr.Search("Sgt Peppers", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Name).To(Equal("Sgt Peppers"))
@@ -315,7 +315,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 		})
 
 		It("finds albums with multi-word search", func() {
-			results, err := alr.Search("Abbey Road", 0, 10)
+			results, err := alr.Search("Abbey Road", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(2))
 		})
@@ -323,7 +323,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 
 	Describe("Artist search", func() {
 		It("finds artists by name", func() {
-			results, err := arr.Search("Kraftwerk", 0, 10)
+			results, err := arr.Search("Kraftwerk", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Name).To(Equal("Kraftwerk"))
@@ -333,7 +333,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 
 	Describe("CJK search", func() {
 		It("finds media files by CJK title", func() {
-			results, err := mr.Search("プラチナ", 0, 10)
+			results, err := mr.Search("プラチナ", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Title).To(Equal("プラチナ・ジェット"))
@@ -341,14 +341,14 @@ var _ = Describe("FTS5 Integration Search", func() {
 		})
 
 		It("finds media files by CJK artist name", func() {
-			results, err := mr.Search("シートベルツ", 0, 10)
+			results, err := mr.Search("シートベルツ", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Artist).To(Equal("シートベルツ"))
 		})
 
 		It("finds albums by CJK artist name", func() {
-			results, err := alr.Search("シートベルツ", 0, 10)
+			results, err := alr.Search("シートベルツ", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Name).To(Equal("COWBOY BEBOP"))
@@ -356,7 +356,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 		})
 
 		It("finds artists by CJK name", func() {
-			results, err := arr.Search("シートベルツ", 0, 10)
+			results, err := arr.Search("シートベルツ", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Name).To(Equal("シートベルツ"))
@@ -366,7 +366,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 
 	Describe("Album version search", func() {
 		It("finds albums by version tag via FTS", func() {
-			results, err := alr.Search("Deluxe", 0, 10)
+			results, err := alr.Search("Deluxe", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].ID).To(Equal(albumWithVersion.ID))
@@ -375,7 +375,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 
 	Describe("Punctuation-only search", func() {
 		It("finds media files with punctuation-only title", func() {
-			results, err := mr.Search("!!!!!!!", 0, 10)
+			results, err := mr.Search("!!!!!!!", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Title).To(Equal("!!!!!!!"))
@@ -388,7 +388,7 @@ var _ = Describe("FTS5 Integration Search", func() {
 			DeferCleanup(configtest.SetupConfig())
 			conf.Server.Search.Backend = "legacy"
 
-			results, err := mr.Search("Radioactivity", 0, 10)
+			results, err := mr.Search("Radioactivity", model.QueryOptions{Max: 10})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(HaveLen(1))
 			Expect(results[0].Title).To(Equal("Radioactivity"))

--- a/persistence/sql_search_like.go
+++ b/persistence/sql_search_like.go
@@ -27,12 +27,8 @@ func (s *likeSearch) execute(r sqlRepository, sq SelectBuilder, dest any, cfg se
 }
 
 // newLegacySearch creates a LIKE search against the full_text column.
-// Returns nil when the query is too short or produces no searchable tokens.
-// Single-character queries are rejected because LIKE '%x%' against full_text is too broad.
+// Returns nil when the query produces no searchable tokens.
 func newLegacySearch(tableName, query string) searchStrategy {
-	if len(query) < 2 {
-		return nil
-	}
 	filter := legacySearchExpr(tableName, query)
 	if filter == nil {
 		return nil

--- a/persistence/sql_search_like.go
+++ b/persistence/sql_search_like.go
@@ -1,0 +1,111 @@
+package persistence
+
+import (
+	"strings"
+
+	. "github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/str"
+)
+
+// likeSearch implements searchStrategy using LIKE-based SQL filters.
+// Used for legacy full_text searches, CJK fallback, and punctuation-only fallback.
+type likeSearch struct {
+	filter Sqlizer
+}
+
+func (s *likeSearch) ToSql() (string, []interface{}, error) {
+	return s.filter.ToSql()
+}
+
+func (s *likeSearch) execute(r sqlRepository, sq SelectBuilder, offset, size int, dest any, orderBys ...string) error {
+	sq = sq.Where(s.filter)
+	sq = sq.OrderBy(orderBys...)
+	sq = sq.Limit(uint64(size)).Offset(uint64(offset))
+	return r.queryAll(sq, dest, model.QueryOptions{Offset: offset})
+}
+
+// newLegacySearch creates a LIKE search against the full_text column.
+// Returns nil when the query is too short or produces no searchable tokens.
+// Single-character queries are rejected because LIKE '%x%' against full_text is too broad.
+func newLegacySearch(tableName, query string) searchStrategy {
+	if len(query) < 2 {
+		return nil
+	}
+	filter := legacySearchExpr(tableName, query)
+	if filter == nil {
+		return nil
+	}
+	return &likeSearch{filter: filter}
+}
+
+// newLikeSearch creates a LIKE search against core entity columns (CJK, punctuation fallback).
+// No minimum length is enforced, since single CJK characters are meaningful words.
+// Returns nil when the query produces no searchable tokens.
+func newLikeSearch(tableName, query string) searchStrategy {
+	filter := likeSearchExpr(tableName, query)
+	if filter == nil {
+		return nil
+	}
+	return &likeSearch{filter: filter}
+}
+
+// legacySearchExpr generates LIKE-based search filters against the full_text column.
+// This is the original search implementation, used when Search.Backend="legacy".
+func legacySearchExpr(tableName string, s string) Sqlizer {
+	q := str.SanitizeStrings(s)
+	if q == "" {
+		log.Trace("Search using legacy backend, query is empty", "table", tableName)
+		return nil
+	}
+	var sep string
+	if !conf.Server.Search.FullString {
+		sep = " "
+	}
+	parts := strings.Split(q, " ")
+	filters := And{}
+	for _, part := range parts {
+		filters = append(filters, Like{tableName + ".full_text": "%" + sep + part + "%"})
+	}
+	log.Trace("Search using legacy backend", "query", filters, "table", tableName)
+	return filters
+}
+
+// likeSearchColumns defines the core columns to search with LIKE queries.
+// These are the primary user-visible fields for each entity type.
+// Used as a fallback when FTS5 cannot handle the query (e.g., CJK text, punctuation-only input).
+var likeSearchColumns = map[string][]string{
+	"media_file": {"title", "album", "artist", "album_artist"},
+	"album":      {"name", "album_artist"},
+	"artist":     {"name"},
+}
+
+// likeSearchExpr generates LIKE-based search filters against core columns.
+// Each word in the query must match at least one column (AND between words),
+// and each word can match any column (OR within a word).
+// Used as a fallback when FTS5 cannot handle the query (e.g., CJK text, punctuation-only input).
+func likeSearchExpr(tableName string, s string) Sqlizer {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		log.Trace("Search using LIKE backend, query is empty", "table", tableName)
+		return nil
+	}
+	columns, ok := likeSearchColumns[tableName]
+	if !ok {
+		log.Trace("Search using LIKE backend, couldn't find columns for this table", "table", tableName)
+		return nil
+	}
+	words := strings.Fields(s)
+	wordFilters := And{}
+	for _, word := range words {
+		colFilters := Or{}
+		for _, col := range columns {
+			colFilters = append(colFilters, Like{tableName + "." + col: "%" + word + "%"})
+		}
+		wordFilters = append(wordFilters, colFilters)
+	}
+	log.Trace("Search using LIKE backend", "query", wordFilters, "table", tableName)
+	return wordFilters
+}

--- a/persistence/sql_search_like.go
+++ b/persistence/sql_search_like.go
@@ -20,11 +20,10 @@ func (s *likeSearch) ToSql() (string, []interface{}, error) {
 	return s.filter.ToSql()
 }
 
-func (s *likeSearch) execute(r sqlRepository, sq SelectBuilder, offset, size int, dest any, orderBys ...string) error {
+func (s *likeSearch) execute(r sqlRepository, sq SelectBuilder, dest any, cfg searchConfig, options model.QueryOptions) error {
 	sq = sq.Where(s.filter)
-	sq = sq.OrderBy(orderBys...)
-	sq = sq.Limit(uint64(size)).Offset(uint64(offset))
-	return r.queryAll(sq, dest, model.QueryOptions{Offset: offset})
+	sq = sq.OrderBy(cfg.OrderBy...)
+	return r.queryAll(sq, dest, options)
 }
 
 // newLegacySearch creates a LIKE search against the full_text column.

--- a/persistence/sql_search_like_test.go
+++ b/persistence/sql_search_like_test.go
@@ -5,6 +5,16 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("newLegacySearch", func() {
+	It("returns non-nil for single-character query", func() {
+		strategy := newLegacySearch("media_file", "a")
+		Expect(strategy).ToNot(BeNil(), "single-char queries must not be rejected; min-length is enforced in doSearch, not here")
+		sql, _, err := strategy.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("LIKE"))
+	})
+})
+
 var _ = Describe("legacySearchExpr", func() {
 	It("returns nil for empty query", func() {
 		Expect(legacySearchExpr("media_file", "")).To(BeNil())

--- a/persistence/sql_search_like_test.go
+++ b/persistence/sql_search_like_test.go
@@ -1,0 +1,84 @@
+package persistence
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("legacySearchExpr", func() {
+	It("returns nil for empty query", func() {
+		Expect(legacySearchExpr("media_file", "")).To(BeNil())
+	})
+
+	It("generates LIKE filter for single word", func() {
+		expr := legacySearchExpr("media_file", "beatles")
+		sql, args, err := expr.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("media_file.full_text LIKE"))
+		Expect(args).To(ContainElement("% beatles%"))
+	})
+
+	It("generates AND of LIKE filters for multiple words", func() {
+		expr := legacySearchExpr("media_file", "abbey road")
+		sql, args, err := expr.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("AND"))
+		Expect(args).To(HaveLen(2))
+	})
+})
+
+var _ = Describe("likeSearchExpr", func() {
+	It("returns nil for empty query", func() {
+		Expect(likeSearchExpr("media_file", "")).To(BeNil())
+	})
+
+	It("returns nil for whitespace-only query", func() {
+		Expect(likeSearchExpr("media_file", "   ")).To(BeNil())
+	})
+
+	It("generates LIKE filters against core columns for single CJK word", func() {
+		expr := likeSearchExpr("media_file", "周杰伦")
+		sql, args, err := expr.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		// Should have OR between columns for the single word
+		Expect(sql).To(ContainSubstring("OR"))
+		Expect(sql).To(ContainSubstring("media_file.title LIKE"))
+		Expect(sql).To(ContainSubstring("media_file.album LIKE"))
+		Expect(sql).To(ContainSubstring("media_file.artist LIKE"))
+		Expect(sql).To(ContainSubstring("media_file.album_artist LIKE"))
+		Expect(args).To(HaveLen(4))
+		for _, arg := range args {
+			Expect(arg).To(Equal("%周杰伦%"))
+		}
+	})
+
+	It("generates AND of OR groups for multi-word query", func() {
+		expr := likeSearchExpr("media_file", "周杰伦 greatest")
+		sql, args, err := expr.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		// Two groups AND'd together, each with 4 columns OR'd
+		Expect(sql).To(ContainSubstring("AND"))
+		Expect(args).To(HaveLen(8))
+	})
+
+	It("uses correct columns for album table", func() {
+		expr := likeSearchExpr("album", "周杰伦")
+		sql, args, err := expr.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("album.name LIKE"))
+		Expect(sql).To(ContainSubstring("album.album_artist LIKE"))
+		Expect(args).To(HaveLen(2))
+	})
+
+	It("uses correct columns for artist table", func() {
+		expr := likeSearchExpr("artist", "周杰伦")
+		sql, args, err := expr.ToSql()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sql).To(ContainSubstring("artist.name LIKE"))
+		Expect(args).To(HaveLen(1))
+	})
+
+	It("returns nil for unknown table", func() {
+		Expect(likeSearchExpr("unknown_table", "周杰伦")).To(BeNil())
+	})
+})

--- a/persistence/sql_search_like_test.go
+++ b/persistence/sql_search_like_test.go
@@ -1,6 +1,13 @@
 package persistence
 
 import (
+	"context"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -90,5 +97,38 @@ var _ = Describe("likeSearchExpr", func() {
 
 	It("returns nil for unknown table", func() {
 		Expect(likeSearchExpr("unknown_table", "周杰伦")).To(BeNil())
+	})
+})
+
+var _ = Describe("Legacy Integration Search", func() {
+	var mr model.MediaFileRepository
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.Search.Backend = "legacy"
+
+		ctx := log.NewContext(context.TODO())
+		ctx = request.WithUser(ctx, adminUser)
+		conn := GetDBXBuilder()
+		mr = NewMediaFileRepository(ctx, conn)
+	})
+
+	It("returns results using legacy LIKE-based search", func() {
+		results, err := mr.Search("Radioactivity", model.QueryOptions{Max: 10})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results[0].Title).To(Equal("Radioactivity"))
+	})
+
+	It("returns empty results for single-char query (doSearch min-length guard)", func() {
+		results, err := mr.Search("a", model.QueryOptions{Max: 10})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(results).To(BeEmpty(), "doSearch should reject single-char queries")
+	})
+
+	It("returns results with Max=0 (regression: must not produce LIMIT 0)", func() {
+		results, err := mr.Search("Beatles", model.QueryOptions{Max: 0})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(results).ToNot(BeEmpty(), "Max=0 should mean no limit, not LIMIT 0")
 	})
 })

--- a/persistence/sql_search_test.go
+++ b/persistence/sql_search_test.go
@@ -77,6 +77,24 @@ var _ = Describe("sqlRepository", func() {
 			Expect(sql).To(ContainSubstring("MATCH"))
 		})
 
+		It("returns non-nil for single-character query (no min-length in strategy)", func() {
+			DeferCleanup(configtest.SetupConfig())
+			conf.Server.Search.Backend = "fts"
+			conf.Server.Search.FullString = false
+
+			strategy := getSearchStrategy("media_file", "a")
+			Expect(strategy).ToNot(BeNil(), "single-char queries must be accepted by strategies (min-length is enforced in doSearch)")
+		})
+
+		It("returns non-nil for single-character query with legacy backend", func() {
+			DeferCleanup(configtest.SetupConfig())
+			conf.Server.Search.Backend = "legacy"
+			conf.Server.Search.FullString = false
+
+			strategy := getSearchStrategy("media_file", "a")
+			Expect(strategy).ToNot(BeNil(), "single-char queries must be accepted by legacy strategy (min-length is enforced in doSearch)")
+		})
+
 		It("uses legacy for CJK when SearchBackend is legacy", func() {
 			DeferCleanup(configtest.SetupConfig())
 			conf.Server.Search.Backend = "legacy"

--- a/persistence/sql_search_test.go
+++ b/persistence/sql_search_test.go
@@ -14,82 +14,65 @@ var _ = Describe("sqlRepository", func() {
 		})
 	})
 
-	Describe("legacySearchExpr", func() {
-		It("returns nil for empty query", func() {
-			Expect(legacySearchExpr("media_file", "")).To(BeNil())
-		})
-
-		It("generates LIKE filter for single word", func() {
-			expr := legacySearchExpr("media_file", "beatles")
-			sql, args, err := expr.ToSql()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sql).To(ContainSubstring("media_file.full_text LIKE"))
-			Expect(args).To(ContainElement("% beatles%"))
-		})
-
-		It("generates AND of LIKE filters for multiple words", func() {
-			expr := legacySearchExpr("media_file", "abbey road")
-			sql, args, err := expr.ToSql()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sql).To(ContainSubstring("AND"))
-			Expect(args).To(HaveLen(2))
-		})
-	})
-
-	Describe("getSearchExpr", func() {
-		It("returns ftsSearchExpr by default", func() {
+	Describe("getSearchStrategy", func() {
+		It("returns FTS strategy by default", func() {
 			DeferCleanup(configtest.SetupConfig())
 			conf.Server.Search.Backend = "fts"
 			conf.Server.Search.FullString = false
 
-			expr := getSearchExpr()("media_file", "test")
-			sql, _, err := expr.ToSql()
+			strategy := getSearchStrategy("media_file", "test")
+			Expect(strategy).ToNot(BeNil())
+			sql, _, err := strategy.ToSql()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sql).To(ContainSubstring("MATCH"))
 		})
 
-		It("returns legacySearchExpr when SearchBackend is legacy", func() {
+		It("returns legacy LIKE strategy when SearchBackend is legacy", func() {
 			DeferCleanup(configtest.SetupConfig())
 			conf.Server.Search.Backend = "legacy"
 			conf.Server.Search.FullString = false
 
-			expr := getSearchExpr()("media_file", "test")
-			sql, _, err := expr.ToSql()
+			strategy := getSearchStrategy("media_file", "test")
+			Expect(strategy).ToNot(BeNil())
+			sql, _, err := strategy.ToSql()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sql).To(ContainSubstring("LIKE"))
 		})
 
-		It("falls back to legacySearchExpr when SearchFullString is enabled", func() {
+		It("falls back to legacy LIKE strategy when SearchFullString is enabled", func() {
 			DeferCleanup(configtest.SetupConfig())
 			conf.Server.Search.Backend = "fts"
 			conf.Server.Search.FullString = true
 
-			expr := getSearchExpr()("media_file", "test")
-			sql, _, err := expr.ToSql()
+			strategy := getSearchStrategy("media_file", "test")
+			Expect(strategy).ToNot(BeNil())
+			sql, _, err := strategy.ToSql()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sql).To(ContainSubstring("LIKE"))
 		})
 
-		It("routes CJK queries to likeSearchExpr instead of ftsSearchExpr", func() {
+		It("routes CJK queries to LIKE strategy instead of FTS", func() {
 			DeferCleanup(configtest.SetupConfig())
 			conf.Server.Search.Backend = "fts"
 			conf.Server.Search.FullString = false
 
-			expr := getSearchExpr()("media_file", "周杰伦")
-			sql, _, err := expr.ToSql()
+			strategy := getSearchStrategy("media_file", "周杰伦")
+			Expect(strategy).ToNot(BeNil())
+			sql, _, err := strategy.ToSql()
 			Expect(err).ToNot(HaveOccurred())
 			// CJK should use LIKE, not MATCH
 			Expect(sql).To(ContainSubstring("LIKE"))
 			Expect(sql).NotTo(ContainSubstring("MATCH"))
 		})
 
-		It("routes non-CJK queries to ftsSearchExpr", func() {
+		It("routes non-CJK queries to FTS strategy", func() {
 			DeferCleanup(configtest.SetupConfig())
 			conf.Server.Search.Backend = "fts"
 			conf.Server.Search.FullString = false
 
-			expr := getSearchExpr()("media_file", "beatles")
-			sql, _, err := expr.ToSql()
+			strategy := getSearchStrategy("media_file", "beatles")
+			Expect(strategy).ToNot(BeNil())
+			sql, _, err := strategy.ToSql()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sql).To(ContainSubstring("MATCH"))
 		})
@@ -99,13 +82,13 @@ var _ = Describe("sqlRepository", func() {
 			conf.Server.Search.Backend = "legacy"
 			conf.Server.Search.FullString = false
 
-			expr := getSearchExpr()("media_file", "周杰伦")
-			sql, _, err := expr.ToSql()
+			strategy := getSearchStrategy("media_file", "周杰伦")
+			Expect(strategy).ToNot(BeNil())
+			sql, _, err := strategy.ToSql()
 			Expect(err).ToNot(HaveOccurred())
 			// Legacy should still use full_text column LIKE
 			Expect(sql).To(ContainSubstring("LIKE"))
 			Expect(sql).To(ContainSubstring("full_text"))
 		})
 	})
-
 })

--- a/server/e2e/e2e_suite_test.go
+++ b/server/e2e/e2e_suite_test.go
@@ -115,6 +115,7 @@ func buildTestFS() storagetest.FakeFS {
 	ledZepIV := template(_t{"albumartist": "Led Zeppelin", "artist": "Led Zeppelin", "album": "IV", "year": 1971, "genre": "Rock"})
 	kindOfBlue := template(_t{"albumartist": "Miles Davis", "artist": "Miles Davis", "album": "Kind of Blue", "year": 1959, "genre": "Jazz"})
 	popTrack := template(_t{"albumartist": "Various", "artist": "Various", "album": "Pop", "year": 2020, "genre": "Pop"})
+	cowboyBebop := template(_t{"albumartist": "シートベルツ", "artist": "シートベルツ", "album": "COWBOY BEBOP", "year": 1998, "genre": "Jazz"})
 
 	return createFS(fstest.MapFS{
 		// Rock / The Beatles / Abbey Road (with MBIDs)
@@ -132,6 +133,8 @@ func buildTestFS() storagetest.FakeFS {
 		"Jazz/Miles Davis/Kind of Blue/01 - So What.mp3": kindOfBlue(track(1, "So What")),
 		// Pop (standalone track, no MBIDs)
 		"Pop/01 - Standalone Track.mp3": popTrack(track(1, "Standalone Track")),
+		// CJK / シートベルツ / COWBOY BEBOP (Japanese artist, for CJK search tests)
+		"CJK/シートベルツ/COWBOY BEBOP/01 - プラチナ・ジェット.mp3": cowboyBebop(track(1, "プラチナ・ジェット")),
 		// _empty folder (directory with no audio)
 		"_empty/.keep": &fstest.MapFile{Data: []byte{}, ModTime: time.Now()},
 	})

--- a/server/e2e/subsonic_album_lists_test.go
+++ b/server/e2e/subsonic_album_lists_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Album List Endpoints", func() {
 
 			Expect(resp.Status).To(Equal(responses.StatusOK))
 			Expect(resp.AlbumList).ToNot(BeNil())
-			Expect(resp.AlbumList.Album).To(HaveLen(5))
+			Expect(resp.AlbumList.Album).To(HaveLen(6))
 		})
 
 		It("type=alphabeticalByName sorts albums by name", func() {
@@ -27,13 +27,14 @@ var _ = Describe("Album List Endpoints", func() {
 
 			Expect(resp.AlbumList).ToNot(BeNil())
 			albums := resp.AlbumList.Album
-			Expect(albums).To(HaveLen(5))
-			// Verify alphabetical order: Abbey Road, Help!, IV, Kind of Blue, Pop
+			Expect(albums).To(HaveLen(6))
+			// Verify alphabetical order: Abbey Road, COWBOY BEBOP, Help!, IV, Kind of Blue, Pop
 			Expect(albums[0].Title).To(Equal("Abbey Road"))
-			Expect(albums[1].Title).To(Equal("Help!"))
-			Expect(albums[2].Title).To(Equal("IV"))
-			Expect(albums[3].Title).To(Equal("Kind of Blue"))
-			Expect(albums[4].Title).To(Equal("Pop"))
+			Expect(albums[1].Title).To(Equal("COWBOY BEBOP"))
+			Expect(albums[2].Title).To(Equal("Help!"))
+			Expect(albums[3].Title).To(Equal("IV"))
+			Expect(albums[4].Title).To(Equal("Kind of Blue"))
+			Expect(albums[5].Title).To(Equal("Pop"))
 		})
 
 		It("type=alphabeticalByArtist sorts albums by artist name", func() {
@@ -41,29 +42,33 @@ var _ = Describe("Album List Endpoints", func() {
 
 			Expect(resp.AlbumList).ToNot(BeNil())
 			albums := resp.AlbumList.Album
-			Expect(albums).To(HaveLen(5))
+			Expect(albums).To(HaveLen(6))
 			// Articles like "The" are stripped for sorting, so "The Beatles" sorts as "Beatles"
-			// Non-compilations first: Beatles (x2), Led Zeppelin, Miles Davis, then compilations: Various
+			// Non-compilations first: Beatles (x2), Led Zeppelin, Miles Davis, then compilations: Various, then CJK: シートベルツ
 			Expect(albums[0].Artist).To(Equal("The Beatles"))
 			Expect(albums[1].Artist).To(Equal("The Beatles"))
 			Expect(albums[2].Artist).To(Equal("Led Zeppelin"))
 			Expect(albums[3].Artist).To(Equal("Miles Davis"))
 			Expect(albums[4].Artist).To(Equal("Various"))
+			Expect(albums[5].Artist).To(Equal("シートベルツ"))
 		})
 
 		It("type=random returns albums", func() {
 			resp := doReq("getAlbumList", "type", "random")
 
 			Expect(resp.AlbumList).ToNot(BeNil())
-			Expect(resp.AlbumList.Album).To(HaveLen(5))
+			Expect(resp.AlbumList.Album).To(HaveLen(6))
 		})
 
 		It("type=byGenre filters by genre parameter", func() {
 			resp := doReq("getAlbumList", "type", "byGenre", "genre", "Jazz")
 
 			Expect(resp.AlbumList).ToNot(BeNil())
-			Expect(resp.AlbumList.Album).To(HaveLen(1))
-			Expect(resp.AlbumList.Album[0].Title).To(Equal("Kind of Blue"))
+			Expect(resp.AlbumList.Album).To(HaveLen(2))
+			for _, a := range resp.AlbumList.Album {
+				Expect(a.Genre).To(Equal("Jazz"))
+			}
+
 		})
 
 		It("type=byYear filters by fromYear/toYear range", func() {
@@ -184,7 +189,7 @@ var _ = Describe("Album List Endpoints", func() {
 			Expect(resp.Status).To(Equal(responses.StatusOK))
 			Expect(resp.AlbumList2).ToNot(BeNil())
 			albums := resp.AlbumList2.Album
-			Expect(albums).To(HaveLen(5))
+			Expect(albums).To(HaveLen(6))
 			// Verify AlbumID3 format fields
 			Expect(albums[0].Name).To(Equal("Abbey Road"))
 			Expect(albums[0].Id).ToNot(BeEmpty())
@@ -195,7 +200,7 @@ var _ = Describe("Album List Endpoints", func() {
 			resp := doReq("getAlbumList2", "type", "newest")
 
 			Expect(resp.AlbumList2).ToNot(BeNil())
-			Expect(resp.AlbumList2.Album).To(HaveLen(5))
+			Expect(resp.AlbumList2.Album).To(HaveLen(6))
 		})
 	})
 
@@ -240,7 +245,7 @@ var _ = Describe("Album List Endpoints", func() {
 			Expect(resp.Status).To(Equal(responses.StatusOK))
 			Expect(resp.RandomSongs).ToNot(BeNil())
 			Expect(resp.RandomSongs.Songs).ToNot(BeEmpty())
-			Expect(len(resp.RandomSongs.Songs)).To(BeNumerically("<=", 6))
+			Expect(resp.RandomSongs.Songs).To(HaveLen(7))
 		})
 
 		It("respects size parameter", func() {
@@ -254,8 +259,10 @@ var _ = Describe("Album List Endpoints", func() {
 			resp := doReq("getRandomSongs", "size", "500", "genre", "Jazz")
 
 			Expect(resp.RandomSongs).ToNot(BeNil())
-			Expect(resp.RandomSongs.Songs).To(HaveLen(1))
-			Expect(resp.RandomSongs.Songs[0].Genre).To(Equal("Jazz"))
+			Expect(resp.RandomSongs.Songs).To(HaveLen(2))
+			for _, s := range resp.RandomSongs.Songs {
+				Expect(s.Genre).To(Equal("Jazz"))
+			}
 		})
 	})
 

--- a/server/e2e/subsonic_album_lists_test.go
+++ b/server/e2e/subsonic_album_lists_test.go
@@ -68,7 +68,6 @@ var _ = Describe("Album List Endpoints", func() {
 			for _, a := range resp.AlbumList.Album {
 				Expect(a.Genre).To(Equal("Jazz"))
 			}
-
 		})
 
 		It("type=byYear filters by fromYear/toYear range", func() {

--- a/server/e2e/subsonic_browsing_test.go
+++ b/server/e2e/subsonic_browsing_test.go
@@ -327,8 +327,8 @@ var _ = Describe("Browsing Endpoints", func() {
 				}
 			}
 			Expect(jazzGenre).ToNot(BeNil())
-			Expect(jazzGenre.SongCount).To(Equal(int32(1)))
-			Expect(jazzGenre.AlbumCount).To(Equal(int32(1)))
+			Expect(jazzGenre.SongCount).To(Equal(int32(2)))
+			Expect(jazzGenre.AlbumCount).To(Equal(int32(2)))
 		})
 
 		It("reports correct song and album counts for Pop", func() {

--- a/server/e2e/subsonic_multilibrary_test.go
+++ b/server/e2e/subsonic_multilibrary_test.go
@@ -275,5 +275,21 @@ var _ = Describe("Multi-Library Support", Ordered, func() {
 			Expect(artistNames).To(ContainElements("The Beatles", "Led Zeppelin", "Miles Davis"))
 			Expect(artistNames).ToNot(ContainElement("Ludwig van Beethoven"))
 		})
+
+		It("non-admin user search returns only their library's content", func() {
+			resp := doReqWithUser(userLib1Only, "search3", "query", "Beethoven")
+
+			Expect(resp.SearchResult3).ToNot(BeNil())
+			Expect(resp.SearchResult3.Artist).To(BeEmpty(), "userLib1Only should not see Beethoven (lib2)")
+			Expect(resp.SearchResult3.Album).To(BeEmpty())
+			Expect(resp.SearchResult3.Song).To(BeEmpty())
+		})
+
+		It("non-admin user search finds content from their library", func() {
+			resp := doReqWithUser(userLib1Only, "search3", "query", "Beatles")
+
+			Expect(resp.SearchResult3).ToNot(BeNil())
+			Expect(resp.SearchResult3.Artist).ToNot(BeEmpty(), "userLib1Only should find Beatles (lib1)")
+		})
 	})
 })

--- a/server/e2e/subsonic_multilibrary_test.go
+++ b/server/e2e/subsonic_multilibrary_test.go
@@ -141,7 +141,7 @@ var _ = Describe("Multi-Library Support", Ordered, func() {
 			resp := doReqWithUser(adminWithLibs, "getAlbumList", "type", "alphabeticalByName", "musicFolderId", fmt.Sprintf("%d", lib.ID))
 
 			Expect(resp.AlbumList).ToNot(BeNil())
-			Expect(resp.AlbumList.Album).To(HaveLen(5))
+			Expect(resp.AlbumList.Album).To(HaveLen(6))
 			for _, a := range resp.AlbumList.Album {
 				Expect(a.Title).ToNot(Equal("Symphony No. 9"))
 			}

--- a/server/subsonic/searching.go
+++ b/server/subsonic/searching.go
@@ -42,17 +42,17 @@ func (api *Router) getSearchParams(r *http.Request) (*searchParams, error) {
 	return sp, nil
 }
 
-type searchFunc[T any] func(q string, offset int, size int, options ...model.QueryOptions) (T, error)
+type searchFunc[T any] func(q string, options ...model.QueryOptions) (T, error)
 
-func callSearch[T any](ctx context.Context, s searchFunc[T], q string, offset, size int, result *T, options ...model.QueryOptions) func() error {
+func callSearch[T any](ctx context.Context, s searchFunc[T], q string, result *T, options ...model.QueryOptions) func() error {
 	return func() error {
-		if size == 0 {
+		if len(options) > 0 && options[0].Max == 0 {
 			return nil
 		}
 		typ := strings.TrimPrefix(reflect.TypeOf(*result).String(), "model.")
 		var err error
 		start := time.Now()
-		*result, err = s(q, offset, size, options...)
+		*result, err = s(q, options...)
 		if err != nil {
 			log.Error(ctx, "Error searching "+typ, "query", q, "elapsed", time.Since(start), err)
 		} else {
@@ -66,27 +66,22 @@ func (api *Router) searchAll(ctx context.Context, sp *searchParams, musicFolderI
 	start := time.Now()
 	q := sanitize.Accents(strings.ToLower(strings.TrimSuffix(sp.query, "*")))
 
-	// Create query options for library filtering
-	var options []model.QueryOptions
-	var artistOptions []model.QueryOptions
+	// Build options with offset/size/filters packed in
+	songOpts := model.QueryOptions{Max: sp.songCount, Offset: sp.songOffset}
+	albumOpts := model.QueryOptions{Max: sp.albumCount, Offset: sp.albumOffset}
+	artistOpts := model.QueryOptions{Max: sp.artistCount, Offset: sp.artistOffset}
+
 	if len(musicFolderIds) > 0 {
-		// For MediaFiles and Albums, use direct library_id filter
-		options = append(options, model.QueryOptions{
-			Filters: Eq{"library_id": musicFolderIds},
-		})
-		// For Artists, use the repository's built-in library filtering mechanism
-		// which properly handles the library_artist table joins
-		// TODO Revisit library filtering in sql_base_repository.go
-		artistOptions = append(artistOptions, model.QueryOptions{
-			Filters: Eq{"library_artist.library_id": musicFolderIds},
-		})
+		songOpts.Filters = Eq{"library_id": musicFolderIds}
+		albumOpts.Filters = Eq{"library_id": musicFolderIds}
+		artistOpts.Filters = Eq{"library_artist.library_id": musicFolderIds}
 	}
 
 	// Run searches in parallel
 	g, ctx := errgroup.WithContext(ctx)
-	g.Go(callSearch(ctx, api.ds.MediaFile(ctx).Search, q, sp.songOffset, sp.songCount, &mediaFiles, options...))
-	g.Go(callSearch(ctx, api.ds.Album(ctx).Search, q, sp.albumOffset, sp.albumCount, &albums, options...))
-	g.Go(callSearch(ctx, api.ds.Artist(ctx).Search, q, sp.artistOffset, sp.artistCount, &artists, artistOptions...))
+	g.Go(callSearch(ctx, api.ds.MediaFile(ctx).Search, q, &mediaFiles, songOpts))
+	g.Go(callSearch(ctx, api.ds.Album(ctx).Search, q, &albums, albumOpts))
+	g.Go(callSearch(ctx, api.ds.Artist(ctx).Search, q, &artists, artistOpts))
 	err := g.Wait()
 	if err == nil {
 		log.Debug(ctx, fmt.Sprintf("Search resulted in %d songs, %d albums and %d artists",

--- a/tests/mock_album_repo.go
+++ b/tests/mock_album_repo.go
@@ -119,7 +119,7 @@ func (m *MockAlbumRepo) UpdateExternalInfo(album *model.Album) error {
 	return nil
 }
 
-func (m *MockAlbumRepo) Search(q string, offset int, size int, options ...model.QueryOptions) (model.Albums, error) {
+func (m *MockAlbumRepo) Search(q string, options ...model.QueryOptions) (model.Albums, error) {
 	if len(options) > 0 {
 		m.Options = options[0]
 	}

--- a/tests/mock_artist_repo.go
+++ b/tests/mock_artist_repo.go
@@ -145,7 +145,7 @@ func (m *MockArtistRepo) GetIndex(includeMissing bool, libraryIds []int, roles .
 	return result, nil
 }
 
-func (m *MockArtistRepo) Search(q string, offset int, size int, options ...model.QueryOptions) (model.Artists, error) {
+func (m *MockArtistRepo) Search(q string, options ...model.QueryOptions) (model.Artists, error) {
 	if len(options) > 0 {
 		m.Options = options[0]
 	}

--- a/tests/mock_mediafile_repo.go
+++ b/tests/mock_mediafile_repo.go
@@ -238,7 +238,7 @@ func (m *MockMediaFileRepo) NewInstance() any {
 	return &model.MediaFile{}
 }
 
-func (m *MockMediaFileRepo) Search(q string, offset int, size int, options ...model.QueryOptions) (model.MediaFiles, error) {
+func (m *MockMediaFileRepo) Search(q string, options ...model.QueryOptions) (model.MediaFiles, error) {
 	if len(options) > 0 {
 		m.Options = options[0]
 	}


### PR DESCRIPTION
### Description

Refactors `search3` full-text search into a **strategy pattern** and introduces a **two-phase query optimization** for FTS5 searches on high-cardinality results.

**Problem**: When FTS5 returns tens of thousands of rowids for common words (e.g. "the"), the `rowid IN (SELECT rowid FROM fts ... MATCH ?)` pattern forces SQLite to materialize all matches, perform LEFT JOINs (annotation, bookmark, library) on every row, sort, and only then apply LIMIT — resulting in multi-second response times on large libraries.

**Solution**:

1. **Strategy pattern refactor**: Extracted search logic into a `searchStrategy` interface with two implementations:
   - `ftsSearch` — FTS5 MATCH-based search with BM25 ranking
   - `likeSearch` — LIKE-based search (legacy backend, CJK fallback, punctuation-only fallback)

   Each strategy implements both `Sqlizer` (for use as a WHERE clause in REST filter contexts) and `execute()` (for full search with pagination and ordering).

2. **Two-phase FTS query**: The `ftsSearch.execute()` splits queries into two phases:
   - **Phase 1** (lightweight): `SELECT rowid FROM table JOIN fts ... ORDER BY bm25(...) LIMIT/OFFSET` — only main table + FTS index, no expensive JOINs
   - **Phase 2** (hydrate): Full SELECT with all JOINs filtered by the small set of Phase 1 rowids, preserving ordering via `row_number() OVER ()`

3. **BM25 relevance ranking**: Added explicit column weights (e.g. `title=10.0`, `album=5.0`, `artist=3.0`) via `ftsColumnDefs`, precomputed at init time. Replaces the unweighted default `rank` column.

4. **Complex ORDER BY handling**: The `qualifyOrderBy` helper detects expressions containing function calls or aggregations (e.g. artist's `sum(json_extract(stats, ...))`) and drops them from Phase 1, ensuring correct fallback behavior.

5. **New LIKE search file**: Moved `legacySearchExpr`, `likeSearchExpr`, and related code into `sql_search_like.go` for better organization.

6. **E2E test coverage**: Added CJK test data (Japanese artist/album/song) and new e2e tests for CJK search and legacy backend search.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start the dev server with a large music library
2. Search for a high-cardinality term like "the" via the Subsonic API:
   ```
   /rest/search3?query=the&songCount=20&albumCount=10&artistCount=5
   ```
3. Verify the response time is significantly faster than before (target: <500ms, down from ~2.6s on large libraries)
4. Verify search results are ranked by relevance (exact title matches should appear before partial matches in other fields)
5. Test CJK search (e.g. `query=周杰伦`) — should use LIKE fallback and return correct results
6. Test punctuation-only search (e.g. `query=!!!!!!!`) — should fall back to LIKE and find matching entries
7. Test with `Search.Backend=legacy` config — should use full_text LIKE search as before
8. Run `make test PKG=./persistence` and `make test PKG=./server/e2e` to verify all tests pass

### Additional Notes

- The `ftsSearch` struct implements `Sqlizer` for backward compatibility, so it can be used as a WHERE clause fallback in any code path that doesn't handle the two-phase optimization (e.g. REST filters via `fullTextFilter`).
- The `qualifyOrderBy` helper detects complex ORDER BY expressions (containing parentheses or commas) and drops them from Phase 1. This ensures the artist repository's `sum(json_extract(stats, ...))` sort works correctly — Phase 2 re-sorts by `_ranked._rn` which preserves the FTS rank order.
- On small libraries (< ~1000 FTS matches for a term), both approaches are fast; the improvement is most visible on libraries with 10k+ matches for common words.
- The e2e test suite now includes a Japanese artist/album/song to exercise the CJK LIKE search fallback path end-to-end.
