### PR TITLE
fix(playlists): evaluate smart playlists in background after scanner import

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -75,7 +75,8 @@ func CreateNativeAPIRouter(ctx context.Context) *nativeapi.Router {
 	provider := external.NewProvider(dataStore, agentsAgents)
 	artworkArtwork := artwork.NewArtwork(dataStore, fileCache, fFmpeg, provider)
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
-	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, metricsMetrics)
+	smartPlaylistEvaluator := playlists.NewSmartPlaylistEvaluator(dataStore)
+	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, smartPlaylistEvaluator, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, modelScanner)
 	library := core.NewLibrary(dataStore, modelScanner, watcher, broker, manager)
 	user := core.NewUser(dataStore, manager)
@@ -103,7 +104,8 @@ func CreateSubsonicAPIRouter(ctx context.Context) *subsonic.Router {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	imageUploadService := core.NewImageUploadService()
 	playlistsPlaylists := playlists.NewPlaylists(dataStore, imageUploadService)
-	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, metricsMetrics)
+	smartPlaylistEvaluator := playlists.NewSmartPlaylistEvaluator(dataStore)
+	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, smartPlaylistEvaluator, metricsMetrics)
 	playTracker := scrobbler.GetPlayTracker(dataStore, broker, manager)
 	playbackServer := playback.GetInstance(dataStore)
 	lyricsLyrics := lyrics.NewLyrics(manager)
@@ -173,7 +175,8 @@ func CreateScanner(ctx context.Context) model.Scanner {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	imageUploadService := core.NewImageUploadService()
 	playlistsPlaylists := playlists.NewPlaylists(dataStore, imageUploadService)
-	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, metricsMetrics)
+	smartPlaylistEvaluator := playlists.NewSmartPlaylistEvaluator(dataStore)
+	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, smartPlaylistEvaluator, metricsMetrics)
 	return modelScanner
 }
 
@@ -191,7 +194,8 @@ func CreateScanWatcher(ctx context.Context) scanner.Watcher {
 	cacheWarmer := artwork.NewCacheWarmer(artworkArtwork, fileCache)
 	imageUploadService := core.NewImageUploadService()
 	playlistsPlaylists := playlists.NewPlaylists(dataStore, imageUploadService)
-	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, metricsMetrics)
+	smartPlaylistEvaluator := playlists.NewSmartPlaylistEvaluator(dataStore)
+	modelScanner := scanner.New(ctx, dataStore, cacheWarmer, broker, playlistsPlaylists, smartPlaylistEvaluator, metricsMetrics)
 	watcher := scanner.GetWatcher(dataStore, modelScanner)
 	return watcher
 }

