### PR TITLE
fix(server): return correct scanType in startScan response

### DIFF
--- a/server/subsonic/library_scanning.go
+++ b/server/subsonic/library_scanning.go
@@ -99,5 +99,20 @@ func (api *Router) StartScan(r *http.Request) (*responses.Subsonic, error) {
 		log.Info(ctx, "On-demand scan complete", "user", loggedUser.UserName, "elapsed", time.Since(start))
 	}()
 
+	// Wait briefly for the scanner to start and update its status, so the response
+	// reflects the current scan (not stale data from a previous scan).
+	const (
+		pollInterval = 50 * time.Millisecond
+		pollTimeout  = 3 * time.Second
+	)
+	deadline := time.Now().Add(pollTimeout)
+	for time.Now().Before(deadline) {
+		status, err := api.scanner.Status(ctx)
+		if err == nil && status.Scanning {
+			break
+		}
+		time.Sleep(pollInterval)
+	}
+
 	return api.GetScanStatus(r)
 }

--- a/server/subsonic/library_scanning.go
+++ b/server/subsonic/library_scanning.go
@@ -80,7 +80,9 @@ func (api *Router) StartScan(r *http.Request) (*responses.Subsonic, error) {
 		}
 	}
 
+	fastScanCompleted := make(chan struct{})
 	go func() {
+		defer close(fastScanCompleted)
 		start := time.Now()
 		var err error
 
@@ -117,6 +119,9 @@ loop:
 			break
 		}
 		select {
+		case <-fastScanCompleted:
+			log.Info(ctx, "Fast scan completed", "user", loggedUser.UserName)
+			break loop
 		case <-timer.C:
 			log.Warn(ctx, "Timed out waiting for scanner to start; response may be stale")
 			break loop

--- a/server/subsonic/library_scanning.go
+++ b/server/subsonic/library_scanning.go
@@ -105,13 +105,25 @@ func (api *Router) StartScan(r *http.Request) (*responses.Subsonic, error) {
 		pollInterval = 50 * time.Millisecond
 		pollTimeout  = 3 * time.Second
 	)
-	deadline := time.Now().Add(pollTimeout)
-	for time.Now().Before(deadline) {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	timer := time.NewTimer(pollTimeout)
+	defer timer.Stop()
+
+loop:
+	for {
 		status, err := api.scanner.Status(ctx)
 		if err == nil && status.Scanning {
 			break
 		}
-		time.Sleep(pollInterval)
+		select {
+		case <-timer.C:
+			log.Warn(ctx, "Timed out waiting for scanner to start; response may be stale")
+			break loop
+		case <-ctx.Done():
+			return nil, newError(responses.ErrorGeneric, "Request cancelled while waiting for scanner to start")
+		case <-ticker.C:
+		}
 	}
 
 	return api.GetScanStatus(r)

--- a/server/subsonic/library_scanning_test.go
+++ b/server/subsonic/library_scanning_test.go
@@ -365,6 +365,66 @@ var _ = Describe("LibraryScanning", func() {
 			Expect(targets[0].LibraryID).To(Equal(1))
 			Expect(targets[0].FolderPath).To(Equal(""))
 		})
+
+		It("returns correct scanType in response when fullScan=false", func() {
+			// Setup mock to update status when scan starts (simulating the real scanner)
+			ms.SetScanStatusFunc(func(fullScan bool, targets []model.ScanTarget) *model.ScannerStatus {
+				scanType := "quick"
+				if fullScan {
+					scanType = "full"
+				}
+				return &model.ScannerStatus{
+					Scanning: true,
+					ScanType: scanType,
+				}
+			})
+
+			ctx := request.WithUser(context.Background(), model.User{
+				ID:      "admin-id",
+				IsAdmin: true,
+			})
+
+			r := httptest.NewRequest("GET", "/rest/startScan", nil)
+			r = r.WithContext(ctx)
+
+			response, err := api.StartScan(r)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.ScanStatus).ToNot(BeNil())
+			Expect(response.ScanStatus.Scanning).To(BeTrue())
+			Expect(response.ScanStatus.ScanType).To(Equal("quick"))
+		})
+
+		It("returns correct scanType in response when fullScan=true", func() {
+			// Setup mock to update status when scan starts (simulating the real scanner)
+			ms.SetScanStatusFunc(func(fullScan bool, targets []model.ScanTarget) *model.ScannerStatus {
+				scanType := "quick"
+				if fullScan {
+					scanType = "full"
+				}
+				return &model.ScannerStatus{
+					Scanning: true,
+					ScanType: scanType,
+				}
+			})
+
+			ctx := request.WithUser(context.Background(), model.User{
+				ID:      "admin-id",
+				IsAdmin: true,
+			})
+
+			r := httptest.NewRequest("GET", "/rest/startScan?fullScan=true", nil)
+			r = r.WithContext(ctx)
+
+			response, err := api.StartScan(r)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(response).ToNot(BeNil())
+			Expect(response.ScanStatus).ToNot(BeNil())
+			Expect(response.ScanStatus.Scanning).To(BeTrue())
+			Expect(response.ScanStatus.ScanType).To(Equal("full"))
+		})
 	})
 
 	Describe("GetScanStatus", func() {

--- a/tests/mock_scanner.go
+++ b/tests/mock_scanner.go
@@ -14,6 +14,7 @@ type MockScanner struct {
 	scanFoldersCalls []ScanFoldersCall
 	scanningStatus   bool
 	statusResponse   *model.ScannerStatus
+	scanStatusFunc   func(fullScan bool, targets []model.ScanTarget) *model.ScannerStatus
 }
 
 type ScanAllCall struct {
@@ -38,6 +39,13 @@ func (m *MockScanner) ScanAll(_ context.Context, fullScan bool) ([]string, error
 
 	m.scanAllCalls = append(m.scanAllCalls, ScanAllCall{FullScan: fullScan})
 
+	// Simulate the scanner updating its status when the scan starts
+	if m.scanStatusFunc != nil {
+		m.statusResponse = m.scanStatusFunc(fullScan, nil)
+	} else {
+		m.scanningStatus = true
+	}
+
 	return nil, nil
 }
 
@@ -53,6 +61,13 @@ func (m *MockScanner) ScanFolders(_ context.Context, fullScan bool, targets []mo
 		FullScan: fullScan,
 		Targets:  targetsCopy,
 	})
+
+	// Simulate the scanner updating its status when the scan starts
+	if m.scanStatusFunc != nil {
+		m.statusResponse = m.scanStatusFunc(fullScan, targetsCopy)
+	} else {
+		m.scanningStatus = true
+	}
 
 	return nil, nil
 }
@@ -117,4 +132,12 @@ func (m *MockScanner) SetStatusResponse(status *model.ScannerStatus) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.statusResponse = status
+}
+
+// SetScanStatusFunc sets a function that will be called when ScanAll/ScanFolders is invoked,
+// simulating the scanner updating its status when the scan starts.
+func (m *MockScanner) SetScanStatusFunc(fn func(fullScan bool, targets []model.ScanTarget) *model.ScannerStatus) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.scanStatusFunc = fn
 }


