### PR TITLE
fix: add syslog priority prefixes for systemd-journald

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -346,6 +346,10 @@ func Load(noConfigDump bool) {
 			os.Exit(1)
 		}
 		log.SetOutput(out)
+	} else if os.Getenv("JOURNAL_STREAM") != "" {
+		// When running under systemd, prepend syslog priority prefixes so
+		// journald assigns the correct severity to each log line.
+		log.EnableJournalFormat()
 	}
 
 	log.SetLevelString(Server.LogLevel)

--- a/log/journal.go
+++ b/log/journal.go
@@ -1,0 +1,41 @@
+package log
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+// journalFormatter wraps a logrus.Formatter and prepends a syslog priority
+// prefix (<N>) to each log line. When stderr is captured by systemd-journald,
+// this prefix tells journald the correct severity for each message.
+//
+// See https://www.freedesktop.org/software/systemd/man/sd-daemon.html
+type journalFormatter struct {
+	inner logrus.Formatter
+}
+
+// levelToPriority maps logrus levels to syslog priority values.
+// The mapping follows RFC 5424 severity levels.
+var levelToPriority = map[logrus.Level]int{
+	logrus.PanicLevel: 0, // emerg
+	logrus.FatalLevel: 2, // crit
+	logrus.ErrorLevel: 3, // err
+	logrus.WarnLevel:  4, // warning
+	logrus.InfoLevel:  6, // info
+	logrus.DebugLevel: 7, // debug
+	logrus.TraceLevel: 7, // debug
+}
+
+func (f *journalFormatter) Format(entry *logrus.Entry) ([]byte, error) {
+	formatted, err := f.inner.Format(entry)
+	if err != nil {
+		return formatted, err
+	}
+	priority, ok := levelToPriority[entry.Level]
+	if !ok {
+		priority = 6 // default to info for unknown levels
+	}
+	prefix := []byte(fmt.Sprintf("<%d>", priority))
+	return append(prefix, formatted...), nil
+}

--- a/log/journal_test.go
+++ b/log/journal_test.go
@@ -1,48 +1,41 @@
 package log
 
 import (
-	"testing"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 )
 
-func TestJournalFormatterPrefixes(t *testing.T) {
-	inner := &logrus.TextFormatter{
-		DisableTimestamp: true,
-		DisableColors:   true,
-	}
-	formatter := &journalFormatter{inner: inner}
+var _ = Describe("journalFormatter", func() {
+	var formatter *journalFormatter
 
-	tests := []struct {
-		level          logrus.Level
-		expectedPrefix string
-	}{
-		{logrus.ErrorLevel, "<3>"},
-		{logrus.WarnLevel, "<4>"},
-		{logrus.InfoLevel, "<6>"},
-		{logrus.DebugLevel, "<7>"},
-		{logrus.TraceLevel, "<7>"},
-		{logrus.FatalLevel, "<2>"},
-		{logrus.PanicLevel, "<0>"},
-		{logrus.Level(99), "<6>"}, // unknown level defaults to info
-	}
+	BeforeEach(func() {
+		inner := &logrus.TextFormatter{
+			DisableTimestamp: true,
+			DisableColors:    true,
+		}
+		formatter = &journalFormatter{inner: inner}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.level.String(), func(t *testing.T) {
+	DescribeTable("prefixes log lines with syslog priority",
+		func(level logrus.Level, expectedPrefix string) {
 			entry := &logrus.Entry{
 				Logger:  logrus.New(),
-				Level:   tt.level,
+				Level:   level,
 				Message: "test message",
 				Data:    logrus.Fields{},
 			}
 			out, err := formatter.Format(entry)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			got := string(out)
-			if len(got) < len(tt.expectedPrefix) || got[:len(tt.expectedPrefix)] != tt.expectedPrefix {
-				t.Errorf("expected prefix %q, got %q", tt.expectedPrefix, got)
-			}
-		})
-	}
-}
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(out)).To(HavePrefix(expectedPrefix))
+		},
+		Entry("error", logrus.ErrorLevel, "<3>"),
+		Entry("warning", logrus.WarnLevel, "<4>"),
+		Entry("info", logrus.InfoLevel, "<6>"),
+		Entry("debug", logrus.DebugLevel, "<7>"),
+		Entry("trace", logrus.TraceLevel, "<7>"),
+		Entry("fatal", logrus.FatalLevel, "<2>"),
+		Entry("panic", logrus.PanicLevel, "<0>"),
+		Entry("unknown level defaults to info", logrus.Level(99), "<6>"),
+	)
+})

