### PR TITLE
feat(plugins): allow mounting library directories as read-write

### DIFF
--- a/db/migrations/20260228020813_add_plugin_allow_write_access.sql
+++ b/db/migrations/20260228020813_add_plugin_allow_write_access.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE plugin ADD COLUMN allow_write_access BOOL NOT NULL DEFAULT false;
+
+-- +goose Down
+ALTER TABLE plugin DROP COLUMN allow_write_access;

--- a/model/plugin.go
+++ b/model/plugin.go
@@ -3,19 +3,20 @@ package model
 import "time"
 
 type Plugin struct {
-	ID           string    `structs:"id"            json:"id"`
-	Path         string    `structs:"path"          json:"path"`
-	Manifest     string    `structs:"manifest"      json:"manifest"`
-	Config       string    `structs:"config"        json:"config,omitempty"`
-	Users        string    `structs:"users"         json:"users,omitempty"`
-	AllUsers     bool      `structs:"all_users"     json:"allUsers,omitempty"`
-	Libraries    string    `structs:"libraries"     json:"libraries,omitempty"`
-	AllLibraries bool      `structs:"all_libraries" json:"allLibraries,omitempty"`
-	Enabled      bool      `structs:"enabled"       json:"enabled"`
-	LastError    string    `structs:"last_error"    json:"lastError,omitempty"`
-	SHA256       string    `structs:"sha256"        json:"sha256"`
-	CreatedAt    time.Time `structs:"created_at"    json:"createdAt"`
-	UpdatedAt    time.Time `structs:"updated_at"    json:"updatedAt"`
+	ID               string    `structs:"id"                 json:"id"`
+	Path             string    `structs:"path"               json:"path"`
+	Manifest         string    `structs:"manifest"           json:"manifest"`
+	Config           string    `structs:"config"             json:"config,omitempty"`
+	Users            string    `structs:"users"              json:"users,omitempty"`
+	AllUsers         bool      `structs:"all_users"          json:"allUsers,omitempty"`
+	Libraries        string    `structs:"libraries"          json:"libraries,omitempty"`
+	AllLibraries     bool      `structs:"all_libraries"      json:"allLibraries,omitempty"`
+	AllowWriteAccess bool      `structs:"allow_write_access" json:"allowWriteAccess,omitempty"`
+	Enabled          bool      `structs:"enabled"            json:"enabled"`
+	LastError        string    `structs:"last_error"         json:"lastError,omitempty"`
+	SHA256           string    `structs:"sha256"             json:"sha256"`
+	CreatedAt        time.Time `structs:"created_at"         json:"createdAt"`
+	UpdatedAt        time.Time `structs:"updated_at"         json:"updatedAt"`
 }
 
 type Plugins []Plugin

