### PR TITLE
fix(server): improve transcoding failure diagnostics and error responses

### DIFF
--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -1,6 +1,7 @@
 package ffmpeg
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -258,10 +259,11 @@ func (e *ffmpeg) start(ctx context.Context, args []string, input ...io.Reader) (
 
 type ffCmd struct {
 	*io.PipeReader
-	out   *io.PipeWriter
-	args  []string
-	cmd   *exec.Cmd
-	input io.Reader // optional stdin source
+	out    *io.PipeWriter
+	args   []string
+	cmd    *exec.Cmd
+	input  io.Reader // optional stdin source
+	stderr *bytes.Buffer
 }
 
 func (j *ffCmd) start(ctx context.Context) error {
@@ -270,10 +272,12 @@ func (j *ffCmd) start(ctx context.Context) error {
 	if j.input != nil {
 		cmd.Stdin = j.input
 	}
+	j.stderr = &bytes.Buffer{}
+	stderrWriter := &limitedWriter{buf: j.stderr, limit: 4096}
 	if log.IsGreaterOrEqualTo(log.LevelTrace) {
-		cmd.Stderr = os.Stderr
+		cmd.Stderr = io.MultiWriter(os.Stderr, stderrWriter)
 	} else {
-		cmd.Stderr = io.Discard
+		cmd.Stderr = stderrWriter
 	}
 	j.cmd = cmd
 
@@ -287,13 +291,36 @@ func (j *ffCmd) wait() {
 	if err := j.cmd.Wait(); err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) {
-			_ = j.out.CloseWithError(fmt.Errorf("%s exited with non-zero status code: %d", j.args[0], exitErr.ExitCode()))
+			errMsg := fmt.Sprintf("%s exited with non-zero status code: %d", j.args[0], exitErr.ExitCode())
+			if stderrOutput := strings.TrimSpace(j.stderr.String()); stderrOutput != "" {
+				errMsg += ": " + stderrOutput
+			}
+			_ = j.out.CloseWithError(errors.New(errMsg))
 		} else {
 			_ = j.out.CloseWithError(fmt.Errorf("waiting %s cmd: %w", j.args[0], err))
 		}
 		return
 	}
 	_ = j.out.Close()
+}
+
+// limitedWriter wraps a bytes.Buffer and stops writing once the limit is reached.
+// Writes that would exceed the limit are silently discarded to prevent unbounded memory usage.
+type limitedWriter struct {
+	buf   *bytes.Buffer
+	limit int
+}
+
+func (w *limitedWriter) Write(p []byte) (int, error) {
+	remaining := w.limit - w.buf.Len()
+	if remaining <= 0 {
+		return len(p), nil // Discard but report success to avoid breaking the writer
+	}
+	if len(p) > remaining {
+		p = p[:remaining]
+	}
+	w.buf.Write(p)
+	return len(p), nil
 }
 
 // formatCodecMap maps target format to ffmpeg codec flag.

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -312,15 +312,16 @@ type limitedWriter struct {
 }
 
 func (w *limitedWriter) Write(p []byte) (int, error) {
+	n := len(p)
 	remaining := w.limit - w.buf.Len()
 	if remaining <= 0 {
-		return len(p), nil // Discard but report success to avoid breaking the writer
+		return n, nil // Discard but report success to avoid breaking the writer
 	}
 	if len(p) > remaining {
 		p = p[:remaining]
 	}
 	w.buf.Write(p)
-	return len(p), nil
+	return n, nil // Always report full write to avoid ErrShortWrite from io.MultiWriter
 }
 
 // formatCodecMap maps target format to ffmpeg codec flag.

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -604,6 +604,40 @@ var _ = Describe("ffmpeg", func() {
 			})
 		})
 
