### PR TITLE
fix: use ADTS for AAC transcoding, temporarily exclude AAC from transcode decisions

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -153,7 +153,7 @@ var (
 			Name:           "aac audio",
 			TargetFormat:   "aac",
 			DefaultBitRate: 256,
-			Command:        "ffmpeg -i %s -ss %t -map 0:a:0 -b:a %bk -v 0 -c:a aac -f ipod -movflags frag_keyframe+empty_moov -",
+			Command:        "ffmpeg -i %s -ss %t -map 0:a:0 -b:a %bk -v 0 -c:a aac -f adts -",
 		},
 		{
 			Name:           "flac audio",

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -283,7 +283,7 @@ var formatCodecMap = map[string]string{
 var formatOutputMap = map[string]string{
 	"mp3":  "mp3",
 	"opus": "opus",
-	"aac":  "ipod",
+	"aac":  "adts",
 	"flac": "flac",
 }
 
@@ -337,11 +337,6 @@ func buildDynamicArgs(opts TranscodeOptions) []string {
 
 	if outputFmt, ok := formatOutputMap[opts.Format]; ok {
 		args = append(args, "-f", outputFmt)
-	}
-
-	// For AAC in MP4 container, enable fragmented MP4 for pipe-safe streaming
-	if opts.Format == "aac" {
-		args = append(args, "-movflags", "frag_keyframe+empty_moov")
 	}
 
 	args = append(args, "-")

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -86,7 +86,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(isDefaultCommand("opus", "ffmpeg -i %s -ss %t -map 0:a:0 -b:a %bk -v 0 -c:a libopus -f opus -")).To(BeTrue())
 		})
 		It("returns true for known default aac command", func() {
-			Expect(isDefaultCommand("aac", "ffmpeg -i %s -ss %t -map 0:a:0 -b:a %bk -v 0 -c:a aac -f ipod -movflags frag_keyframe+empty_moov -")).To(BeTrue())
+			Expect(isDefaultCommand("aac", "ffmpeg -i %s -ss %t -map 0:a:0 -b:a %bk -v 0 -c:a aac -f adts -")).To(BeTrue())
 		})
 		It("returns true for known default flac command", func() {
 			Expect(isDefaultCommand("flac", "ffmpeg -i %s -ss %t -map 0:a:0 -v 0 -c:a flac -f flac -")).To(BeTrue())
@@ -174,7 +174,7 @@ var _ = Describe("ffmpeg", func() {
 			}))
 		})
 