--- a/persistence/plugin_repository.go
+++ b/persistence/plugin_repository.go
@@ -79,8 +79,8 @@ func (r *pluginRepository) Put(plugin *model.Plugin) error {
 
 	// Upsert using INSERT ... ON CONFLICT for atomic operation
 	_, err := r.db.NewQuery(`
-		INSERT INTO plugin (id, path, manifest, config, users, all_users, libraries, all_libraries, enabled, last_error, sha256, created_at, updated_at)
-		VALUES ({:id}, {:path}, {:manifest}, {:config}, {:users}, {:all_users}, {:libraries}, {:all_libraries}, {:enabled}, {:last_error}, {:sha256}, {:created_at}, {:updated_at})
+		INSERT INTO plugin (id, path, manifest, config, users, all_users, libraries, all_libraries, allow_write_access, enabled, last_error, sha256, created_at, updated_at)
+		VALUES ({:id}, {:path}, {:manifest}, {:config}, {:users}, {:all_users}, {:libraries}, {:all_libraries}, {:allow_write_access}, {:enabled}, {:last_error}, {:sha256}, {:created_at}, {:updated_at})
 		ON CONFLICT(id) DO UPDATE SET
 			path = excluded.path,
 			manifest = excluded.manifest,
@@ -89,24 +89,26 @@ func (r *pluginRepository) Put(plugin *model.Plugin) error {
 			all_users = excluded.all_users,
 			libraries = excluded.libraries,
 			all_libraries = excluded.all_libraries,
+			allow_write_access = excluded.allow_write_access,
 			enabled = excluded.enabled,
 			last_error = excluded.last_error,
 			sha256 = excluded.sha256,
 			updated_at = excluded.updated_at
 	`).Bind(dbx.Params{
-		"id":            plugin.ID,
-		"path":          plugin.Path,
-		"manifest":      plugin.Manifest,
-		"config":        plugin.Config,
-		"users":         plugin.Users,
-		"all_users":     plugin.AllUsers,
-		"libraries":     plugin.Libraries,
-		"all_libraries": plugin.AllLibraries,
-		"enabled":       plugin.Enabled,
-		"last_error":    plugin.LastError,
-		"sha256":        plugin.SHA256,
-		"created_at":    time.Now(),
-		"updated_at":    plugin.UpdatedAt,
+		"id":                 plugin.ID,
+		"path":               plugin.Path,
+		"manifest":           plugin.Manifest,
+		"config":             plugin.Config,
+		"users":              plugin.Users,
+		"all_users":          plugin.AllUsers,
+		"libraries":          plugin.Libraries,
+		"all_libraries":      plugin.AllLibraries,
+		"allow_write_access": plugin.AllowWriteAccess,
+		"enabled":            plugin.Enabled,
+		"last_error":         plugin.LastError,
+		"sha256":             plugin.SHA256,
+		"created_at":         time.Now(),
+		"updated_at":         plugin.UpdatedAt,
 	}).Execute()
 	return err
 }

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -428,10 +428,11 @@ func (m *Manager) UpdatePluginUsers(ctx context.Context, id, usersJSON string, a
 // If the plugin is enabled, it will be reloaded with the new settings.
 // If the plugin requires library permission and no libraries are configured (and allLibraries is false),
 // the plugin will be automatically disabled.
-func (m *Manager) UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries bool) error {
+func (m *Manager) UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries, allowWriteAccess bool) error {
 	return m.updatePluginSettings(ctx, id, func(p *model.Plugin) {
 		p.Libraries = librariesJSON
 		p.AllLibraries = allLibraries
+		p.AllowWriteAccess = allowWriteAccess
 	})
 }
 

--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -226,6 +226,8 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 // loadPluginWithConfig loads a plugin with configuration from DB.
 // The p.Path should point to an .ndp package file.
 func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
+	ctx := log.NewContext(m.ctx, "plugin", p.ID)
+
 	if m.stopped.Load() {
 		return fmt.Errorf("manager is stopped")
 	}
@@ -283,33 +285,13 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 
 	// Configure filesystem access for library permission
 	if pkg.Manifest.Permissions != nil && pkg.Manifest.Permissions.Library != nil && pkg.Manifest.Permissions.Library.Filesystem {
-		adminCtx := adminContext(m.ctx)
+		adminCtx := adminContext(ctx)
 		libraries, err := m.ds.Library(adminCtx).GetAll()
 		if err != nil {
 			return fmt.Errorf("failed to get libraries for filesystem access: %w", err)
 		}
 
-		// Build a set of allowed library IDs for fast lookup
-		allowedLibrarySet := make(map[int]struct{}, len(allowedLibraries))
-		for _, id := range allowedLibraries {
-			allowedLibrarySet[id] = struct{}{}
-		}
-
-		allowedPaths := make(map[string]string)
-		for _, lib := range libraries {
-			// Only mount if allLibraries is true or library is in the allowed list
-			_, allowed := allowedLibrarySet[lib.ID]
-			if p.AllLibraries || allowed {
-				mountPoint := toPluginMountPoint(int32(lib.ID))
-				if p.AllowWriteAccess {
-					log.Info(m.ctx, "Granting read-write filesystem access to library", "plugin", p.ID, "libraryID", lib.ID, "mountPoint", mountPoint)
-					allowedPaths[lib.Path] = mountPoint // read-write
-				} else {
-					log.Debug(m.ctx, "Granting read-only filesystem access to library", "plugin", p.ID, "libraryID", lib.ID, "mountPoint", mountPoint)
-					allowedPaths["ro:"+lib.Path] = mountPoint // read-only (default)
-				}
-			}
-		}
+		allowedPaths := buildAllowedPaths(ctx, libraries, allowedLibraries, p.AllLibraries, p.AllowWriteAccess)
 		pluginManifest.AllowedPaths = allowedPaths
 	}
 
