### PR TITLE
fix(scanner): prevent duplicate tracks when multiple missing files match same target

### DIFF
--- a/scanner/phase_2_missing_tracks.go
+++ b/scanner/phase_2_missing_tracks.go
@@ -114,6 +114,10 @@ func (p *phaseMissingTracks) stages() []ppl.Stage[*missingTracks] {
 
 func (p *phaseMissingTracks) processMissingTracks(in *missingTracks) (*missingTracks, error) {
 	hasMatches := false
+	// Track which matched entries have already been consumed, so each matched track
+	// is only used once. Without this, the same matched track could be paired with
+	// multiple missing tracks, creating duplicate records with the same path.
+	usedMatched := make(map[string]bool, len(in.matched))
 
 	for _, ms := range in.missing {
 		var exactMatch model.MediaFile
@@ -121,6 +125,9 @@ func (p *phaseMissingTracks) processMissingTracks(in *missingTracks) (*missingTr
 
 		// Identify exact and equivalent matches
 		for _, mt := range in.matched {
+			if usedMatched[mt.ID] {
+				continue
+			}
 			if ms.Equals(mt) {
 				exactMatch = mt
 				break // Prioritize exact match
@@ -138,13 +145,14 @@ func (p *phaseMissingTracks) processMissingTracks(in *missingTracks) (*missingTr
 				log.Error(p.ctx, "Scanner: Error moving matched track", "missing", ms.Path, "movedTo", exactMatch.Path, "lib", in.lib.Name, err)
 				return nil, err
 			}
+			usedMatched[exactMatch.ID] = true
 			p.totalMatched.Add(1)
 			hasMatches = true
 			continue
 		}
 
 		// If there is only one missing and one matched track, consider them equivalent (same PID)
-		if len(in.missing) == 1 && len(in.matched) == 1 {
+		if len(in.missing) == 1 && len(in.matched) == 1 && !usedMatched[in.matched[0].ID] {
 			singleMatch := in.matched[0]
 			log.Debug(p.ctx, "Scanner: Found track with same persistent ID in a new place", "missing", ms.Path, "movedTo", singleMatch.Path, "lib", in.lib.Name)
 			err := p.moveMatched(singleMatch, ms)
@@ -152,6 +160,7 @@ func (p *phaseMissingTracks) processMissingTracks(in *missingTracks) (*missingTr
 				log.Error(p.ctx, "Scanner: Error updating matched track", "missing", ms.Path, "movedTo", singleMatch.Path, "lib", in.lib.Name, err)
 				return nil, err
 			}
+			usedMatched[singleMatch.ID] = true
 			p.totalMatched.Add(1)
 			hasMatches = true
 			continue
@@ -165,6 +174,7 @@ func (p *phaseMissingTracks) processMissingTracks(in *missingTracks) (*missingTr
 				log.Error(p.ctx, "Scanner: Error updating matched track", "missing", ms.Path, "movedTo", equivalentMatch.Path, "lib", in.lib.Name, err)
 				return nil, err
 			}
+			usedMatched[equivalentMatch.ID] = true
 			p.totalMatched.Add(1)
 			hasMatches = true
 		}

--- a/scanner/phase_2_missing_tracks_test.go
+++ b/scanner/phase_2_missing_tracks_test.go
@@ -241,6 +241,39 @@ var _ = Describe("phaseMissingTracks", func() {
 			Expect(movedTrack.Size).To(Equal(missingTrack.Size))
 		})
 
+		It("should not match the same target to multiple missing tracks (prevents duplicate paths)", func() {
+			// Simulate a scenario where two missing tracks from different locations have the same
+			// base filename and match the same newly imported track via IsEquivalent.
+			// Without deduplication, both missing tracks would be "moved" to the same target,
+			// creating two non-missing records with the same path.
+			missingTrack1 := model.MediaFile{ID: "1", PID: "A", Path: "old_dir1/song.mp3", Title: "title1", Size: 100}
+			missingTrack2 := model.MediaFile{ID: "2", PID: "A", Path: "old_dir2/song.mp3", Title: "title1", Size: 100}
+			matchedTrack := model.MediaFile{ID: "3", PID: "A", Path: "new_dir/song.mp3", Title: "title1", Size: 200}
+
+			_ = ds.MediaFile(ctx).Put(&missingTrack1)
+			_ = ds.MediaFile(ctx).Put(&missingTrack2)
+			_ = ds.MediaFile(ctx).Put(&matchedTrack)
+
+			in := &missingTracks{
+				missing: []model.MediaFile{missingTrack1, missingTrack2},
+				matched: []model.MediaFile{matchedTrack},
+			}
+
+			_, err := phase.processMissingTracks(in)
+			Expect(err).ToNot(HaveOccurred())
+			// Only one of the missing tracks should be matched
+			Expect(phase.totalMatched.Load()).To(Equal(uint32(1)))
+			Expect(state.changesDetected.Load()).To(BeTrue())
+
+			// The matched track should have been consumed by the first missing track
+			movedTrack, _ := ds.MediaFile(ctx).Get("1")
+			Expect(movedTrack.Path).To(Equal(matchedTrack.Path))
+
+			// The second missing track should remain unchanged
+			unmatchedTrack, _ := ds.MediaFile(ctx).Get("2")
+			Expect(unmatchedTrack.Path).To(Equal(missingTrack2.Path))
+		})
+
 		It("should return an error when there's an error moving the matched track", func() {
 			missingTrack := model.MediaFile{ID: "1", PID: "A", Path: "path1.mp3", Tags: model.Tags{"title": []string{"title1"}}}
 			matchedTrack := model.MediaFile{ID: "2", PID: "A", Path: "path1.mp3", Tags: model.Tags{"title": []string{"title1"}}}


### PR DESCRIPTION
### Description

When multiple missing tracks share the same PID and have the same base filename, the scanner's move detection (`processMissingTracks`) could match all of them to the same newly-imported target track. Each call to `moveMatched` would update a different missing record to point to the target's path, while the delete of the target record only succeeds on the first call (subsequent deletes silently affect 0 rows). This creates multiple non-missing records with identical paths — the duplicate songs the user sees.

The fix tracks which matched tracks have already been consumed in a `usedMatched` map, so each target is used at most once.

### Related Issues

Fixes #5169

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run `make test PKG=./scanner` — all 235 tests should pass
2. The new test `should not match the same target to multiple missing tracks (prevents duplicate paths)` specifically verifies that when two missing tracks with the same base filename match the same target, only one gets matched and the other remains unchanged
3. The test was verified to **fail** on the unfixed code and **pass** with the fix

### Additional Notes

The bug is triggered when files are moved between folders and their tags are modified by external tools (e.g., MusicBrainz Picard, beets). The watcher accumulates changes from multiple file operations, and when the scan runs, multiple "missing" entries from different historical locations can share the same PID group. If they have the same base filename, they all match the same target via `IsEquivalent`, creating duplicates.