+		Context("stderr capture", func() {
+			It("should include stderr in error when process fails", func() {
+				ff := &ffmpeg{}
+				ctx := GinkgoT().Context()
+
+				// Directly call start() with a bash command that writes to stderr and fails
+				args := []string{"/bin/sh", "-c", "echo 'codec not found: libopus' >&2; exit 1"}
+				stream, err := ff.start(ctx, args)
+				Expect(err).ToNot(HaveOccurred())
+				defer stream.Close()
+
+				buf := make([]byte, 1024)
+				_, err = stream.Read(buf)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("codec not found: libopus"))
+			})
+
+			It("should not include stderr in error when process succeeds", func() {
+				ff := &ffmpeg{}
+				ctx := GinkgoT().Context()
+
+				// Command that writes to stderr but exits successfully
+				args := []string{"/bin/sh", "-c", "echo 'warning: something' >&2; printf 'output'"}
+				stream, err := ff.start(ctx, args)
+				Expect(err).ToNot(HaveOccurred())
+				defer stream.Close()
+
+				buf := make([]byte, 1024)
+				n, err := stream.Read(buf)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(buf[:n])).To(Equal("output"))
+			})
+		})
+
 		Context("with mock process behavior", func() {
 			var longRunningCmd string
 			BeforeEach(func() {

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -605,6 +605,12 @@ var _ = Describe("ffmpeg", func() {
 		})
 
 		Context("stderr capture", func() {
+			BeforeEach(func() {
+				if runtime.GOOS == "windows" {
+					Skip("stderr capture tests use /bin/sh, skipping on Windows")
+				}
+			})
+
 			It("should include stderr in error when process fails", func() {
 				ff := &ffmpeg{}
 				ctx := GinkgoT().Context()

--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -2,7 +2,6 @@ package stream
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"mime"
@@ -140,13 +139,14 @@ func (s *Stream) EstimatedContentLength() int {
 }
 
 // Serve writes the stream to the HTTP response. For seekable streams it uses http.ServeContent
-// (supporting range requests). For non-seekable streams it writes directly, detecting empty output
-// and io.Copy errors. It returns a non-nil error only when no bytes have been written and the caller
-// can still send an error response; once bytes are committed (HTTP 200 flushed) it logs and returns nil.
-func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+// (supporting range requests). For non-seekable streams it writes directly and logs any errors.
+// Returns the number of bytes written and an error only when io.Copy fails with 0 bytes written
+// (meaning the HTTP 200 status has not been flushed yet and the caller can still send an error response).
+// Empty output (0 bytes, no error) is logged but not treated as an error.
+func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Request) (int64, error) {
 	if s.Seekable() {
 		http.ServeContent(w, r, s.Name(), s.ModTime(), s)
-		return nil
+		return -1, nil
 	}
 
 	w.Header().Set("Accept-Ranges", "none")
@@ -160,7 +160,7 @@ func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Reque
 
 	if r.Method == http.MethodHead {
 		go func() { _, _ = io.Copy(io.Discard, s) }()
-		return nil
+		return 0, nil
 	}
 
 	id := s.mf.ID
@@ -169,19 +169,18 @@ func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		log.Error(ctx, "Error sending transcoded file", "id", id, err)
 		if c == 0 {
 			w.Header().Del("Content-Length")
-			return fmt.Errorf("sending transcoded file: %w", err)
+			return 0, fmt.Errorf("sending transcoded file: %w", err)
 		}
-		return nil
+		return c, nil
 	}
 	if c == 0 {
 		log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
 			"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
 			"id", id, "format", s.ContentType())
-		w.Header().Del("Content-Length")
-		return errors.New("transcoding failed: empty output")
+	} else {
+		log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
 	}
-	log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
-	return nil
+	return c, nil
 }
 
 // NewStream creates a non-seekable Stream from the given components.

--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -140,7 +140,7 @@ func NewTestStream(mf *model.MediaFile, format string, bitRate int) *Stream {
 		mf:         mf,
 		format:     format,
 		bitRate:    bitRate,
-		ReadCloser: io.NopCloser(strings.NewReader("")),
+		ReadCloser: io.NopCloser(strings.NewReader("fake audio data")),
 	}
 }
 

--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -2,10 +2,13 @@ package stream
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"mime"
+	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -16,6 +19,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/req"
 )
 
 type MediaStreamer interface {
@@ -133,6 +137,51 @@ func (s *Stream) Name() string        { return s.mf.Title + "." + s.format }
 func (s *Stream) ModTime() time.Time  { return s.mf.UpdatedAt }
 func (s *Stream) EstimatedContentLength() int {
 	return int(s.mf.Duration * float32(s.bitRate) / 8 * 1024)
+}
+
+// Serve writes the stream to the HTTP response. For seekable streams it uses http.ServeContent
+// (supporting range requests). For non-seekable streams it writes directly, detecting empty output
+// and io.Copy errors. It returns a non-nil error only when no bytes have been written and the caller
+// can still send an error response; once bytes are committed (HTTP 200 flushed) it logs and returns nil.
+func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	if s.Seekable() {
+		http.ServeContent(w, r, s.Name(), s.ModTime(), s)
+		return nil
+	}
+
+	w.Header().Set("Accept-Ranges", "none")
+	w.Header().Set("Content-Type", s.ContentType())
+
+	if req.Params(r).BoolOr("estimateContentLength", false) {
+		length := strconv.Itoa(s.EstimatedContentLength())
+		log.Trace(ctx, "Estimated content-length", "contentLength", length)
+		w.Header().Set("Content-Length", length)
+	}
+
+	if r.Method == http.MethodHead {
+		go func() { _, _ = io.Copy(io.Discard, s) }()
+		return nil
+	}
+
+	id := s.mf.ID
+	c, err := io.Copy(w, s)
+	if err != nil {
+		log.Error(ctx, "Error sending transcoded file", "id", id, err)
+		if c == 0 {
+			w.Header().Del("Content-Length")
+			return fmt.Errorf("sending transcoded file: %w", err)
+		}
+		return nil
+	}
+	if c == 0 {
+		log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
+			"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
+			"id", id, "format", s.ContentType())
+		w.Header().Del("Content-Length")
+		return errors.New("transcoding failed: empty output")
+	}
+	log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
+	return nil
 }
 
 // NewStream creates a non-seekable Stream from the given components.

--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"mime"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -51,6 +50,9 @@ func (j *streamJob) Key() string {
 	return fmt.Sprintf("%s.%s.%d.%d.%d.%d.%s.%d", j.mf.ID, j.mf.UpdatedAt.Format(time.RFC3339Nano), j.bitRate, j.sampleRate, j.bitDepth, j.channels, j.format, j.offset)
 }
 
+// NewStream creates a Stream for the given MediaFile and Request. It handles both raw streaming (no transcoding)
+// and transcoded streaming based on the requested format and bitrate. It also logs detailed information about
+// the streaming request and whether the transcoding result was served from cache or not.
 func (ms *mediaStreamer) NewStream(ctx context.Context, mf *model.MediaFile, req Request) (*Stream, error) {
 	var format string
 	var bitRate int
@@ -133,14 +135,14 @@ func (s *Stream) EstimatedContentLength() int {
 	return int(s.mf.Duration * float32(s.bitRate) / 8 * 1024)
 }
 
-// NewTestStream creates a Stream for testing purposes.
-func NewTestStream(mf *model.MediaFile, format string, bitRate int) *Stream {
+// NewStream creates a non-seekable Stream from the given components.
+func NewStream(mf *model.MediaFile, format string, bitRate int, r io.ReadCloser) *Stream {
 	return &Stream{
 		ctx:        context.Background(),
 		mf:         mf,
 		format:     format,
 		bitRate:    bitRate,
-		ReadCloser: io.NopCloser(strings.NewReader("fake audio data")),
+		ReadCloser: r,
 	}
 }
 

--- a/server/e2e/e2e_suite_test.go
+++ b/server/e2e/e2e_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -287,18 +288,28 @@ func (n noopArtwork) GetOrPlaceholder(_ context.Context, _ string, _ int, _ bool
 // spyStreamer captures the Request passed to NewStream for test assertions,
 // then returns a minimal fake Stream so the handler completes without error.
 type spyStreamer struct {
-	LastRequest   stream.Request
-	LastMediaFile *model.MediaFile
+	LastRequest         stream.Request
+	LastMediaFile       *model.MediaFile
+	SimulateError       error // When set, NewStream returns this error
+	SimulateEmptyStream bool  // When true, returns a 0-byte stream (simulates ffmpeg producing no output)
 }
 
 func (s *spyStreamer) NewStream(_ context.Context, mf *model.MediaFile, req stream.Request) (*stream.Stream, error) {
 	s.LastRequest = req
 	s.LastMediaFile = mf
+	if s.SimulateError != nil {
+		return nil, s.SimulateError
+	}
 	format := req.Format
 	if format == "" || format == "raw" {
 		format = mf.Suffix
 	}
-	return stream.NewTestStream(mf, format, req.BitRate), nil
+	content := "fake audio data"
+	if s.SimulateEmptyStream {
+		content = ""
+	}
+	r := io.NopCloser(strings.NewReader(content))
+	return stream.NewStream(mf, format, req.BitRate, r), nil
 }
 
 // noopFFmpeg implements ffmpeg.FFmpeg with no-op methods.

--- a/server/e2e/subsonic_stream_test.go
+++ b/server/e2e/subsonic_stream_test.go
@@ -166,27 +166,17 @@ var _ = Describe("stream.view (legacy streaming)", Ordered, func() {
 			streamerSpy.SimulateEmptyStream = false
 		})
 
-		It("returns a Subsonic error for stream endpoint", func() {
+		It("returns 200 with empty body for stream endpoint", func() {
 			w := doRawReq("stream", "id", flacTrackID, "format", "opus")
 			Expect(w.Code).To(Equal(http.StatusOK))
-
-			var wrapper responses.JsonWrapper
-			Expect(json.Unmarshal(w.Body.Bytes(), &wrapper)).To(Succeed())
-			Expect(wrapper.Subsonic.Status).To(Equal(responses.StatusFailed))
-			Expect(wrapper.Subsonic.Error).ToNot(BeNil())
-			Expect(wrapper.Subsonic.Error.Message).To(ContainSubstring("transcoding failed"))
+			Expect(w.Body.Len()).To(Equal(0))
 		})
 
-		It("returns a Subsonic error for download endpoint", func() {
+		It("returns 200 with empty body for download endpoint", func() {
 			conf.Server.EnableDownloads = true
 			w := doRawReq("download", "id", flacTrackID, "format", "opus")
 			Expect(w.Code).To(Equal(http.StatusOK))
-
-			var wrapper responses.JsonWrapper
-			Expect(json.Unmarshal(w.Body.Bytes(), &wrapper)).To(Succeed())
-			Expect(wrapper.Subsonic.Status).To(Equal(responses.StatusFailed))
-			Expect(wrapper.Subsonic.Error).ToNot(BeNil())
-			Expect(wrapper.Subsonic.Error.Message).To(ContainSubstring("transcoding failed"))
+			Expect(w.Body.Len()).To(Equal(0))
 		})
 	})
 })

--- a/server/e2e/subsonic_stream_test.go
+++ b/server/e2e/subsonic_stream_test.go
@@ -1,9 +1,12 @@
 package e2e
 
 import (
+	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/server/subsonic/responses"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -122,6 +125,68 @@ var _ = Describe("stream.view (legacy streaming)", Ordered, func() {
 			w := doRawReq("stream", "id", flacTrackID, "format", "mp3", "timeOffset", "30")
 			Expect(w.Code).To(Equal(http.StatusOK))
 			Expect(streamerSpy.LastRequest.Offset).To(Equal(30))
+		})
+	})
+
+	Describe("stream creation failure", func() {
+		BeforeEach(func() {
+			streamerSpy.SimulateError = errors.New("ffmpeg exited with non-zero status code: 1: Unknown encoder 'libopus'")
+		})
+		AfterEach(func() {
+			streamerSpy.SimulateError = nil
+		})
+
+		It("returns a Subsonic error for stream endpoint", func() {
+			w := doRawReq("stream", "id", flacTrackID, "format", "opus")
+			Expect(w.Code).To(Equal(http.StatusOK)) // Subsonic errors are returned as 200
+
+			var wrapper responses.JsonWrapper
+			Expect(json.Unmarshal(w.Body.Bytes(), &wrapper)).To(Succeed())
+			Expect(wrapper.Subsonic.Status).To(Equal(responses.StatusFailed))
+			Expect(wrapper.Subsonic.Error).ToNot(BeNil())
+		})
+
+		It("returns a Subsonic error for download endpoint", func() {
+			conf.Server.EnableDownloads = true
+			w := doRawReq("download", "id", flacTrackID, "format", "opus")
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var wrapper responses.JsonWrapper
+			Expect(json.Unmarshal(w.Body.Bytes(), &wrapper)).To(Succeed())
+			Expect(wrapper.Subsonic.Status).To(Equal(responses.StatusFailed))
+			Expect(wrapper.Subsonic.Error).ToNot(BeNil())
+		})
+	})
+
+	Describe("empty transcoded output", func() {
+		BeforeEach(func() {
+			streamerSpy.SimulateEmptyStream = true
+		})
+		AfterEach(func() {
+			streamerSpy.SimulateEmptyStream = false
+		})
+
+		It("returns a Subsonic error for stream endpoint", func() {
+			w := doRawReq("stream", "id", flacTrackID, "format", "opus")
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var wrapper responses.JsonWrapper
+			Expect(json.Unmarshal(w.Body.Bytes(), &wrapper)).To(Succeed())
+			Expect(wrapper.Subsonic.Status).To(Equal(responses.StatusFailed))
+			Expect(wrapper.Subsonic.Error).ToNot(BeNil())
+			Expect(wrapper.Subsonic.Error.Message).To(ContainSubstring("transcoding failed"))
+		})
+
+		It("returns a Subsonic error for download endpoint", func() {
+			conf.Server.EnableDownloads = true
+			w := doRawReq("download", "id", flacTrackID, "format", "opus")
+			Expect(w.Code).To(Equal(http.StatusOK))
+
+			var wrapper responses.JsonWrapper
+			Expect(json.Unmarshal(w.Body.Bytes(), &wrapper)).To(Succeed())
+			Expect(wrapper.Subsonic.Status).To(Equal(responses.StatusFailed))
+			Expect(wrapper.Subsonic.Error).ToNot(BeNil())
+			Expect(wrapper.Subsonic.Error.Message).To(ContainSubstring("transcoding failed"))
 		})
 	})
 })

