### PR TITLE
fix(scanner): add nil guards to cursor wrapping in folder and mediafile repos

### DIFF
--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"maps"
 	"slices"
 	"strings"
@@ -302,17 +303,21 @@ func (r *albumRepository) GetTouchedAlbums(libID int) (model.AlbumCursor, error)
 	if err != nil {
 		return nil, err
 	}
+	return wrapAlbumCursor(cursor), nil
+}
+
+func wrapAlbumCursor(cursor iter.Seq2[dbAlbum, error]) model.AlbumCursor {
 	return func(yield func(model.Album, error) bool) {
 		for a, err := range cursor {
 			if a.Album == nil {
-				yield(model.Album{}, fmt.Errorf("unexpected nil album: %v", a))
+				yield(model.Album{}, fmt.Errorf("unexpected nil album (%v): %w", a, err))
 				return
 			}
 			if !yield(*a.Album, err) || err != nil {
 				return
 			}
 		}
-	}, nil
+	}
 }
 
 // RefreshPlayCounts updates the play count and last play date annotations for all albums, based

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -741,6 +742,46 @@ var _ = Describe("AlbumRepository", func() {
 			// Clean up
 			_, _ = artistRepo.executeSQL(squirrel.Delete("artist").Where(squirrel.Eq{"id": artist.ID}))
 			_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": album.ID}))
+		})
+	})
+
+	Describe("wrapAlbumCursor", func() {
+		It("does not panic when the cursor yields a dbAlbum with nil Album", func() {
+			// Simulate what queryWithStableResults does on the rows.Err() path:
+			// it yields a zero-value dbAlbum (where Album is nil) with an error.
+			dbErr := fmt.Errorf("database is locked")
+			cursor := func(yield func(dbAlbum, error) bool) {
+				var empty dbAlbum // Album pointer is nil
+				yield(empty, dbErr)
+			}
+
+			// wrapAlbumCursor should handle the nil Album without panicking
+			wrappedCursor := wrapAlbumCursor(cursor)
+			var gotErr error
+			Expect(func() {
+				for _, err := range wrappedCursor {
+					gotErr = err
+				}
+			}).ToNot(Panic())
+			Expect(gotErr).To(HaveOccurred())
+			Expect(gotErr.Error()).To(ContainSubstring("unexpected nil album"))
+			Expect(errors.Is(gotErr, dbErr)).To(BeTrue(), "should wrap the original cursor error")
+		})
+
+		It("yields albums from a valid cursor", func() {
+			album := &model.Album{ID: "a1", Name: "Test"}
+			cursor := func(yield func(dbAlbum, error) bool) {
+				yield(dbAlbum{Album: album}, nil)
+			}
+
+			wrappedCursor := wrapAlbumCursor(cursor)
+			var albums []model.Album
+			for a, err := range wrappedCursor {
+				Expect(err).ToNot(HaveOccurred())
+				albums = append(albums, a)
+			}
+			Expect(albums).To(HaveLen(1))
+			Expect(albums[0].ID).To(Equal("a1"))
 		})
 	})
 })

--- a/persistence/folder_repository.go
+++ b/persistence/folder_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"maps"
 	"os"
 	"path/filepath"
@@ -221,7 +222,7 @@ func (r folderRepository) GetTouchedWithPlaylists() (model.FolderCursor, error) 
 	return wrapFolderCursor(cursor), nil
 }
 