--- a/core/playlists/evaluator.go
+++ b/core/playlists/evaluator.go
@@ -1,0 +1,107 @@
+package playlists
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"time"
+
+	"github.com/navidrome/navidrome/core/auth"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+)
+
+// SmartPlaylistEvaluator evaluates smart playlists in the background.
+// Call Enqueue to queue a playlist for evaluation. The evaluation happens
+// asynchronously in a background goroutine.
+type SmartPlaylistEvaluator interface {
+	Enqueue(playlistID string)
+}
+
+func NewSmartPlaylistEvaluator(ds model.DataStore) SmartPlaylistEvaluator {
+	e := &smartPlaylistEvaluator{
+		ds:         ds,
+		buffer:     make(map[string]struct{}),
+		wakeSignal: make(chan struct{}, 1),
+	}
+	go e.run()
+	return e
+}
+
+type smartPlaylistEvaluator struct {
+	ds         model.DataStore
+	buffer     map[string]struct{}
+	mutex      sync.Mutex
+	wakeSignal chan struct{}
+}
+
+func (e *smartPlaylistEvaluator) Enqueue(playlistID string) {
+	e.mutex.Lock()
+	defer e.mutex.Unlock()
+	e.buffer[playlistID] = struct{}{}
+	e.sendWakeSignal()
+}
+
+func (e *smartPlaylistEvaluator) sendWakeSignal() {
+	select {
+	case e.wakeSignal <- struct{}{}:
+	default:
+	}
+}
+
+func (e *smartPlaylistEvaluator) run() {
+	for {
+		e.waitSignal(10 * time.Second)
+
+		e.mutex.Lock()
+		if len(e.buffer) == 0 {
+			e.mutex.Unlock()
+			continue
+		}
+
+		batch := slices.Collect(maps.Keys(e.buffer))
+		e.buffer = make(map[string]struct{})
+		e.mutex.Unlock()
+
+		e.processBatch(batch)
+	}
+}
+
+func (e *smartPlaylistEvaluator) waitSignal(timeout time.Duration) {
+	select {
+	case <-time.After(timeout):
+	case <-e.wakeSignal:
+	}
+}
+
+func (e *smartPlaylistEvaluator) processBatch(batch []string) {
+	log.Debug("Evaluating smart playlists in background", "count", len(batch))
+	for _, id := range batch {
+		e.doEvaluate(id)
+	}
+}
+
+func (e *smartPlaylistEvaluator) doEvaluate(id string) {
+	// Use admin context so userFilter() returns all playlists.
+	// Evaluate() internally uses pls.OwnerID for annotation JOINs.
+	ctx := auth.WithAdminUser(context.TODO(), e.ds)
+
+	start := time.Now()
+	err := e.ds.Playlist(ctx).Evaluate(id)
+	if err != nil {
+		log.Error("Error evaluating smart playlist in background", "id", id, err)
+		return
+	}
+	log.Debug("Background smart playlist evaluation complete", "id", id, "elapsed", time.Since(start))
+}
+
+// NoopSmartPlaylistEvaluator returns an evaluator that does nothing.
+// Used in CLI scan and test contexts.
+func NoopSmartPlaylistEvaluator() SmartPlaylistEvaluator {
+	return &noopSmartPlaylistEvaluator{}
+}
+
+type noopSmartPlaylistEvaluator struct{}
+
+func (n *noopSmartPlaylistEvaluator) Enqueue(string) {}

--- a/core/playlists/evaluator.go
+++ b/core/playlists/evaluator.go
@@ -69,31 +69,29 @@ func (e *smartPlaylistEvaluator) run() {
 }
 
 func (e *smartPlaylistEvaluator) waitSignal(timeout time.Duration) {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
 	select {
-	case <-time.After(timeout):
+	case <-timer.C:
 	case <-e.wakeSignal:
 	}
 }
 
 func (e *smartPlaylistEvaluator) processBatch(batch []string) {
-	log.Debug("Evaluating smart playlists in background", "count", len(batch))
-	for _, id := range batch {
-		e.doEvaluate(id)
-	}
-}
-
-func (e *smartPlaylistEvaluator) doEvaluate(id string) {
 	// Use admin context so userFilter() returns all playlists.
 	// Evaluate() internally uses pls.OwnerID for annotation JOINs.
 	ctx := auth.WithAdminUser(context.TODO(), e.ds)
 
-	start := time.Now()
-	err := e.ds.Playlist(ctx).Evaluate(id)
-	if err != nil {
-		log.Error("Error evaluating smart playlist in background", "id", id, err)
-		return
+	log.Debug(ctx, "Evaluating smart playlists in background", "count", len(batch))
+	for _, id := range batch {
+		start := time.Now()
+		err := e.ds.Playlist(ctx).Evaluate(id)
+		if err != nil {
+			log.Error(ctx, "Error evaluating smart playlist in background", "id", id, err)
+			continue
+		}
+		log.Debug(ctx, "Smart playlist evaluation complete", "id", id, "elapsed", time.Since(start))
 	}
-	log.Debug("Background smart playlist evaluation complete", "id", id, "elapsed", time.Since(start))
 }
 
 // NoopSmartPlaylistEvaluator returns an evaluator that does nothing.

--- a/core/playlists/evaluator_test.go
+++ b/core/playlists/evaluator_test.go
@@ -1,0 +1,17 @@
+package playlists_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/navidrome/navidrome/core/playlists"
+)
+
+var _ = Describe("SmartPlaylistEvaluator", func() {
+	Describe("NoopSmartPlaylistEvaluator", func() {
+		It("does not panic when enqueuing", func() {
+			noop := playlists.NoopSmartPlaylistEvaluator()
+			Expect(func() { noop.Enqueue("some-id") }).ToNot(Panic())
+		})
+	})
+})