@@ -345,7 +327,7 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 	// Enable experimental threads if requested in manifest
 	if pkg.Manifest.HasExperimentalThreads() {
 		runtimeConfig = runtimeConfig.WithCoreFeatures(api.CoreFeaturesV2 | experimental.CoreFeaturesThreads)
-		log.Debug(m.ctx, "Enabling experimental threads support", "plugin", p.ID)
+		log.Debug(ctx, "Enabling experimental threads support")
 	}
 
 	extismConfig := extism.PluginConfig{
@@ -353,24 +335,24 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 		RuntimeConfig:             runtimeConfig,
 		EnableHttpResponseHeaders: true,
 	}
-	compiled, err := extism.NewCompiledPlugin(m.ctx, pluginManifest, extismConfig, hostFunctions)
+	compiled, err := extism.NewCompiledPlugin(ctx, pluginManifest, extismConfig, hostFunctions)
 	if err != nil {
 		return fmt.Errorf("compiling plugin: %w", err)
 	}
 
 	// Create instance to detect capabilities
-	instance, err := compiled.Instance(m.ctx, extism.PluginInstanceConfig{})
+	instance, err := compiled.Instance(ctx, extism.PluginInstanceConfig{})
 	if err != nil {
-		compiled.Close(m.ctx)
+		compiled.Close(ctx)
 		return fmt.Errorf("creating instance: %w", err)
 	}
 	instance.SetLogger(extismLogger(p.ID))
 	capabilities := detectCapabilities(instance)
-	instance.Close(m.ctx)
+	instance.Close(ctx)
 
 	// Validate manifest against detected capabilities
 	if err := ValidateWithCapabilities(pkg.Manifest, capabilities); err != nil {
-		compiled.Close(m.ctx)
+		compiled.Close(ctx)
 		return fmt.Errorf("manifest validation: %w", err)
 	}
 
@@ -389,7 +371,7 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 	m.mu.Unlock()
 
 	// Call plugin init function
-	callPluginInit(m.ctx, m.plugins[p.ID])
+	callPluginInit(ctx, m.plugins[p.ID])
 
 	return nil
 }
@@ -419,4 +401,30 @@ func parsePluginConfig(configJSON string) (map[string]string, error) {
 		}
 	}
 	return pluginConfig, nil
+}
+
+// buildAllowedPaths constructs the extism AllowedPaths map for filesystem access.
+// When allowWriteAccess is false (default), paths are prefixed with "ro:" for read-only.
+// Only libraries that match the allowed set (or all libraries if allLibraries is true) are included.
+func buildAllowedPaths(ctx context.Context, libraries model.Libraries, allowedLibraryIDs []int, allLibraries, allowWriteAccess bool) map[string]string {
+	allowedLibrarySet := make(map[int]struct{}, len(allowedLibraryIDs))
+	for _, id := range allowedLibraryIDs {
+		allowedLibrarySet[id] = struct{}{}
+	}
+
+	allowedPaths := make(map[string]string)
+	for _, lib := range libraries {
+		_, allowed := allowedLibrarySet[lib.ID]
+		if allLibraries || allowed {
+			mountPoint := toPluginMountPoint(int32(lib.ID))
+			if allowWriteAccess {
+				log.Info(ctx, "Granting read-write filesystem access to library", "libraryID", lib.ID, "mountPoint", mountPoint)
+				allowedPaths[lib.Path] = mountPoint
+			} else {
+				log.Debug(ctx, "Granting read-only filesystem access to library", "libraryID", lib.ID, "mountPoint", mountPoint)
+				allowedPaths["ro:"+lib.Path] = mountPoint
+			}
+		}
+	}
+	return allowedPaths
 }

--- a/resources/i18n/pt-br.json
+++ b/resources/i18n/pt-br.json
@@ -353,7 +353,8 @@
         "allUsers": "Permitir todos os usuários",
         "selectedUsers": "Usuários selecionados",
         "allLibraries": "Permitir todas as bibliotecas",
