### PR TITLE
fix(smartplaylist): allow inPlaylist/notInPlaylist to reference same-owner private playlists

### DIFF
--- a/model/criteria/criteria.go
+++ b/model/criteria/criteria.go
@@ -152,6 +152,14 @@ func (c Criteria) RequiredJoins() JoinType {
 	return result
 }
 
+// SetOwnerID injects the owner's user ID into all InPlaylist/NotInPlaylist
+// expressions, allowing them to reference the owner's private playlists.
+func (c *Criteria) SetOwnerID(ownerID string) {
+	if c.Expression != nil {
+		injectOwnerID(c.Expression, ownerID)
+	}
+}
+
 func (c Criteria) ChildPlaylistIds() []string {
 	if c.Expression == nil {
 		return nil

--- a/model/criteria/criteria_test.go
+++ b/model/criteria/criteria_test.go
@@ -471,4 +471,42 @@ var _ = Describe("Criteria", func() {
 			gomega.Expect(ids).To(gomega.BeEmpty())
 		})
 	})
+
+	Context("SetOwnerID", func() {
+		It("injects ownerID into InPlaylist and NotInPlaylist nodes", func() {
+			c := Criteria{
+				Expression: All{
+					InPlaylist{"id": "pl1"},
+					NotInPlaylist{"id": "pl2"},
+					Any{
+						InPlaylist{"id": "pl3"},
+					},
+				},
+			}
+			c.SetOwnerID("user-abc")
+
+			all := c.Expression.(All)
+			gomega.Expect(all[0].(InPlaylist)["ownerID"]).To(gomega.Equal("user-abc"))
+			gomega.Expect(all[1].(NotInPlaylist)["ownerID"]).To(gomega.Equal("user-abc"))
+			nested := all[2].(Any)
+			gomega.Expect(nested[0].(InPlaylist)["ownerID"]).To(gomega.Equal("user-abc"))
+		})
+
+		It("does not affect other expression types", func() {
+			c := Criteria{
+				Expression: All{
+					Is{"title": "test"},
+					InPlaylist{"id": "pl1"},
+				},
+			}
+			c.SetOwnerID("user-abc")
+			gomega.Expect(c.Expression.(All)[0].(Is)).To(gomega.HaveLen(1))
+			gomega.Expect(c.Expression.(All)[1].(InPlaylist)["ownerID"]).To(gomega.Equal("user-abc"))
+		})
+
+		It("handles nil expression", func() {
+			c := Criteria{}
+			c.SetOwnerID("user-abc") // should not panic
+		})
+	})
 })

--- a/model/criteria/operators.go
+++ b/model/criteria/operators.go
@@ -286,7 +286,7 @@ func (ipl InPlaylist) ToSql() (sql string, args []any, err error) {
 }
 
 func (ipl InPlaylist) MarshalJSON() ([]byte, error) {
-	return marshalExpression("inPlaylist", ipl)
+	return marshalPlaylistExpression("inPlaylist", ipl)
 }
 
 type NotInPlaylist map[string]any
@@ -296,7 +296,7 @@ func (ipl NotInPlaylist) ToSql() (sql string, args []any, err error) {
 }
 
 func (ipl NotInPlaylist) MarshalJSON() ([]byte, error) {
-	return marshalExpression("notInPlaylist", ipl)
+	return marshalPlaylistExpression("notInPlaylist", ipl)
 }
 
 func inList(m map[string]any, negate bool) (sql string, args []any, err error) {
@@ -306,14 +306,19 @@ func inList(m map[string]any, negate bool) (sql string, args []any, err error) {
 		return "", nil, errors.New("playlist id not given")
 	}
 
-	// Subquery to fetch all media files that are contained in given playlist
-	// Only evaluate playlist if it is public
+	// Subquery to fetch all media files that are contained in given playlist.
+	// Allow the playlist if it is public OR owned by the same user.
+	ownerID, _ := m[ownerIDKey].(string)
 	subQuery := squirrel.Select("media_file_id").
 		From("playlist_tracks pl").
 		LeftJoin("playlist on pl.playlist_id = playlist.id").
 		Where(squirrel.And{
 			squirrel.Eq{"pl.playlist_id": playlistid},
-			squirrel.Eq{"playlist.public": 1}})
+			squirrel.Or{
+				squirrel.Eq{"playlist.public": 1},
+				squirrel.Eq{"playlist.owner_id": ownerID},
+			},
+		})
 	subQText, subQArgs, err := subQuery.PlaceholderFormat(squirrel.Question).ToSql()
 
 	if err != nil {
@@ -323,6 +328,43 @@ func inList(m map[string]any, negate bool) (sql string, args []any, err error) {
 		return "media_file.id NOT IN (" + subQText + ")", subQArgs, nil
 	} else {
 		return "media_file.id IN (" + subQText + ")", subQArgs, nil
+	}
+}
+
+const ownerIDKey = "ownerID"
+
+// marshalPlaylistExpression marshals an InPlaylist/NotInPlaylist expression,
+// filtering out the transient ownerID key that should never be persisted.
+func marshalPlaylistExpression(name string, m map[string]any) ([]byte, error) {
+	if _, has := m[ownerIDKey]; !has {
+		return marshalExpression(name, m)
+	}
+	filtered := make(map[string]any, 1)
+	for k, v := range m {
+		if k != ownerIDKey {
+			filtered[k] = v
+		}
+	}
+	return marshalExpression(name, filtered)
+}
+
+// injectOwnerID walks the expression tree and sets the ownerID key on all
+// InPlaylist and NotInPlaylist nodes, allowing inList() to relax the
+// public-only constraint when the referenced playlist belongs to the same owner.
+func injectOwnerID(inputRule any, ownerID string) {
+	switch rule := inputRule.(type) {
+	case Any:
+		for _, r := range rule {
+			injectOwnerID(r, ownerID)
+		}
+	case All:
+		for _, r := range rule {
+			injectOwnerID(r, ownerID)
+		}
+	case InPlaylist:
+		rule[ownerIDKey] = ownerID
+	case NotInPlaylist:
+		rule[ownerIDKey] = ownerID
 	}
 }
 