### PR DESCRIPTION
### Description

The `startScan` endpoint launches the scan in a goroutine and immediately calls `GetScanStatus` to build the response. Because the scanner goroutine hasn't had time to initialize and write its state to the database, the response contained stale data from the **previous** scan — e.g., `scanType: "quick"` even when `fullScan=true` was requested.

This PR adds a brief polling loop (up to 3s, every 50ms) that waits for the scanner to report `Scanning=true` before returning the status. In practice, the scanner starts within milliseconds so the added latency is negligible. If the timeout expires, the handler falls back to the existing behavior (returning whatever `GetScanStatus` has), so there is no regression.

### Related Issues

Fixes #5158

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start Navidrome dev server with `make dev`
2. Call `GET /rest/startScan?fullScan=true` with valid Subsonic auth params
3. Verify the response contains `"scanType": "full"` and `"scanning": true`
4. Call `GET /rest/startScan` (without fullScan) and verify `"scanType": "quick"`
5. Run `make test PKG=./server/subsonic/` to verify all unit tests pass

### Additional Notes

- The `MockScanner` test helper was updated to automatically set `scanningStatus=true` when `ScanAll`/`ScanFolders` is called, matching real scanner behavior. A `SetScanStatusFunc` callback was also added for tests that need to control the exact status returned (e.g., verifying the `scanType` field).
- The polling approach was chosen over simpler alternatives (like overriding the `scanType` field in the handler) because the race affected **all** status fields, not just `scanType`.