-        "selectedLibraries": "Bibliotecas selecionadas"
+        "selectedLibraries": "Bibliotecas selecionadas",
+        "allowWriteAccess": "Permitir acesso de escrita"
       },
       "sections": {
         "status": "Status",
@@ -396,6 +397,7 @@
         "allLibrariesHelp": "Quando habilitado, o plugin terá acesso a todas as bibliotecas, incluindo as criadas no futuro.",
         "noLibraries": "Nenhuma biblioteca selecionada",
         "librariesRequired": "Este plugin requer acesso a informações de bibliotecas. Selecione quais bibliotecas o plugin pode acessar, ou habilite 'Permitir todas as bibliotecas'.",
+        "allowWriteAccessHelp": "Quando habilitado, o plugin pode modificar arquivos nos diretórios das bibliotecas. Por padrão, plugins têm acesso somente leitura.",
         "requiredHosts": "Hosts necessários",
         "configValidationError": "Falha na validação da configuração:",
         "schemaRenderError": "Não foi possível renderizar o formulário de configuração. O schema do plugin pode estar inválido."

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -29,7 +29,7 @@ type PluginManager interface {
 	ValidatePluginConfig(ctx context.Context, id, configJSON string) error
 	UpdatePluginConfig(ctx context.Context, id, configJSON string) error
 	UpdatePluginUsers(ctx context.Context, id, usersJSON string, allUsers bool) error
-	UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries bool) error
+	UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries, allowWriteAccess bool) error
 	RescanPlugins(ctx context.Context) error
 	UnloadDisabledPlugins(ctx context.Context)
 }

--- a/tests/mock_plugin_manager.go
+++ b/tests/mock_plugin_manager.go
@@ -18,7 +18,7 @@ type MockPluginManager struct {
 	// UpdatePluginUsersFn is called when UpdatePluginUsers is invoked. If nil, returns UsersError.
 	UpdatePluginUsersFn func(ctx context.Context, id, usersJSON string, allUsers bool) error
 	// UpdatePluginLibrariesFn is called when UpdatePluginLibraries is invoked. If nil, returns LibrariesError.
-	UpdatePluginLibrariesFn func(ctx context.Context, id, librariesJSON string, allLibraries bool) error
+	UpdatePluginLibrariesFn func(ctx context.Context, id, librariesJSON string, allLibraries, allowWriteAccess bool) error
 	// RescanPluginsFn is called when RescanPlugins is invoked. If nil, returns RescanError.
 	RescanPluginsFn func(ctx context.Context) error
 
@@ -48,9 +48,10 @@ type MockPluginManager struct {
 		AllUsers  bool
 	}
 	UpdatePluginLibrariesCalls []struct {
-		ID            string
-		LibrariesJSON string
-		AllLibraries  bool
+		ID               string
+		LibrariesJSON    string
+		AllLibraries     bool
+		AllowWriteAccess bool
 	}
 	RescanPluginsCalls int
 }
@@ -105,14 +106,15 @@ func (m *MockPluginManager) UpdatePluginUsers(ctx context.Context, id, usersJSON
 	return m.UsersError
 }
 
-func (m *MockPluginManager) UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries bool) error {
+func (m *MockPluginManager) UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries, allowWriteAccess bool) error {
 	m.UpdatePluginLibrariesCalls = append(m.UpdatePluginLibrariesCalls, struct {
-		ID            string
-		LibrariesJSON string
-		AllLibraries  bool
-	}{ID: id, LibrariesJSON: librariesJSON, AllLibraries: allLibraries})
+		ID               string
+		LibrariesJSON    string
+		AllLibraries     bool
+		AllowWriteAccess bool
+	}{ID: id, LibrariesJSON: librariesJSON, AllLibraries: allLibraries, AllowWriteAccess: allowWriteAccess})
 	if m.UpdatePluginLibrariesFn != nil {
-		return m.UpdatePluginLibrariesFn(ctx, id, librariesJSON, allLibraries)
+		return m.UpdatePluginLibrariesFn(ctx, id, librariesJSON, allLibraries, allowWriteAccess)
 	}
 	return m.LibrariesError
 }

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -355,7 +355,8 @@
         "allUsers": "Allow all users",
         "selectedUsers": "Selected users",
         "allLibraries": "Allow all libraries",
