### PR TITLE
fix(server): use http.TimeFormat for Last-Modified header

### DIFF
--- a/server/public/handle_images.go
+++ b/server/public/handle_images.go
@@ -60,7 +60,7 @@ func (pub *Router) handleImages(w http.ResponseWriter, r *http.Request) {
 
 	defer imgReader.Close()
 	w.Header().Set("Cache-Control", "public, max-age=315360000")
-	w.Header().Set("Last-Modified", lastUpdate.Format(time.RFC1123))
+	w.Header().Set("Last-Modified", lastUpdate.Format(http.TimeFormat))
 	cnt, err := io.Copy(w, imgReader)
 	if err != nil {
 		log.Warn(ctx, "Error sending image", "count", cnt, err)

--- a/server/subsonic/media_retrieval.go
+++ b/server/subsonic/media_retrieval.go
@@ -81,7 +81,7 @@ func (api *Router) GetCoverArt(w http.ResponseWriter, r *http.Request) (*respons
 
 	defer imgReader.Close()
 	w.Header().Set("cache-control", "public, max-age=315360000")
-	w.Header().Set("last-modified", lastUpdate.Format(time.RFC1123))
+	w.Header().Set("last-modified", lastUpdate.Format(http.TimeFormat))
 
 	cnt, err := io.Copy(w, imgReader)
 	if err != nil {


### PR DESCRIPTION
### Description
Navidrome returns Last-Modified values like `Fri, 12 Dec 2025 03:32:26 UTC`. This is invalid according to RFC 7231 which requires HTTP dates to use GMT instead of UTC. Switch to http.TimeFormat instead of time.RFC1123 to resolve the issue. This issue breaks date parsing in HTTP libraries with strict parsing.

### Related Issues
Couldn't find any.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

I haven't updated the documentation as this is a bug fix. I haven't added any tests, this is presumably tested by the authors of `http.TimeFormat` already.

### How to Test
Request cover art from the navidrome server:
```
$ curl -v 'http://your-navidrome-instance/rest/getCoverArt.view?id=ar-4FeYwc29BTXY22PUtaP2oL_0&u=simon&s=REDACTED&v=0.1.0&c=foo' 2>&1 | grep Last-Mod
< Last-Modified: Sat, 14 Feb 2026 15:37:18 UTC
$
```
Before the patch this returns a UTC timestamp, after the patch it says GMT instead.
