### PR TITLE
fix(external): refresh stale artist image URLs on expiry

### DIFF
--- a/core/external/provider.go
+++ b/core/external/provider.go
@@ -374,14 +374,6 @@ func (e *provider) ArtistImage(ctx context.Context, id string) (*url.URL, error)
 		return nil, err
 	}
 
-	// If cached info is expired, enqueue a background refresh so that config changes
-	// (e.g. disabling an agent) take effect without waiting for a full artist info refresh.
-	updatedAt := V(artist.ExternalInfoUpdatedAt)
-	if !updatedAt.IsZero() && time.Since(updatedAt) > conf.Server.DevArtistInfoTimeToLive {
-		log.Debug(ctx, "Artist image info expired, enqueuing background refresh", "artist", artist.Name(), "updatedAt", updatedAt)
-		e.artistQueue.enqueue(&artist)
-	}
-
 	imageUrl := artist.ArtistImageUrl()
 	if imageUrl == "" {
 		// No cached URL — must fetch from external source synchronously
@@ -391,6 +383,14 @@ func (e *provider) ArtistImage(ctx context.Context, id string) (*url.URL, error)
 			return nil, ctx.Err()
 		}
 		imageUrl = artist.ArtistImageUrl()
+	} else {
+		// If cached info is expired, enqueue a background refresh so that config changes
+		// (e.g. disabling an agent) take effect without waiting for a full artist info refresh.
+		updatedAt := V(artist.ExternalInfoUpdatedAt)
+		if !updatedAt.IsZero() && time.Since(updatedAt) > conf.Server.DevArtistInfoTimeToLive {
+			log.Debug(ctx, "Artist image info expired, enqueuing background refresh", "artist", artist.Name(), "updatedAt", updatedAt)
+			e.artistQueue.enqueue(&artist)
+		}
 	}
 
 	if imageUrl == "" {

--- a/core/external/provider.go
+++ b/core/external/provider.go
@@ -374,8 +374,14 @@ func (e *provider) ArtistImage(ctx context.Context, id string) (*url.URL, error)
 		return nil, err
 	}
 