--- a/model/criteria/operators_test.go
+++ b/model/criteria/operators_test.go
@@ -45,11 +45,15 @@ var _ = Describe("Operators", func() {
 		Entry("before", Before{"lastPlayed": rangeStart}, "annotation.play_date < ?", rangeStart),
 		Entry("after", After{"lastPlayed": rangeStart}, "annotation.play_date > ?", rangeStart),
 
-		// InPlaylist and NotInPlaylist are special cases
+		// InPlaylist and NotInPlaylist: always allow public or same-owner playlists
 		Entry("inPlaylist", InPlaylist{"id": "deadbeef-dead-beef"}, "media_file.id IN "+
-			"(SELECT media_file_id FROM playlist_tracks pl LEFT JOIN playlist on pl.playlist_id = playlist.id WHERE (pl.playlist_id = ? AND playlist.public = ?))", "deadbeef-dead-beef", 1),
+			"(SELECT media_file_id FROM playlist_tracks pl LEFT JOIN playlist on pl.playlist_id = playlist.id WHERE (pl.playlist_id = ? AND (playlist.public = ? OR playlist.owner_id = ?)))", "deadbeef-dead-beef", 1, ""),
 		Entry("notInPlaylist", NotInPlaylist{"id": "deadbeef-dead-beef"}, "media_file.id NOT IN "+
-			"(SELECT media_file_id FROM playlist_tracks pl LEFT JOIN playlist on pl.playlist_id = playlist.id WHERE (pl.playlist_id = ? AND playlist.public = ?))", "deadbeef-dead-beef", 1),
+			"(SELECT media_file_id FROM playlist_tracks pl LEFT JOIN playlist on pl.playlist_id = playlist.id WHERE (pl.playlist_id = ? AND (playlist.public = ? OR playlist.owner_id = ?)))", "deadbeef-dead-beef", 1, ""),
+		Entry("inPlaylist with ownerID", InPlaylist{"id": "deadbeef-dead-beef", "ownerID": "user123"}, "media_file.id IN "+
+			"(SELECT media_file_id FROM playlist_tracks pl LEFT JOIN playlist on pl.playlist_id = playlist.id WHERE (pl.playlist_id = ? AND (playlist.public = ? OR playlist.owner_id = ?)))", "deadbeef-dead-beef", 1, "user123"),
+		Entry("notInPlaylist with ownerID", NotInPlaylist{"id": "deadbeef-dead-beef", "ownerID": "user123"}, "media_file.id NOT IN "+
+			"(SELECT media_file_id FROM playlist_tracks pl LEFT JOIN playlist on pl.playlist_id = playlist.id WHERE (pl.playlist_id = ? AND (playlist.public = ? OR playlist.owner_id = ?)))", "deadbeef-dead-beef", 1, "user123"),
 
 		Entry("inTheLast", InTheLast{"lastPlayed": 30}, "annotation.play_date > ?", StartOfPeriod(30, time.Now())),
 		Entry("notInTheLast", NotInTheLast{"lastPlayed": 30}, "(annotation.play_date < ? OR annotation.play_date IS NULL)", StartOfPeriod(30, time.Now())),
@@ -224,4 +228,19 @@ var _ = Describe("Operators", func() {
 		Entry("inPlaylist", InPlaylist{"id": "deadbeef-dead-beef"}, `{"inPlaylist":{"id":"deadbeef-dead-beef"}}`),
 		Entry("notInPlaylist", NotInPlaylist{"id": "deadbeef-dead-beef"}, `{"notInPlaylist":{"id":"deadbeef-dead-beef"}}`),
 	)
+
+	Describe("JSON Marshaling excludes ownerID", func() {
+		It("excludes ownerID from InPlaylist JSON", func() {
+			op := InPlaylist{"id": "deadbeef-dead-beef", "ownerID": "user123"}
+			j, err := json.Marshal(op)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(string(j)).To(gomega.Equal(`{"inPlaylist":{"id":"deadbeef-dead-beef"}}`))
+		})
+		It("excludes ownerID from NotInPlaylist JSON", func() {
+			op := NotInPlaylist{"id": "deadbeef-dead-beef", "ownerID": "user123"}
+			j, err := json.Marshal(op)
+			gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			gomega.Expect(string(j)).To(gomega.Equal(`{"notInPlaylist":{"id":"deadbeef-dead-beef"}}`))
+		})
+	})
 })

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -228,6 +228,7 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 
 	// Re-populate playlist based on Smart Playlist criteria
 	rules := *pls.Rules