--- a/core/wire_providers.go
+++ b/core/wire_providers.go
@@ -20,6 +20,7 @@ var Set = wire.NewSet(
 	NewPlayers,
 	NewShare,
 	playlists.NewPlaylists,
+	playlists.NewSmartPlaylistEvaluator,
 	NewLibrary,
 	NewUser,
 	NewMaintenance,

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -131,6 +131,7 @@ type PlaylistRepository interface {
 	Delete(id string) error
 	Tracks(playlistId string, refreshSmartPlaylist bool) PlaylistTrackRepository
 	GetPlaylists(mediaFileId string) (Playlists, error)
+	Evaluate(id string) error
 }
 
 type PlaylistTrack struct {

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -215,10 +215,6 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 		return false
 	}
 
-	return r.doRefreshSmartPlaylist(pls, usr.ID)
-}
-
-func (r *playlistRepository) doRefreshSmartPlaylist(pls *model.Playlist, userID string) bool {
 	log.Debug(r.ctx, "Refreshing smart playlist", "playlist", pls.Name, "id", pls.ID)
 	start := time.Now()
 
@@ -248,11 +244,11 @@ func (r *playlistRepository) doRefreshSmartPlaylist(pls *model.Playlist, userID 
 		From("media_file").LeftJoin("annotation on ("+
 		"annotation.item_id = media_file.id"+
 		" AND annotation.item_type = 'media_file'"+
-		" AND annotation.user_id = ?)", userID)
+		" AND annotation.user_id = ?)", usr.ID)
 
 	// Conditionally join album/artist annotation tables only when referenced by criteria or sort
 	requiredJoins := rules.RequiredJoins()
-	sq = r.addSmartPlaylistAnnotationJoins(sq, requiredJoins, userID)
+	sq = r.addSmartPlaylistAnnotationJoins(sq, requiredJoins, usr.ID)
 
 	// Only include media files from libraries the user has access to
 	sq = r.applyLibraryFilter(sq, "media_file")
@@ -265,8 +261,8 @@ func (r *playlistRepository) doRefreshSmartPlaylist(pls *model.Playlist, userID 
 			LeftJoin("annotation on ("+
 				"annotation.item_id = media_file.id"+
 				" AND annotation.item_type = 'media_file'"+
-				" AND annotation.user_id = ?)", userID)
-		countSq = r.addSmartPlaylistAnnotationJoins(countSq, exprJoins, userID)
+				" AND annotation.user_id = ?)", usr.ID)
+		countSq = r.addSmartPlaylistAnnotationJoins(countSq, exprJoins, usr.ID)
 		countSq = r.applyLibraryFilter(countSq, "media_file")
 		countSq = countSq.Where(rules)
 
@@ -322,7 +318,11 @@ func (r *playlistRepository) Evaluate(id string) error {
 	if !pls.IsSmartPlaylist() {
 		return nil
 	}
-	r.doRefreshSmartPlaylist(pls, pls.OwnerID)
+	// Reset EvaluatedAt so refreshSmartPlaylist won't skip due to delay check
+	pls.EvaluatedAt = nil
+	if !r.refreshSmartPlaylist(pls) {
+		return fmt.Errorf("failed to evaluate smart playlist %s", id)
+	}
 	return nil
 }
 

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -215,6 +215,10 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 		return false
 	}
 
+	return r.doRefreshSmartPlaylist(pls, usr.ID)
+}
+
+func (r *playlistRepository) doRefreshSmartPlaylist(pls *model.Playlist, userID string) bool {
 	log.Debug(r.ctx, "Refreshing smart playlist", "playlist", pls.Name, "id", pls.ID)
 	start := time.Now()
 
@@ -244,11 +248,11 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 		From("media_file").LeftJoin("annotation on ("+
 		"annotation.item_id = media_file.id"+
 		" AND annotation.item_type = 'media_file'"+
-		" AND annotation.user_id = ?)", usr.ID)
+		" AND annotation.user_id = ?)", userID)
 
 	// Conditionally join album/artist annotation tables only when referenced by criteria or sort
 	requiredJoins := rules.RequiredJoins()