-		It("builds aac args with fragmented MP4 container", func() {
+		It("builds aac args with ADTS output", func() {
 			args := buildDynamicArgs(TranscodeOptions{
 				Format:   "aac",
 				FilePath: "/music/file.flac",
@@ -186,8 +186,7 @@ var _ = Describe("ffmpeg", func() {
 				"-c:a", "aac",
 				"-b:a", "256k",
 				"-v", "0",
-				"-f", "ipod",
-				"-movflags", "frag_keyframe+empty_moov",
+				"-f", "adts",
 				"-",
 			}))
 		})

--- a/core/stream/aliases.go
+++ b/core/stream/aliases.go
@@ -80,6 +80,11 @@ func matchesCodec(codec string, codecs []string) bool {
 	return matchesWithAliases(codec, codecs, codecAliasGroups)
 }
 
+// IsAACCodec returns true if the given codec or container name resolves to AAC.
+func IsAACCodec(name string) bool {
+	return matchesCodec(name, []string{"aac"}) || matchesContainer(name, []string{"aac"})
+}
+
 func containsIgnoreCase(slice []string, s string) bool {
 	return slices.ContainsFunc(slice, func(item string) bool {
 		return strings.EqualFold(item, s)

--- a/core/stream/aliases_test.go
+++ b/core/stream/aliases_test.go
@@ -1,0 +1,30 @@
+package stream
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Aliases", func() {
+	Describe("IsAACCodec", func() {
+		It("returns true for AAC and its aliases", func() {
+			Expect(IsAACCodec("aac")).To(BeTrue())
+			Expect(IsAACCodec("AAC")).To(BeTrue())
+			Expect(IsAACCodec("adts")).To(BeTrue())
+			Expect(IsAACCodec("m4a")).To(BeTrue())
+			Expect(IsAACCodec("mp4")).To(BeTrue())
+			Expect(IsAACCodec("m4b")).To(BeTrue())
+		})
+
+		It("returns false for non-AAC formats", func() {
+			Expect(IsAACCodec("mp3")).To(BeFalse())
+			Expect(IsAACCodec("opus")).To(BeFalse())
+			Expect(IsAACCodec("flac")).To(BeFalse())
+			Expect(IsAACCodec("ogg")).To(BeFalse())
+		})
+
+		It("returns false for empty string", func() {
+			Expect(IsAACCodec("")).To(BeFalse())
+		})
+	})
+})

--- a/db/migrations/20260310113858_fix_aac_transcode_command.go
+++ b/db/migrations/20260310113858_fix_aac_transcode_command.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upFixAacTranscodeCommand, downFixAacTranscodeCommand)
+}
+
+func upFixAacTranscodeCommand(_ context.Context, tx *sql.Tx) error {
+	// The old AAC command used `-f ipod -movflags frag_keyframe+empty_moov` which produces
+	// corrupt/silent audio when ffmpeg pipes to stdout (confirmed in ffmpeg 8.0+).
+	// Switch to `-f adts` (raw AAC framing) which works reliably via pipe.
+	// Only update rows that still have the old default command.
+	const oldCommand = "ffmpeg -i %s -ss %t -map 0:a:0 -b:a %bk -v 0 -c:a aac -f ipod -movflags frag_keyframe+empty_moov -"
+	const newCommand = "ffmpeg -i %s -ss %t -map 0:a:0 -b:a %bk -v 0 -c:a aac -f adts -"
+	_, err := tx.Exec(
+		"UPDATE transcoding SET command = ? WHERE target_format = 'aac' AND command = ?",
+		newCommand, oldCommand,
+	)
+	return err
+}
+
+func downFixAacTranscodeCommand(_ context.Context, tx *sql.Tx) error {
+	return nil
+}

--- a/server/subsonic/transcode.go
+++ b/server/subsonic/transcode.go
@@ -268,6 +268,16 @@ func (api *Router) GetTranscodeDecision(w http.ResponseWriter, r *http.Request) 
 	}
 	clientInfo := clientInfoReq.toCoreClientInfo()
 
+	// TODO: Remove this filter once AAC transcoding works reliably
+	// with streaming clients (Sonos, etc).
+	// See https://github.com/navidrome/navidrome/discussions/4832#discussioncomment-16068231
+	clientInfo.TranscodingProfiles = slices.DeleteFunc(clientInfo.TranscodingProfiles, func(p stream.Profile) bool {
+		if p.AudioCodec != "" {
+			return stream.IsAACCodec(p.AudioCodec)
+		}
+		return stream.IsAACCodec(p.Container)
+	})
+
 	// Get media file
 	mf, err := api.ds.MediaFile(ctx).Get(mediaID)
 	if err != nil {

--- a/server/subsonic/transcode_test.go
+++ b/server/subsonic/transcode_test.go
@@ -180,6 +180,29 @@ var _ = Describe("Transcode endpoints", func() {
 			Expect(resp.TranscodeDecision.SourceStream.AudioBitrate).To(Equal(int32(320_000)))
 		})
 
+		It("filters AAC from transcoding profiles", func() {
+			mockMFRepo.SetData(model.MediaFiles{
+				{ID: "song-1", Suffix: "opus", Codec: "opus", BitRate: 128, Channels: 2, SampleRate: 48000},
+			})
+			mockTD.decision = &stream.TranscodeDecision{MediaID: "song-1", CanDirectPlay: true}
+			mockTD.token = "token"
+
+			body := `{
+				"transcodingProfiles": [
+					{"container": "aac", "audioCodec": "aac", "protocol": "http"},
+					{"container": "mp3", "audioCodec": "mp3", "protocol": "http"},
+					{"container": "m4a", "audioCodec": "aac", "protocol": "http"}
+				]
+			}`
+			r := newJSONPostRequest("mediaId=song-1&mediaType=song", body)
+			_, err := router.GetTranscodeDecision(w, r)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mockTD.capturedClient).ToNot(BeNil())
+			Expect(mockTD.capturedClient.TranscodingProfiles).To(HaveLen(1))
+			Expect(mockTD.capturedClient.TranscodingProfiles[0].AudioCodec).To(Equal("mp3"))
+		})
+
 		It("includes transcode stream when transcoding", func() {
 			mockMFRepo.SetData(model.MediaFiles{
 				{ID: "song-2", Suffix: "flac", Codec: "FLAC", BitRate: 1000, Channels: 2, SampleRate: 96000, BitDepth: 24},
@@ -354,14 +377,16 @@ func newJSONPostRequest(queryParams string, jsonBody string) *http.Request {
 
 // mockTranscodeDecision is a test double for stream.TranscodeDecider
 type mockTranscodeDecision struct {
-	decision    *stream.TranscodeDecision
-	token       string
-	tokenErr    error
-	resolvedReq stream.Request
-	resolveErr  error
+	decision       *stream.TranscodeDecision
+	token          string
+	tokenErr       error
+	resolvedReq    stream.Request
+	resolveErr     error
+	capturedClient *stream.ClientInfo
 }
 
-func (m *mockTranscodeDecision) MakeDecision(_ context.Context, _ *model.MediaFile, _ *stream.ClientInfo, _ stream.TranscodeOptions) (*stream.TranscodeDecision, error) {
+func (m *mockTranscodeDecision) MakeDecision(_ context.Context, _ *model.MediaFile, ci *stream.ClientInfo, _ stream.TranscodeOptions) (*stream.TranscodeDecision, error) {
+	m.capturedClient = ci
 	if m.decision != nil {
 		return m.decision, nil
 	}


### PR DESCRIPTION
### Description

Fixes AAC transcoding issues affecting streaming clients (especially Sonos/UPnP devices):

1. **Switch AAC output format from fragmented MP4 to ADTS**: The old command used `-f ipod -movflags frag_keyframe+empty_moov`, which produces corrupt/silent audio when ffmpeg pipes to stdout (confirmed on ffmpeg 8.0+ — the `moof` atom offsets are zeroed out in pipe mode). Switching to `-f adts` (raw AAC ADTS framing) works reliably via pipe and is widely supported by clients.

2. **Temporarily exclude AAC profiles from transcode decisions**: Until AAC transcoding is confirmed to work reliably with streaming clients like Sonos, the `getTranscodeDecision` endpoint now filters out AAC-based transcoding profiles from client requests. This prevents clients from being offered an AAC transcode path that may not work correctly.

3. **DB migration**: Updates existing AAC transcoding rows that still have the old default command, without touching user-customized commands.

### Related Issues

Related to https://github.com/navidrome/navidrome/discussions/4832#discussioncomment-16068231

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Have a media file (e.g., opus) in your library and a client profile that requests AAC transcoding (e.g., Sonos/UPnP)
2. Call `getTranscodeDecision` with a client info that includes AAC transcoding profiles — verify AAC profiles are filtered out and not offered
3. For the ADTS format change: transcode any file to AAC and verify the output is valid and audible:
   ```bash
   ffmpeg -i input.opus -map 0:a:0 -c:a aac -b:a 128k -v 0 -f adts - > output.aac
   ffmpeg -i output.aac -af volumedetect -f null /dev/null
   ```
4. Verify the DB migration updates the old AAC command (`-f ipod -movflags frag_keyframe+empty_moov`) to the new one (`-f adts`)

### Additional Notes

- The fragmented MP4 issue affects **all input formats** transcoded to AAC, not just opus
- The AAC profile filtering is intended as a temporary measure (marked with a TODO) until AAC transcoding is validated with Sonos and similar clients
- A new `IsAACCodec` helper was added to `core/stream/aliases.go` to centralize AAC codec/container detection
