### PR TITLE
fix(scanner): Increases BatchSize to allow for filesystems with many (>4k) folders - #4781

### DIFF
--- a/persistence/folder_repository.go
+++ b/persistence/folder_repository.go
@@ -109,8 +109,8 @@ func (r folderRepository) GetFolderUpdateInfo(lib model.Library, targetPaths ...
 	}
 
 	// Process paths in batches to avoid SQLite's expression tree depth limit (max 1000).
-	// Each path generates ~3 conditions, so batch size of 100 keeps us well under the limit.
-	const batchSize = 100
+	// Each path generates ~3 conditions, so batch size of 200 keeps us well under the limit while supporting large nested folder structures
+	const batchSize = 200
 	result := make(map[string]model.FolderUpdateInfo)
 
 	for batch := range slices.Chunk(targetPaths, batchSize) {


### PR DESCRIPTION
Closes #4781 (https://github.com/navidrome/navidrome/issues/4781)

The BatchSize in in /persistance/folder_repository.go was increased from 100 to 200 to allow the scanner to process libraries with a lot of folders while still remaining within the SQLite expression tree depth limit.