-func wrapFolderCursor(cursor func(func(dbFolder, error) bool)) model.FolderCursor {
+func wrapFolderCursor(cursor iter.Seq2[dbFolder, error]) model.FolderCursor {
 	return func(yield func(model.Folder, error) bool) {
 		for f, err := range cursor {
 			if f.Folder == nil {

--- a/persistence/folder_repository.go
+++ b/persistence/folder_repository.go
@@ -225,7 +225,7 @@ func wrapFolderCursor(cursor func(func(dbFolder, error) bool)) model.FolderCurso
 	return func(yield func(model.Folder, error) bool) {
 		for f, err := range cursor {
 			if f.Folder == nil {
-				yield(model.Folder{}, fmt.Errorf("unexpected nil folder: %v", f))
+				yield(model.Folder{}, fmt.Errorf("unexpected nil folder (%v): %w", f, err))
 				return
 			}
 			if !yield(*f.Folder, err) || err != nil {

--- a/persistence/folder_repository.go
+++ b/persistence/folder_repository.go
@@ -218,13 +218,21 @@ func (r folderRepository) GetTouchedWithPlaylists() (model.FolderCursor, error) 
 	if err != nil {
 		return nil, err
 	}
+	return wrapFolderCursor(cursor), nil
+}
+
+func wrapFolderCursor(cursor func(func(dbFolder, error) bool)) model.FolderCursor {
 	return func(yield func(model.Folder, error) bool) {
 		for f, err := range cursor {
+			if f.Folder == nil {
+				yield(model.Folder{}, fmt.Errorf("unexpected nil folder: %v", f))
+				return
+			}
 			if !yield(*f.Folder, err) || err != nil {
 				return
 			}
 		}
-	}, nil
+	}
 }
 
 func (r folderRepository) purgeEmpty(libraryIDs ...int) error {

--- a/persistence/folder_repository_test.go
+++ b/persistence/folder_repository_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/navidrome/navidrome/log"
@@ -215,9 +216,10 @@ var _ = Describe("FolderRepository", func() {
 		It("does not panic when the cursor yields a dbFolder with nil Folder", func() {
 			// Simulate what queryWithStableResults does on the rows.Err() path:
 			// it yields a zero-value dbFolder (where Folder is nil) with an error.
+			dbErr := fmt.Errorf("database is locked")
 			cursor := func(yield func(dbFolder, error) bool) {
 				var empty dbFolder // Folder pointer is nil
-				yield(empty, fmt.Errorf("database is locked"))
+				yield(empty, dbErr)
 			}
 
 			// wrapFolderCursor should handle the nil Folder without panicking
@@ -230,6 +232,7 @@ var _ = Describe("FolderRepository", func() {
 			}).ToNot(Panic())
 			Expect(gotErr).To(HaveOccurred())
 			Expect(gotErr.Error()).To(ContainSubstring("unexpected nil folder"))
+			Expect(errors.Is(gotErr, dbErr)).To(BeTrue(), "should wrap the original cursor error")
 		})
 
 		It("yields folders from a valid cursor", func() {

--- a/persistence/folder_repository_test.go
+++ b/persistence/folder_repository_test.go
@@ -210,4 +210,42 @@ var _ = Describe("FolderRepository", func() {
 			})
 		})
 	})
+
+	Describe("wrapFolderCursor", func() {
+		It("does not panic when the cursor yields a dbFolder with nil Folder", func() {
+			// Simulate what queryWithStableResults does on the rows.Err() path:
+			// it yields a zero-value dbFolder (where Folder is nil) with an error.
+			cursor := func(yield func(dbFolder, error) bool) {
+				var empty dbFolder // Folder pointer is nil
+				yield(empty, fmt.Errorf("database is locked"))
+			}
+
+			// wrapFolderCursor should handle the nil Folder without panicking
+			wrappedCursor := wrapFolderCursor(cursor)
+			var gotErr error
+			Expect(func() {
+				for _, err := range wrappedCursor {
+					gotErr = err
+				}
+			}).ToNot(Panic())
+			Expect(gotErr).To(HaveOccurred())
+			Expect(gotErr.Error()).To(ContainSubstring("unexpected nil folder"))
+		})
+
+		It("yields folders from a valid cursor", func() {
+			folder := &model.Folder{ID: "f1", Name: "Test"}
+			cursor := func(yield func(dbFolder, error) bool) {
+				yield(dbFolder{Folder: folder}, nil)
+			}
+
+			wrappedCursor := wrapFolderCursor(cursor)
+			var folders []model.Folder
+			for f, err := range wrappedCursor {
+				Expect(err).ToNot(HaveOccurred())
+				folders = append(folders, f)
+			}
+			Expect(folders).To(HaveLen(1))
+			Expect(folders[0].ID).To(Equal("f1"))
+		})
+	})
 })

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"fmt"
+	"iter"
 	"slices"
 	"strconv"
 	"strings"
@@ -364,7 +365,7 @@ func (r *mediaFileRepository) GetMissingAndMatching(libId int) (model.MediaFileC
 	return wrapMediaFileCursor(cursor), nil
 }
 
-func wrapMediaFileCursor(cursor func(func(dbMediaFile, error) bool)) model.MediaFileCursor {
+func wrapMediaFileCursor(cursor iter.Seq2[dbMediaFile, error]) model.MediaFileCursor {
 	return func(yield func(model.MediaFile, error) bool) {
 		for m, err := range cursor {
 			if m.MediaFile == nil {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -231,17 +231,7 @@ func (r *mediaFileRepository) GetCursor(options ...model.QueryOptions) (model.Me
 	if err != nil {
 		return nil, err
 	}
-	return func(yield func(model.MediaFile, error) bool) {
-		for m, err := range cursor {
-			if m.MediaFile == nil {
-				yield(model.MediaFile{}, fmt.Errorf("unexpected nil mediafile: %v", m))
-				return
-			}
-			if !yield(*m.MediaFile, err) || err != nil {
-				return
-			}
-		}
-	}, nil
+	return wrapMediaFileCursor(cursor), nil
 }
 
 // FindByPaths finds media files by their paths.
@@ -371,13 +361,21 @@ func (r *mediaFileRepository) GetMissingAndMatching(libId int) (model.MediaFileC
 	if err != nil {
 		return nil, err
 	}
+	return wrapMediaFileCursor(cursor), nil
+}
+
+func wrapMediaFileCursor(cursor func(func(dbMediaFile, error) bool)) model.MediaFileCursor {
 	return func(yield func(model.MediaFile, error) bool) {
 		for m, err := range cursor {
+			if m.MediaFile == nil {
+				yield(model.MediaFile{}, fmt.Errorf("unexpected nil mediafile: %v", m))
+				return
+			}
 			if !yield(*m.MediaFile, err) || err != nil {
 				return
 			}
 		}
-	}, nil
+	}
 }
 
 // FindRecentFilesByMBZTrackID finds recently added files by MusicBrainz Track ID in other libraries

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -368,7 +368,7 @@ func wrapMediaFileCursor(cursor func(func(dbMediaFile, error) bool)) model.Media
 	return func(yield func(model.MediaFile, error) bool) {
 		for m, err := range cursor {
 			if m.MediaFile == nil {
-				yield(model.MediaFile{}, fmt.Errorf("unexpected nil mediafile: %v", m))
+				yield(model.MediaFile{}, fmt.Errorf("unexpected nil mediafile (%v): %w", m, err))
 				return
 			}
 			if !yield(*m.MediaFile, err) || err != nil {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -709,6 +710,44 @@ var _ = Describe("MediaRepository", func() {
 			results, err = mr.FindByPaths([]string{"2:artist/Album/track.mp3"})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(BeEmpty())
+		})
+	})
+
+	Describe("wrapMediaFileCursor", func() {
+		It("does not panic when the cursor yields a dbMediaFile with nil MediaFile", func() {
+			// Simulate what queryWithStableResults does on the rows.Err() path:
+			// it yields a zero-value dbMediaFile (where MediaFile is nil) with an error.
+			cursor := func(yield func(dbMediaFile, error) bool) {
+				var empty dbMediaFile // MediaFile pointer is nil
+				yield(empty, fmt.Errorf("database is locked"))
+			}
+
+			// wrapMediaFileCursor should handle the nil MediaFile without panicking
+			wrappedCursor := wrapMediaFileCursor(cursor)
+			var gotErr error
+			Expect(func() {
+				for _, err := range wrappedCursor {
+					gotErr = err
+				}
+			}).ToNot(Panic())
+			Expect(gotErr).To(HaveOccurred())
+			Expect(gotErr.Error()).To(ContainSubstring("unexpected nil mediafile"))
+		})
+
+		It("yields mediafiles from a valid cursor", func() {
+			mf := &model.MediaFile{ID: "mf1", Title: "Test"}
+			cursor := func(yield func(dbMediaFile, error) bool) {
+				yield(dbMediaFile{MediaFile: mf}, nil)
+			}
+
+			wrappedCursor := wrapMediaFileCursor(cursor)
+			var mediafiles []model.MediaFile
+			for m, err := range wrappedCursor {
+				Expect(err).ToNot(HaveOccurred())
+				mediafiles = append(mediafiles, m)
+			}
+			Expect(mediafiles).To(HaveLen(1))
+			Expect(mediafiles[0].ID).To(Equal("mf1"))
 		})
 	})
 })

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -717,9 +718,10 @@ var _ = Describe("MediaRepository", func() {
 		It("does not panic when the cursor yields a dbMediaFile with nil MediaFile", func() {
 			// Simulate what queryWithStableResults does on the rows.Err() path:
 			// it yields a zero-value dbMediaFile (where MediaFile is nil) with an error.
+			dbErr := fmt.Errorf("database is locked")
 			cursor := func(yield func(dbMediaFile, error) bool) {
 				var empty dbMediaFile // MediaFile pointer is nil
-				yield(empty, fmt.Errorf("database is locked"))
+				yield(empty, dbErr)
 			}
 
 			// wrapMediaFileCursor should handle the nil MediaFile without panicking
@@ -732,6 +734,7 @@ var _ = Describe("MediaRepository", func() {
 			}).ToNot(Panic())
 			Expect(gotErr).To(HaveOccurred())
 			Expect(gotErr.Error()).To(ContainSubstring("unexpected nil mediafile"))
+			Expect(errors.Is(gotErr, dbErr)).To(BeTrue(), "should wrap the original cursor error")
 		})
 
 		It("yields mediafiles from a valid cursor", func() {


### PR DESCRIPTION
### Description

During scanning, a `SIGSEGV` panic can occur in `folderRepository.GetTouchedWithPlaylists` when `queryWithStableResults` yields a zero-value `dbFolder` (with nil `Folder` pointer) through the `rows.Err()` error path. For example, when SQLite returns "database is locked" under high write pressure from concurrent scanner goroutines.

The dereference `*f.Folder` happens **before** the error is checked, causing the crash. The same pattern exists in `mediaFileRepository.GetMissingAndMatching`.

This PR:
- Extracts cursor wrapping into `wrapFolderCursor` and `wrapMediaFileCursor` helper functions
- Adds nil guards before dereferencing embedded pointers, matching the existing pattern already present in `album_repository.go` and the first `GetCursor` in `mediafile_repository.go`
- Adds tests verifying the nil guard behavior

### Related Issues

Fixes #5138

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run the persistence tests: `make test PKG=./persistence`
2. Verify all tests pass, including the new `wrapFolderCursor` and `wrapMediaFileCursor` test cases
3. The new tests verify that:
   - A cursor yielding a nil embedded pointer does **not** panic and returns an error containing "unexpected nil folder/mediafile"
   - A cursor yielding a valid embedded pointer correctly yields the model value

### Additional Notes

The root cause is in `queryWithStableResults` (`sql_base_repository.go:324-326`) where `rows.Err()` yields a zero-value struct with the error. The callers (`GetTouchedWithPlaylists`, `GetMissingAndMatching`) then dereference the nil pointer before checking the error. Two of the four call sites already had the guard (`album_repository.go:307`, `mediafile_repository.go:236`); this PR adds it to the two missing sites.