-	sq = r.addSmartPlaylistAnnotationJoins(sq, requiredJoins, usr.ID)
+	sq = r.addSmartPlaylistAnnotationJoins(sq, requiredJoins, userID)
 
 	// Only include media files from libraries the user has access to
 	sq = r.applyLibraryFilter(sq, "media_file")
@@ -261,8 +265,8 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 			LeftJoin("annotation on ("+
 				"annotation.item_id = media_file.id"+
 				" AND annotation.item_type = 'media_file'"+
-				" AND annotation.user_id = ?)", usr.ID)
-		countSq = r.addSmartPlaylistAnnotationJoins(countSq, exprJoins, usr.ID)
+				" AND annotation.user_id = ?)", userID)
+		countSq = r.addSmartPlaylistAnnotationJoins(countSq, exprJoins, userID)
 		countSq = r.applyLibraryFilter(countSq, "media_file")
 		countSq = countSq.Where(rules)
 
@@ -308,6 +312,18 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 	log.Debug(r.ctx, "Refreshed playlist", "playlist", pls.Name, "id", pls.ID, "numTracks", pls.SongCount, "elapsed", time.Since(start))
 
 	return true
+}
+
+func (r *playlistRepository) Evaluate(id string) error {
+	pls, err := r.Get(id)
+	if err != nil {
+		return err
+	}
+	if !pls.IsSmartPlaylist() {
+		return nil
+	}
+	r.doRefreshSmartPlaylist(pls, pls.OwnerID)
+	return nil
 }
 
 func (r *playlistRepository) addSmartPlaylistAnnotationJoins(sq SelectBuilder, joins criteria.JoinType, userID string) SelectBuilder {

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -254,6 +254,57 @@ var _ = Describe("PlaylistRepository", func() {
 		})
 	})
 
