### PR TITLE
feat(scheduler): add crontab(5) random ~ syntax support

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -16,8 +16,8 @@ import (
 	"github.com/kr/pretty"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/scheduler"
 	"github.com/navidrome/navidrome/utils/run"
-	"github.com/robfig/cron/v3"
 	"github.com/spf13/viper"
 )
 
@@ -570,15 +570,9 @@ func validateBackupSchedule() error {
 }
 
 func validateSchedule(schedule, field string) (string, error) {
-	if _, err := time.ParseDuration(schedule); err == nil {
-		schedule = "@every " + schedule
-	}
-	c := cron.New()
-	id, err := c.AddFunc(schedule, func() {})
+	_, err := scheduler.ParseCrontab(schedule)
 	if err != nil {
 		log.Error(fmt.Sprintf("Invalid %s. Please read format spec at https://pkg.go.dev/github.com/robfig/cron#hdr-CRON_Expression_Format", field), "schedule", schedule, err)
-	} else {
-		c.Remove(id)
 	}
 	return schedule, err
 }

--- a/scheduler/crontab_schedule.go
+++ b/scheduler/crontab_schedule.go
@@ -14,6 +14,9 @@ var parser = cron.NewParser(
 	cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
 )
 
+// ParseCrontab parses a cron expression with support for the crontab(5) random ~ syntax.
+// Random values are resolved once at parse time. If no ~ is present, it delegates to
+// robfig/cron's standard parser. Duration strings (e.g., "5m") are converted to "@every 5m".
 func ParseCrontab(spec string) (cron.Schedule, error) {
 	if spec == "" {
 		return nil, fmt.Errorf("empty spec string")
@@ -28,18 +31,13 @@ func ParseCrontab(spec string) (cron.Schedule, error) {
 	}
 
 	// Handle TZ=/CRON_TZ= prefix
-	var loc *time.Location
+	var tzPrefix string
 	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
 		i := strings.Index(spec, " ")
 		if i == -1 {
 			return nil, fmt.Errorf("missing spec after timezone")
 		}
-		eq := strings.Index(spec, "=")
-		var err error
-		loc, err = time.LoadLocation(spec[eq+1 : i])
-		if err != nil {
-			return nil, fmt.Errorf("provided bad location %s: %w", spec[eq+1:i], err)
-		}
+		tzPrefix = spec[:i] + " "
 		spec = strings.TrimSpace(spec[i:])
 	}
 
@@ -54,82 +52,24 @@ func ParseCrontab(spec string) (cron.Schedule, error) {
 		return nil, err
 	}
 
-	randomFields := make([]randomField, 6)
-	substituteFields := make([]string, 6)
+	// Resolve each ~ field to a concrete random value
 	for i, field := range fields {
-		if strings.Contains(field, "~") {
-			if strings.ContainsAny(field, ",/") {
-				return nil, fmt.Errorf("random ~ cannot be combined with lists or steps: %s", field)
-			}
-			rf, parseErr := parseRandomField(field, fieldBounds[i])
-			if parseErr != nil {
-				return nil, parseErr
-			}
-			randomFields[i] = rf
-			substituteFields[i] = fieldDefaults[i]
-		} else {
-			randomFields[i] = randomField{IsRandom: false}
-			substituteFields[i] = field
+		if !strings.Contains(field, "~") {
+			continue
 		}
+		if strings.ContainsAny(field, ",/") {
+			return nil, fmt.Errorf("random ~ cannot be combined with lists or steps: %s", field)
+		}
+		v, parseErr := resolveRandomField(field, fieldBounds[i])
+		if parseErr != nil {
+			return nil, parseErr
+		}
+		fields[i] = strconv.FormatUint(uint64(v), 10)
 	}
 
-	substituteSpec := strings.Join(substituteFields, " ")
-	baseSched, err := parser.Parse(substituteSpec)
-	if err != nil {
-		return nil, fmt.Errorf("error parsing non-random fields: %w", err)
-	}
-
-	baseSpec, ok := baseSched.(*cron.SpecSchedule)
-	if !ok {
-		return nil, fmt.Errorf("unexpected schedule type from parser")
-	}
-
-	if loc == nil {
-		loc = baseSpec.Location
-	}
-
-	return &CrontabSchedule{
-		Second:   randomFields[0],
-		Minute:   randomFields[1],
-		Hour:     randomFields[2],
-		Dom:      randomFields[3],
-		Month:    randomFields[4],
-		Dow:      randomFields[5],
-		base:     *baseSpec,
-		Location: loc,
-	}, nil
-}
-
-type randomField struct {
-	IsRandom bool
-	Min, Max uint
-}
-
-type CrontabSchedule struct {
-	Second, Minute, Hour, Dom, Month, Dow randomField
-	base                                  cron.SpecSchedule
-	Location                              *time.Location
-}
-
-func (s *CrontabSchedule) Next(t time.Time) time.Time {
-	resolved := cron.SpecSchedule{
-		Second:   s.resolveField(s.Second, s.base.Second),
-		Minute:   s.resolveField(s.Minute, s.base.Minute),
-		Hour:     s.resolveField(s.Hour, s.base.Hour),
-		Dom:      s.resolveField(s.Dom, s.base.Dom),
-		Month:    s.resolveField(s.Month, s.base.Month),
-		Dow:      s.resolveField(s.Dow, s.base.Dow),
-		Location: s.Location,
-	}
-	return resolved.Next(t)
-}
-
-func (s *CrontabSchedule) resolveField(f randomField, baseBits uint64) uint64 {
-	if !f.IsRandom {
-		return baseBits
-	}
-	v := f.Min + uint(rand.IntN(int(f.Max-f.Min+1))) //nolint:gosec // Cryptographic randomness not needed for schedule jitter
-	return 1 << v
+	// Re-assemble and parse with robfig
+	resolved := tzPrefix + strings.Join(fields, " ")
+	return parser.Parse(resolved)
 }
 
 type bounds struct {
@@ -145,9 +85,8 @@ var fieldBounds = [6]bounds{
 	{0, 6},  // Dow
 }
 
-var fieldDefaults = [6]string{"0", "0", "0", "1", "1", "0"}
-
-func parseRandomField(field string, b bounds) (randomField, error) {
+// resolveRandomField parses a ~ field and returns a random value within the range.
+func resolveRandomField(field string, b bounds) (uint, error) {
 	parts := strings.SplitN(field, "~", 2)
 
 	min := b.min
@@ -156,7 +95,7 @@ func parseRandomField(field string, b bounds) (randomField, error) {
 	if parts[0] != "" {
 		v, err := strconv.ParseUint(parts[0], 10, 0)
 		if err != nil {
-			return randomField{}, fmt.Errorf("invalid random range start: %s", parts[0])
+			return 0, fmt.Errorf("invalid random range start: %s", parts[0])
 		}
 		min = uint(v)
 	}
@@ -164,22 +103,22 @@ func parseRandomField(field string, b bounds) (randomField, error) {
 	if parts[1] != "" {
 		v, err := strconv.ParseUint(parts[1], 10, 0)
 		if err != nil {
-			return randomField{}, fmt.Errorf("invalid random range end: %s", parts[1])
+			return 0, fmt.Errorf("invalid random range end: %s", parts[1])
 		}
 		max = uint(v)
 	}
 
 	if min < b.min {
-		return randomField{}, fmt.Errorf("random range start (%d) below minimum (%d): %s", min, b.min, field)
+		return 0, fmt.Errorf("random range start (%d) below minimum (%d): %s", min, b.min, field)
 	}
 	if max > b.max {
-		return randomField{}, fmt.Errorf("random range end (%d) above maximum (%d): %s", max, b.max, field)
+		return 0, fmt.Errorf("random range end (%d) above maximum (%d): %s", max, b.max, field)
 	}
 	if min > max {
-		return randomField{}, fmt.Errorf("random range start (%d) beyond end (%d): %s", min, max, field)
+		return 0, fmt.Errorf("random range start (%d) beyond end (%d): %s", min, max, field)
 	}
 
-	return randomField{IsRandom: true, Min: min, Max: max}, nil
+	return min + uint(rand.IntN(int(max-min+1))), nil //nolint:gosec // Cryptographic randomness not needed for schedule jitter
 }
 
 func normalizeFields(fields []string) ([]string, error) {

--- a/scheduler/crontab_schedule.go
+++ b/scheduler/crontab_schedule.go
@@ -1,0 +1,194 @@
+package scheduler
+
+import (
+	"fmt"
+	"math/rand/v2"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+var parser = cron.NewParser(
+	cron.SecondOptional | cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor,
+)
+
+func ParseCrontab(spec string) (cron.Schedule, error) {
+	if spec == "" {
+		return nil, fmt.Errorf("empty spec string")
+	}
+
+	if _, err := time.ParseDuration(spec); err == nil {
+		spec = "@every " + spec
+	}
+
+	if !strings.Contains(spec, "~") {
+		return parser.Parse(spec)
+	}
+
+	// Handle TZ=/CRON_TZ= prefix
+	var loc *time.Location
+	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
+		i := strings.Index(spec, " ")
+		if i == -1 {
+			return nil, fmt.Errorf("missing spec after timezone")
+		}
+		eq := strings.Index(spec, "=")
+		var err error
+		loc, err = time.LoadLocation(spec[eq+1 : i])
+		if err != nil {
+			return nil, fmt.Errorf("provided bad location %s: %w", spec[eq+1:i], err)
+		}
+		spec = strings.TrimSpace(spec[i:])
+	}
+
+	// @ descriptors cannot contain ~
+	if strings.HasPrefix(spec, "@") {
+		return nil, fmt.Errorf("random ~ syntax cannot be used with descriptors: %s", spec)
+	}
+
+	fields := strings.Fields(spec)
+	fields, err := normalizeFields(fields)
+	if err != nil {
+		return nil, err
+	}
+
+	randomFields := make([]randomField, 6)
+	substituteFields := make([]string, 6)
+	for i, field := range fields {
+		if strings.Contains(field, "~") {
+			if strings.ContainsAny(field, ",/") {
+				return nil, fmt.Errorf("random ~ cannot be combined with lists or steps: %s", field)
+			}
+			rf, parseErr := parseRandomField(field, fieldBounds[i])
+			if parseErr != nil {
+				return nil, parseErr
+			}
+			randomFields[i] = rf
+			substituteFields[i] = fieldDefaults[i]
+		} else {
+			randomFields[i] = randomField{IsRandom: false}
+			substituteFields[i] = field
+		}
+	}
+
+	substituteSpec := strings.Join(substituteFields, " ")
+	baseSched, err := parser.Parse(substituteSpec)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing non-random fields: %w", err)
+	}
+
+	baseSpec, ok := baseSched.(*cron.SpecSchedule)
+	if !ok {
+		return nil, fmt.Errorf("unexpected schedule type from parser")
+	}
+
+	if loc == nil {
+		loc = baseSpec.Location
+	}
+
+	return &CrontabSchedule{
+		Second:   randomFields[0],
+		Minute:   randomFields[1],
+		Hour:     randomFields[2],
+		Dom:      randomFields[3],
+		Month:    randomFields[4],
+		Dow:      randomFields[5],
+		base:     *baseSpec,
+		Location: loc,
+	}, nil
+}
+
+type randomField struct {
+	IsRandom bool
+	Min, Max uint
+}
+
+type CrontabSchedule struct {
+	Second, Minute, Hour, Dom, Month, Dow randomField
+	base                                  cron.SpecSchedule
+	Location                              *time.Location
+}
+
+func (s *CrontabSchedule) Next(t time.Time) time.Time {
+	resolved := cron.SpecSchedule{
+		Second:   s.resolveField(s.Second, s.base.Second),
+		Minute:   s.resolveField(s.Minute, s.base.Minute),
+		Hour:     s.resolveField(s.Hour, s.base.Hour),
+		Dom:      s.resolveField(s.Dom, s.base.Dom),
+		Month:    s.resolveField(s.Month, s.base.Month),
+		Dow:      s.resolveField(s.Dow, s.base.Dow),
+		Location: s.Location,
+	}
+	return resolved.Next(t)
+}
+
+func (s *CrontabSchedule) resolveField(f randomField, baseBits uint64) uint64 {
+	if !f.IsRandom {
+		return baseBits
+	}
+	v := f.Min + uint(rand.IntN(int(f.Max-f.Min+1))) //nolint:gosec // Cryptographic randomness not needed for schedule jitter
+	return 1 << v
+}
+
+type bounds struct {
+	min, max uint
+}
+
+var fieldBounds = [6]bounds{
+	{0, 59}, // Second
+	{0, 59}, // Minute
+	{0, 23}, // Hour
+	{1, 31}, // Dom
+	{1, 12}, // Month
+	{0, 6},  // Dow
+}
+
+var fieldDefaults = [6]string{"0", "0", "0", "1", "1", "0"}
+
+func parseRandomField(field string, b bounds) (randomField, error) {
+	parts := strings.SplitN(field, "~", 2)
+
+	min := b.min
+	max := b.max
+
+	if parts[0] != "" {
+		v, err := strconv.ParseUint(parts[0], 10, 0)
+		if err != nil {
+			return randomField{}, fmt.Errorf("invalid random range start: %s", parts[0])
+		}
+		min = uint(v)
+	}
+
+	if parts[1] != "" {
+		v, err := strconv.ParseUint(parts[1], 10, 0)
+		if err != nil {
+			return randomField{}, fmt.Errorf("invalid random range end: %s", parts[1])
+		}
+		max = uint(v)
+	}
+
+	if min < b.min {
+		return randomField{}, fmt.Errorf("random range start (%d) below minimum (%d): %s", min, b.min, field)
+	}
+	if max > b.max {
+		return randomField{}, fmt.Errorf("random range end (%d) above maximum (%d): %s", max, b.max, field)
+	}
+	if min > max {
+		return randomField{}, fmt.Errorf("random range start (%d) beyond end (%d): %s", min, max, field)
+	}
+
+	return randomField{IsRandom: true, Min: min, Max: max}, nil
+}
+
+func normalizeFields(fields []string) ([]string, error) {
+	switch len(fields) {
+	case 5:
+		return append([]string{"0"}, fields...), nil
+	case 6:
+		return fields, nil
+	default:
+		return nil, fmt.Errorf("expected 5 or 6 fields, found %d: %v", len(fields), fields)
+	}
+}

--- a/scheduler/crontab_schedule_test.go
+++ b/scheduler/crontab_schedule_test.go
@@ -8,11 +8,9 @@ import (
 	"github.com/robfig/cron/v3"
 )
 
-const starBit = 1 << 63
-
 var _ = Describe("ParseCrontab", func() {
-	Describe("passthrough (no ~ present)", func() {
-		It("parses a standard 5-field expression", func() {
+	Describe("standard expressions", func() {
+		It("parses a 5-field expression", func() {
 			sched, err := ParseCrontab("5 * * * *")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
@@ -24,33 +22,10 @@ var _ = Describe("ParseCrontab", func() {
 			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
 		})
 
-		It("parses @every descriptor", func() {
-			sched, err := ParseCrontab("@every 5m")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sched).To(BeAssignableToTypeOf(cron.ConstantDelaySchedule{}))
-		})
-
-		It("parses @daily descriptor", func() {
-			sched, err := ParseCrontab("@daily")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
-		})
-
-		It("parses duration string as @every", func() {
+		It("converts duration string to @every", func() {
 			sched, err := ParseCrontab("5m")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(sched).To(BeAssignableToTypeOf(cron.ConstantDelaySchedule{}))
-		})
-
-		It("parses expression with TZ= prefix", func() {
-			sched, err := ParseCrontab("TZ=America/New_York 5 * * * *")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
-		})
-
-		It("returns error for invalid expression", func() {
-			_, err := ParseCrontab("invalid")
-			Expect(err).To(HaveOccurred())
 		})
 
 		It("returns error for empty string", func() {
@@ -60,107 +35,101 @@ var _ = Describe("ParseCrontab", func() {
 	})
 
 	Describe("random ~ syntax", func() {
-		It("parses A~B in minute field", func() {
+		It("resolves A~B to a value within range", func() {
 			sched, err := ParseCrontab("0~30 * * * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs, ok := sched.(*CrontabSchedule)
-			Expect(ok).To(BeTrue(), "expected *CrontabSchedule")
-			Expect(cs.Minute.IsRandom).To(BeTrue())
-			Expect(cs.Minute.Min).To(Equal(uint(0)))
-			Expect(cs.Minute.Max).To(Equal(uint(30)))
-			Expect(cs.Second.IsRandom).To(BeFalse())
-			Expect(cs.Hour.IsRandom).To(BeFalse())
+			spec := sched.(*cron.SpecSchedule)
+			minute := findSetBit(spec.Minute)
+			Expect(minute).To(BeNumerically(">=", 0))
+			Expect(minute).To(BeNumerically("<=", 30))
 		})
 
-		It("parses ~ alone as full range for minute field", func() {
+		It("resolves ~ alone to full field range", func() {
 			sched, err := ParseCrontab("~ * * * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Minute.IsRandom).To(BeTrue())
-			Expect(cs.Minute.Min).To(Equal(uint(0)))
-			Expect(cs.Minute.Max).To(Equal(uint(59)))
+			spec := sched.(*cron.SpecSchedule)
+			minute := findSetBit(spec.Minute)
+			Expect(minute).To(BeNumerically(">=", 0))
+			Expect(minute).To(BeNumerically("<=", 59))
 		})
 
-		It("parses ~B as min~B", func() {
+		It("resolves ~B as min~B", func() {
 			sched, err := ParseCrontab("~15 * * * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Minute.Min).To(Equal(uint(0)))
-			Expect(cs.Minute.Max).To(Equal(uint(15)))
+			spec := sched.(*cron.SpecSchedule)
+			minute := findSetBit(spec.Minute)
+			Expect(minute).To(BeNumerically(">=", 0))
+			Expect(minute).To(BeNumerically("<=", 15))
 		})
 
-		It("parses A~ as A~max", func() {
+		It("resolves A~ as A~max", func() {
 			sched, err := ParseCrontab("15~ * * * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Minute.Min).To(Equal(uint(15)))
-			Expect(cs.Minute.Max).To(Equal(uint(59)))
+			spec := sched.(*cron.SpecSchedule)
+			minute := findSetBit(spec.Minute)
+			Expect(minute).To(BeNumerically(">=", 15))
+			Expect(minute).To(BeNumerically("<=", 59))
 		})
 
-		It("parses multiple random fields", func() {
+		It("resolves multiple random fields independently", func() {
 			sched, err := ParseCrontab("0~30 0~12 * * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Minute.IsRandom).To(BeTrue())
-			Expect(cs.Minute.Min).To(Equal(uint(0)))
-			Expect(cs.Minute.Max).To(Equal(uint(30)))
-			Expect(cs.Hour.IsRandom).To(BeTrue())
-			Expect(cs.Hour.Min).To(Equal(uint(0)))
-			Expect(cs.Hour.Max).To(Equal(uint(12)))
+			spec := sched.(*cron.SpecSchedule)
+			Expect(findSetBit(spec.Minute)).To(BeNumerically("<=", 30))
+			Expect(findSetBit(spec.Hour)).To(BeNumerically("<=", 12))
 		})
 
-		It("parses 6-field expression with random and seconds", func() {
-			sched, err := ParseCrontab("0 0~30 * * * *")
-			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Second.IsRandom).To(BeFalse())
-			Expect(cs.Minute.IsRandom).To(BeTrue())
-			Expect(cs.Minute.Min).To(Equal(uint(0)))
-			Expect(cs.Minute.Max).To(Equal(uint(30)))
-		})
-
-		It("parses ~ in DOM field with correct bounds", func() {
+		It("resolves ~ in DOM field with correct bounds", func() {
 			sched, err := ParseCrontab("0 0 ~ * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Dom.IsRandom).To(BeTrue())
-			Expect(cs.Dom.Min).To(Equal(uint(1)))
-			Expect(cs.Dom.Max).To(Equal(uint(31)))
+			spec := sched.(*cron.SpecSchedule)
+			dom := findSetBit(spec.Dom)
+			Expect(dom).To(BeNumerically(">=", 1))
+			Expect(dom).To(BeNumerically("<=", 31))
 		})
 
-		It("parses ~ in month field with correct bounds", func() {
+		It("resolves ~ in month field with correct bounds", func() {
 			sched, err := ParseCrontab("0 0 1 ~ *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Month.IsRandom).To(BeTrue())
-			Expect(cs.Month.Min).To(Equal(uint(1)))
-			Expect(cs.Month.Max).To(Equal(uint(12)))
+			spec := sched.(*cron.SpecSchedule)
+			month := findSetBit(spec.Month)
+			Expect(month).To(BeNumerically(">=", 1))
+			Expect(month).To(BeNumerically("<=", 12))
 		})
 
-		It("parses ~ in DOW field with correct bounds", func() {
+		It("resolves ~ in DOW field with correct bounds", func() {
 			sched, err := ParseCrontab("0 0 * * ~")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Dow.IsRandom).To(BeTrue())
-			Expect(cs.Dow.Min).To(Equal(uint(0)))
-			Expect(cs.Dow.Max).To(Equal(uint(6)))
+			spec := sched.(*cron.SpecSchedule)
+			dow := findSetBit(spec.Dow)
+			Expect(dow).To(BeNumerically(">=", 0))
+			Expect(dow).To(BeNumerically("<=", 6))
 		})
 
-		It("parses with TZ= prefix", func() {
+		It("preserves TZ= prefix through resolution", func() {
 			sched, err := ParseCrontab("TZ=America/New_York 0~30 * * * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Minute.IsRandom).To(BeTrue())
+			spec := sched.(*cron.SpecSchedule)
 			nyc, _ := time.LoadLocation("America/New_York")
-			Expect(cs.Location).To(Equal(nyc))
+			Expect(spec.Location).To(Equal(nyc))
 		})
 
-		It("preserves non-random field bitmasks from base", func() {
+		It("preserves non-random fields", func() {
 			sched, err := ParseCrontab("0~30 10 * * *")
 			Expect(err).ToNot(HaveOccurred())
-			cs := sched.(*CrontabSchedule)
-			Expect(cs.Hour.IsRandom).To(BeFalse())
-			Expect(cs.base.Hour & (1 << 10)).ToNot(BeZero())
+			spec := sched.(*cron.SpecSchedule)
+			Expect(spec.Hour & (1 << 10)).ToNot(BeZero())
+		})
+
+		It("resolves to a stable value across repeated Next calls", func() {
+			sched, err := ParseCrontab("0~30 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+
+			ref := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+			first := sched.Next(ref)
+			for range 50 {
+				Expect(sched.Next(ref)).To(Equal(first))
+			}
 		})
 	})
 
@@ -213,118 +182,13 @@ var _ = Describe("ParseCrontab", func() {
 	})
 })
 
-var _ = Describe("CrontabSchedule", func() {
-	Describe("Next", func() {
-		It("delegates to base SpecSchedule when no fields are random", func() {
-			base := cron.SpecSchedule{
-				Second:   1 << 0,
-				Minute:   1 << 5,
-				Hour:     0x00FFFFFF | starBit,
-				Dom:      0xFFFFFFFE | starBit,
-				Month:    0x1FFE | starBit,
-				Dow:      0x7F | starBit,
-				Location: time.UTC,
-			}
-			cs := &CrontabSchedule{
-				Second:   randomField{IsRandom: false},
-				Minute:   randomField{IsRandom: false},
-				Hour:     randomField{IsRandom: false},
-				Dom:      randomField{IsRandom: false},
-				Month:    randomField{IsRandom: false},
-				Dow:      randomField{IsRandom: false},
-				base:     base,
-				Location: time.UTC,
-			}
-
-			ref := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-			result := cs.Next(ref)
-			expected := base.Next(ref)
-			Expect(result).To(Equal(expected))
-		})
-
-		It("does not set starBit on random DOM field", func() {
-			base := cron.SpecSchedule{
-				Second:   1 << 0,
-				Minute:   1 << 0,
-				Hour:     1 << 0,
-				Dom:      1 << 1,
-				Month:    0x1FFE | starBit,
-				Dow:      1 << 1,
-				Location: time.UTC,
-			}
-			cs := &CrontabSchedule{
-				Second:   randomField{IsRandom: false},
-				Minute:   randomField{IsRandom: false},
-				Hour:     randomField{IsRandom: false},
-				Dom:      randomField{IsRandom: true, Min: 1, Max: 15},
-				Month:    randomField{IsRandom: false},
-				Dow:      randomField{IsRandom: false},
-				base:     base,
-				Location: time.UTC,
-			}
-
-			ref := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-			for i := 0; i < 50; i++ {
-				result := cs.Next(ref)
-				day := result.Day()
-				weekday := result.Weekday()
-				Expect(day <= 15 || weekday == time.Monday).To(BeTrue(),
-					"day=%d weekday=%s should match DOM 1-15 OR Monday", day, weekday)
-			}
-		})
-	})
-})
-
-var _ = Describe("CrontabSchedule Next with parsed schedules", func() {
-	It("produces minutes within range for 0~30 * * * *", func() {
-		sched, err := ParseCrontab("0~30 * * * *")
-		Expect(err).ToNot(HaveOccurred())
-
-		ref := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
-		seen := make(map[int]bool)
-		for i := 0; i < 100; i++ {
-			result := sched.Next(ref)
-			Expect(result.Minute()).To(BeNumerically(">=", 0))
-			Expect(result.Minute()).To(BeNumerically("<=", 30))
-			seen[result.Minute()] = true
+// findSetBit returns the lowest bit position set in v, ignoring the starBit (bit 63).
+func findSetBit(v uint64) int {
+	v &^= 1 << 63 // clear starBit
+	for i := 0; i < 63; i++ {
+		if v&(1<<uint(i)) != 0 {
+			return i
 		}
-		Expect(len(seen)).To(BeNumerically(">", 1), "expected multiple distinct minutes")
-	})
-
-	It("handles wrap-around with 55~ * * * *", func() {
-		sched, err := ParseCrontab("55~ * * * *")
-		Expect(err).ToNot(HaveOccurred())
-
-		ref := time.Date(2025, 1, 1, 12, 58, 0, 0, time.UTC)
-		for i := 0; i < 50; i++ {
-			result := sched.Next(ref)
-			Expect(result.Minute()).To(BeNumerically(">=", 55))
-			Expect(result.Minute()).To(BeNumerically("<=", 59))
-			Expect(result.After(ref)).To(BeTrue())
-		}
-	})
-
-	It("returns zero time for impossible schedule (Feb 31)", func() {
-		sched, err := ParseCrontab("~ ~ 31~ 2 *")
-		Expect(err).ToNot(HaveOccurred())
-
-		ref := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-		result := sched.Next(ref)
-		Expect(result.IsZero()).To(BeTrue())
-	})
-
-	It("handles ~ in DOM field with correct bounds", func() {
-		sched, err := ParseCrontab("0 0 ~ * *")
-		Expect(err).ToNot(HaveOccurred())
-
-		ref := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-		seen := make(map[int]bool)
-		for i := 0; i < 200; i++ {
-			result := sched.Next(ref)
-			Expect(result.Day()).To(BeNumerically(">=", 1))
-			Expect(result.Day()).To(BeNumerically("<=", 31))
-			seen[result.Day()] = true
-		}
-		Expect(len(seen)).To(BeNumerically(">", 1), "expected multiple distinct days")
-	})
-})
+	}
+	return -1
+}

--- a/scheduler/crontab_schedule_test.go
+++ b/scheduler/crontab_schedule_test.go
@@ -1,0 +1,330 @@
+package scheduler
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/robfig/cron/v3"
+)
+
+const starBit = 1 << 63
+
+var _ = Describe("ParseCrontab", func() {
+	Describe("passthrough (no ~ present)", func() {
+		It("parses a standard 5-field expression", func() {
+			sched, err := ParseCrontab("5 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
+		})
+
+		It("parses a 6-field expression with seconds", func() {
+			sched, err := ParseCrontab("30 5 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
+		})
+
+		It("parses @every descriptor", func() {
+			sched, err := ParseCrontab("@every 5m")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sched).To(BeAssignableToTypeOf(cron.ConstantDelaySchedule{}))
+		})
+
+		It("parses @daily descriptor", func() {
+			sched, err := ParseCrontab("@daily")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
+		})
+
+		It("parses duration string as @every", func() {
+			sched, err := ParseCrontab("5m")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sched).To(BeAssignableToTypeOf(cron.ConstantDelaySchedule{}))
+		})
+
+		It("parses expression with TZ= prefix", func() {
+			sched, err := ParseCrontab("TZ=America/New_York 5 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sched).To(BeAssignableToTypeOf(&cron.SpecSchedule{}))
+		})
+
+		It("returns error for invalid expression", func() {
+			_, err := ParseCrontab("invalid")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns error for empty string", func() {
+			_, err := ParseCrontab("")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("random ~ syntax", func() {
+		It("parses A~B in minute field", func() {
+			sched, err := ParseCrontab("0~30 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs, ok := sched.(*CrontabSchedule)
+			Expect(ok).To(BeTrue(), "expected *CrontabSchedule")
+			Expect(cs.Minute.IsRandom).To(BeTrue())
+			Expect(cs.Minute.Min).To(Equal(uint(0)))
+			Expect(cs.Minute.Max).To(Equal(uint(30)))
+			Expect(cs.Second.IsRandom).To(BeFalse())
+			Expect(cs.Hour.IsRandom).To(BeFalse())
+		})
+
+		It("parses ~ alone as full range for minute field", func() {
+			sched, err := ParseCrontab("~ * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Minute.IsRandom).To(BeTrue())
+			Expect(cs.Minute.Min).To(Equal(uint(0)))
+			Expect(cs.Minute.Max).To(Equal(uint(59)))
+		})
+
+		It("parses ~B as min~B", func() {
+			sched, err := ParseCrontab("~15 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Minute.Min).To(Equal(uint(0)))
+			Expect(cs.Minute.Max).To(Equal(uint(15)))
+		})
+
+		It("parses A~ as A~max", func() {
+			sched, err := ParseCrontab("15~ * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Minute.Min).To(Equal(uint(15)))
+			Expect(cs.Minute.Max).To(Equal(uint(59)))
+		})
+
+		It("parses multiple random fields", func() {
+			sched, err := ParseCrontab("0~30 0~12 * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Minute.IsRandom).To(BeTrue())
+			Expect(cs.Minute.Min).To(Equal(uint(0)))
+			Expect(cs.Minute.Max).To(Equal(uint(30)))
+			Expect(cs.Hour.IsRandom).To(BeTrue())
+			Expect(cs.Hour.Min).To(Equal(uint(0)))
+			Expect(cs.Hour.Max).To(Equal(uint(12)))
+		})
+
+		It("parses 6-field expression with random and seconds", func() {
+			sched, err := ParseCrontab("0 0~30 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Second.IsRandom).To(BeFalse())
+			Expect(cs.Minute.IsRandom).To(BeTrue())
+			Expect(cs.Minute.Min).To(Equal(uint(0)))
+			Expect(cs.Minute.Max).To(Equal(uint(30)))
+		})
+
+		It("parses ~ in DOM field with correct bounds", func() {
+			sched, err := ParseCrontab("0 0 ~ * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Dom.IsRandom).To(BeTrue())
+			Expect(cs.Dom.Min).To(Equal(uint(1)))
+			Expect(cs.Dom.Max).To(Equal(uint(31)))
+		})
+
+		It("parses ~ in month field with correct bounds", func() {
+			sched, err := ParseCrontab("0 0 1 ~ *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Month.IsRandom).To(BeTrue())
+			Expect(cs.Month.Min).To(Equal(uint(1)))
+			Expect(cs.Month.Max).To(Equal(uint(12)))
+		})
+
+		It("parses ~ in DOW field with correct bounds", func() {
+			sched, err := ParseCrontab("0 0 * * ~")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Dow.IsRandom).To(BeTrue())
+			Expect(cs.Dow.Min).To(Equal(uint(0)))
+			Expect(cs.Dow.Max).To(Equal(uint(6)))
+		})
+
+		It("parses with TZ= prefix", func() {
+			sched, err := ParseCrontab("TZ=America/New_York 0~30 * * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Minute.IsRandom).To(BeTrue())
+			nyc, _ := time.LoadLocation("America/New_York")
+			Expect(cs.Location).To(Equal(nyc))
+		})
+
+		It("preserves non-random field bitmasks from base", func() {
+			sched, err := ParseCrontab("0~30 10 * * *")
+			Expect(err).ToNot(HaveOccurred())
+			cs := sched.(*CrontabSchedule)
+			Expect(cs.Hour.IsRandom).To(BeFalse())
+			Expect(cs.base.Hour & (1 << 10)).ToNot(BeZero())
+		})
+	})
+
+	Describe("error cases", func() {
+		It("rejects min > max", func() {
+			_, err := ParseCrontab("30~0 * * * *")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("beyond end"))
+		})
+
+		It("rejects value above field maximum", func() {
+			_, err := ParseCrontab("0~60 * * * *")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("above maximum"))
+		})
+
+		It("rejects value below field minimum", func() {
+			_, err := ParseCrontab("0 0 0~15 * *")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("below minimum"))
+		})
+
+		It("rejects ~ mixed with comma (list)", func() {
+			_, err := ParseCrontab("0~30,45 * * * *")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be combined"))
+		})
+
+		It("rejects ~ mixed with slash (step)", func() {
+			_, err := ParseCrontab("0~30/5 * * * *")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot be combined"))
+		})
+
+		It("rejects @ descriptor with ~", func() {
+			_, err := ParseCrontab("@every 0~30m")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("descriptor"))
+		})
+
+		It("rejects wrong number of fields", func() {
+			_, err := ParseCrontab("0~30 * *")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("rejects non-numeric range values", func() {
+			_, err := ParseCrontab("a~b * * * *")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})
+
+var _ = Describe("CrontabSchedule", func() {
+	Describe("Next", func() {
+		It("delegates to base SpecSchedule when no fields are random", func() {
+			base := cron.SpecSchedule{
+				Second:   1 << 0,
+				Minute:   1 << 5,
+				Hour:     0x00FFFFFF | starBit,
+				Dom:      0xFFFFFFFE | starBit,
+				Month:    0x1FFE | starBit,
+				Dow:      0x7F | starBit,
+				Location: time.UTC,
+			}
+			cs := &CrontabSchedule{
+				Second:   randomField{IsRandom: false},
+				Minute:   randomField{IsRandom: false},
+				Hour:     randomField{IsRandom: false},
+				Dom:      randomField{IsRandom: false},
+				Month:    randomField{IsRandom: false},
+				Dow:      randomField{IsRandom: false},
+				base:     base,
+				Location: time.UTC,
+			}
+
+			ref := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+			result := cs.Next(ref)
+			expected := base.Next(ref)
+			Expect(result).To(Equal(expected))
+		})
+
+		It("does not set starBit on random DOM field", func() {
+			base := cron.SpecSchedule{
+				Second:   1 << 0,
+				Minute:   1 << 0,
+				Hour:     1 << 0,
+				Dom:      1 << 1,
+				Month:    0x1FFE | starBit,
+				Dow:      1 << 1,
+				Location: time.UTC,
+			}
+			cs := &CrontabSchedule{
+				Second:   randomField{IsRandom: false},
+				Minute:   randomField{IsRandom: false},
+				Hour:     randomField{IsRandom: false},
+				Dom:      randomField{IsRandom: true, Min: 1, Max: 15},
+				Month:    randomField{IsRandom: false},
+				Dow:      randomField{IsRandom: false},
+				base:     base,
+				Location: time.UTC,
+			}
+
+			ref := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+			for i := 0; i < 50; i++ {
+				result := cs.Next(ref)
+				day := result.Day()
+				weekday := result.Weekday()
+				Expect(day <= 15 || weekday == time.Monday).To(BeTrue(),
+					"day=%d weekday=%s should match DOM 1-15 OR Monday", day, weekday)
+			}
+		})
+	})
+})
+
+var _ = Describe("CrontabSchedule Next with parsed schedules", func() {
+	It("produces minutes within range for 0~30 * * * *", func() {
+		sched, err := ParseCrontab("0~30 * * * *")
+		Expect(err).ToNot(HaveOccurred())
+
+		ref := time.Date(2025, 1, 1, 12, 0, 0, 0, time.UTC)
+		seen := make(map[int]bool)
+		for i := 0; i < 100; i++ {
+			result := sched.Next(ref)
+			Expect(result.Minute()).To(BeNumerically(">=", 0))
+			Expect(result.Minute()).To(BeNumerically("<=", 30))
+			seen[result.Minute()] = true
+		}
+		Expect(len(seen)).To(BeNumerically(">", 1), "expected multiple distinct minutes")
+	})
+
+	It("handles wrap-around with 55~ * * * *", func() {
+		sched, err := ParseCrontab("55~ * * * *")
+		Expect(err).ToNot(HaveOccurred())
+
+		ref := time.Date(2025, 1, 1, 12, 58, 0, 0, time.UTC)
+		for i := 0; i < 50; i++ {
+			result := sched.Next(ref)
+			Expect(result.Minute()).To(BeNumerically(">=", 55))
+			Expect(result.Minute()).To(BeNumerically("<=", 59))
+			Expect(result.After(ref)).To(BeTrue())
+		}
+	})
+
+	It("returns zero time for impossible schedule (Feb 31)", func() {
+		sched, err := ParseCrontab("~ ~ 31~ 2 *")
+		Expect(err).ToNot(HaveOccurred())
+
+		ref := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		result := sched.Next(ref)
+		Expect(result.IsZero()).To(BeTrue())
+	})
+
+	It("handles ~ in DOM field with correct bounds", func() {
+		sched, err := ParseCrontab("0 0 ~ * *")
+		Expect(err).ToNot(HaveOccurred())
+
+		ref := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		seen := make(map[int]bool)
+		for i := 0; i < 200; i++ {
+			result := sched.Next(ref)
+			Expect(result.Day()).To(BeNumerically(">=", 1))
+			Expect(result.Day()).To(BeNumerically("<=", 31))
+			seen[result.Day()] = true
+		}
+		Expect(len(seen)).To(BeNumerically(">", 1), "expected multiple distinct days")
+	})
+})

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -33,10 +33,11 @@ func (s *scheduler) Run(ctx context.Context) {
 }
 
 func (s *scheduler) Add(crontab string, cmd func()) (int, error) {
-	entryID, err := s.c.AddFunc(crontab, cmd)
+	schedule, err := ParseCrontab(crontab)
 	if err != nil {
 		return 0, err
 	}
+	entryID := s.c.Schedule(schedule, cron.FuncJob(cmd))
 	return int(entryID), nil
 }
 

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -1,7 +1,6 @@
 package scheduler
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -31,20 +30,16 @@ var _ = Describe("Scheduler", func() {
 	})
 
 	It("adds and executes a job", func() {
-		wg := sync.WaitGroup{}
-		wg.Add(1)
+		done := make(chan struct{})
 
-		executed := false
-		id, err := s.Add("@every 100ms", func() {
-			executed = true
-			wg.Done()
+		id, err := s.Add("@every 50ms", func() {
+			close(done)
 		})
 
 		Expect(err).ToNot(HaveOccurred())
 		Expect(id).ToNot(BeZero())
 
-		wg.Wait()
-		Expect(executed).To(BeTrue())
+		Eventually(done).Should(BeClosed())
 	})
 
 	It("adds a job with random ~ syntax", func() {
@@ -55,37 +50,29 @@ var _ = Describe("Scheduler", func() {
 	})
 
 	It("removes a job", func() {
-		// Use a WaitGroup to ensure the job executes once
-		wg := sync.WaitGroup{}
-		wg.Add(1)
+		done := make(chan struct{})
 
 		counter := 0
-		id, err := s.Add("@every 100ms", func() {
+		id, err := s.Add("@every 50ms", func() {
 			counter++
 			if counter == 1 {
-				wg.Done() // Signal that the job has executed once
+				close(done)
 			}
 		})
-
 		Expect(err).ToNot(HaveOccurred())
 		Expect(id).ToNot(BeZero())
 
-		// Wait for the job to execute at least once
-		wg.Wait()
-
 		// Verify job executed
+		Eventually(done).Should(BeClosed())
 		Expect(counter).To(Equal(1))
 
 		// Remove the job
 		s.Remove(id)
 
-		// Store the counter value
-		currentCount := counter
-
 		// Wait some time to ensure job doesn't execute again
 		time.Sleep(200 * time.Millisecond)
 
 		// Verify counter didn't increase
-		Expect(counter).To(Equal(currentCount))
+		Expect(counter).To(Equal(1))
 	})
 })

--- a/scheduler/scheduler_test.go
+++ b/scheduler/scheduler_test.go
@@ -6,14 +6,12 @@ import (
 	"time"
 
 	"github.com/navidrome/navidrome/log"
-	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/robfig/cron/v3"
 )
 
 func TestScheduler(t *testing.T) {
-	tests.Init(t, false)
 	log.SetLevel(log.LevelFatal)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Scheduler Suite")
@@ -47,6 +45,13 @@ var _ = Describe("Scheduler", func() {
 
 		wg.Wait()
 		Expect(executed).To(BeTrue())
+	})
+
+	It("adds a job with random ~ syntax", func() {
+		id, err := s.Add("0~59 * * * *", func() {})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(id).ToNot(BeZero())
+		s.Remove(id)
 	})
 
 	It("removes a job", func() {


### PR DESCRIPTION
### Description

Add support for crontab(5) random `~` syntax in cron schedule expressions. This allows expressions like `0~30 * * * *` to pick a random minute between 0 and 30, providing load spreading across instances and a convenient way to express "run sometime in this window."

Random values are resolved **once at parse time** (matching crontab(5) semantics), so the chosen value remains stable for the lifetime of the process. Each restart picks new random values, spreading load across instances.

`ParseCrontab` resolves `~` fields to concrete random values, substitutes them into the spec string, and delegates to robfig/cron's standard parser — returning a plain `*cron.SpecSchedule`. When no `~` is present, it delegates directly with zero overhead.

**Supported syntax (per crontab(5)):**
- `A~B` — random value in [A, B] inclusive
- `~B` — field minimum to B
- `A~` — A to field maximum
- `~` — full field range

All 6 cron fields are supported (seconds, minutes, hours, DOM, month, DOW). The `~` operator cannot be combined with lists (`,`) or steps (`/`).

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run the scheduler tests: `make test PKG=./scheduler`
2. Run the full test suite: `make test`
3. Run the race detector: `make test-race PKG=./scheduler`
4. Configure `scanner.schedule` or `backup.schedule` with a `~` expression (e.g., `0~30 * * * *`) and verify the server starts without validation errors

### Additional Notes

- `ParseCrontab` also handles duration strings (e.g., `"5m"` → `"@every 5m"`) and optional seconds (5 or 6 field expressions), matching the existing behavior
- The `conf.validateSchedule()` function now uses `ParseCrontab` instead of creating an ad-hoc `cron.New()` instance
- Random values are resolved once at parse time to prevent double-firing within the same period (e.g., a random DOM value that keeps landing after the current day would cause multiple executions per month)
