### PR TITLE
fix(ui): add tooltips for truncated playlist and album names

### DIFF
--- a/ui/src/album/AlbumGridView.jsx
+++ b/ui/src/album/AlbumGridView.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {
   GridList,
   GridListTile,
+  Tooltip,
   Typography,
   GridListTileBar,
   useMediaQuery,
@@ -198,11 +199,17 @@ const AlbumGridTile = ({ showArtist, record, basePath, ...props }) => {
         to={linkToRecord(basePath, record.id, 'show')}
       >
         <span>
-          <Typography className={classes.albumName}>{record.name}</Typography>
-          {record.tags && record.tags['albumversion'] && (
-            <Typography className={classes.albumVersion}>
-              {record.tags['albumversion']}
+          <Tooltip title={record.name}>
+            <Typography className={classes.albumName}>
+              {record.name}
             </Typography>
+          </Tooltip>
+          {record.tags && record.tags['albumversion'] && (
+            <Tooltip title={record.tags['albumversion']}>
+              <Typography className={classes.albumVersion}>
+                {record.tags['albumversion']}
+              </Typography>
+            </Tooltip>
           )}
         </span>
       </Link>

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -7,7 +7,7 @@ import {
 } from 'react-admin'
 import { useHistory } from 'react-router-dom'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
-import { Typography } from '@material-ui/core'
+import { Typography, Tooltip } from '@material-ui/core'
 import QueueMusicOutlinedIcon from '@material-ui/icons/QueueMusicOutlined'
 import { BiCog } from 'react-icons/bi'
 import { useDrop } from 'react-dnd'
@@ -39,9 +39,11 @@ const PlaylistMenuItemLink = ({ pls, sidebarIsOpen }) => {
     <MenuItemLink
       to={`/playlist/${pls.id}/show`}
       primaryText={
-        <Typography variant="inherit" noWrap ref={dropRef}>
-          {pls.name}
-        </Typography>
+        <Tooltip title={pls.name}>
+          <Typography variant="inherit" noWrap ref={dropRef}>
+            {pls.name}
+          </Typography>
+        </Tooltip>
       }
       sidebarIsOpen={sidebarIsOpen}
       dense={false}

--- a/ui/src/playlist/PlaylistDetails.jsx
+++ b/ui/src/playlist/PlaylistDetails.jsx
@@ -274,12 +274,14 @@ const PlaylistDetails = (props) => {
         </div>
         <div className={classes.details}>
           <CardContent className={classes.content}>
-            <Typography
-              variant={isDesktop ? 'h5' : 'h6'}
-              className={classes.title}
-            >
-              {record.name || translate('ra.page.loading')}
-            </Typography>
+            <Tooltip title={record.name || ''}>
+              <Typography
+                variant={isDesktop ? 'h5' : 'h6'}
+                className={classes.title}
+              >
+                {record.name || translate('ra.page.loading')}
+              </Typography>
+            </Tooltip>
             <Typography component="p" className={classes.stats}>
               {record.songCount ? (
                 <span>


### PR DESCRIPTION
## Summary

Add native `title` attributes to truncated text elements so hovering reveals the full name without navigating away.

### Changes

- **Album grid view:** tooltip on album name and album version tag
- **Sidebar playlists:** tooltip on playlist name
- **Playlist detail header:** tooltip on playlist name

Fixes #5068