### PR TITLE
 fix(extauth): handle user creation in authenticateRequest #4733

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -253,7 +253,7 @@ func authenticateRequest(ds model.DataStore, r *http.Request, findUsernameFns ..
 	if username == "" {
 		return nil, ErrUnauthenticated
 	}
-
+	handleLoginFromHeaders(ds, r)
 	return contextWithUser(r.Context(), ds, username)
 }
 


### PR DESCRIPTION
### Description
[Externalized Authentication Quick Start Documentation](https://www.navidrome.org/docs/getting-started/extauth-quickstart/) states that
```
If the user doesn’t exist in Navidrome’s database, a new account is created automatically
```

but currently the `Authenticator` in `auth.go` does not handle new accounts creation, resulting in
```
level=error msg="Authenticated username not found in DB"
```

This PR adds the relevant call to `handleLoginFromHeaders` in `authenticateRequest` before trying to authenticate against existing users in the database.

### Related Issues
Fixes #4733

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [ ] All existing and new tests pass

### How to Test
- clone repo
- self-build with docker
- configure external authentication via reverse proxy
- login with any user after authentication

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->