### PR TITLE
fix(scanner): widen WASM panic recovery to cover tag/property reading

### DIFF
--- a/adapters/gotaglib/gotaglib.go
+++ b/adapters/gotaglib/gotaglib.go
@@ -58,7 +58,19 @@ func (e extractor) Version() string {
 	return "unknown"
 }
 
-func (e extractor) extractMetadata(filePath string) (*metadata.Info, error) {
+func (e extractor) extractMetadata(filePath string) (info *metadata.Info, err error) {
+	// Recover from panics in the WASM runtime that can occur during any taglib
+	// operation (opening, reading tags, or reading properties). This catches crashes
+	// from malformed files or WASM runtime issues (e.g., wazero mmap failures on
+	// hardened systems with MemoryDenyWriteExecute=true).
+	debug.SetPanicOnFault(true)
+	defer func() {
+		if r := recover(); r != nil {
+			log.Error("gotaglib: WASM runtime panic reading file. Skipping", "file", filePath, "panic", r)
+			err = fmt.Errorf("WASM runtime panic: %v", r)
+		}
+	}()
+
 	f, close, err := e.openFile(filePath)
 	if err != nil {
 		log.Warn("gotaglib: Error reading metadata from file. Skipping", "filePath", filePath, err)
@@ -112,16 +124,6 @@ func (e extractor) extractMetadata(filePath string) (*metadata.Info, error) {
 // openFile opens the file at filePath using the extractor's filesystem.
 // It returns a TagLib File handle and a cleanup function to close resources.
 func (e extractor) openFile(filePath string) (f *taglib.File, closeFunc func(), err error) {
-	// Recover from panics in the WASM runtime (e.g., wazero failing to mmap executable memory
-	// on hardened systems like NixOS with MemoryDenyWriteExecute=true)
-	debug.SetPanicOnFault(true)
-	defer func() {
-		if r := recover(); r != nil {
-			log.Error("WASM runtime panic: This may be caused by a hardened system that blocks executable memory mapping.", "file", filePath, "panic", r)
-			err = fmt.Errorf("WASM runtime panic (hardened system?): %v", r)
-		}
-	}()
-
 	// Open the file from the filesystem
 	file, err := e.fs.Open(filePath)
 	if err != nil {

--- a/adapters/gotaglib/gotaglib.go
+++ b/adapters/gotaglib/gotaglib.go
@@ -67,6 +67,7 @@ func (e extractor) extractMetadata(filePath string) (info *metadata.Info, err er
 	defer func() {
 		if r := recover(); r != nil {
 			log.Error("gotaglib: WASM runtime panic reading file. Skipping", "filePath", filePath, "panic", r)
+			debug.PrintStack()
 			err = fmt.Errorf("WASM runtime panic: %v", r)
 		}
 	}()

--- a/adapters/gotaglib/gotaglib.go
+++ b/adapters/gotaglib/gotaglib.go
@@ -66,7 +66,7 @@ func (e extractor) extractMetadata(filePath string) (info *metadata.Info, err er
 	debug.SetPanicOnFault(true)
 	defer func() {
 		if r := recover(); r != nil {
-			log.Error("gotaglib: WASM runtime panic reading file. Skipping", "file", filePath, "panic", r)
+			log.Error("gotaglib: WASM runtime panic reading file. Skipping", "filePath", filePath, "panic", r)
 			err = fmt.Errorf("WASM runtime panic: %v", r)
 		}
 	}()


### PR DESCRIPTION
### Description

The WASM panic recovery in `gotaglib.go` was only inside `openFile()`, which covers the `taglib.OpenStream()` call. However, panics can also occur during `f.AllTags()` and `f.Properties()` — for example, when `readString()` crashes on malformed files or due to WASM runtime issues. These uncaught panics crash the scanner subprocess with exit status 2, causing the scan to fail entirely.

This PR moves the `recover()` from `openFile()` up to `extractMetadata()` so it covers the entire tag reading lifecycle (open, read tags, read properties). This matches the pattern used by the CGO-based taglib wrapper, which wraps the entire operation in a single `recover()`.

With this fix, files that trigger WASM panics are logged and skipped instead of crashing the scanner.

### Related Issues

Fixes #5220

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

Note: A unit test for this specific scenario would require triggering a WASM runtime panic from `AllTags()`/`Properties()`, which depends on specific malformed files that crash the WASM runtime — not feasible to reproduce in a unit test. The existing test suite passes, and the fix is a straightforward relocation of the existing panic recovery to a wider scope.

### How to Test

1. Apply the fix and scan a library containing files that previously caused the crash
2. Verify the scanner completes without `exit status 2` errors
3. Check logs for `gotaglib: WASM runtime panic reading file. Skipping` messages for problematic files (these files are now skipped instead of crashing)

### Additional Notes

The CGO-based taglib wrapper (`taglib_wrapper.go`) already wraps its entire `Read()` function in a `recover()`. This PR brings the WASM-based `gotaglib` extractor to parity with that approach.