+	Describe("Evaluate", func() {
+		var testPlaylistID string
+
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
+		})
+
+		AfterEach(func() {
+			if testPlaylistID != "" {
+				_ = repo.Delete(testPlaylistID)
+				testPlaylistID = ""
+			}
+		})
+
+		It("evaluates a smart playlist and sets EvaluatedAt and SongCount", func() {
+			rules := &criteria.Criteria{
+				Expression: criteria.All{
+					criteria.Contains{"title": "Day"},
+				},
+			}
+			newPls := model.Playlist{Name: "Evaluate Test", OwnerID: "userid", Rules: rules}
+			Expect(repo.Put(&newPls)).To(Succeed())
+			testPlaylistID = newPls.ID
+
+			Expect(repo.Evaluate(newPls.ID)).To(Succeed())
+
+			saved, err := repo.Get(newPls.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(saved.EvaluatedAt).ToNot(BeNil())
+			Expect(*saved.EvaluatedAt).To(BeTemporally("~", time.Now(), 2*time.Second))
+			Expect(saved.SongCount).To(BeNumerically(">", 0))
+		})
+
+		It("is a no-op for non-smart playlists", func() {
+			newPls := model.Playlist{Name: "Regular Playlist", OwnerID: "userid"}
+			Expect(repo.Put(&newPls)).To(Succeed())
+			testPlaylistID = newPls.ID
+
+			Expect(repo.Evaluate(newPls.ID)).To(Succeed())
+
+			saved, err := repo.Get(newPls.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(saved.EvaluatedAt).To(BeNil())
+		})
+
+		It("returns ErrNotFound for a non-existent playlist ID", func() {
+			err := repo.Evaluate("nonexistent-id")
+			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+	})
+
 	Describe("Playlist Track Sorting", func() {
 		var testPlaylistID string
 

--- a/scanner/controller.go
+++ b/scanner/controller.go
@@ -27,13 +27,14 @@ var (
 )
 
 func New(rootCtx context.Context, ds model.DataStore, cw artwork.CacheWarmer, broker events.Broker,
-	pls playlists.Playlists, m metrics.Metrics) model.Scanner {
+	pls playlists.Playlists, spe playlists.SmartPlaylistEvaluator, m metrics.Metrics) model.Scanner {
 	c := &controller{
 		rootCtx:            rootCtx,
 		ds:                 ds,
 		cw:                 cw,
 		broker:             broker,
 		pls:                pls,
+		spe:                spe,
 		metrics:            m,
 		devExternalScanner: conf.Server.DevExternalScanner,
 	}
@@ -47,7 +48,7 @@ func (s *controller) getScanner() scanner {
 	if s.devExternalScanner {
 		return &scannerExternal{}
 	}
-	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls}
+	return &scannerImpl{ds: s.ds, cw: s.cw, pls: s.pls, spe: s.spe}
 }
 
 // CallScan starts an in-process scan of specific library/folder pairs.
@@ -64,7 +65,7 @@ func CallScan(ctx context.Context, ds model.DataStore, pls playlists.Playlists, 
 	progress := make(chan *ProgressInfo, 100)
 	go func() {
 		defer close(progress)
-		scanner := &scannerImpl{ds: ds, cw: artwork.NoopCacheWarmer(), pls: pls}
+		scanner := &scannerImpl{ds: ds, cw: artwork.NoopCacheWarmer(), pls: pls, spe: playlists.NoopSmartPlaylistEvaluator()}
 		scanner.scanFolders(ctx, fullScan, targets, progress)
 	}()
 	return progress, nil
@@ -99,6 +100,7 @@ type controller struct {
 	broker             events.Broker
 	metrics            metrics.Metrics
 	pls                playlists.Playlists
+	spe                playlists.SmartPlaylistEvaluator
 	limiter            *rate.Sometimes
 	devExternalScanner bool
 	count              atomic.Uint32

--- a/scanner/controller_test.go
+++ b/scanner/controller_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Controller", func() {
 			DeferCleanup(configtest.SetupConfig())
 			ds = &tests.MockDataStore{RealDS: persistence.New(db.Db())}
 			ds.MockedProperty = &tests.MockedPropertyRepo{}
-			ctrl = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(), playlists.NewPlaylists(ds, core.NewImageUploadService()), metrics.NewNoopInstance())
+			ctrl = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(), playlists.NewPlaylists(ds, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 		})
 
 		It("includes last scan error", func() {

--- a/scanner/phase_4_playlists.go
+++ b/scanner/phase_4_playlists.go
@@ -109,7 +109,7 @@ func (p *phasePlaylists) processPlaylistsInFolder(folder *model.Folder) (*model.
 		}
 		if pls.IsSmartPlaylist() {
 			p.spe.Enqueue(pls.ID)
-			log.Debug("Scanner: Imported smart playlist", "name", pls.Name, "lastUpdated", pls.UpdatedAt, "path", pls.Path, "elapsed", time.Since(started))
+			log.Debug(p.ctx, "Scanner: Imported smart playlist", "name", pls.Name, "lastUpdated", pls.UpdatedAt, "path", pls.Path, "elapsed", time.Since(started))
 		} else {
 			log.Debug("Scanner: Imported playlist", "name", pls.Name, "lastUpdated", pls.UpdatedAt, "path", pls.Path, "numTracks", len(pls.Tracks), "elapsed", time.Since(started))
 		}

--- a/scanner/phase_4_playlists.go
+++ b/scanner/phase_4_playlists.go
@@ -23,16 +23,19 @@ type phasePlaylists struct {
 	ds        model.DataStore
 	pls       playlists.Playlists
 	cw        artwork.CacheWarmer
+	spe       playlists.SmartPlaylistEvaluator
 	refreshed atomic.Uint32
 }
 
-func createPhasePlaylists(ctx context.Context, scanState *scanState, ds model.DataStore, pls playlists.Playlists, cw artwork.CacheWarmer) *phasePlaylists {
+func createPhasePlaylists(ctx context.Context, scanState *scanState, ds model.DataStore,
+	pls playlists.Playlists, cw artwork.CacheWarmer, spe playlists.SmartPlaylistEvaluator) *phasePlaylists {
 	return &phasePlaylists{
 		ctx:       ctx,
 		scanState: scanState,
 		ds:        ds,
 		pls:       pls,
 		cw:        cw,
+		spe:       spe,
 	}
 }
 
@@ -105,6 +108,7 @@ func (p *phasePlaylists) processPlaylistsInFolder(folder *model.Folder) (*model.
 			continue
 		}
 		if pls.IsSmartPlaylist() {
+			p.spe.Enqueue(pls.ID)
 			log.Debug("Scanner: Imported smart playlist", "name", pls.Name, "lastUpdated", pls.UpdatedAt, "path", pls.Path, "elapsed", time.Since(started))
 		} else {
 			log.Debug("Scanner: Imported playlist", "name", pls.Name, "lastUpdated", pls.UpdatedAt, "path", pls.Path, "numTracks", len(pls.Tracks), "elapsed", time.Since(started))

--- a/scanner/phase_4_playlists_test.go
+++ b/scanner/phase_4_playlists_test.go
@@ -42,7 +42,7 @@ var _ = Describe("phasePlaylists", func() {
 		pls = &mockPlaylists{}
 		cw = artwork.NoopCacheWarmer()
 		state = &scanState{}
-		phase = createPhasePlaylists(ctx, state, ds, pls, cw)
+		phase = createPhasePlaylists(ctx, state, ds, pls, cw, playlists.NoopSmartPlaylistEvaluator())
 	})
 
 	Describe("description", func() {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -24,6 +24,7 @@ type scannerImpl struct {
 	ds  model.DataStore
 	cw  artwork.CacheWarmer
 	pls playlists.Playlists
+	spe playlists.SmartPlaylistEvaluator
 }
 
 // scanState holds the state of an in-progress scan, to be passed to the various phases
@@ -148,7 +149,7 @@ func (s *scannerImpl) scanFolders(ctx context.Context, fullScan bool, targets []
 			runPhase[*model.Album](ctx, 3, createPhaseRefreshAlbums(ctx, &state, s.ds)),
 
 			// Phase 4: Import/update playlists
-			runPhase[*model.Folder](ctx, 4, createPhasePlaylists(ctx, &state, s.ds, s.pls, s.cw)),
+			runPhase[*model.Folder](ctx, 4, createPhasePlaylists(ctx, &state, s.ds, s.pls, s.cw, s.spe)),
 		),
 
 		// Final Steps (cannot be parallelized):

--- a/scanner/scanner_benchmark_test.go
+++ b/scanner/scanner_benchmark_test.go
@@ -41,7 +41,7 @@ func BenchmarkScan(b *testing.B) {
 	ds := persistence.New(db.Db())
 	conf.Server.DevExternalScanner = false
 	s := scanner.New(context.Background(), ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-		playlists.NewPlaylists(ds, core.NewImageUploadService()), metrics.NewNoopInstance())
+		playlists.NewPlaylists(ds, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 
 	fs := storagetest.FakeFS{}
 	storagetest.Register("fake", &fs)

--- a/scanner/scanner_multilibrary_test.go
+++ b/scanner/scanner_multilibrary_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Scanner - Multi-Library", Ordered, func() {
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
 		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			playlists.NewPlaylists(ds, core.NewImageUploadService()), metrics.NewNoopInstance())
+			playlists.NewPlaylists(ds, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 
 		// Create two test libraries (let DB auto-assign IDs)
 		lib1 = model.Library{Name: "Rock Collection", Path: "rock:///music"}

--- a/scanner/scanner_selective_test.go
+++ b/scanner/scanner_selective_test.go
@@ -64,7 +64,7 @@ var _ = Describe("ScanFolders", Ordered, func() {
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
 		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			playlists.NewPlaylists(ds, core.NewImageUploadService()), metrics.NewNoopInstance())
+			playlists.NewPlaylists(ds, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 
 		lib = model.Library{ID: 1, Name: "Fake Library", Path: "fake:///music"}
 		Expect(ds.Library(ctx).Put(&lib)).To(Succeed())

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Scanner", Ordered, func() {
 		Expect(ds.User(ctx).Put(&adminUser)).To(Succeed())
 
 		s = scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			playlists.NewPlaylists(ds, core.NewImageUploadService()), metrics.NewNoopInstance())
+			playlists.NewPlaylists(ds, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 
 		lib = model.Library{ID: 1, Name: "Fake Library", Path: "fake:///music"}
 		Expect(ds.Library(ctx).Put(&lib)).To(Succeed())

--- a/server/e2e/e2e_suite_test.go
+++ b/server/e2e/e2e_suite_test.go
@@ -453,7 +453,7 @@ var _ = BeforeSuite(func() {
 
 	buildTestFS()
 	s := scanner.New(ctx, initDS, artwork.NoopCacheWarmer(), events.NoopBroker(),
-		playlists.NewPlaylists(initDS, core.NewImageUploadService()), metrics.NewNoopInstance())
+		playlists.NewPlaylists(initDS, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 	_, err = s.ScanAll(ctx, true)
 	Expect(err).ToNot(HaveOccurred())
 
@@ -490,7 +490,7 @@ func setupTestDB() {
 	streamerSpy = &spyStreamer{}
 	decider := stream.NewTranscodeDecider(ds, noopFFmpeg{})
 	s := scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-		playlists.NewPlaylists(ds, core.NewImageUploadService()), metrics.NewNoopInstance())
+		playlists.NewPlaylists(ds, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 	router = subsonic.New(
 		ds,
 		noopArtwork{},

--- a/server/e2e/subsonic_multilibrary_test.go
+++ b/server/e2e/subsonic_multilibrary_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Multi-Library Support", Ordered, func() {
 
 		// Run incremental scan to import lib2 content (lib1 files unchanged → skipped)
 		s := scanner.New(ctx, ds, artwork.NoopCacheWarmer(), events.NoopBroker(),
-			playlists.NewPlaylists(ds, core.NewImageUploadService()), metrics.NewNoopInstance())
+			playlists.NewPlaylists(ds, core.NewImageUploadService()), playlists.NoopSmartPlaylistEvaluator(), metrics.NewNoopInstance())
 		_, err = s.ScanAll(ctx, false)
 		Expect(err).ToNot(HaveOccurred())
 

--- a/tests/mock_playlist_repo.go
+++ b/tests/mock_playlist_repo.go
@@ -108,4 +108,11 @@ func (m *MockPlaylistRepo) CountAll(_ ...model.QueryOptions) (int64, error) {
 	return int64(len(m.Data)), nil
 }
 
+func (m *MockPlaylistRepo) Evaluate(_ string) error {
+	if m.Err {
+		return errors.New("error")
+	}
+	return nil
+}
+
 var _ model.PlaylistRepository = (*MockPlaylistRepo)(nil)


### PR DESCRIPTION
### Description

Smart playlists (`.nsp` files) show 0 tracks on both server and client until the owner (default is first admin) manually opens each playlist in the WebUI of via the Subsonic API with `getPlaylist`. This happens because smart playlist criteria rules are saved during scanner import but not immediately evaluated — tracks are only populated lazily when a user views a specific playlist.

This PR adds background evaluation of smart playlists after scanner import, following the existing `CacheWarmer` pattern:

1. **`Evaluate` method on `PlaylistRepository`** — A public method that triggers smart playlist evaluation, bypassing ownership/delay guards (system-level operation). Reuses the existing `refreshSmartPlaylist` logic.

2. **`SmartPlaylistEvaluator`** — A background goroutine (CacheWarmer pattern) that processes batched playlist IDs asynchronously. Uses `auth.WithAdminUser` context for DB access. Includes a noop implementation for CLI/test contexts.

3. **Scanner integration** — After importing a `.nsp` file, the scanner enqueues the playlist ID for background evaluation via `spe.Enqueue(pls.ID)`. The evaluation happens asynchronously, so the scanner is not slowed down.

After this change, `song_count`/`duration`/`size` are populated shortly after scan completes, and clients calling `getPlaylists` see correct track counts immediately.

### Related Issues

Fixes #4539

### Type of Change

- [ ] Bug fix
- [x] New feature (improvement) 
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Create a `.nsp` smart playlist file in your music library (e.g., with criteria matching some tracks by title)
2. Trigger a library scan
3. Without opening the playlist in the WebUI, check the playlist list via a Subsonic client or `getPlaylists` API call
4. Verify the playlist shows the correct track count (previously showed 0)

### Additional Notes

- The `SmartPlaylistEvaluator` follows the exact same pattern as `CacheWarmer` (`core/artwork/cache_warmer.go`): buffered map + mutex + wake signal + background goroutine processing batches
- `Evaluate` resets `EvaluatedAt` to nil before calling `refreshSmartPlaylist`, which bypasses the refresh delay guard while preserving all other checks (ownership, smart playlist detection)
- The evaluator creates the admin context once per batch (not per playlist) to avoid redundant DB lookups
- Uses `time.NewTimer` instead of `time.After` to prevent timer leaks in the background loop