### PR TITLE
fix(share): add ownership checks to Delete and Update

### DIFF
--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -149,9 +149,19 @@ func sortByIdPosition(mfs model.MediaFiles, ids []string) model.MediaFiles {
 	return sorted
 }
 
+// TODO: Ownership checks should be moved to the service layer (core/share.go)
 func (r *shareRepository) Update(id string, entity any, cols ...string) error {
 	s := entity.(*model.Share)
-	// TODO Validate record
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && usr.ID != invalidUserId {
+		existing, err := r.Get(id)
+		if err != nil {
+			return err
+		}
+		if existing.UserID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
 	s.ID = id
 	s.UpdatedAt = time.Now()
 	cols = append(cols, "updated_at")

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -31,16 +31,28 @@ func NewShareRepository(ctx context.Context, db dbx.Builder) model.ShareReposito
 }
 
 // TODO: Ownership checks should be moved to the service layer (core/share.go)
-func (r *shareRepository) Delete(id string) error {
+func (r *shareRepository) checkOwnership(id string) error {
 	usr := loggedUser(r.ctx)
-	if !usr.IsAdmin && usr.ID != invalidUserId {
-		share, err := r.Get(id)
-		if err != nil {
-			return err
-		}
-		if share.UserID != usr.ID {
-			return rest.ErrPermissionDenied
-		}
+	if usr.IsAdmin || usr.ID == invalidUserId {
+		return nil
+	}
+	sel := r.newSelect().Columns("user_id").Where(Eq{"id": id})
+	var share struct {
+		UserID string `db:"user_id"`
+	}
+	err := r.queryOne(sel, &share)
+	if err != nil {
+		return err
+	}
+	if share.UserID != usr.ID {
+		return rest.ErrPermissionDenied
+	}
+	return nil
+}
+
+func (r *shareRepository) Delete(id string) error {
+	if err := r.checkOwnership(id); err != nil {
+		return err
 	}
 	err := r.delete(Eq{"id": id})
 	if errors.Is(err, model.ErrNotFound) {
@@ -149,18 +161,10 @@ func sortByIdPosition(mfs model.MediaFiles, ids []string) model.MediaFiles {
 	return sorted
 }
 
-// TODO: Ownership checks should be moved to the service layer (core/share.go)
 func (r *shareRepository) Update(id string, entity any, cols ...string) error {
 	s := entity.(*model.Share)
-	usr := loggedUser(r.ctx)
-	if !usr.IsAdmin && usr.ID != invalidUserId {
-		existing, err := r.Get(id)
-		if err != nil {
-			return err
-		}
-		if existing.UserID != usr.ID {
-			return rest.ErrPermissionDenied
-		}
+	if err := r.checkOwnership(id); err != nil {
+		return err
 	}
 	s.ID = id
 	s.UpdatedAt = time.Now()

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -42,6 +42,9 @@ func (r *shareRepository) checkOwnership(id string) error {
 	}
 	err := r.queryOne(sel, &share)
 	if err != nil {
+		if errors.Is(err, model.ErrNotFound) {
+			return rest.ErrNotFound
+		}
 		return err
 	}
 	if share.UserID != usr.ID {

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -30,7 +30,18 @@ func NewShareRepository(ctx context.Context, db dbx.Builder) model.ShareReposito
 	return r
 }
 
+// TODO: Ownership checks should be moved to the service layer (core/share.go)
 func (r *shareRepository) Delete(id string) error {
+	usr := loggedUser(r.ctx)
+	if !usr.IsAdmin && usr.ID != invalidUserId {
+		share, err := r.Get(id)
+		if err != nil {
+			return err
+		}
+		if share.UserID != usr.ID {
+			return rest.ErrPermissionDenied
+		}
+	}
 	err := r.delete(Eq{"id": id})
 	if errors.Is(err, model.ErrNotFound) {
 		return rest.ErrNotFound

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -184,5 +184,38 @@ var _ = Describe("ShareRepository", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 		})
+
+		Describe("Update", func() {
+			It("allows a non-admin user to update their own share", func() {
+				insertShare("own-share-upd", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), ownerUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Update("own-share-upd", &model.Share{Description: "Updated"}, "description")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("denies a non-admin user from updating another user's share", func() {
+				insertShare("other-share-upd", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), otherUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Update("other-share-upd", &model.Share{Description: "Hacked"}, "description")
+				Expect(err).To(Equal(rest.ErrPermissionDenied))
+			})
+
+			It("allows an admin to update any user's share", func() {
+				insertShare("admin-upd-share", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), adminUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Update("admin-upd-share", &model.Share{Description: "Admin Updated"}, "description")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("allows headless context (no user) to update a share", func() {
+				insertShare("headless-upd-share", ownerUser.ID)
+				repo := NewShareRepository(context.Background(), GetDBXBuilder())
+				err := repo.(rest.Persistable).Update("headless-upd-share", &model.Share{Description: "Headless"}, "description")
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
 	})
 })

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -128,6 +129,60 @@ var _ = Describe("ShareRepository", func() {
 			Expect(share.ID).To(Equal(shareID))
 			// Albums array should be empty since we used non-existent album ID
 			Expect(share.Albums).To(BeEmpty())
+		})
+	})
+
+	Describe("Ownership Checks", func() {
+		var ownerUser = model.User{ID: "2222", UserName: "regular-user"}
+		var otherUser = model.User{ID: "3333", UserName: "third-user"}
+
+		insertShare := func(shareID, userID string) {
+			_, err := GetDBXBuilder().NewQuery(`
+				INSERT INTO share (id, user_id, description, resource_type, resource_ids, created_at, updated_at)
+				VALUES ({:id}, {:user}, {:desc}, {:type}, {:ids}, {:created}, {:updated})
+			`).Bind(map[string]any{
+				"id":      shareID,
+				"user":    userID,
+				"desc":    "Test Share",
+				"type":    "media_file",
+				"ids":     "1001",
+				"created": time.Now(),
+				"updated": time.Now(),
+			}).Execute()
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		Describe("Delete", func() {
+			It("allows a non-admin user to delete their own share", func() {
+				insertShare("own-share-del", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), ownerUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Delete("own-share-del")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("denies a non-admin user from deleting another user's share", func() {
+				insertShare("other-share-del", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), otherUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Delete("other-share-del")
+				Expect(err).To(Equal(rest.ErrPermissionDenied))
+			})
+
+			It("allows an admin to delete any user's share", func() {
+				insertShare("admin-del-share", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), adminUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Delete("admin-del-share")
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("allows headless context (no user) to delete a share", func() {
+				insertShare("headless-del-share", ownerUser.ID)
+				repo := NewShareRepository(context.Background(), GetDBXBuilder())
+				err := repo.(rest.Persistable).Delete("headless-del-share")
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 	})
 })


### PR DESCRIPTION
### Description

The share repository (`persistence/share_repository.go`) lacked user ownership validation on `Delete` and `Update` operations. Any authenticated user could modify or delete shares belonging to other users via the Subsonic API (`deleteShare.view`, `updateShare.view`) or the native REST API (`DELETE/PUT /api/share/{id}`).

This PR adds ownership checks to both operations:
- Before deleting or updating a share, the repository now verifies that the logged-in user owns the share
- Admins and headless/background contexts (public share access) bypass the check
- A lightweight single-column query fetches only `user_id` for the check, avoiding the overhead of loading full share media data

The fix follows existing codebase patterns (e.g., `playerRepository`, `radioRepository`) and includes a TODO noting that these checks should eventually move to the service layer (`core/share.go`).

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Run the persistence test suite:
```bash
make test PKG=./persistence
```

The new tests cover 8 scenarios across Delete and Update:
1. Non-admin user deleting/updating their own share — succeeds
2. Non-admin user deleting/updating another user's share — returns `ErrPermissionDenied`
3. Admin deleting/updating any user's share — succeeds
4. Headless context (no user, e.g. public share access) — succeeds (bypass)

### Additional Notes

- **Public share access is preserved**: `core/share.go`'s `Load` method calls `Update` on the raw repository (not the wrapper) to increment visit counts from public endpoints. The `invalidUserId` bypass ensures this continues to work.
- **No read filtering**: All users can still see all shares via `GetAll`/`ReadAll`. Only mutations are restricted.
- **Future improvement**: A TODO marks that ownership checks should move to `core/share.go` (service layer) for better architectural separation.