--- a/server/e2e/subsonic_transcode_test.go
+++ b/server/e2e/subsonic_transcode_test.go
@@ -1,6 +1,7 @@
 package e2e
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -601,6 +602,36 @@ var _ = Describe("Transcode Endpoints", Ordered, func() {
 				// Restore original UpdatedAt
 				mf.UpdatedAt = originalUpdatedAt
 				Expect(ds.MediaFile(ctx).Put(mf)).To(Succeed())
+			})
+
+			It("returns 500 when stream creation fails", func() {
+				// Get a valid decision token
+				resp := doPostReq("getTranscodeDecision", mp3OnlyClient, "mediaId", flacTrackID, "mediaType", "song")
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				token := resp.TranscodeDecision.TranscodeParams
+				Expect(token).ToNot(BeEmpty())
+
+				// Simulate streamer failure (e.g., ffmpeg missing codec)
+				streamerSpy.SimulateError = errors.New("ffmpeg exited with non-zero status code: 1: Unknown encoder 'libopus'")
+				defer func() { streamerSpy.SimulateError = nil }()
+
+				w := doRawReq("getTranscodeStream", "mediaId", flacTrackID, "mediaType", "song", "transcodeParams", token)
+				Expect(w.Code).To(Equal(http.StatusInternalServerError))
+			})
+
+			It("returns 500 when transcoded stream is empty", func() {
+				// Get a valid decision token
+				resp := doPostReq("getTranscodeDecision", mp3OnlyClient, "mediaId", flacTrackID, "mediaType", "song")
+				Expect(resp.Status).To(Equal(responses.StatusOK))
+				token := resp.TranscodeDecision.TranscodeParams
+				Expect(token).ToNot(BeEmpty())
+
+				// Simulate ffmpeg producing 0 bytes
+				streamerSpy.SimulateEmptyStream = true
+				defer func() { streamerSpy.SimulateEmptyStream = false }()
+
+				w := doRawReq("getTranscodeStream", "mediaId", flacTrackID, "mediaType", "song", "transcodeParams", token)
+				Expect(w.Code).To(Equal(http.StatusInternalServerError))
 			})
 		})
 

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -53,7 +53,8 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Content-Duration", strconv.FormatFloat(float64(stream.Duration()), 'G', -1, 32))
 
