### PR TITLE
fix(bookmark): always return required queue fields

### DIFF
--- a/server/e2e/subsonic_bookmarks_test.go
+++ b/server/e2e/subsonic_bookmarks_test.go
@@ -77,12 +77,28 @@ var _ = Describe("Bookmark and PlayQueue Endpoints", Ordered, func() {
 			}
 		})
 
-		It("getPlayQueue returns empty when nothing saved", func() {
+		It("getPlayQueue returns minimum required fields when nothing specified", func() {
 			resp := doReq("getPlayQueue")
 
 			Expect(resp.Status).To(Equal(responses.StatusOK))
-			// When no play queue exists, PlayQueue should be nil (no entry returned)
-			Expect(resp.PlayQueue).To(BeNil())
+			Expect(resp.PlayQueue).ToNot(BeNil())
+			Expect(resp.PlayQueue.Entry).To(HaveLen(0))
+			Expect(resp.PlayQueue.Current).To(BeEmpty())
+			Expect(resp.PlayQueue.Position).To(Equal(int64(0)))
+			Expect(resp.PlayQueue.Username).To(Equal(adminUser.UserName))
+			Expect(resp.PlayQueue.ChangedBy).To(BeEmpty())
+		})
+
+		It("getPlayQueueByIndex returns minimum required fields when nothing specified", func() {
+			resp := doReq("getPlayQueueByIndex")
+
+			Expect(resp.Status).To(Equal(responses.StatusOK))
+			Expect(resp.PlayQueueByIndex).ToNot(BeNil())
+			Expect(resp.PlayQueueByIndex.Entry).To(HaveLen(0))
+			Expect(resp.PlayQueueByIndex.CurrentIndex).To(BeNil())
+			Expect(resp.PlayQueueByIndex.Position).To(Equal(int64(0)))
+			Expect(resp.PlayQueueByIndex.Username).To(Equal(adminUser.UserName))
+			Expect(resp.PlayQueueByIndex.ChangedBy).To(BeEmpty())
 		})
 
 		It("savePlayQueue stores current play queue", func() {

--- a/server/subsonic/bookmarks.go
+++ b/server/subsonic/bookmarks.go
@@ -78,7 +78,11 @@ func (api *Router) GetPlayQueue(r *http.Request) (*responses.Subsonic, error) {
 		return nil, err
 	}
 	if pq == nil || len(pq.Items) == 0 {
-		return newResponse(), nil
+		response := newResponse()
+		response.PlayQueue = &responses.PlayQueue{
+			Username: user.UserName,
+		}
+		return response, nil
 	}
 
 	response := newResponse()
@@ -145,7 +149,11 @@ func (api *Router) GetPlayQueueByIndex(r *http.Request) (*responses.Subsonic, er
 		return nil, err
 	}
 	if pq == nil || len(pq.Items) == 0 {
-		return newResponse(), nil
+		response := newResponse()
+		response.PlayQueueByIndex = &responses.PlayQueueByIndex{
+			Username: user.UserName,
+		}
+		return response, nil
 	}
 
 	response := newResponse()


### PR DESCRIPTION
### Description
In `getPlayQueue` and `getPlayQueueByIndex`, if no queue was specified, it would return no fields.
This goes against OS spec, where some fields are always required.

### Related Issues
Discovered by https://github.com/jeffvli/feishin/pull/1828

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [X] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
`make test`. Or, create a user and fetch the queue where the user has no queue.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->