### PR TITLE
fix(ui): allow DefaultTheme "Auto" from config

### DIFF
--- a/ui/src/consts.js
+++ b/ui/src/consts.js
@@ -7,6 +7,8 @@ export const M3U_MIME_TYPE = 'audio/x-mpegurl'
 
 export const AUTO_THEME_ID = 'AUTO_THEME_ID'
 
+export const AUTO_THEME_CONFIG_VALUE = 'Auto'
+
 export const DraggableTypes = {
   SONG: 'song',
   ALBUM: 'album',

--- a/ui/src/reducers/themeReducer.js
+++ b/ui/src/reducers/themeReducer.js
@@ -1,8 +1,12 @@
 import { CHANGE_THEME } from '../actions'
+import { AUTO_THEME_ID, AUTO_THEME_CONFIG_VALUE } from '../consts'
 import config from '../config'
 import themes from '../themes'
 
 const defaultTheme = () => {
+  if (config.defaultTheme === AUTO_THEME_CONFIG_VALUE) {
+    return AUTO_THEME_ID
+  }
   return (
     Object.keys(themes).find(
       (t) => themes[t].themeName === config.defaultTheme,

--- a/ui/src/reducers/themeReducer.test.js
+++ b/ui/src/reducers/themeReducer.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AUTO_THEME_ID, AUTO_THEME_CONFIG_VALUE } from '../consts'
+
+describe('themeReducer', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it.each([
+    { configTheme: AUTO_THEME_CONFIG_VALUE, expected: AUTO_THEME_ID, description: 'is "Auto"' },
+    { configTheme: 'Dark', expected: 'DarkTheme', description: 'is "Dark"' },
+    { configTheme: 'NonExistent', expected: 'DarkTheme', description: 'is unrecognized' },
+  ])('returns $expected when defaultTheme config $description', async ({ configTheme, expected }) => {
+    vi.doMock('../config', () => ({
+      default: { defaultTheme: configTheme },
+    }))
+    const { themeReducer } = await import('./themeReducer')
+    const result = themeReducer(undefined, { type: 'UNKNOWN' })
+    expect(result).toBe(expected)
+  })
+})

--- a/ui/src/reducers/themeReducer.test.js
+++ b/ui/src/reducers/themeReducer.test.js
@@ -7,15 +7,26 @@ describe('themeReducer', () => {
   })
 
   it.each([
-    { configTheme: AUTO_THEME_CONFIG_VALUE, expected: AUTO_THEME_ID, description: 'is "Auto"' },
+    {
+      configTheme: AUTO_THEME_CONFIG_VALUE,
+      expected: AUTO_THEME_ID,
+      description: 'is "Auto"',
+    },
     { configTheme: 'Dark', expected: 'DarkTheme', description: 'is "Dark"' },
-    { configTheme: 'NonExistent', expected: 'DarkTheme', description: 'is unrecognized' },
-  ])('returns $expected when defaultTheme config $description', async ({ configTheme, expected }) => {
-    vi.doMock('../config', () => ({
-      default: { defaultTheme: configTheme },
-    }))
-    const { themeReducer } = await import('./themeReducer')
-    const result = themeReducer(undefined, { type: 'UNKNOWN' })
-    expect(result).toBe(expected)
-  })
+    {
+      configTheme: 'NonExistent',
+      expected: 'DarkTheme',
+      description: 'is unrecognized',
+    },
+  ])(
+    'returns $expected when defaultTheme config $description',
+    async ({ configTheme, expected }) => {
+      vi.doMock('../config', () => ({
+        default: { defaultTheme: configTheme },
+      }))
+      const { themeReducer } = await import('./themeReducer')
+      const result = themeReducer(undefined, { type: 'UNKNOWN' })
+      expect(result).toBe(expected)
+    },
+  )
 })


### PR DESCRIPTION
## Problem

When `DefaultTheme` is set to `"Auto"` in the Navidrome config, new or incognito users always get the Dark theme instead of having their OS `prefers-color-scheme` respected.

## Root Cause

`defaultTheme()` in `themeReducer.js` searches for a theme whose `themeName === "Auto"`, finds nothing, and falls back to `"DarkTheme"`. There was no special handling for the `"Auto"` value.

## Fix

Added an early check: when `config.defaultTheme === "Auto"`, return `AUTO_THEME_ID` directly. The existing `useCurrentTheme` hook already handles `AUTO_THEME_ID` correctly by reading `prefers-color-scheme`.

## Tests

Added `themeReducer.test.js` with 3 cases:
- `"Auto"` → `AUTO_THEME_ID`
- `"Dark"` → `"DarkTheme"` (named theme lookup)
- `"NonExistent"` → `"DarkTheme"` (fallback)

All existing `useCurrentTheme` tests pass unchanged (11/11).