### PR TITLE
feat(plugins): add TTL support, batch operations, and hardening to kvstore

### DIFF
--- a/plugins/host/kvstore.go
+++ b/plugins/host/kvstore.go
@@ -86,7 +86,7 @@ type KVStoreService interface {
 	// DeleteByPrefix removes all keys matching the given prefix.
 	//
 	// Parameters:
-	//   - prefix: Key prefix to match (empty string deletes ALL keys)
+	//   - prefix: Key prefix to match (must not be empty)
 	//
 	// Returns the number of keys deleted. Includes expired keys.
 	//nd:hostfunc

--- a/plugins/host/kvstore.go
+++ b/plugins/host/kvstore.go
@@ -62,4 +62,37 @@ type KVStoreService interface {
 	// GetStorageUsed returns the total storage used by this plugin in bytes.
 	//nd:hostfunc
 	GetStorageUsed(ctx context.Context) (bytes int64, err error)
+
+	// SetWithTTL stores a byte value with the given key and a time-to-live.
+	//
+	// After ttlSeconds, the key is treated as non-existent and will be
+	// cleaned up lazily. ttlSeconds must be greater than 0.
+	//
+	// Parameters:
+	//   - key: The storage key (max 256 bytes, UTF-8)
+	//   - value: The byte slice to store
+	//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+	//
+	// Returns an error if the storage limit would be exceeded or the operation fails.
+	//nd:hostfunc
+	SetWithTTL(ctx context.Context, key string, value []byte, ttlSeconds int64) error
+
+	// DeleteByPrefix removes all keys matching the given prefix.
+	//
+	// Parameters:
+	//   - prefix: Key prefix to match (empty string deletes ALL keys)
+	//
+	// Returns the number of keys deleted. Includes expired keys.
+	//nd:hostfunc
+	DeleteByPrefix(ctx context.Context, prefix string) (deletedCount int64, err error)
+
+	// GetMany retrieves multiple values in a single call.
+	//
+	// Parameters:
+	//   - keys: The storage keys to retrieve
+	//
+	// Returns a map of key to value for keys that exist and have not expired.
+	// Missing or expired keys are omitted from the result.
+	//nd:hostfunc
+	GetMany(ctx context.Context, keys []string) (values map[string][]byte, err error)
 }

--- a/plugins/host/kvstore.go
+++ b/plugins/host/kvstore.go
@@ -23,6 +23,20 @@ type KVStoreService interface {
 	//nd:hostfunc
 	Set(ctx context.Context, key string, value []byte) error
 
+	// SetWithTTL stores a byte value with the given key and a time-to-live.
+	//
+	// After ttlSeconds, the key is treated as non-existent and will be
+	// cleaned up lazily. ttlSeconds must be greater than 0.
+	//
+	// Parameters:
+	//   - key: The storage key (max 256 bytes, UTF-8)
+	//   - value: The byte slice to store
+	//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+	//
+	// Returns an error if the storage limit would be exceeded or the operation fails.
+	//nd:hostfunc
+	SetWithTTL(ctx context.Context, key string, value []byte, ttlSeconds int64) error
+
 	// Get retrieves a byte value from storage.
 	//
 	// Parameters:
@@ -32,14 +46,15 @@ type KVStoreService interface {
 	//nd:hostfunc
 	Get(ctx context.Context, key string) (value []byte, exists bool, err error)
 
-	// Delete removes a value from storage.
+	// GetMany retrieves multiple values in a single call.
 	//
 	// Parameters:
-	//   - key: The storage key
+	//   - keys: The storage keys to retrieve
 	//
-	// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
+	// Returns a map of key to value for keys that exist and have not expired.
+	// Missing or expired keys are omitted from the result.
 	//nd:hostfunc
-	Delete(ctx context.Context, key string) error
+	GetMany(ctx context.Context, keys []string) (values map[string][]byte, err error)
 
 	// Has checks if a key exists in storage.
 	//
@@ -59,23 +74,14 @@ type KVStoreService interface {
 	//nd:hostfunc
 	List(ctx context.Context, prefix string) (keys []string, err error)
 
-	// GetStorageUsed returns the total storage used by this plugin in bytes.
-	//nd:hostfunc
-	GetStorageUsed(ctx context.Context) (bytes int64, err error)
-
-	// SetWithTTL stores a byte value with the given key and a time-to-live.
-	//
-	// After ttlSeconds, the key is treated as non-existent and will be
-	// cleaned up lazily. ttlSeconds must be greater than 0.
+	// Delete removes a value from storage.
 	//
 	// Parameters:
-	//   - key: The storage key (max 256 bytes, UTF-8)
-	//   - value: The byte slice to store
-	//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+	//   - key: The storage key
 	//
-	// Returns an error if the storage limit would be exceeded or the operation fails.
+	// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
 	//nd:hostfunc
-	SetWithTTL(ctx context.Context, key string, value []byte, ttlSeconds int64) error
+	Delete(ctx context.Context, key string) error
 
 	// DeleteByPrefix removes all keys matching the given prefix.
 	//
@@ -86,13 +92,7 @@ type KVStoreService interface {
 	//nd:hostfunc
 	DeleteByPrefix(ctx context.Context, prefix string) (deletedCount int64, err error)
 
-	// GetMany retrieves multiple values in a single call.
-	//
-	// Parameters:
-	//   - keys: The storage keys to retrieve
-	//
-	// Returns a map of key to value for keys that exist and have not expired.
-	// Missing or expired keys are omitted from the result.
+	// GetStorageUsed returns the total storage used by this plugin in bytes.
 	//nd:hostfunc
-	GetMany(ctx context.Context, keys []string) (values map[string][]byte, err error)
+	GetStorageUsed(ctx context.Context) (bytes int64, err error)
 }

--- a/plugins/host_kvstore.go
+++ b/plugins/host_kvstore.go
@@ -347,7 +347,7 @@ func (s *kvstoreServiceImpl) DeleteByPrefix(ctx context.Context, prefix string) 
 	if err != nil {
 		return 0, fmt.Errorf("starting transaction: %w", err)
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 
 	var totalSize int64
 	var count int64
@@ -401,7 +401,7 @@ func (s *kvstoreServiceImpl) GetMany(ctx context.Context, keys []string) (map[st
 		args[i] = key
 	}
 
-	query := `SELECT key, value FROM kvstore WHERE key IN (` + strings.Join(placeholders, ",") + `) AND (expires_at IS NULL OR expires_at > datetime('now'))`
+	query := `SELECT key, value FROM kvstore WHERE key IN (` + strings.Join(placeholders, ",") + `) AND (expires_at IS NULL OR expires_at > datetime('now'))` //nolint:gosec // placeholders are always "?"
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("querying values: %w", err)

--- a/plugins/host_kvstore_test.go
+++ b/plugins/host_kvstore_test.go
@@ -5,6 +5,7 @@ package plugins
 import (
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -341,6 +342,51 @@ var _ = Describe("KVStoreService", func() {
 			// After close, operations should fail
 			_, _, err = service.Get(ctx, "any")
 			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("Schema Migration", func() {
+		It("adds expires_at column to existing databases without it", func() {
+			// Close the service that was auto-created in BeforeEach
+			service.Close()
+
+			// Create a legacy database manually (without expires_at column)
+			dataDir := filepath.Join(tmpDir, "plugins", "legacy_plugin")
+			Expect(os.MkdirAll(dataDir, 0700)).To(Succeed())
+			dbPath := filepath.Join(dataDir, "kvstore.db")
+
+			legacyDB, err := sql.Open("sqlite3", dbPath+"?_journal_mode=WAL")
+			Expect(err).ToNot(HaveOccurred())
+			_, err = legacyDB.Exec(`
+				CREATE TABLE kvstore (
+					key TEXT PRIMARY KEY NOT NULL,
+					value BLOB NOT NULL,
+					size INTEGER NOT NULL,
+					created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+					updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+				)
+			`)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = legacyDB.Exec(`INSERT INTO kvstore (key, value, size) VALUES ('old_key', 'old_value', 9)`)
+			Expect(err).ToNot(HaveOccurred())
+			legacyDB.Close()
+
+			// Open with new service — should migrate schema
+			maxSize := "1KB"
+			service, err = newKVStoreService("legacy_plugin", &KVStorePermission{MaxSize: &maxSize})
+			Expect(err).ToNot(HaveOccurred())
+
+			// Old data should still be accessible
+			value, exists, err := service.Get(ctx, "old_key")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(exists).To(BeTrue())
+			Expect(value).To(Equal([]byte("old_value")))
+
+			// expires_at should be NULL for old data (no expiration)
+			var expiresAt sql.NullTime
+			err = service.db.QueryRow(`SELECT expires_at FROM kvstore WHERE key = 'old_key'`).Scan(&expiresAt)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(expiresAt.Valid).To(BeFalse())
 		})
 	})
 })

--- a/plugins/host_kvstore_test.go
+++ b/plugins/host_kvstore_test.go
@@ -38,7 +38,7 @@ var _ = Describe("KVStoreService", func() {
 
 		// Create service with 1KB limit for testing
 		maxSize := "1KB"
-		service, err = newKVStoreService("test_plugin", &KVStorePermission{MaxSize: &maxSize})
+		service, err = newKVStoreService(ctx, "test_plugin", &KVStorePermission{MaxSize: &maxSize})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
@@ -254,7 +254,7 @@ var _ = Describe("KVStoreService", func() {
 			Expect(service.Close()).To(Succeed())
 
 			maxSize := "1KB"
-			service2, err := newKVStoreService("test_plugin", &KVStorePermission{MaxSize: &maxSize})
+			service2, err := newKVStoreService(ctx, "test_plugin", &KVStorePermission{MaxSize: &maxSize})
 			Expect(err).ToNot(HaveOccurred())
 			defer service2.Close()
 
@@ -303,7 +303,7 @@ var _ = Describe("KVStoreService", func() {
 
 	Describe("Plugin Isolation", func() {
 		It("isolates data between plugins", func() {
-			service2, err := newKVStoreService("other_plugin", &KVStorePermission{})
+			service2, err := newKVStoreService(ctx, "other_plugin", &KVStorePermission{})
 			Expect(err).ToNot(HaveOccurred())
 			defer service2.Close()
 
@@ -322,7 +322,7 @@ var _ = Describe("KVStoreService", func() {
 		})
 
 		It("creates separate database files per plugin", func() {
-			service2, err := newKVStoreService("other_plugin", &KVStorePermission{})
+			service2, err := newKVStoreService(ctx, "other_plugin", &KVStorePermission{})
 			Expect(err).ToNot(HaveOccurred())
 			defer service2.Close()
 

--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -103,7 +103,7 @@ var hostServices = []hostServiceEntry{
 		hasPermission: func(p *Permissions) bool { return p != nil && p.Kvstore != nil },
 		create: func(ctx *serviceContext) ([]extism.HostFunction, io.Closer) {
 			perm := ctx.permissions.Kvstore
-			service, err := newKVStoreService(ctx.pluginName, perm)
+			service, err := newKVStoreService(ctx.manager.ctx, ctx.pluginName, perm)
 			if err != nil {
 				log.Error("Failed to create KVStore service", "plugin", ctx.pluginName, err)
 				return nil, nil

--- a/plugins/migrate.go
+++ b/plugins/migrate.go
@@ -1,0 +1,47 @@
+package plugins
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+// migrateDB applies schema migrations to a SQLite database.
+//
+// Each entry in migrations is a single SQL statement. The current schema version
+// is tracked using SQLite's built-in PRAGMA user_version. Only statements after
+// the current version are executed, within a single transaction.
+func migrateDB(db *sql.DB, migrations []string) error {
+	var version int
+	if err := db.QueryRow(`PRAGMA user_version`).Scan(&version); err != nil {
+		return fmt.Errorf("reading schema version: %w", err)
+	}
+
+	if version >= len(migrations) {
+		return nil
+	}
+
+	tx, err := db.Begin()
+	if err != nil {
+		return fmt.Errorf("starting migration transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	for i := version; i < len(migrations); i++ {
+		if _, err := tx.Exec(migrations[i]); err != nil {
+			return fmt.Errorf("migration %d failed: %w", i+1, err)
+		}
+	}
+
+	// PRAGMA statements cannot be executed inside a transaction in some SQLite
+	// drivers, but with mattn/go-sqlite3 this works. We set it inside the tx
+	// so that a failed commit leaves the version unchanged.
+	if _, err := tx.Exec(fmt.Sprintf(`PRAGMA user_version = %d`, len(migrations))); err != nil {
+		return fmt.Errorf("updating schema version: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("committing migrations: %w", err)
+	}
+
+	return nil
+}

--- a/plugins/migrate_test.go
+++ b/plugins/migrate_test.go
@@ -1,0 +1,99 @@
+//go:build !windows
+
+package plugins
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("migrateDB", func() {
+	var db *sql.DB
+
+	BeforeEach(func() {
+		var err error
+		db, err = sql.Open("sqlite3", ":memory:")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if db != nil {
+			db.Close()
+		}
+	})
+
+	getUserVersion := func() int {
+		var version int
+		Expect(db.QueryRow(`PRAGMA user_version`).Scan(&version)).To(Succeed())
+		return version
+	}
+
+	It("applies all migrations on a fresh database", func() {
+		migrations := []string{
+			`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`,
+			`ALTER TABLE test ADD COLUMN email TEXT`,
+		}
+
+		Expect(migrateDB(db, migrations)).To(Succeed())
+		Expect(getUserVersion()).To(Equal(2))
+
+		// Verify schema
+		_, err := db.Exec(`INSERT INTO test (id, name, email) VALUES (1, 'Alice', 'alice@test.com')`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("skips already applied migrations", func() {
+		migrations1 := []string{
+			`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`,
+		}
+		Expect(migrateDB(db, migrations1)).To(Succeed())
+		Expect(getUserVersion()).To(Equal(1))
+
+		// Add a new migration
+		migrations2 := []string{
+			`CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)`,
+			`ALTER TABLE test ADD COLUMN email TEXT`,
+		}
+		Expect(migrateDB(db, migrations2)).To(Succeed())
+		Expect(getUserVersion()).To(Equal(2))
+
+		// Verify the new column exists
+		_, err := db.Exec(`INSERT INTO test (id, name, email) VALUES (1, 'Alice', 'alice@test.com')`)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("is a no-op when all migrations are applied", func() {
+		migrations := []string{
+			`CREATE TABLE test (id INTEGER PRIMARY KEY)`,
+		}
+		Expect(migrateDB(db, migrations)).To(Succeed())
+		Expect(migrateDB(db, migrations)).To(Succeed())
+		Expect(getUserVersion()).To(Equal(1))
+	})
+
+	It("is a no-op with empty migrations slice", func() {
+		Expect(migrateDB(db, nil)).To(Succeed())
+		Expect(getUserVersion()).To(Equal(0))
+	})
+
+	It("rolls back on failure", func() {
+		migrations := []string{
+			`CREATE TABLE test (id INTEGER PRIMARY KEY)`,
+			`INVALID SQL STATEMENT`,
+		}
+
+		err := migrateDB(db, migrations)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("migration 2 failed"))
+
+		// Version should remain 0 (rolled back)
+		Expect(getUserVersion()).To(Equal(0))
+
+		// Table should not exist (rolled back)
+		_, err = db.Exec(`INSERT INTO test (id) VALUES (1)`)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/plugins/pdk/go/host/nd_host_kvstore.go
+++ b/plugins/pdk/go/host/nd_host_kvstore.go
@@ -416,7 +416,7 @@ func KVStoreDelete(key string) error {
 // DeleteByPrefix removes all keys matching the given prefix.
 //
 // Parameters:
-//   - prefix: Key prefix to match (empty string deletes ALL keys)
+//   - prefix: Key prefix to match (must not be empty)
 //
 // Returns the number of keys deleted. Includes expired keys.
 func KVStoreDeleteByPrefix(prefix string) (int64, error) {

--- a/plugins/pdk/go/host/nd_host_kvstore.go
+++ b/plugins/pdk/go/host/nd_host_kvstore.go
@@ -19,15 +19,20 @@ import (
 //go:wasmimport extism:host/user kvstore_set
 func kvstore_set(uint64) uint64
 
+// kvstore_setwithttl is the host function provided by Navidrome.
+//
+//go:wasmimport extism:host/user kvstore_setwithttl
+func kvstore_setwithttl(uint64) uint64
+
 // kvstore_get is the host function provided by Navidrome.
 //
 //go:wasmimport extism:host/user kvstore_get
 func kvstore_get(uint64) uint64
 
-// kvstore_delete is the host function provided by Navidrome.
+// kvstore_getmany is the host function provided by Navidrome.
 //
-//go:wasmimport extism:host/user kvstore_delete
-func kvstore_delete(uint64) uint64
+//go:wasmimport extism:host/user kvstore_getmany
+func kvstore_getmany(uint64) uint64
 
 // kvstore_has is the host function provided by Navidrome.
 //
@@ -39,29 +44,30 @@ func kvstore_has(uint64) uint64
 //go:wasmimport extism:host/user kvstore_list
 func kvstore_list(uint64) uint64
 
-// kvstore_getstorageused is the host function provided by Navidrome.
+// kvstore_delete is the host function provided by Navidrome.
 //
-//go:wasmimport extism:host/user kvstore_getstorageused
-func kvstore_getstorageused(uint64) uint64
-
-// kvstore_setwithttl is the host function provided by Navidrome.
-//
-//go:wasmimport extism:host/user kvstore_setwithttl
-func kvstore_setwithttl(uint64) uint64
+//go:wasmimport extism:host/user kvstore_delete
+func kvstore_delete(uint64) uint64
 
 // kvstore_deletebyprefix is the host function provided by Navidrome.
 //
 //go:wasmimport extism:host/user kvstore_deletebyprefix
 func kvstore_deletebyprefix(uint64) uint64
 
-// kvstore_getmany is the host function provided by Navidrome.
+// kvstore_getstorageused is the host function provided by Navidrome.
 //
-//go:wasmimport extism:host/user kvstore_getmany
-func kvstore_getmany(uint64) uint64
+//go:wasmimport extism:host/user kvstore_getstorageused
+func kvstore_getstorageused(uint64) uint64
 
 type kVStoreSetRequest struct {
 	Key   string `json:"key"`
 	Value []byte `json:"value"`
+}
+
+type kVStoreSetWithTTLRequest struct {
+	Key        string `json:"key"`
+	Value      []byte `json:"value"`
+	TtlSeconds int64  `json:"ttlSeconds"`
 }
 
 type kVStoreGetRequest struct {
@@ -74,8 +80,13 @@ type kVStoreGetResponse struct {
 	Error  string `json:"error,omitempty"`
 }
 
-type kVStoreDeleteRequest struct {
-	Key string `json:"key"`
+type kVStoreGetManyRequest struct {
+	Keys []string `json:"keys"`
+}
+
+type kVStoreGetManyResponse struct {
+	Values map[string][]byte `json:"values,omitempty"`
+	Error  string            `json:"error,omitempty"`
 }
 
 type kVStoreHasRequest struct {
@@ -96,15 +107,8 @@ type kVStoreListResponse struct {
 	Error string   `json:"error,omitempty"`
 }
 
-type kVStoreGetStorageUsedResponse struct {
-	Bytes int64  `json:"bytes,omitempty"`
-	Error string `json:"error,omitempty"`
-}
-
-type kVStoreSetWithTTLRequest struct {
-	Key        string `json:"key"`
-	Value      []byte `json:"value"`
-	TtlSeconds int64  `json:"ttlSeconds"`
+type kVStoreDeleteRequest struct {
+	Key string `json:"key"`
 }
 
 type kVStoreDeleteByPrefixRequest struct {
@@ -116,13 +120,9 @@ type kVStoreDeleteByPrefixResponse struct {
 	Error        string `json:"error,omitempty"`
 }
 
-type kVStoreGetManyRequest struct {
-	Keys []string `json:"keys"`
-}
-
-type kVStoreGetManyResponse struct {
-	Values map[string][]byte `json:"values,omitempty"`
-	Error  string            `json:"error,omitempty"`
+type kVStoreGetStorageUsedResponse struct {
+	Bytes int64  `json:"bytes,omitempty"`
+	Error string `json:"error,omitempty"`
 }
 
 // KVStoreSet calls the kvstore_set host function.
@@ -148,6 +148,52 @@ func KVStoreSet(key string, value []byte) error {
 
 	// Call the host function
 	responsePtr := kvstore_set(reqMem.Offset())
+
+	// Read the response from memory
+	responseMem := pdk.FindMemory(responsePtr)
+	responseBytes := responseMem.ReadBytes()
+
+	// Parse error-only response
+	var response struct {
+		Error string `json:"error,omitempty"`
+	}
+	if err := json.Unmarshal(responseBytes, &response); err != nil {
+		return err
+	}
+	if response.Error != "" {
+		return errors.New(response.Error)
+	}
+	return nil
+}
+
+// KVStoreSetWithTTL calls the kvstore_setwithttl host function.
+// SetWithTTL stores a byte value with the given key and a time-to-live.
+//
+// After ttlSeconds, the key is treated as non-existent and will be
+// cleaned up lazily. ttlSeconds must be greater than 0.
+//
+// Parameters:
+//   - key: The storage key (max 256 bytes, UTF-8)
+//   - value: The byte slice to store
+//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+//
+// Returns an error if the storage limit would be exceeded or the operation fails.
+func KVStoreSetWithTTL(key string, value []byte, ttlSeconds int64) error {
+	// Marshal request to JSON
+	req := kVStoreSetWithTTLRequest{
+		Key:        key,
+		Value:      value,
+		TtlSeconds: ttlSeconds,
+	}
+	reqBytes, err := json.Marshal(req)
+	if err != nil {
+		return err
+	}
+	reqMem := pdk.AllocateBytes(reqBytes)
+	defer reqMem.Free()
+
+	// Call the host function
+	responsePtr := kvstore_setwithttl(reqMem.Offset())
 
 	// Read the response from memory
 	responseMem := pdk.FindMemory(responsePtr)
@@ -206,43 +252,45 @@ func KVStoreGet(key string) ([]byte, bool, error) {
 	return response.Value, response.Exists, nil
 }
 
-// KVStoreDelete calls the kvstore_delete host function.
-// Delete removes a value from storage.
+// KVStoreGetMany calls the kvstore_getmany host function.
+// GetMany retrieves multiple values in a single call.
 //
 // Parameters:
-//   - key: The storage key
+//   - keys: The storage keys to retrieve
 //
-// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
-func KVStoreDelete(key string) error {
+// Returns a map of key to value for keys that exist and have not expired.
+// Missing or expired keys are omitted from the result.
+func KVStoreGetMany(keys []string) (map[string][]byte, error) {
 	// Marshal request to JSON
-	req := kVStoreDeleteRequest{
-		Key: key,
+	req := kVStoreGetManyRequest{
+		Keys: keys,
 	}
 	reqBytes, err := json.Marshal(req)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	reqMem := pdk.AllocateBytes(reqBytes)
 	defer reqMem.Free()
 
 	// Call the host function
-	responsePtr := kvstore_delete(reqMem.Offset())
+	responsePtr := kvstore_getmany(reqMem.Offset())
 
 	// Read the response from memory
 	responseMem := pdk.FindMemory(responsePtr)
 	responseBytes := responseMem.ReadBytes()
 
-	// Parse error-only response
-	var response struct {
-		Error string `json:"error,omitempty"`
-	}
+	// Parse the response
+	var response kVStoreGetManyResponse
 	if err := json.Unmarshal(responseBytes, &response); err != nil {
-		return err
+		return nil, err
 	}
+
+	// Convert Error field to Go error
 	if response.Error != "" {
-		return errors.New(response.Error)
+		return nil, errors.New(response.Error)
 	}
-	return nil
+
+	return response.Values, nil
 }
 
 // KVStoreHas calls the kvstore_has host function.
@@ -325,52 +373,17 @@ func KVStoreList(prefix string) ([]string, error) {
 	return response.Keys, nil
 }
 
-// KVStoreGetStorageUsed calls the kvstore_getstorageused host function.
-// GetStorageUsed returns the total storage used by this plugin in bytes.
-func KVStoreGetStorageUsed() (int64, error) {
-	// No parameters - allocate empty JSON object
-	reqMem := pdk.AllocateBytes([]byte("{}"))
-	defer reqMem.Free()
-
-	// Call the host function
-	responsePtr := kvstore_getstorageused(reqMem.Offset())
-
-	// Read the response from memory
-	responseMem := pdk.FindMemory(responsePtr)
-	responseBytes := responseMem.ReadBytes()
-
-	// Parse the response
-	var response kVStoreGetStorageUsedResponse
-	if err := json.Unmarshal(responseBytes, &response); err != nil {
-		return 0, err
-	}
-
-	// Convert Error field to Go error
-	if response.Error != "" {
-		return 0, errors.New(response.Error)
-	}
-
-	return response.Bytes, nil
-}
-
-// KVStoreSetWithTTL calls the kvstore_setwithttl host function.
-// SetWithTTL stores a byte value with the given key and a time-to-live.
-//
-// After ttlSeconds, the key is treated as non-existent and will be
-// cleaned up lazily. ttlSeconds must be greater than 0.
+// KVStoreDelete calls the kvstore_delete host function.
+// Delete removes a value from storage.
 //
 // Parameters:
-//   - key: The storage key (max 256 bytes, UTF-8)
-//   - value: The byte slice to store
-//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+//   - key: The storage key
 //
-// Returns an error if the storage limit would be exceeded or the operation fails.
-func KVStoreSetWithTTL(key string, value []byte, ttlSeconds int64) error {
+// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
+func KVStoreDelete(key string) error {
 	// Marshal request to JSON
-	req := kVStoreSetWithTTLRequest{
-		Key:        key,
-		Value:      value,
-		TtlSeconds: ttlSeconds,
+	req := kVStoreDeleteRequest{
+		Key: key,
 	}
 	reqBytes, err := json.Marshal(req)
 	if err != nil {
@@ -380,7 +393,7 @@ func KVStoreSetWithTTL(key string, value []byte, ttlSeconds int64) error {
 	defer reqMem.Free()
 
 	// Call the host function
-	responsePtr := kvstore_setwithttl(reqMem.Offset())
+	responsePtr := kvstore_delete(reqMem.Offset())
 
 	// Read the response from memory
 	responseMem := pdk.FindMemory(responsePtr)
@@ -439,43 +452,30 @@ func KVStoreDeleteByPrefix(prefix string) (int64, error) {
 	return response.DeletedCount, nil
 }
 
-// KVStoreGetMany calls the kvstore_getmany host function.
-// GetMany retrieves multiple values in a single call.
-//
-// Parameters:
-//   - keys: The storage keys to retrieve
-//
-// Returns a map of key to value for keys that exist and have not expired.
-// Missing or expired keys are omitted from the result.
-func KVStoreGetMany(keys []string) (map[string][]byte, error) {
-	// Marshal request to JSON
-	req := kVStoreGetManyRequest{
-		Keys: keys,
-	}
-	reqBytes, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
-	}
-	reqMem := pdk.AllocateBytes(reqBytes)
+// KVStoreGetStorageUsed calls the kvstore_getstorageused host function.
+// GetStorageUsed returns the total storage used by this plugin in bytes.
+func KVStoreGetStorageUsed() (int64, error) {
+	// No parameters - allocate empty JSON object
+	reqMem := pdk.AllocateBytes([]byte("{}"))
 	defer reqMem.Free()
 
 	// Call the host function
-	responsePtr := kvstore_getmany(reqMem.Offset())
+	responsePtr := kvstore_getstorageused(reqMem.Offset())
 
 	// Read the response from memory
 	responseMem := pdk.FindMemory(responsePtr)
 	responseBytes := responseMem.ReadBytes()
 
 	// Parse the response
-	var response kVStoreGetManyResponse
+	var response kVStoreGetStorageUsedResponse
 	if err := json.Unmarshal(responseBytes, &response); err != nil {
-		return nil, err
+		return 0, err
 	}
 
 	// Convert Error field to Go error
 	if response.Error != "" {
-		return nil, errors.New(response.Error)
+		return 0, errors.New(response.Error)
 	}
 
-	return response.Values, nil
+	return response.Bytes, nil
 }

--- a/plugins/pdk/go/host/nd_host_kvstore_stub.go
+++ b/plugins/pdk/go/host/nd_host_kvstore_stub.go
@@ -37,6 +37,28 @@ func KVStoreSet(key string, value []byte) error {
 	return KVStoreMock.Set(key, value)
 }
 
+// SetWithTTL is the mock method for KVStoreSetWithTTL.
+func (m *mockKVStoreService) SetWithTTL(key string, value []byte, ttlSeconds int64) error {
+	args := m.Called(key, value, ttlSeconds)
+	return args.Error(0)
+}
+
+// KVStoreSetWithTTL delegates to the mock instance.
+// SetWithTTL stores a byte value with the given key and a time-to-live.
+//
+// After ttlSeconds, the key is treated as non-existent and will be
+// cleaned up lazily. ttlSeconds must be greater than 0.
+//
+// Parameters:
+//   - key: The storage key (max 256 bytes, UTF-8)
+//   - value: The byte slice to store
+//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+//
+// Returns an error if the storage limit would be exceeded or the operation fails.
+func KVStoreSetWithTTL(key string, value []byte, ttlSeconds int64) error {
+	return KVStoreMock.SetWithTTL(key, value, ttlSeconds)
+}
+
 // Get is the mock method for KVStoreGet.
 func (m *mockKVStoreService) Get(key string) ([]byte, bool, error) {
 	args := m.Called(key)
@@ -54,21 +76,22 @@ func KVStoreGet(key string) ([]byte, bool, error) {
 	return KVStoreMock.Get(key)
 }
 
-// Delete is the mock method for KVStoreDelete.
-func (m *mockKVStoreService) Delete(key string) error {
-	args := m.Called(key)
-	return args.Error(0)
+// GetMany is the mock method for KVStoreGetMany.
+func (m *mockKVStoreService) GetMany(keys []string) (map[string][]byte, error) {
+	args := m.Called(keys)
+	return args.Get(0).(map[string][]byte), args.Error(1)
 }
 
-// KVStoreDelete delegates to the mock instance.
-// Delete removes a value from storage.
+// KVStoreGetMany delegates to the mock instance.
+// GetMany retrieves multiple values in a single call.
 //
 // Parameters:
-//   - key: The storage key
+//   - keys: The storage keys to retrieve
 //
-// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
-func KVStoreDelete(key string) error {
-	return KVStoreMock.Delete(key)
+// Returns a map of key to value for keys that exist and have not expired.
+// Missing or expired keys are omitted from the result.
+func KVStoreGetMany(keys []string) (map[string][]byte, error) {
+	return KVStoreMock.GetMany(keys)
 }
 
 // Has is the mock method for KVStoreHas.
@@ -105,38 +128,21 @@ func KVStoreList(prefix string) ([]string, error) {
 	return KVStoreMock.List(prefix)
 }
 
-// GetStorageUsed is the mock method for KVStoreGetStorageUsed.
-func (m *mockKVStoreService) GetStorageUsed() (int64, error) {
-	args := m.Called()
-	return args.Get(0).(int64), args.Error(1)
-}
-
-// KVStoreGetStorageUsed delegates to the mock instance.
-// GetStorageUsed returns the total storage used by this plugin in bytes.
-func KVStoreGetStorageUsed() (int64, error) {
-	return KVStoreMock.GetStorageUsed()
-}
-
-// SetWithTTL is the mock method for KVStoreSetWithTTL.
-func (m *mockKVStoreService) SetWithTTL(key string, value []byte, ttlSeconds int64) error {
-	args := m.Called(key, value, ttlSeconds)
+// Delete is the mock method for KVStoreDelete.
+func (m *mockKVStoreService) Delete(key string) error {
+	args := m.Called(key)
 	return args.Error(0)
 }
 
-// KVStoreSetWithTTL delegates to the mock instance.
-// SetWithTTL stores a byte value with the given key and a time-to-live.
-//
-// After ttlSeconds, the key is treated as non-existent and will be
-// cleaned up lazily. ttlSeconds must be greater than 0.
+// KVStoreDelete delegates to the mock instance.
+// Delete removes a value from storage.
 //
 // Parameters:
-//   - key: The storage key (max 256 bytes, UTF-8)
-//   - value: The byte slice to store
-//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+//   - key: The storage key
 //
-// Returns an error if the storage limit would be exceeded or the operation fails.
-func KVStoreSetWithTTL(key string, value []byte, ttlSeconds int64) error {
-	return KVStoreMock.SetWithTTL(key, value, ttlSeconds)
+// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
+func KVStoreDelete(key string) error {
+	return KVStoreMock.Delete(key)
 }
 
 // DeleteByPrefix is the mock method for KVStoreDeleteByPrefix.
@@ -156,20 +162,14 @@ func KVStoreDeleteByPrefix(prefix string) (int64, error) {
 	return KVStoreMock.DeleteByPrefix(prefix)
 }
 
-// GetMany is the mock method for KVStoreGetMany.
-func (m *mockKVStoreService) GetMany(keys []string) (map[string][]byte, error) {
-	args := m.Called(keys)
-	return args.Get(0).(map[string][]byte), args.Error(1)
+// GetStorageUsed is the mock method for KVStoreGetStorageUsed.
+func (m *mockKVStoreService) GetStorageUsed() (int64, error) {
+	args := m.Called()
+	return args.Get(0).(int64), args.Error(1)
 }
 
-// KVStoreGetMany delegates to the mock instance.
-// GetMany retrieves multiple values in a single call.
-//
-// Parameters:
-//   - keys: The storage keys to retrieve
-//
-// Returns a map of key to value for keys that exist and have not expired.
-// Missing or expired keys are omitted from the result.
-func KVStoreGetMany(keys []string) (map[string][]byte, error) {
-	return KVStoreMock.GetMany(keys)
+// KVStoreGetStorageUsed delegates to the mock instance.
+// GetStorageUsed returns the total storage used by this plugin in bytes.
+func KVStoreGetStorageUsed() (int64, error) {
+	return KVStoreMock.GetStorageUsed()
 }

--- a/plugins/pdk/go/host/nd_host_kvstore_stub.go
+++ b/plugins/pdk/go/host/nd_host_kvstore_stub.go
@@ -155,7 +155,7 @@ func (m *mockKVStoreService) DeleteByPrefix(prefix string) (int64, error) {
 // DeleteByPrefix removes all keys matching the given prefix.
 //
 // Parameters:
-//   - prefix: Key prefix to match (empty string deletes ALL keys)
+//   - prefix: Key prefix to match (must not be empty)
 //
 // Returns the number of keys deleted. Includes expired keys.
 func KVStoreDeleteByPrefix(prefix string) (int64, error) {

--- a/plugins/pdk/go/host/nd_host_kvstore_stub.go
+++ b/plugins/pdk/go/host/nd_host_kvstore_stub.go
@@ -116,3 +116,60 @@ func (m *mockKVStoreService) GetStorageUsed() (int64, error) {
 func KVStoreGetStorageUsed() (int64, error) {
 	return KVStoreMock.GetStorageUsed()
 }
+
+// SetWithTTL is the mock method for KVStoreSetWithTTL.
+func (m *mockKVStoreService) SetWithTTL(key string, value []byte, ttlSeconds int64) error {
+	args := m.Called(key, value, ttlSeconds)
+	return args.Error(0)
+}
+
+// KVStoreSetWithTTL delegates to the mock instance.
+// SetWithTTL stores a byte value with the given key and a time-to-live.
+//
+// After ttlSeconds, the key is treated as non-existent and will be
+// cleaned up lazily. ttlSeconds must be greater than 0.
+//
+// Parameters:
+//   - key: The storage key (max 256 bytes, UTF-8)
+//   - value: The byte slice to store
+//   - ttlSeconds: Time-to-live in seconds (must be > 0)
+//
+// Returns an error if the storage limit would be exceeded or the operation fails.
+func KVStoreSetWithTTL(key string, value []byte, ttlSeconds int64) error {
+	return KVStoreMock.SetWithTTL(key, value, ttlSeconds)
+}
+
+// DeleteByPrefix is the mock method for KVStoreDeleteByPrefix.
+func (m *mockKVStoreService) DeleteByPrefix(prefix string) (int64, error) {
+	args := m.Called(prefix)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+// KVStoreDeleteByPrefix delegates to the mock instance.
+// DeleteByPrefix removes all keys matching the given prefix.
+//
+// Parameters:
+//   - prefix: Key prefix to match (empty string deletes ALL keys)
+//
+// Returns the number of keys deleted. Includes expired keys.
+func KVStoreDeleteByPrefix(prefix string) (int64, error) {
+	return KVStoreMock.DeleteByPrefix(prefix)
+}
+
+// GetMany is the mock method for KVStoreGetMany.
+func (m *mockKVStoreService) GetMany(keys []string) (map[string][]byte, error) {
+	args := m.Called(keys)
+	return args.Get(0).(map[string][]byte), args.Error(1)
+}
+
+// KVStoreGetMany delegates to the mock instance.
+// GetMany retrieves multiple values in a single call.
+//
+// Parameters:
+//   - keys: The storage keys to retrieve
+//
+// Returns a map of key to value for keys that exist and have not expired.
+// Missing or expired keys are omitted from the result.
+func KVStoreGetMany(keys []string) (map[string][]byte, error) {
+	return KVStoreMock.GetMany(keys)
+}

--- a/plugins/pdk/python/host/nd_host_kvstore.py
+++ b/plugins/pdk/python/host/nd_host_kvstore.py
@@ -313,7 +313,7 @@ def kvstore_delete_by_prefix(prefix: str) -> int:
     """DeleteByPrefix removes all keys matching the given prefix.
 
 Parameters:
-  - prefix: Key prefix to match (empty string deletes ALL keys)
+  - prefix: Key prefix to match (must not be empty)
 
 Returns the number of keys deleted. Includes expired keys.
 

--- a/plugins/pdk/python/host/nd_host_kvstore.py
+++ b/plugins/pdk/python/host/nd_host_kvstore.py
@@ -56,6 +56,24 @@ def _kvstore_getstorageused(offset: int) -> int:
     ...
 
 
+@extism.import_fn("extism:host/user", "kvstore_setwithttl")
+def _kvstore_setwithttl(offset: int) -> int:
+    """Raw host function - do not call directly."""
+    ...
+
+
+@extism.import_fn("extism:host/user", "kvstore_deletebyprefix")
+def _kvstore_deletebyprefix(offset: int) -> int:
+    """Raw host function - do not call directly."""
+    ...
+
+
+@extism.import_fn("extism:host/user", "kvstore_getmany")
+def _kvstore_getmany(offset: int) -> int:
+    """Raw host function - do not call directly."""
+    ...
+
+
 @dataclass
 class KVStoreGetResult:
     """Result type for kvstore_get."""
@@ -240,3 +258,105 @@ def kvstore_get_storage_used() -> int:
         raise HostFunctionError(response["error"])
 
     return response.get("bytes", 0)
+
+
+def kvstore_set_with_ttl(key: str, value: bytes, ttl_seconds: int) -> None:
+    """SetWithTTL stores a byte value with the given key and a time-to-live.
+
+After ttlSeconds, the key is treated as non-existent and will be
+cleaned up lazily. ttlSeconds must be greater than 0.
+
+Parameters:
+  - key: The storage key (max 256 bytes, UTF-8)
+  - value: The byte slice to store
+  - ttlSeconds: Time-to-live in seconds (must be > 0)
+
+Returns an error if the storage limit would be exceeded or the operation fails.
+
+    Args:
+        key: str parameter.
+        value: bytes parameter.
+        ttl_seconds: int parameter.
+
+    Raises:
+        HostFunctionError: If the host function returns an error.
+    """
+    request = {
+        "key": key,
+        "value": base64.b64encode(value).decode("ascii"),
+        "ttlSeconds": ttl_seconds,
+    }
+    request_bytes = json.dumps(request).encode("utf-8")
+    request_mem = extism.memory.alloc(request_bytes)
+    response_offset = _kvstore_setwithttl(request_mem.offset)
+    response_mem = extism.memory.find(response_offset)
+    response = json.loads(extism.memory.string(response_mem))
+
+    if response.get("error"):
+        raise HostFunctionError(response["error"])
+
+
+
+def kvstore_delete_by_prefix(prefix: str) -> int:
+    """DeleteByPrefix removes all keys matching the given prefix.
+
+Parameters:
+  - prefix: Key prefix to match (empty string deletes ALL keys)
+
+Returns the number of keys deleted. Includes expired keys.
+
+    Args:
+        prefix: str parameter.
+
+    Returns:
+        int: The result value.
+
+    Raises:
+        HostFunctionError: If the host function returns an error.
+    """
+    request = {
+        "prefix": prefix,
+    }
+    request_bytes = json.dumps(request).encode("utf-8")
+    request_mem = extism.memory.alloc(request_bytes)
+    response_offset = _kvstore_deletebyprefix(request_mem.offset)
+    response_mem = extism.memory.find(response_offset)
+    response = json.loads(extism.memory.string(response_mem))
+
+    if response.get("error"):
+        raise HostFunctionError(response["error"])
+
+    return response.get("deletedCount", 0)
+
+
+def kvstore_get_many(keys: Any) -> Any:
+    """GetMany retrieves multiple values in a single call.
+
+Parameters:
+  - keys: The storage keys to retrieve
+
+Returns a map of key to value for keys that exist and have not expired.
+Missing or expired keys are omitted from the result.
+
+    Args:
+        keys: Any parameter.
+
+    Returns:
+        Any: The result value.
+
+    Raises:
+        HostFunctionError: If the host function returns an error.
+    """
+    request = {
+        "keys": keys,
+    }
+    request_bytes = json.dumps(request).encode("utf-8")
+    request_mem = extism.memory.alloc(request_bytes)
+    response_offset = _kvstore_getmany(request_mem.offset)
+    response_mem = extism.memory.find(response_offset)
+    response = json.loads(extism.memory.string(response_mem))
+
+    if response.get("error"):
+        raise HostFunctionError(response["error"])
+
+    return response.get("values", None)

--- a/plugins/pdk/rust/nd-pdk-host/src/nd_host_kvstore.rs
+++ b/plugins/pdk/rust/nd-pdk-host/src/nd_host_kvstore.rs
@@ -387,7 +387,7 @@ pub fn delete(key: &str) -> Result<(), Error> {
 /// DeleteByPrefix removes all keys matching the given prefix.
 /// 
 /// Parameters:
-///   - prefix: Key prefix to match (empty string deletes ALL keys)
+///   - prefix: Key prefix to match (must not be empty)
 /// 
 /// Returns the number of keys deleted. Includes expired keys.
 ///

--- a/plugins/pdk/rust/nd-pdk-host/src/nd_host_kvstore.rs
+++ b/plugins/pdk/rust/nd-pdk-host/src/nd_host_kvstore.rs
@@ -46,6 +46,22 @@ struct KVStoreSetResponse {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+struct KVStoreSetWithTTLRequest {
+    key: String,
+    #[serde(with = "base64_bytes")]
+    value: Vec<u8>,
+    ttl_seconds: i64,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct KVStoreSetWithTTLResponse {
+    #[serde(default)]
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct KVStoreGetRequest {
     key: String,
 }
@@ -64,13 +80,15 @@ struct KVStoreGetResponse {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct KVStoreDeleteRequest {
-    key: String,
+struct KVStoreGetManyRequest {
+    keys: Vec<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct KVStoreDeleteResponse {
+struct KVStoreGetManyResponse {
+    #[serde(default)]
+    values: std::collections::HashMap<String, Vec<u8>>,
     #[serde(default)]
     error: Option<String>,
 }
@@ -105,27 +123,15 @@ struct KVStoreListResponse {
     error: Option<String>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "camelCase")]
-struct KVStoreGetStorageUsedResponse {
-    #[serde(default)]
-    bytes: i64,
-    #[serde(default)]
-    error: Option<String>,
-}
-
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct KVStoreSetWithTTLRequest {
+struct KVStoreDeleteRequest {
     key: String,
-    #[serde(with = "base64_bytes")]
-    value: Vec<u8>,
-    ttl_seconds: i64,
 }
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct KVStoreSetWithTTLResponse {
+struct KVStoreDeleteResponse {
     #[serde(default)]
     error: Option<String>,
 }
@@ -145,17 +151,11 @@ struct KVStoreDeleteByPrefixResponse {
     error: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct KVStoreGetManyRequest {
-    keys: Vec<String>,
-}
-
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct KVStoreGetManyResponse {
+struct KVStoreGetStorageUsedResponse {
     #[serde(default)]
-    values: std::collections::HashMap<String, Vec<u8>>,
+    bytes: i64,
     #[serde(default)]
     error: Option<String>,
 }
@@ -163,14 +163,14 @@ struct KVStoreGetManyResponse {
 #[host_fn]
 extern "ExtismHost" {
     fn kvstore_set(input: Json<KVStoreSetRequest>) -> Json<KVStoreSetResponse>;
+    fn kvstore_setwithttl(input: Json<KVStoreSetWithTTLRequest>) -> Json<KVStoreSetWithTTLResponse>;
     fn kvstore_get(input: Json<KVStoreGetRequest>) -> Json<KVStoreGetResponse>;
-    fn kvstore_delete(input: Json<KVStoreDeleteRequest>) -> Json<KVStoreDeleteResponse>;
+    fn kvstore_getmany(input: Json<KVStoreGetManyRequest>) -> Json<KVStoreGetManyResponse>;
     fn kvstore_has(input: Json<KVStoreHasRequest>) -> Json<KVStoreHasResponse>;
     fn kvstore_list(input: Json<KVStoreListRequest>) -> Json<KVStoreListResponse>;
-    fn kvstore_getstorageused(input: Json<serde_json::Value>) -> Json<KVStoreGetStorageUsedResponse>;
-    fn kvstore_setwithttl(input: Json<KVStoreSetWithTTLRequest>) -> Json<KVStoreSetWithTTLResponse>;
+    fn kvstore_delete(input: Json<KVStoreDeleteRequest>) -> Json<KVStoreDeleteResponse>;
     fn kvstore_deletebyprefix(input: Json<KVStoreDeleteByPrefixRequest>) -> Json<KVStoreDeleteByPrefixResponse>;
-    fn kvstore_getmany(input: Json<KVStoreGetManyRequest>) -> Json<KVStoreGetManyResponse>;
+    fn kvstore_getstorageused(input: Json<serde_json::Value>) -> Json<KVStoreGetStorageUsedResponse>;
 }
 
 /// Set stores a byte value with the given key.
@@ -192,6 +192,41 @@ pub fn set(key: &str, value: Vec<u8>) -> Result<(), Error> {
         kvstore_set(Json(KVStoreSetRequest {
             key: key.to_owned(),
             value: value,
+        }))?
+    };
+
+    if let Some(err) = response.0.error {
+        return Err(Error::msg(err));
+    }
+
+    Ok(())
+}
+
+/// SetWithTTL stores a byte value with the given key and a time-to-live.
+/// 
+/// After ttlSeconds, the key is treated as non-existent and will be
+/// cleaned up lazily. ttlSeconds must be greater than 0.
+/// 
+/// Parameters:
+///   - key: The storage key (max 256 bytes, UTF-8)
+///   - value: The byte slice to store
+///   - ttlSeconds: Time-to-live in seconds (must be > 0)
+/// 
+/// Returns an error if the storage limit would be exceeded or the operation fails.
+///
+/// # Arguments
+/// * `key` - String parameter.
+/// * `value` - Vec<u8> parameter.
+/// * `ttl_seconds` - i64 parameter.
+///
+/// # Errors
+/// Returns an error if the host function call fails.
+pub fn set_with_ttl(key: &str, value: Vec<u8>, ttl_seconds: i64) -> Result<(), Error> {
+    let response = unsafe {
+        kvstore_setwithttl(Json(KVStoreSetWithTTLRequest {
+            key: key.to_owned(),
+            value: value,
+            ttl_seconds: ttl_seconds,
         }))?
     };
 
@@ -235,22 +270,26 @@ pub fn get(key: &str) -> Result<Option<Vec<u8>>, Error> {
     }
 }
 
-/// Delete removes a value from storage.
+/// GetMany retrieves multiple values in a single call.
 /// 
 /// Parameters:
-///   - key: The storage key
+///   - keys: The storage keys to retrieve
 /// 
-/// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
+/// Returns a map of key to value for keys that exist and have not expired.
+/// Missing or expired keys are omitted from the result.
 ///
 /// # Arguments
-/// * `key` - String parameter.
+/// * `keys` - Vec<String> parameter.
+///
+/// # Returns
+/// The values value.
 ///
 /// # Errors
 /// Returns an error if the host function call fails.
-pub fn delete(key: &str) -> Result<(), Error> {
+pub fn get_many(keys: Vec<String>) -> Result<std::collections::HashMap<String, Vec<u8>>, Error> {
     let response = unsafe {
-        kvstore_delete(Json(KVStoreDeleteRequest {
-            key: key.to_owned(),
+        kvstore_getmany(Json(KVStoreGetManyRequest {
+            keys: keys,
         }))?
     };
 
@@ -258,7 +297,7 @@ pub fn delete(key: &str) -> Result<(), Error> {
         return Err(Error::msg(err));
     }
 
-    Ok(())
+    Ok(response.0.values)
 }
 
 /// Has checks if a key exists in storage.
@@ -319,50 +358,22 @@ pub fn list(prefix: &str) -> Result<Vec<String>, Error> {
     Ok(response.0.keys)
 }
 
-/// GetStorageUsed returns the total storage used by this plugin in bytes.
-///
-/// # Returns
-/// The bytes value.
-///
-/// # Errors
-/// Returns an error if the host function call fails.
-pub fn get_storage_used() -> Result<i64, Error> {
-    let response = unsafe {
-        kvstore_getstorageused(Json(serde_json::json!({})))?
-    };
-
-    if let Some(err) = response.0.error {
-        return Err(Error::msg(err));
-    }
-
-    Ok(response.0.bytes)
-}
-
-/// SetWithTTL stores a byte value with the given key and a time-to-live.
-/// 
-/// After ttlSeconds, the key is treated as non-existent and will be
-/// cleaned up lazily. ttlSeconds must be greater than 0.
+/// Delete removes a value from storage.
 /// 
 /// Parameters:
-///   - key: The storage key (max 256 bytes, UTF-8)
-///   - value: The byte slice to store
-///   - ttlSeconds: Time-to-live in seconds (must be > 0)
+///   - key: The storage key
 /// 
-/// Returns an error if the storage limit would be exceeded or the operation fails.
+/// Returns an error if the operation fails. Does not return an error if the key doesn't exist.
 ///
 /// # Arguments
 /// * `key` - String parameter.
-/// * `value` - Vec<u8> parameter.
-/// * `ttl_seconds` - i64 parameter.
 ///
 /// # Errors
 /// Returns an error if the host function call fails.
-pub fn set_with_ttl(key: &str, value: Vec<u8>, ttl_seconds: i64) -> Result<(), Error> {
+pub fn delete(key: &str) -> Result<(), Error> {
     let response = unsafe {
-        kvstore_setwithttl(Json(KVStoreSetWithTTLRequest {
+        kvstore_delete(Json(KVStoreDeleteRequest {
             key: key.to_owned(),
-            value: value,
-            ttl_seconds: ttl_seconds,
         }))?
     };
 
@@ -402,32 +413,21 @@ pub fn delete_by_prefix(prefix: &str) -> Result<i64, Error> {
     Ok(response.0.deleted_count)
 }
 
-/// GetMany retrieves multiple values in a single call.
-/// 
-/// Parameters:
-///   - keys: The storage keys to retrieve
-/// 
-/// Returns a map of key to value for keys that exist and have not expired.
-/// Missing or expired keys are omitted from the result.
-///
-/// # Arguments
-/// * `keys` - Vec<String> parameter.
+/// GetStorageUsed returns the total storage used by this plugin in bytes.
 ///
 /// # Returns
-/// The values value.
+/// The bytes value.
 ///
 /// # Errors
 /// Returns an error if the host function call fails.
-pub fn get_many(keys: Vec<String>) -> Result<std::collections::HashMap<String, Vec<u8>>, Error> {
+pub fn get_storage_used() -> Result<i64, Error> {
     let response = unsafe {
-        kvstore_getmany(Json(KVStoreGetManyRequest {
-            keys: keys,
-        }))?
+        kvstore_getstorageused(Json(serde_json::json!({})))?
     };
 
     if let Some(err) = response.0.error {
         return Err(Error::msg(err));
     }
 
-    Ok(response.0.values)
+    Ok(response.0.bytes)
 }


### PR DESCRIPTION
### Description

Extends the plugin KVStore host service with TTL support, batch operations, and several robustness improvements.

**New API methods:**
- `SetWithTTL` — store keys with an expiration time (lazy filtering at read + periodic cleanup)
- `GetMany` — batch-retrieve multiple keys in a single call
- `DeleteByPrefix` — bulk-delete keys by prefix

**Infrastructure:**
- Generic SQLite migration helper (`migrateDB`) using `PRAGMA user_version` with transactional rollback on failure
- Schema migration adds `expires_at` column with index to the kvstore table
- Expired keys are filtered at read time (Get, Has, List, GetMany, GetStorageUsed) and cleaned up on Close

**Refactoring & hardening:**
- Removed in-memory size cache (`atomic.Int64`) in favor of querying the DB directly — simpler and always consistent
- Uses `sql.NullString` for explicit NULL handling on `expires_at` instead of relying on SQLite's `datetime('now', '')` behavior
- `DeleteByPrefix` rejects empty prefix to prevent accidental data wipe
- `Close()` cleanup uses a 5-second timeout context

**Multi-language PDK updates:**
- Go, Python, and Rust PDKs all updated with the new methods
- Test plugin extended with new operations for integration testing

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

```bash
# Run all plugin tests (unit + integration through WASM)
make test PKG=./plugins/...
```

Key test coverage:
- Unit tests for all new methods (SetWithTTL, GetMany, DeleteByPrefix) including edge cases
- TTL expiration tests using pre-expired timestamps (no time.Sleep in unit tests)
- Migration helper tests covering fresh DB, incremental migration, idempotency, and rollback on failure
- Integration tests exercising the full path through the WASM plugin boundary

### Additional Notes

- The `migrateDB` helper is generic and can be reused for other plugin SQLite databases in the future
- TTL precision is second-level, which is appropriate for plugin use cases (caching, rate limiting, etc.)
- The integration test for TTL still uses `time.Sleep(2s)` since it goes through the WASM boundary and can't manipulate the DB directly — this is intentional