--- a/log/journal_test.go
+++ b/log/journal_test.go
@@ -1,0 +1,48 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+)
+
+func TestJournalFormatterPrefixes(t *testing.T) {
+	inner := &logrus.TextFormatter{
+		DisableTimestamp: true,
+		DisableColors:   true,
+	}
+	formatter := &journalFormatter{inner: inner}
+
+	tests := []struct {
+		level          logrus.Level
+		expectedPrefix string
+	}{
+		{logrus.ErrorLevel, "<3>"},
+		{logrus.WarnLevel, "<4>"},
+		{logrus.InfoLevel, "<6>"},
+		{logrus.DebugLevel, "<7>"},
+		{logrus.TraceLevel, "<7>"},
+		{logrus.FatalLevel, "<2>"},
+		{logrus.PanicLevel, "<0>"},
+		{logrus.Level(99), "<6>"}, // unknown level defaults to info
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level.String(), func(t *testing.T) {
+			entry := &logrus.Entry{
+				Logger:  logrus.New(),
+				Level:   tt.level,
+				Message: "test message",
+				Data:    logrus.Fields{},
+			}
+			out, err := formatter.Format(entry)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got := string(out)
+			if len(got) < len(tt.expectedPrefix) || got[:len(tt.expectedPrefix)] != tt.expectedPrefix {
+				t.Errorf("expected prefix %q, got %q", tt.expectedPrefix, got)
+			}
+		})
+	}
+}

--- a/log/log.go
+++ b/log/log.go
@@ -146,6 +146,15 @@ func SetOutput(w io.Writer) {
 	defaultLogger.SetOutput(w)
 }
 
+// EnableJournalFormat wraps the current logger formatter with syslog
+// priority prefixes for systemd-journald. Only call this when output
+// goes to stderr and JOURNAL_STREAM is set.
+func EnableJournalFormat() {
+	loggerMu.Lock()
+	defer loggerMu.Unlock()
+	defaultLogger.Formatter = &journalFormatter{inner: defaultLogger.Formatter}
+}
+
 // Redact applies redaction to a single string
 func Redact(msg string) string {
 	r, _ := redacted.redact(msg)


### PR DESCRIPTION
## Summary

When running under systemd, all navidrome log messages appear as priority 3 (error) in journald because plain text on stderr has no syslog priority metadata. This makes `journalctl` show every line in red, regardless of actual severity.

### Fix

Add a `journalFormatter` that wraps the existing logrus formatter and prepends `<N>` syslog priority prefixes ([sd-daemon protocol](https://www.freedesktop.org/software/systemd/man/sd-daemon.html)) to each log line. Automatically enabled when `JOURNAL_STREAM` is set (systemd-managed process) and no log file is configured.

### Priority mapping (RFC 5424)

| Logrus level | Syslog priority | Prefix |
|---|---|---|
| Panic | emerg | `<0>` |
| Fatal | crit | `<2>` |
| Error | err | `<3>` |
| Warn | warning | `<4>` |
| Info | info | `<6>` |
| Debug/Trace | debug | `<7>` |

### Changes

- `log/journal.go` — formatter wrapper with level-to-priority mapping
- `log/log.go` — `EnableJournalFormat()` public API
- `conf/configuration.go` — auto-detect systemd via `JOURNAL_STREAM` env var
- `log/journal_test.go` — tests for all priority levels

No behavior change outside systemd.

Fixes #5142