### PR TITLE
fix: improve browser codec detection and limit Safari transcoding to mp3

### DIFF
--- a/ui/src/transcode/browserProfile.js
+++ b/ui/src/transcode/browserProfile.js
@@ -1,4 +1,4 @@
-// Each entry: { codec name for the server, container, MIME to probe }
+// Each entry: { codec name for the server, container, mime: [MIME probe strings] }
 export const CODEC_PROBES = [
   { codec: 'mp3', container: 'mp3', mime: ['audio/mpeg; codecs="mp3"'] },
   { codec: 'opus', container: 'ogg', mime: ['audio/ogg; codecs="opus"'] },

--- a/ui/src/transcode/browserProfile.js
+++ b/ui/src/transcode/browserProfile.js
@@ -18,6 +18,11 @@ export const CODEC_PROBES = [
 // MP3 is always included as a universal fallback.
 const TRANSCODE_CODECS = ['flac', 'opus', 'mp3']
 
+// Safari transcoding is limited to mp3 only. Safari cannot reliably stream
+// Ogg containers (reports canPlayType support but fails on non-seekable
+// transcoded streams), and FLAC transcoding also fails in practice.
+const SAFARI_TRANSCODE_CODECS = ['mp3']
+
 function canPlay(audio, mimeList) {
   return mimeList.some((m) => {
     const result = audio.canPlayType(m)
@@ -27,6 +32,13 @@ function canPlay(audio, mimeList) {
 
 function probeSupported(audio, probes) {
   return probes.filter(({ mime }) => canPlay(audio, mime))
+}
+
+function isSafari() {
+  const ua = navigator.userAgent
+  return (
+    ua.includes('Safari') && !ua.includes('Chrome') && !ua.includes('Chromium')
+  )
 }
 
 export function detectBrowserProfile() {
@@ -40,13 +52,15 @@ export function detectBrowserProfile() {
     }),
   )
 
-  // Build transcoding profiles from supported codecs, always keeping mp3 as fallback
-  const transcodingProfiles = TRANSCODE_CODECS.reduce((profiles, codec) => {
+  // Build transcoding profiles from supported codecs, always keeping mp3 as fallback.
+  // Safari is limited to mp3 transcoding only.
+  const transcodeCodecs = isSafari()
+    ? SAFARI_TRANSCODE_CODECS
+    : TRANSCODE_CODECS
+  const transcodingProfiles = transcodeCodecs.reduce((profiles, codec) => {
     const probe = CODEC_PROBES.find((p) => p.codec === codec)
-    if (
-      canPlay(audio, probe.mime) ||
-      codec === 'mp3'
-    ) {
+    if (!probe) return profiles
+    if (canPlay(audio, probe.mime) || codec === 'mp3') {
       profiles.push({
         container: probe.container,
         audioCodec: codec,

--- a/ui/src/transcode/browserProfile.js
+++ b/ui/src/transcode/browserProfile.js
@@ -1,12 +1,16 @@
 // Each entry: { codec name for the server, container, MIME to probe }
 export const CODEC_PROBES = [
-  { codec: 'mp3', container: 'mp3', mime: 'audio/mpeg' },
-  { codec: 'aac', container: 'mp4', mime: 'audio/mp4; codecs="mp4a.40.2"' },
-  { codec: 'opus', container: 'ogg', mime: 'audio/ogg; codecs="opus"' },
-  { codec: 'vorbis', container: 'ogg', mime: 'audio/ogg; codecs="vorbis"' },
-  { codec: 'flac', container: 'flac', mime: 'audio/flac' },
-  { codec: 'wav', container: 'wav', mime: 'audio/wav' },
-  { codec: 'alac', container: 'mp4', mime: 'audio/mp4; codecs="alac"' },
+  { codec: 'mp3', container: 'mp3', mime: ['audio/mpeg; codecs="mp3"'] },
+  { codec: 'opus', container: 'ogg', mime: ['audio/ogg; codecs="opus"'] },
+  { codec: 'vorbis', container: 'ogg', mime: ['audio/ogg; codecs="vorbis"'] },
+  {
+    codec: 'flac',
+    container: 'flac',
+    mime: ['audio/flac', 'audio/flac; codecs="flac"'],
+  },
+  { codec: 'wav', container: 'wav', mime: ['audio/wav; codecs="1"'] },
+  { codec: 'alac', container: 'mp4', mime: ['audio/mp4; codecs="alac"'] },
+  { codec: 'aac', container: 'mp4', mime: ['audio/mp4; codecs="mp4a.40.2"'] },
 ]
 
 // Transcoding targets in preference order (lossless first, then lossy).
@@ -14,8 +18,15 @@ export const CODEC_PROBES = [
 // MP3 is always included as a universal fallback.
 const TRANSCODE_CODECS = ['flac', 'opus', 'mp3']
 
+function canPlay(audio, mimeList) {
+  return mimeList.some((m) => {
+    const result = audio.canPlayType(m)
+    return result === 'probably' || result === 'maybe'
+  })
+}
+
 function probeSupported(audio, probes) {
-  return probes.filter(({ mime }) => audio.canPlayType(mime) === 'probably')
+  return probes.filter(({ mime }) => canPlay(audio, mime))
 }
 
 export function detectBrowserProfile() {
@@ -32,7 +43,10 @@ export function detectBrowserProfile() {
   // Build transcoding profiles from supported codecs, always keeping mp3 as fallback
   const transcodingProfiles = TRANSCODE_CODECS.reduce((profiles, codec) => {
     const probe = CODEC_PROBES.find((p) => p.codec === codec)
-    if (audio.canPlayType(probe.mime) === 'probably' || codec === 'mp3') {
+    if (
+      canPlay(audio, probe.mime) ||
+      codec === 'mp3'
+    ) {
       profiles.push({
         container: probe.container,
         audioCodec: codec,

--- a/ui/src/transcode/browserProfile.test.js
+++ b/ui/src/transcode/browserProfile.test.js
@@ -16,7 +16,7 @@ describe('detectBrowserProfile', () => {
 
   it('includes codecs that return "probably"', () => {
     mockCanPlayType.mockImplementation((mime) => {
-      if (mime === 'audio/mpeg') return 'probably'
+      if (mime === 'audio/mpeg; codecs="mp3"') return 'probably'
       if (mime === 'audio/ogg; codecs="opus"') return 'probably'
       return ''
     })
@@ -31,11 +31,15 @@ describe('detectBrowserProfile', () => {
     expect(codecs).toContain('opus')
   })
 
-  it('excludes codecs that return "maybe"', () => {
-    mockCanPlayType.mockReturnValue('maybe')
+  it('includes codecs that return "maybe"', () => {
+    mockCanPlayType.mockImplementation((mime) => {
+      if (mime === 'audio/flac') return 'maybe'
+      return ''
+    })
 
     const profile = detectBrowserProfile()
-    expect(profile.directPlayProfiles).toEqual([])
+    const codecs = profile.directPlayProfiles.flatMap((p) => p.audioCodecs)
+    expect(codecs).toContain('flac')
   })
 
   it('excludes codecs that return empty string', () => {
@@ -56,7 +60,7 @@ describe('detectBrowserProfile', () => {
 
   it('filters transcoding profiles by canPlayType', () => {
     mockCanPlayType.mockImplementation((mime) => {
-      if (mime === 'audio/mpeg') return 'probably'
+      if (mime === 'audio/mpeg; codecs="mp3"') return 'probably'
       if (mime === 'audio/ogg; codecs="opus"') return 'probably'
       return ''
     })
@@ -102,6 +106,17 @@ describe('detectBrowserProfile', () => {
 
     const profile = detectBrowserProfile()
     expect(profile.codecProfiles).toEqual([])
+  })
+
+  it('matches codec when any mime variant returns "probably"', () => {
+    mockCanPlayType.mockImplementation((mime) => {
+      if (mime === 'audio/flac; codecs="flac"') return 'probably'
+      return ''
+    })
+
+    const profile = detectBrowserProfile()
+    const codecs = profile.directPlayProfiles.flatMap((p) => p.audioCodecs)
+    expect(codecs).toContain('flac')
   })
 
   it('includes platform info', () => {

--- a/ui/src/transcode/browserProfile.test.js
+++ b/ui/src/transcode/browserProfile.test.js
@@ -123,4 +123,57 @@ describe('detectBrowserProfile', () => {
     const profile = detectBrowserProfile()
     expect(typeof profile.platform).toBe('string')
   })
+
+  describe('Safari restrictions', () => {
+    beforeEach(() => {
+      // Safari reports canPlayType for Ogg as positive, but can't actually
+      // stream transcoded Ogg. Simulate Safari: supports everything.
+      mockCanPlayType.mockReturnValue('probably')
+    })
+
+    it('still includes ogg in direct play profiles on Safari', () => {
+      vi.stubGlobal(
+        'navigator',
+        { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.2 Safari/605.1.15' },
+      )
+
+      const profile = detectBrowserProfile()
+      const containers = profile.directPlayProfiles.flatMap((p) => p.containers)
+      expect(containers).toContain('ogg')
+    })
+
+    it('limits Safari transcoding to mp3 only', () => {
+      vi.stubGlobal(
+        'navigator',
+        { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.2 Safari/605.1.15' },
+      )
+
+      const profile = detectBrowserProfile()
+      const codecs = profile.transcodingProfiles.map((p) => p.audioCodec)
+      expect(codecs).toEqual(['mp3'])
+    })
+
+    it('does NOT restrict transcoding on Chrome', () => {
+      vi.stubGlobal(
+        'navigator',
+        { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' },
+      )
+
+      const profile = detectBrowserProfile()
+      const codecs = profile.transcodingProfiles.map((p) => p.audioCodec)
+      expect(codecs).toContain('opus')
+      expect(codecs).toContain('flac')
+    })
+
+    it('applies same restrictions on iOS Safari', () => {
+      vi.stubGlobal(
+        'navigator',
+        { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1' },
+      )
+
+      const profile = detectBrowserProfile()
+      const codecs = profile.transcodingProfiles.map((p) => p.audioCodec)
+      expect(codecs).toEqual(['mp3'])
+    })
+  })
 })

--- a/ui/src/transcode/browserProfile.test.js
+++ b/ui/src/transcode/browserProfile.test.js
@@ -132,10 +132,10 @@ describe('detectBrowserProfile', () => {
     })
 
     it('still includes ogg in direct play profiles on Safari', () => {
-      vi.stubGlobal(
-        'navigator',
-        { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.2 Safari/605.1.15' },
-      )
+      vi.stubGlobal('navigator', {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.2 Safari/605.1.15',
+      })
 
       const profile = detectBrowserProfile()
       const containers = profile.directPlayProfiles.flatMap((p) => p.containers)
@@ -143,10 +143,10 @@ describe('detectBrowserProfile', () => {
     })
 
     it('limits Safari transcoding to mp3 only', () => {
-      vi.stubGlobal(
-        'navigator',
-        { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.2 Safari/605.1.15' },
-      )
+      vi.stubGlobal('navigator', {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.2 Safari/605.1.15',
+      })
 
       const profile = detectBrowserProfile()
       const codecs = profile.transcodingProfiles.map((p) => p.audioCodec)
@@ -154,10 +154,10 @@ describe('detectBrowserProfile', () => {
     })
 
     it('does NOT restrict transcoding on Chrome', () => {
-      vi.stubGlobal(
-        'navigator',
-        { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' },
-      )
+      vi.stubGlobal('navigator', {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      })
 
       const profile = detectBrowserProfile()
       const codecs = profile.transcodingProfiles.map((p) => p.audioCodec)
@@ -166,10 +166,10 @@ describe('detectBrowserProfile', () => {
     })
 
     it('applies same restrictions on iOS Safari', () => {
-      vi.stubGlobal(
-        'navigator',
-        { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1' },
-      )
+      vi.stubGlobal('navigator', {
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      })
 
       const profile = detectBrowserProfile()
       const codecs = profile.transcodingProfiles.map((p) => p.audioCodec)


### PR DESCRIPTION
### Description

Fixes browser codec detection and Safari transcoding issues in the web player:

1. **MIME type probes now use codec-qualified strings with multiple variants** — Instead of bare MIME types (e.g. `audio/flac`), probes now use codec-qualified variants (e.g. `audio/flac; codecs="flac"`). Each codec can specify multiple MIME strings to account for browser differences. This also accepts `maybe` in addition to `probably` from `canPlayType`, improving detection on browsers that are conservative in their responses.

2. **Safari transcoding is restricted to MP3 only** — Safari reports `canPlayType` support for Ogg/Opus and FLAC containers, but fails when streaming non-seekable transcoded content. This PR detects Safari via user-agent and limits its transcoding profiles to MP3, while keeping Ogg in direct play profiles (direct play works fine since the server can handle range requests).

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Open Navidrome in **Safari** (macOS or iOS)
2. Play a track that requires transcoding (e.g. a FLAC file when the server is set to transcode)
3. Verify the stream plays correctly as MP3 (check network tab — the transcoded stream should use `mp3` container)
4. Open Navidrome in **Chrome** or **Firefox**
5. Verify that Opus and FLAC transcoding options are still available and work correctly
6. Check the browser profile sent to the server (in network requests) to confirm codec detection is correct

### Additional Notes

- The codec probe order was changed: AAC was moved to the end of the list since it's less commonly used for transcoding
- The `isSafari()` detection uses user-agent string matching, which is the standard approach for Safari-specific workarounds
- Direct play of Ogg files still works on Safari (the restriction only applies to transcoded streams)