-	if err := stream.Serve(ctx, w, r); err != nil {
+	n, err := stream.Serve(ctx, w, r)
+	if err != nil || n == 0 {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 }

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -76,10 +76,16 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 			c, err := io.Copy(w, stream)
 			if err != nil {
 				log.Error(ctx, "Error sending shared transcoded file", "id", info.id, err)
+				if c == 0 {
+					w.Header().Del("Content-Length")
+					http.Error(w, "internal error", http.StatusInternalServerError)
+				}
 			} else if c == 0 {
-				log.Warn(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
+				log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
 					"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
 					"id", info.id, "format", stream.ContentType())
+				w.Header().Del("Content-Length")
+				http.Error(w, "transcoding failed", http.StatusInternalServerError)
 			} else {
 				log.Trace(ctx, "Success sending shared transcoded file", "id", info.id, "size", c)
 			}

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -2,7 +2,6 @@ package public
 
 import (
 	"errors"
-	"io"
 	"net/http"
 	"strconv"
 
@@ -54,42 +53,8 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Content-Duration", strconv.FormatFloat(float64(stream.Duration()), 'G', -1, 32))
 
-	if stream.Seekable() {
-		http.ServeContent(w, r, stream.Name(), stream.ModTime(), stream)
-	} else {
-		// If the stream doesn't provide a size (i.e. is not seekable), we can't support ranges/content-length
-		w.Header().Set("Accept-Ranges", "none")
-		w.Header().Set("Content-Type", stream.ContentType())
-
-		estimateContentLength := p.BoolOr("estimateContentLength", false)
-
-		// if Client requests the estimated content-length, send it
-		if estimateContentLength {
-			length := strconv.Itoa(stream.EstimatedContentLength())
-			log.Trace(ctx, "Estimated content-length", "contentLength", length)
-			w.Header().Set("Content-Length", length)
-		}
-
-		if r.Method == http.MethodHead {
-			go func() { _, _ = io.Copy(io.Discard, stream) }()
-		} else {
-			c, err := io.Copy(w, stream)
-			if err != nil {
-				log.Error(ctx, "Error sending shared transcoded file", "id", info.id, err)
-				if c == 0 {
-					w.Header().Del("Content-Length")
-					http.Error(w, "internal error", http.StatusInternalServerError)
-				}
-			} else if c == 0 {
-				log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
-					"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
-					"id", info.id, "format", stream.ContentType())
-				w.Header().Del("Content-Length")
-				http.Error(w, "transcoding failed", http.StatusInternalServerError)
-			} else {
-				log.Trace(ctx, "Success sending shared transcoded file", "id", info.id, "size", c)
-			}
-		}
+	if err := stream.Serve(ctx, w, r); err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 }
 

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -74,12 +74,14 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 			go func() { _, _ = io.Copy(io.Discard, stream) }()
 		} else {
 			c, err := io.Copy(w, stream)
-			if log.IsGreaterOrEqualTo(log.LevelDebug) {
-				if err != nil {
-					log.Error(ctx, "Error sending shared transcoded file", "id", info.id, err)
-				} else {
-					log.Trace(ctx, "Success sending shared transcode file", "id", info.id, "size", c)
-				}
+			if err != nil {
+				log.Error(ctx, "Error sending shared transcoded file", "id", info.id, err)
+			} else if c == 0 {
+				log.Warn(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
+					"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
+					"id", info.id, "format", stream.ContentType())
+			} else {
+				log.Trace(ctx, "Success sending shared transcoded file", "id", info.id, "size", c)
 			}
 		}
 	}

