### PR TITLE
fix(subsonic): never omit duration for AlbumID3

### DIFF
--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
@@ -8,6 +8,7 @@
     "id": "1",
     "name": "album",
     "artist": "artist",
+    "duration": 292,
     "genre": "rock",
     "userRating": 4,
     "genres": [

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .XML
@@ -1,5 +1,5 @@
 <subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.16.1" type="navidrome" serverVersion="v0.55.0" openSubsonic="true">
-  <album id="1" name="album" artist="artist" genre="rock" userRating="4" musicBrainzId="1234" isCompilation="true" sortName="sorted album" displayArtist="artist1 &amp; artist2" explicitStatus="clean" version="Deluxe Edition">
+  <album id="1" name="album" artist="artist" duration="292" genre="rock" userRating="4" musicBrainzId="1234" isCompilation="true" sortName="sorted album" displayArtist="artist1 &amp; artist2" explicitStatus="clean" version="Deluxe Edition">
     <genres name="rock"></genres>
     <genres name="progressive"></genres>
     <discTitles disc="1" title="disc 1"></discTitles>

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .JSON
@@ -6,6 +6,7 @@
   "openSubsonic": true,
   "album": {
     "id": "",
-    "name": ""
+    "name": "",
+    "duration": 0
   }
 }

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match .XML
@@ -1,3 +1,3 @@
 <subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.16.1" type="navidrome" serverVersion="v0.55.0" openSubsonic="true">
-  <album id="" name=""></album>
+  <album id="" name="" duration="0"></album>
 </subsonic-response>

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match OpenSubsonic .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match OpenSubsonic .JSON
@@ -7,6 +7,7 @@
   "album": {
     "id": "",
     "name": "",
+    "duration": 0,
     "userRating": 0,
     "genres": [],
     "musicBrainzId": "",

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match OpenSubsonic .XML
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 without data should match OpenSubsonic .XML
@@ -1,3 +1,3 @@
 <subsonic-response xmlns="http://subsonic.org/restapi" status="ok" version="1.16.1" type="navidrome" serverVersion="v0.55.0" openSubsonic="true">
-  <album id="" name=""></album>
+  <album id="" name="" duration="0"></album>
 </subsonic-response>

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -250,7 +250,7 @@ type AlbumID3 struct {
 	ArtistId              string     `xml:"artistId,attr,omitempty"            json:"artistId,omitempty"`
 	CoverArt              string     `xml:"coverArt,attr,omitempty"            json:"coverArt,omitempty"`
 	SongCount             int32      `xml:"songCount,attr,omitempty"           json:"songCount,omitempty"`
-	Duration              int32      `xml:"duration,attr,omitempty"            json:"duration,omitempty"`
+	Duration              int32      `xml:"duration,attr"                      json:"duration"`
 	PlayCount             int64      `xml:"playCount,attr,omitempty"           json:"playCount,omitempty"`
 	Created               *time.Time `xml:"created,attr,omitempty"             json:"created,omitempty"`
 	Starred               *time.Time `xml:"starred,attr,omitempty"             json:"starred,omitempty"`

--- a/server/subsonic/responses/responses_test.go
+++ b/server/subsonic/responses/responses_test.go
@@ -288,7 +288,7 @@ var _ = Describe("Responses", func() {
 		Context("with data", func() {
 			BeforeEach(func() {
 				album := AlbumID3{
-					Id: "1", Name: "album", Artist: "artist", Genre: "rock",
+					Id: "1", Name: "album", Artist: "artist", Duration: 292, Genre: "rock",
 				}
 				album.OpenSubsonicAlbumID3 = &OpenSubsonicAlbumID3{
 					Genres:        []ItemGenre{{Name: "rock"}, {Name: "progressive"}},


### PR DESCRIPTION
### Description
<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->

### Related Issues
`duration` is a required field in `AlbumID3` per [OS](https://opensubsonic.netlify.app/docs/responses/albumid3/#:~:text=int-,yes,-Total%20duration%20of) (and subsonic, in the XML) spec.
This removes `omitempty` from `duration` and updates tests to be more meaningful.

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [ ] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [X] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
`make test`. Also, somehow fetch an album whose duration is 0 and verify that 0 is present.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->