-        "selectedLibraries": "Selected libraries"
+        "selectedLibraries": "Selected libraries",
+        "allowWriteAccess": "Allow write access"
       },
       "sections": {
         "status": "Status",
@@ -400,6 +401,7 @@
         "allLibrariesHelp": "When enabled, the plugin will have access to all libraries, including those created in the future.",
         "noLibraries": "No libraries selected",
         "librariesRequired": "This plugin requires access to library information. Select which libraries the plugin can access, or enable 'Allow all libraries'.",
+        "allowWriteAccessHelp": "When enabled, the plugin can modify files in the library directories. By default, plugins have read-only access.",
         "requiredHosts": "Required hosts"
       },
       "placeholders": {

--- a/ui/src/plugin/LibraryPermissionCard.jsx
+++ b/ui/src/plugin/LibraryPermissionCard.jsx
@@ -23,8 +23,10 @@ export const LibraryPermissionCard = ({
   classes,
   selectedLibraries,
   allLibraries,
+  allowWriteAccess,
   onSelectedLibrariesChange,
   onAllLibrariesChange,
+  onAllowWriteAccessChange,
 }) => {
   const translate = useTranslate()
 
@@ -58,9 +60,17 @@ export const LibraryPermissionCard = ({
     [onAllLibrariesChange],
   )
 
+  const handleAllowWriteAccessToggle = React.useCallback(
+    (event) => {
+      onAllowWriteAccessChange(event.target.checked)
+    },
+    [onAllowWriteAccessChange],
+  )
+
   // Get permission reason from manifest
   const libraryPermission = manifest?.permissions?.library
   const reason = libraryPermission?.reason
+  const hasFilesystem = libraryPermission?.filesystem === true
 
   // Check if permission is required but not configured
   const isConfigurationRequired =
@@ -106,6 +116,24 @@ export const LibraryPermissionCard = ({
             {translate('resources.plugin.messages.allLibrariesHelp')}
           </Typography>
         </Box>
+
+        {hasFilesystem && (
+          <Box mb={2}>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={allowWriteAccess}
+                  onChange={handleAllowWriteAccessToggle}
+                  color="primary"
+                />
+              }
+              label={translate('resources.plugin.fields.allowWriteAccess')}
+            />
+            <Typography variant="body2" color="textSecondary">
+              {translate('resources.plugin.messages.allowWriteAccessHelp')}
+            </Typography>
+          </Box>
+        )}
 
         {!allLibraries && (
           <Box className={classes.usersList}>
@@ -166,6 +194,8 @@ LibraryPermissionCard.propTypes = {
   classes: PropTypes.object.isRequired,
   selectedLibraries: PropTypes.array.isRequired,
   allLibraries: PropTypes.bool.isRequired,
+  allowWriteAccess: PropTypes.bool.isRequired,
   onSelectedLibrariesChange: PropTypes.func.isRequired,
   onAllLibrariesChange: PropTypes.func.isRequired,
+  onAllowWriteAccessChange: PropTypes.func.isRequired,
 }

--- a/ui/src/plugin/PluginShow.jsx
+++ b/ui/src/plugin/PluginShow.jsx
@@ -48,8 +48,11 @@ const PluginShowLayout = () => {
   // Libraries permission state
   const [selectedLibraries, setSelectedLibraries] = useState([])
   const [allLibraries, setAllLibraries] = useState(false)
+  const [allowWriteAccess, setAllowWriteAccess] = useState(false)
   const [lastRecordLibraries, setLastRecordLibraries] = useState(null)
   const [lastRecordAllLibraries, setLastRecordAllLibraries] = useState(null)
+  const [lastRecordAllowWriteAccess, setLastRecordAllowWriteAccess] =
+    useState(null)
 
   // Parse JSON config to object
   const jsonToObject = useCallback((jsonString) => {
@@ -99,10 +102,12 @@ const PluginShowLayout = () => {
     if (record && !isDirty) {
       const recordLibraries = record.libraries || ''
       const recordAllLibraries = record.allLibraries || false
+      const recordAllowWriteAccess = record.allowWriteAccess || false
 
       if (
         recordLibraries !== lastRecordLibraries ||
-        recordAllLibraries !== lastRecordAllLibraries
+        recordAllLibraries !== lastRecordAllLibraries ||
+        recordAllowWriteAccess !== lastRecordAllowWriteAccess
       ) {
         try {
           setSelectedLibraries(
@@ -112,11 +117,19 @@ const PluginShowLayout = () => {
           setSelectedLibraries([])
         }
         setAllLibraries(recordAllLibraries)
+        setAllowWriteAccess(recordAllowWriteAccess)
         setLastRecordLibraries(recordLibraries)
         setLastRecordAllLibraries(recordAllLibraries)
+        setLastRecordAllowWriteAccess(recordAllowWriteAccess)
       }
     }
-  }, [record, lastRecordLibraries, lastRecordAllLibraries, isDirty])
+  }, [
+    record,
+    lastRecordLibraries,
+    lastRecordAllLibraries,
+    lastRecordAllowWriteAccess,
+    isDirty,
+  ])
 
   const handleConfigDataChange = useCallback(
     (newData, errors) => {
@@ -152,6 +165,11 @@ const PluginShowLayout = () => {
     setIsDirty(true)
   }, [])
 
+  const handleAllowWriteAccessChange = useCallback((newAllowWriteAccess) => {
+    setAllowWriteAccess(newAllowWriteAccess)
+    setIsDirty(true)
+  }, [])
+
   const [updatePlugin, { loading }] = useUpdate(
     'plugin',
     record?.id,
@@ -167,6 +185,7 @@ const PluginShowLayout = () => {
         setLastRecordAllUsers(null)
         setLastRecordLibraries(null)
         setLastRecordAllLibraries(null)
+        setLastRecordAllowWriteAccess(null)
         notify('resources.plugin.notifications.updated', 'info')
       },
       onFailure: (err) => {
@@ -199,6 +218,7 @@ const PluginShowLayout = () => {
     if (parsedManifest?.permissions?.library) {
       data.libraries = JSON.stringify(selectedLibraries)
       data.allLibraries = allLibraries
+      data.allowWriteAccess = allowWriteAccess
     }
 
     updatePlugin('plugin', record.id, data, record)
@@ -210,6 +230,7 @@ const PluginShowLayout = () => {
     allUsers,
     selectedLibraries,
     allLibraries,
+    allowWriteAccess,
   ])
 
   // Parse manifest
@@ -294,8 +315,10 @@ const PluginShowLayout = () => {
           classes={classes}
           selectedLibraries={selectedLibraries}
           allLibraries={allLibraries}
+          allowWriteAccess={allowWriteAccess}
           onSelectedLibrariesChange={handleSelectedLibrariesChange}
           onAllLibrariesChange={handleAllLibrariesChange}
+          onAllowWriteAccessChange={handleAllowWriteAccessChange}
         />
 
         <Box display="flex" justifyContent="flex-end">


### PR DESCRIPTION
## Description

Currently, when a plugin has the `library` permission with `filesystem: true`, all library directories are mounted as **read-write** in the WASM sandbox. This is a security concern — plugins should default to **read-only** access, and the admin must explicitly grant write access via the configuration UI.

This PR adds an `AllowWriteAccess` boolean to the plugin model (default `false`). When disabled, library directories are mounted using the extism `"ro:"` prefix for read-only access. Admins can grant write access through a new toggle in the Library Permission card, which only appears when the plugin's manifest declares `filesystem: true`.

### Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start the dev server with `make dev`
2. Install a plugin that declares `library` + `filesystem: true` permissions
3. Open the plugin's settings page
4. Verify the "Allow write access" toggle appears in the Library Permission card (default: off)
5. With the toggle off, verify logs show library paths mounted with `"ro:"` prefix (read-only)
6. Enable the toggle, save, and verify the plugin reloads with read-write mounts (no `"ro:"` prefix)
7. Run `make test PKG=./plugins/...` — the new `buildAllowedPaths` tests verify read-only/read-write path construction

### Additional Notes

- The extism Go SDK supports a `"ro:"` prefix on `AllowedPaths` keys to mount directories as read-only
- The toggle is only shown when the plugin's manifest has `filesystem: true` in library permissions
- Translations added for both English and Portuguese (BR)
- The path-building logic was extracted into a `buildAllowedPaths` function with unit tests covering read-only, read-write, selected libraries, all libraries, and edge cases
