### PR TITLE
fix(logging): require additional variable to enable systemd logging

### DIFF
--- a/cmd/svc.go
+++ b/cmd/svc.go
@@ -248,7 +248,7 @@ ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 TimeoutStopSec=20
 RestartSec=120
 EnvironmentFile=-/etc/sysconfig/{{.Name}}
-Environment="EMIT_SYSTEMD_COLORS=1"
+Environment="ND_SYSTEMD_PRIORITY_LOGGING=1"
 
 DevicePolicy=closed
 NoNewPrivileges=yes

--- a/cmd/svc.go
+++ b/cmd/svc.go
@@ -248,6 +248,7 @@ ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
 TimeoutStopSec=20
 RestartSec=120
 EnvironmentFile=-/etc/sysconfig/{{.Name}}
+Environment="EMIT_SYSTEMD_COLORS=1"
 
 DevicePolicy=closed
 NoNewPrivileges=yes

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -341,7 +341,7 @@ func Load(noConfigDump bool) {
 			os.Exit(1)
 		}
 		log.SetOutput(out)
-	} else if os.Getenv("EMIT_SYSTEMD_COLORS") != "" && os.Getenv("JOURNAL_STREAM") != "" {
+	} else if os.Getenv("ND_SYSTEMD_PRIORITY_LOGGING") != "" && os.Getenv("JOURNAL_STREAM") != "" {
 		// When running under systemd, prepend syslog priority prefixes so
 		// journald assigns the correct severity to each log line.
 		// Note that we have an additional environment variable, as JOURNAL_STREAM

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -341,9 +341,11 @@ func Load(noConfigDump bool) {
 			os.Exit(1)
 		}
 		log.SetOutput(out)
-	} else if os.Getenv("JOURNAL_STREAM") != "" {
+	} else if os.Getenv("EMIT_SYSTEMD_COLORS") != "" && os.Getenv("JOURNAL_STREAM") != "" {
 		// When running under systemd, prepend syslog priority prefixes so
 		// journald assigns the correct severity to each log line.
+		// Note that we have an additional environment variable, as JOURNAL_STREAM
+		// can be present in a systemd environment even if not running as a systemd service
 		log.EnableJournalFormat()
 	}
 


### PR DESCRIPTION
### Description
<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->

### Related Issues
In SystemD environments, `JOURNAL_STREAM` can be set even if not _directly_ running in a systemd service.
Consequently, the logging engine will emit systemd color prefixes when not appropriate.
Gate this to a required environment variable, and put it in the systemd svc.
If accepted, this should also be included in the suggested systemd service on the website

### Type of Change
- [X] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
On a system with systemd, but **not** in a systemd service (e.g., most Linux systems).
Run `make dev` (or prod build), and verify that the systemd signals aren't being logged.
Then, install it as a service `navidrome svc install`, start the systemd service, verify that it has `EMIT_SYSTEMD_COLORS=1` in the service file, and that colors are present in the output log.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->