--- a/server/subsonic/stream.go
+++ b/server/subsonic/stream.go
@@ -46,7 +46,8 @@ func (api *Router) Stream(w http.ResponseWriter, r *http.Request) (*responses.Su
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Content-Duration", strconv.FormatFloat(float64(stream.Duration()), 'G', -1, 32))
 
-	return nil, stream.Serve(ctx, w, r)
+	_, err = stream.Serve(ctx, w, r)
+	return nil, err
 }
 
 func (api *Router) Download(w http.ResponseWriter, r *http.Request) (*responses.Subsonic, error) {
@@ -114,7 +115,8 @@ func (api *Router) Download(w http.ResponseWriter, r *http.Request) (*responses.
 		disposition := fmt.Sprintf("attachment; filename=\"%s\"", stream.Name())
 		w.Header().Set("Content-Disposition", disposition)
 
-		return nil, stream.Serve(ctx, w, r)
+		_, err = stream.Serve(ctx, w, r)
+		return nil, err
 	case *model.Album:
 		setHeaders(v.Name)
 		return nil, api.archiver.ZipAlbum(ctx, id, format, maxBitRate, w)

--- a/server/subsonic/stream.go
+++ b/server/subsonic/stream.go
@@ -1,68 +1,18 @@
 package subsonic
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
-	"github.com/navidrome/navidrome/core/stream"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
 	"github.com/navidrome/navidrome/utils/req"
 )
-
-func (api *Router) serveStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream *stream.Stream, id string) error {
-	if stream.Seekable() {
-		http.ServeContent(w, r, stream.Name(), stream.ModTime(), stream)
-		return nil
-	}
-
-	// If the stream doesn't provide a size (i.e. is not seekable), we can't support ranges/content-length
-	w.Header().Set("Accept-Ranges", "none")
-	w.Header().Set("Content-Type", stream.ContentType())
-
-	estimateContentLength := req.Params(r).BoolOr("estimateContentLength", false)
-
-	// if Client requests the estimated content-length, send it
-	if estimateContentLength {
-		length := strconv.Itoa(stream.EstimatedContentLength())
-		log.Trace(ctx, "Estimated content-length", "contentLength", length)
-		w.Header().Set("Content-Length", length)
-	}
-
-	if r.Method == http.MethodHead {
-		go func() { _, _ = io.Copy(io.Discard, stream) }()
-		return nil
-	}
-
-	c, err := io.Copy(w, stream)
-	if err != nil {
-		log.Error(ctx, "Error sending transcoded file", "id", id, err)
-		if c == 0 {
-			// No bytes written yet, safe to send an error response
-			w.Header().Del("Content-Length")
-			return fmt.Errorf("sending transcoded file: %w", err)
-		}
-		// Bytes already written (200 committed), can't change the response
-		return nil
-	}
-	if c == 0 {
-		log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
-			"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
-			"id", id, "format", stream.ContentType())
-		w.Header().Del("Content-Length")
-		return errors.New("transcoding failed: empty output")
-	}
-	log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
-	return nil
-}
 
 func (api *Router) Stream(w http.ResponseWriter, r *http.Request) (*responses.Subsonic, error) {
 	ctx := r.Context()
@@ -96,11 +46,7 @@ func (api *Router) Stream(w http.ResponseWriter, r *http.Request) (*responses.Su
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Content-Duration", strconv.FormatFloat(float64(stream.Duration()), 'G', -1, 32))
 
-	if err := api.serveStream(ctx, w, r, stream, id); err != nil {
-		return nil, err
-	}
-
-	return nil, nil
+	return nil, stream.Serve(ctx, w, r)
 }
 
 func (api *Router) Download(w http.ResponseWriter, r *http.Request) (*responses.Subsonic, error) {
@@ -168,7 +114,7 @@ func (api *Router) Download(w http.ResponseWriter, r *http.Request) (*responses.
 		disposition := fmt.Sprintf("attachment; filename=\"%s\"", stream.Name())
 		w.Header().Set("Content-Disposition", disposition)
 
-		return nil, api.serveStream(ctx, w, r, stream, id)
+		return nil, stream.Serve(ctx, w, r)
 	case *model.Album:
 		setHeaders(v.Name)
 		return nil, api.archiver.ZipAlbum(ctx, id, format, maxBitRate, w)

--- a/server/subsonic/stream.go
+++ b/server/subsonic/stream.go
@@ -38,12 +38,14 @@ func (api *Router) serveStream(ctx context.Context, w http.ResponseWriter, r *ht
 			go func() { _, _ = io.Copy(io.Discard, stream) }()
 		} else {
 			c, err := io.Copy(w, stream)
-			if log.IsGreaterOrEqualTo(log.LevelDebug) {
-				if err != nil {
-					log.Error(ctx, "Error sending transcoded file", "id", id, err)
-				} else {
-					log.Trace(ctx, "Success sending transcode file", "id", id, "size", c)
-				}
+			if err != nil {
+				log.Error(ctx, "Error sending transcoded file", "id", id, err)
+			} else if c == 0 {
+				log.Warn(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
+					"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
+					"id", id, "format", stream.ContentType())
+			} else {
+				log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
 			}
 		}
 	}

--- a/server/subsonic/stream.go
+++ b/server/subsonic/stream.go
@@ -2,6 +2,7 @@ package subsonic
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,38 +18,50 @@ import (
 	"github.com/navidrome/navidrome/utils/req"
 )
 
-func (api *Router) serveStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream *stream.Stream, id string) {
+func (api *Router) serveStream(ctx context.Context, w http.ResponseWriter, r *http.Request, stream *stream.Stream, id string) error {
 	if stream.Seekable() {
 		http.ServeContent(w, r, stream.Name(), stream.ModTime(), stream)
-	} else {
-		// If the stream doesn't provide a size (i.e. is not seekable), we can't support ranges/content-length
-		w.Header().Set("Accept-Ranges", "none")
-		w.Header().Set("Content-Type", stream.ContentType())
-
-		estimateContentLength := req.Params(r).BoolOr("estimateContentLength", false)
-
-		// if Client requests the estimated content-length, send it
-		if estimateContentLength {
-			length := strconv.Itoa(stream.EstimatedContentLength())
-			log.Trace(ctx, "Estimated content-length", "contentLength", length)
-			w.Header().Set("Content-Length", length)
-		}
-
-		if r.Method == http.MethodHead {
-			go func() { _, _ = io.Copy(io.Discard, stream) }()
-		} else {
-			c, err := io.Copy(w, stream)
-			if err != nil {
-				log.Error(ctx, "Error sending transcoded file", "id", id, err)
-			} else if c == 0 {
-				log.Warn(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
-					"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
-					"id", id, "format", stream.ContentType())
-			} else {
-				log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
-			}
-		}
+		return nil
 	}
+
+	// If the stream doesn't provide a size (i.e. is not seekable), we can't support ranges/content-length
+	w.Header().Set("Accept-Ranges", "none")
+	w.Header().Set("Content-Type", stream.ContentType())
+
+	estimateContentLength := req.Params(r).BoolOr("estimateContentLength", false)
+
+	// if Client requests the estimated content-length, send it
+	if estimateContentLength {
+		length := strconv.Itoa(stream.EstimatedContentLength())
+		log.Trace(ctx, "Estimated content-length", "contentLength", length)
+		w.Header().Set("Content-Length", length)
+	}
+
+	if r.Method == http.MethodHead {
+		go func() { _, _ = io.Copy(io.Discard, stream) }()
+		return nil
+	}
+
+	c, err := io.Copy(w, stream)
+	if err != nil {
+		log.Error(ctx, "Error sending transcoded file", "id", id, err)
+		if c == 0 {
+			// No bytes written yet, safe to send an error response
+			w.Header().Del("Content-Length")
+			return fmt.Errorf("sending transcoded file: %w", err)
+		}
+		// Bytes already written (200 committed), can't change the response
+		return nil
+	}
+	if c == 0 {
+		log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
+			"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
+			"id", id, "format", stream.ContentType())
+		w.Header().Del("Content-Length")
+		return errors.New("transcoding failed: empty output")
+	}
+	log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
+	return nil
 }
 
 func (api *Router) Stream(w http.ResponseWriter, r *http.Request) (*responses.Subsonic, error) {
@@ -83,7 +96,9 @@ func (api *Router) Stream(w http.ResponseWriter, r *http.Request) (*responses.Su
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Content-Duration", strconv.FormatFloat(float64(stream.Duration()), 'G', -1, 32))
 
-	api.serveStream(ctx, w, r, stream, id)
+	if err := api.serveStream(ctx, w, r, stream, id); err != nil {
+		return nil, err
+	}
 
 	return nil, nil
 }
@@ -153,20 +168,17 @@ func (api *Router) Download(w http.ResponseWriter, r *http.Request) (*responses.
 		disposition := fmt.Sprintf("attachment; filename=\"%s\"", stream.Name())
 		w.Header().Set("Content-Disposition", disposition)
 
-		api.serveStream(ctx, w, r, stream, id)
-		return nil, nil
+		return nil, api.serveStream(ctx, w, r, stream, id)
 	case *model.Album:
 		setHeaders(v.Name)
-		err = api.archiver.ZipAlbum(ctx, id, format, maxBitRate, w)
+		return nil, api.archiver.ZipAlbum(ctx, id, format, maxBitRate, w)
 	case *model.Artist:
 		setHeaders(v.Name)
-		err = api.archiver.ZipArtist(ctx, id, format, maxBitRate, w)
+		return nil, api.archiver.ZipArtist(ctx, id, format, maxBitRate, w)
 	case *model.Playlist:
 		setHeaders(v.Name)
-		err = api.archiver.ZipPlaylist(ctx, id, format, maxBitRate, w)
+		return nil, api.archiver.ZipPlaylist(ctx, id, format, maxBitRate, w)
 	default:
-		err = model.ErrNotFound
+		return nil, model.ErrNotFound
 	}
-
-	return nil, err
 }

--- a/server/subsonic/transcode.go
+++ b/server/subsonic/transcode.go
@@ -395,7 +395,8 @@ func (api *Router) GetTranscodeStream(w http.ResponseWriter, r *http.Request) (*
 
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
-	if err := stream.Serve(ctx, w, r); err != nil {
+	n, err := stream.Serve(ctx, w, r)
+	if err != nil || n == 0 {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 	return nil, nil

--- a/server/subsonic/transcode.go
+++ b/server/subsonic/transcode.go
@@ -395,7 +395,8 @@ func (api *Router) GetTranscodeStream(w http.ResponseWriter, r *http.Request) (*
 
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
-	api.serveStream(ctx, w, r, stream, mediaID)
-
+	if err := api.serveStream(ctx, w, r, stream, mediaID); err != nil {
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+	}
 	return nil, nil
 }

--- a/server/subsonic/transcode.go
+++ b/server/subsonic/transcode.go
@@ -395,7 +395,7 @@ func (api *Router) GetTranscodeStream(w http.ResponseWriter, r *http.Request) (*
 
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 
-	if err := api.serveStream(ctx, w, r, stream, mediaID); err != nil {
+	if err := stream.Serve(ctx, w, r); err != nil {
 		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
 	}
 	return nil, nil


### PR DESCRIPTION
### Description

When ffmpeg fails during transcoding (e.g., a missing codec like `libopus` on Synology NAS), Navidrome silently returns HTTP 200 with a 0-byte body. The server logs contain no useful diagnostics because ffmpeg's stderr was discarded, and the empty response was treated as success.

This PR improves both **diagnostics** and **error handling** for transcoding failures:

1. **Capture ffmpeg stderr** — stderr is now always captured in a bounded 4 KB buffer (`limitedWriter`). When ffmpeg exits non-zero, the stderr content is appended to the error message propagated through the pipe. At Trace level, stderr is still tee'd to `os.Stderr` for live debugging.

2. **Extract stream serving logic into `Stream.Serve`** — the duplicated stream-serving code in `server/subsonic/stream.go` and `server/public/handle_streams.go` was consolidated into a single `Stream.Serve(ctx, w, r)` method on the `Stream` type. This method returns `(bytesWritten, error)` so callers can detect failures and respond appropriately.

3. **Return proper errors on empty/failed transcoded output** — instead of always returning a silent 200:
   - **Subsonic `stream`/`download` endpoints**: when `NewStream` fails (e.g., ffmpeg startup failure), the error propagates as a Subsonic XML/JSON error response. When transcoding produces 0 bytes with no error, a 200 with empty body is returned (logged as an error server-side).
   - **`getTranscodeStream` endpoint**: returns HTTP 500 on stream creation failure or 0-byte output.
   - **Public shared streams**: returns HTTP 500 on stream creation failure or 0-byte output.

4. **Always log transcoding errors** — removed the `log.IsGreaterOrEqualTo(log.LevelDebug)` guard so transcoding errors are logged at all log levels, not just debug+.

Minor cleanups:
- Renamed `NewTestStream` → `NewStream` (now a general-purpose constructor for non-seekable streams, accepting an `io.ReadCloser`)
- Simplified the `Download` handler's switch to use direct returns instead of a shared `err` variable

Reported at: https://support.symfonium.app/t/cache-transcoding-emptydownloaded-file/13046

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. **Unit tests** — `make test PKG=./core/ffmpeg` verifies stderr is captured in the error message on non-zero exit and omitted on success.
2. **E2E tests** — `make test PKG=./server/e2e` covers:
   - `stream.view` and `download.view` returning Subsonic error responses when `NewStream` fails
   - `stream.view` and `download.view` returning 200 with empty body when transcoding produces 0 bytes
   - `getTranscodeStream` returning HTTP 500 for both failure modes (stream creation error and empty output)
3. **Manual reproduction** — configure opus transcoding, use an ffmpeg binary without `libopus` support, request a transcoded stream. Before: empty 200 with no logs. After: error response + descriptive log message including ffmpeg's stderr output.

### Additional Notes

- The `limitedWriter` caps stderr capture at 4 KB to prevent unbounded memory usage from verbose ffmpeg output. Writes beyond the limit are silently discarded (reporting full length to avoid `ErrShortWrite` from `io.MultiWriter`).
- Sending an error response after 0 bytes works because Go's `http.ResponseWriter` hasn't flushed the 200 status when no bytes have been written — headers can still be changed. If bytes *were* partially written, the 200 is already committed and only a log message is emitted.
- For the legacy Subsonic `stream`/`download` endpoints, empty transcoded output (0 bytes, no error from ffmpeg) results in a 200 with empty body rather than a Subsonic error response. This avoids breaking clients that may handle an empty response differently from an error response. The `getTranscodeStream` and public share endpoints return HTTP 500 in this case since they don't use the Subsonic error format.