-	// Use already-stored image URL if available, avoiding expensive external API calls.
-	// If the info is expired, the background refresh (via UpdateArtistInfo/artistQueue) will update it.
+	// If cached info is expired, enqueue a background refresh so that config changes
+	// (e.g. disabling an agent) take effect without waiting for a full artist info refresh.
+	updatedAt := V(artist.ExternalInfoUpdatedAt)
+	if !updatedAt.IsZero() && time.Since(updatedAt) > conf.Server.DevArtistInfoTimeToLive {
+		log.Debug(ctx, "Artist image info expired, enqueuing background refresh", "artist", artist.Name(), "updatedAt", updatedAt)
+		e.artistQueue.enqueue(&artist)
+	}
+
 	imageUrl := artist.ArtistImageUrl()
 	if imageUrl == "" {
 		// No cached URL — must fetch from external source synchronously

--- a/core/external/provider_artistimage_test.go
+++ b/core/external/provider_artistimage_test.go
@@ -1,6 +1,7 @@
 package external_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"net/url"
@@ -10,6 +11,7 @@ import (
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core/agents"
 	. "github.com/navidrome/navidrome/core/external"
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
@@ -279,6 +281,12 @@ var _ = Describe("Provider - ArtistImage", func() {
 		mockArtistRepo.On("Get", "artist-cached").Return(cachedArtist, nil).Maybe()
 		expectedURL, _ := url.Parse("http://example.com/cached-large.jpg")
 
+		// Capture log output
+		var logBuf bytes.Buffer
+		log.SetOutput(&logBuf)
+		defer log.SetOutput(GinkgoWriter)
+		log.SetLevel(log.LevelDebug)
+
 		// Act
 		imgURL, err := provider.ArtistImage(ctx, "artist-cached")
 
@@ -286,6 +294,41 @@ var _ = Describe("Provider - ArtistImage", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(imgURL).To(Equal(expectedURL))
 		mockImageAgent.AssertNotCalled(GinkgoT(), "GetArtistImages", mock.Anything, "artist-cached", mock.Anything, mock.Anything)
+
+		// Assert: background refresh was NOT enqueued
+		Expect(logBuf.String()).ToNot(ContainSubstring("Artist image info expired, enqueuing background refresh"))
+
+	})
+
+	It("returns stale URL and enqueues refresh when info is expired", func() {
+		// Arrange
+		conf.Server.DevArtistInfoTimeToLive = 1 * time.Nanosecond
+		expiredTime := time.Now().Add(-1 * time.Hour)
+		staleArtist := &model.Artist{
+			ID:                    "artist-expired",
+			Name:                  "Expired Artist",
+			LargeImageUrl:         "http://example.com/expired-large.jpg",
+			ExternalInfoUpdatedAt: &expiredTime,
+		}
+		mockArtistRepo.On("Get", "artist-expired").Return(staleArtist, nil).Maybe()
+		expectedURL, _ := url.Parse("http://example.com/expired-large.jpg")
+
+		// Capture log output
+		var logBuf bytes.Buffer
+		log.SetOutput(&logBuf)
+		defer log.SetOutput(GinkgoWriter)
+		log.SetLevel(log.LevelDebug)
+
+		// Act
+		imgURL, err := provider.ArtistImage(ctx, "artist-expired")
+
+		// Assert: returns stale URL immediately, no agent call
+		Expect(err).ToNot(HaveOccurred())
+		Expect(imgURL).To(Equal(expectedURL))
+		mockImageAgent.AssertNotCalled(GinkgoT(), "GetArtistImages", mock.Anything, "artist-expired", mock.Anything, mock.Anything)
+
+		// Assert: background refresh was enqueued
+		Expect(logBuf.String()).To(ContainSubstring("Artist image info expired, enqueuing background refresh"))
 	})
 
 	Context("Unicode handling in artist names", func() {

--- a/core/external/provider_artistimage_test.go
+++ b/core/external/provider_artistimage_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/url"
+	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -264,6 +265,27 @@ var _ = Describe("Provider - ArtistImage", func() {
 		Expect(imgURL).To(Equal(expectedURL))
 		mockArtistRepo.AssertCalled(GinkgoT(), "Get", "artist-1")
 		mockImageAgent.AssertCalled(GinkgoT(), "GetArtistImages", ctx, "artist-1", "Artist One", "")
+	})
+
+	It("returns cached URL and does not call agent when info is not expired", func() {
+		// Arrange: artist has a cached image URL with recent ExternalInfoUpdatedAt
+		recentTime := time.Now().Add(-1 * time.Minute)
+		cachedArtist := &model.Artist{
+			ID:                    "artist-cached",
+			Name:                  "Cached Artist",
+			LargeImageUrl:         "http://example.com/cached-large.jpg",
+			ExternalInfoUpdatedAt: &recentTime,
+		}
+		mockArtistRepo.On("Get", "artist-cached").Return(cachedArtist, nil).Maybe()
+		expectedURL, _ := url.Parse("http://example.com/cached-large.jpg")
+
+		// Act
+		imgURL, err := provider.ArtistImage(ctx, "artist-cached")
+
+		// Assert
+		Expect(err).ToNot(HaveOccurred())
+		Expect(imgURL).To(Equal(expectedURL))
+		mockImageAgent.AssertNotCalled(GinkgoT(), "GetArtistImages", mock.Anything, "artist-cached", mock.Anything, mock.Anything)
 	})
 
 	Context("Unicode handling in artist names", func() {


### PR DESCRIPTION
### Description

`ArtistImage()` was serving cached image URLs from the database indefinitely, without checking whether the cached external info had expired. This meant that when users changed agent configuration (e.g. disabling the Deezer agent and switching to Last.fm only), old Deezer CDN URLs persisted and continued to be served for artist artwork.

Only the `UpdateArtistInfo` / `refreshArtistInfo` code path (triggered when viewing artist details) checked `ExternalInfoUpdatedAt` against `DevArtistInfoTimeToLive`. The `ArtistImage()` code path (triggered by `getCoverArt` requests) had no such check.

This fix adds an expiry check to `ArtistImage()`: if the cached info is stale, a background refresh is enqueued via the existing `artistQueue`. The stale URL is still returned immediately to avoid blocking clients (important for artist grid views). The next request after the background refresh completes will serve the updated URL.

### Related Issues

Fixes #5266

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Configure Navidrome with `ND_AGENTS=lastfm` and `ND_DEEZER_ENABLED=false`
2. Have an artist whose image was previously fetched via the Deezer agent (stored as a `cdn-images.dzcdn.net` URL in the DB)
3. Set `ND_DEVARTISTINFOTIMETOLIVE=1s` to force expiry
4. Request the artist's cover art via the Subsonic `getCoverArt` API
5. On the first request, the stale URL is returned but a background refresh is enqueued
6. On subsequent requests, the URL should be updated to a Last.fm-sourced URL

### Additional Notes

The fix follows the same pattern already used by `refreshArtistInfo()` (lines 237-241 in `provider.go`): check `ExternalInfoUpdatedAt` against `DevArtistInfoTimeToLive`, and enqueue a background refresh if expired. This is intentionally non-blocking — artist grid views can trigger many `getCoverArt` requests simultaneously, and synchronous agent calls would significantly degrade performance.