+	rules.SetOwnerID(usr.ID)
 
 	// If the playlist depends on other playlists, recursively refresh them first
 	childPlaylistIds := rules.ChildPlaylistIds()

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -210,6 +210,34 @@ var _ = Describe("PlaylistRepository", func() {
 				})
 			})
 
+			When("referenced playlist is private but owned by the same user", func() {
+				It("should include tracks from the private playlist", func() {
+					conf.Server.SmartPlaylistRefreshDelay = -1 * time.Second
+
+					childRules := &criteria.Criteria{
+						Expression: criteria.All{
+							criteria.Contains{"title": "Day"},
+						},
+					}
+					nestedPls := model.Playlist{Name: "Private Nested", OwnerID: "userid", Public: false, Rules: childRules}
+					Expect(repo.Put(&nestedPls)).To(Succeed())
+					DeferCleanup(func() { _ = repo.Delete(nestedPls.ID) })
+
+					parentPls := model.Playlist{Name: "Parent Using Private", OwnerID: "userid", Rules: &criteria.Criteria{
+						Expression: criteria.All{
+							criteria.InPlaylist{"id": nestedPls.ID},
+						},
+					}}
+					Expect(repo.Put(&parentPls)).To(Succeed())
+					DeferCleanup(func() { _ = repo.Delete(parentPls.ID) })
+
+					pls, err := repo.GetWithTracks(parentPls.ID, true, false)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pls.Tracks).To(HaveLen(1))
+					Expect(pls.Tracks[0].MediaFileID).To(Equal(songDayInALife.ID))
+				})
+			})
+
 			When("refresh delay has not expired", func() {
 				It("should NOT refresh tracks for smart playlist referenced in parent smart playlist criteria", func() {
 					conf.Server.SmartPlaylistRefreshDelay = 1 * time.Hour

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -236,6 +236,32 @@ var _ = Describe("PlaylistRepository", func() {
 					Expect(pls.Tracks).To(HaveLen(1))
 					Expect(pls.Tracks[0].MediaFileID).To(Equal(songDayInALife.ID))
 				})
+
+				It("should exclude tracks from the private playlist when using NotInPlaylist", func() {
+					conf.Server.SmartPlaylistRefreshDelay = -1 * time.Second
+
+					childRules := &criteria.Criteria{
+						Expression: criteria.All{
+							criteria.Contains{"title": "Day"},
+						},
+					}
+					nestedPls := model.Playlist{Name: "Private Nested Excluded", OwnerID: "userid", Public: false, Rules: childRules}
+					Expect(repo.Put(&nestedPls)).To(Succeed())
+					DeferCleanup(func() { _ = repo.Delete(nestedPls.ID) })
+
+					parentPls := model.Playlist{Name: "Parent Excluding Private", OwnerID: "userid", Rules: &criteria.Criteria{
+						Expression: criteria.All{
+							criteria.Contains{"title": "Day"},
+							criteria.NotInPlaylist{"id": nestedPls.ID},
+						},
+					}}
+					Expect(repo.Put(&parentPls)).To(Succeed())
+					DeferCleanup(func() { _ = repo.Delete(parentPls.ID) })
+
+					pls, err := repo.GetWithTracks(parentPls.ID, true, false)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(pls.Tracks).To(HaveLen(0))
+				})
 			})
 
 			When("refresh delay has not expired", func() {


### PR DESCRIPTION
### Description

The `inPlaylist` and `notInPlaylist` smart playlist criteria only worked when the referenced playlist was public. This meant users had to make their own playlists public just to reference them in their own smart playlists. If the playlist was private, the filter was silently ignored.

This PR relaxes the public requirement so the filter works when the smart playlist owner also owns the referenced playlist, regardless of public/private status. The SQL subquery condition changes from `playlist.public = 1` to `(playlist.public = 1 OR playlist.owner_id = ?)`, where the owner ID is injected at evaluation time via `SetOwnerID()`.

Cross-user access is unchanged: referencing another user's private playlist still has no effect.

### Related Issues

Fixes #5315

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Create a regular (non-smart) playlist and keep it **private**
2. Create a smart playlist that references it with `notInPlaylist` or `inPlaylist`
3. Verify the filter works correctly — tracks from the private playlist should be properly included/excluded
4. Set the referenced playlist to **public** — behavior should remain the same
5. Create a private playlist owned by a **different user** and reference it — the filter should have no effect (same as before)

### Additional Notes

- The owner ID is injected as a transient key in the expression map at evaluation time and is filtered out during JSON marshaling, so it is never persisted
- When no owner ID is set (e.g., outside of `refreshSmartPlaylist`), the SQL falls back to `owner_id = ''` which matches nothing, preserving the public-only behavior
