### PR TITLE
fix(db): check both name and target_format in default transcodings migration

### DIFF
--- a/db/migrations/20260309203355_ensure_default_transcodings.go
+++ b/db/migrations/20260309203355_ensure_default_transcodings.go
@@ -17,9 +17,12 @@ func upEnsureDefaultTranscodings(_ context.Context, tx *sql.Tx) error {
 	// Older installations may be missing default transcodings that were added
 	// after the initial seeding (e.g., aac was added later than mp3/opus).
 	// Insert any missing defaults without touching user-customized entries.
+	// Check both target_format and name since both have UNIQUE constraints,
+	// and older entries may have a different target_format (e.g., 'oga' vs 'opus')
+	// but the same name.
 	for _, t := range consts.DefaultTranscodings {
 		var count int
-		err := tx.QueryRow("SELECT COUNT(*) FROM transcoding WHERE target_format = ?", t.TargetFormat).Scan(&count)
+		err := tx.QueryRow("SELECT COUNT(*) FROM transcoding WHERE target_format = ? OR name = ?", t.TargetFormat, t.Name).Scan(&count)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### Description

The `ensure_default_transcodings` migration (20260309203355) only checked `target_format` before inserting default transcoding entries, but the `transcoding` table has `UNIQUE` constraints on **both** `name` and `target_format`. Older installations may have entries where the `name` matches a default (e.g., `'opus audio'`) but the `target_format` differs (e.g., `'oga'` instead of `'opus'`), causing a `UNIQUE constraint failed: transcoding.name` error that prevents Navidrome from starting.

The fix adds `OR name = ?` to the existence check so that both unique columns are considered before attempting an INSERT.

**Note:** This modifies an already-merged migration because the bug is fatal on startup — affected users cannot start Navidrome at all, and a new migration cannot run because goose stops at the failing one. Users who already ran this migration successfully are unaffected since the check is purely additive.

### Related Issues

Fixes #5174

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No new tests added — this is a one-line SQL query change in a migration. The scenario requires a specific legacy database state (old `target_format` with matching `name`) that isn't covered by the existing migration test infrastructure.

### How to Test

1. Create a database with a transcoding entry like: `name='opus audio', target_format='oga'` (simulating an older installation)
2. Run Navidrome — the migration should now succeed instead of crashing with `UNIQUE constraint failed`
3. Verify that default transcodings present by name or target_format are not duplicated

### Additional Notes

The original migration `20260309203355` was introduced in #5165. The reporter's database had opus with `target_format='oga'` (old default) instead of `'opus'` (current default), which caused the name collision.
