### PR TITLE
feat(config): make max image upload size configurable

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -273,8 +273,6 @@ var (
 	hooks  []func()
 )
 
-const defaultMaxImageUploadSize = "10MB"
-
 func LoadFromFile(confFile string) {
 	viper.SetConfigFile(confFile)
 	err := viper.ReadInConfig()
@@ -591,7 +589,8 @@ func validatePurgeMissingOption() error {
 
 func validateMaxImageUploadSize() error {
 	if _, err := humanize.ParseBytes(Server.MaxImageUploadSize); err != nil {
-		log.Error("Invalid MaxImageUploadSize. Use values like '10MB', '1GB', or raw bytes like '10485760'", "value", Server.MaxImageUploadSize, err)
+		err = fmt.Errorf("invalid MaxImageUploadSize %q: use values like '10MB', '1GB', or raw bytes like '10485760': %w", Server.MaxImageUploadSize, err)
+		log.Error(err.Error())
 		return err
 	}
 	return nil
@@ -755,7 +754,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablecoveranimation", true)
 	viper.SetDefault("enablenowplaying", true)
 	viper.SetDefault("enableartworkupload", true)
-	viper.SetDefault("maximageuploadsize", defaultMaxImageUploadSize)
+	viper.SetDefault("maximageuploadsize", consts.DefaultMaxImageUploadSize)
 	viper.SetDefault("enablesharing", false)
 	viper.SetDefault("shareurl", "")
 	viper.SetDefault("defaultshareexpiration", 8760*time.Hour)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -80,6 +80,7 @@ type configOptions struct {
 	EnableStarRating                bool
 	EnableUserEditing               bool
 	EnableArtworkUpload             bool
+	MaxImageUploadSize              int64
 	EnableSharing                   bool
 	ShareURL                        string
 	DefaultShareExpiration          time.Duration
@@ -742,6 +743,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablecoveranimation", true)
 	viper.SetDefault("enablenowplaying", true)
 	viper.SetDefault("enableartworkupload", true)
+	viper.SetDefault("maximageuploadsize", int64(10<<20))
 	viper.SetDefault("enablesharing", false)
 	viper.SetDefault("shareurl", "")
 	viper.SetDefault("defaultshareexpiration", 8760*time.Hour)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/dustin/go-humanize"
 	"github.com/go-viper/encoding/ini"
 	"github.com/kr/pretty"
 	"github.com/navidrome/navidrome/consts"
@@ -80,7 +81,7 @@ type configOptions struct {
 	EnableStarRating                bool
 	EnableUserEditing               bool
 	EnableArtworkUpload             bool
-	MaxImageUploadSize              int64
+	MaxImageUploadSize              string
 	EnableSharing                   bool
 	ShareURL                        string
 	DefaultShareExpiration          time.Duration
@@ -272,6 +273,8 @@ var (
 	hooks  []func()
 )
 
+const defaultMaxImageUploadSize = "10MB"
+
 func LoadFromFile(confFile string) {
 	viper.SetConfigFile(confFile)
 	err := viper.ReadInConfig()
@@ -361,6 +364,7 @@ func Load(noConfigDump bool) {
 		validateBackupSchedule,
 		validatePlaylistsPath,
 		validatePurgeMissingOption,
+		validateMaxImageUploadSize,
 		validateURL("ExtAuth.LogoutURL", Server.ExtAuth.LogoutURL),
 	)
 	if err != nil {
@@ -585,6 +589,14 @@ func validatePurgeMissingOption() error {
 	return nil
 }
 
+func validateMaxImageUploadSize() error {
+	if _, err := humanize.ParseBytes(Server.MaxImageUploadSize); err != nil {
+		log.Error("Invalid MaxImageUploadSize. Use values like '10MB', '1GB', or raw bytes like '10485760'", "value", Server.MaxImageUploadSize, err)
+		return err
+	}
+	return nil
+}
+
 func validateScanSchedule() error {
 	if Server.Scanner.Schedule == "0" || Server.Scanner.Schedule == "" {
 		Server.Scanner.Schedule = ""
@@ -743,7 +755,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablecoveranimation", true)
 	viper.SetDefault("enablenowplaying", true)
 	viper.SetDefault("enableartworkupload", true)
-	viper.SetDefault("maximageuploadsize", int64(10<<20))
+	viper.SetDefault("maximageuploadsize", defaultMaxImageUploadSize)
 	viper.SetDefault("enablesharing", false)
 	viper.SetDefault("shareurl", "")
 	viper.SetDefault("defaultshareexpiration", 8760*time.Hour)

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -219,6 +219,37 @@ var _ = Describe("Configuration", func() {
 
 	})
 
+	Describe("ValidateMaxImageUploadSize", func() {
+		BeforeEach(func() {
+			viper.Reset()
+			conf.SetViperDefaults()
+			viper.SetDefault("datafolder", GinkgoT().TempDir())
+			viper.SetDefault("loglevel", "error")
+			conf.ResetConf()
+		})
+
+		DescribeTable("accepts valid size values",
+			func(input string) {
+				conf.Server.MaxImageUploadSize = input
+				Expect(conf.ValidateMaxImageUploadSize()).To(Succeed())
+			},
+			Entry("megabytes", "10MB"),
+			Entry("gigabytes", "1GB"),
+			Entry("raw bytes", "10485760"),
+			Entry("mebibytes", "10MiB"),
+			Entry("lower case", "50mb"),
+		)
+
+		DescribeTable("rejects invalid size values",
+			func(input string) {
+				conf.Server.MaxImageUploadSize = input
+				Expect(conf.ValidateMaxImageUploadSize()).To(MatchError(ContainSubstring("invalid MaxImageUploadSize")))
+			},
+			Entry("garbage string", "not-a-size"),
+			Entry("negative-looking", "-10MB"),
+		)
+	})
+
 	DescribeTable("should load configuration from",
 		func(format string) {
 			filename := filepath.Join("testdata", "cfg."+format)

--- a/conf/export_test.go
+++ b/conf/export_test.go
@@ -14,6 +14,8 @@ var NormalizeSearchBackend = normalizeSearchBackend
 
 var ToPascalCase = toPascalCase
 
+var ValidateMaxImageUploadSize = validateMaxImageUploadSize
+
 func SetLogFatal(f func(...any)) func() {
 	old := logFatal
 	logFatal = f

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -85,7 +85,8 @@ const (
 )
 
 const (
-	DefaultUICoverArtSize = 300
+	DefaultUICoverArtSize     = 300
+	DefaultMaxImageUploadSize = "10MB"
 )
 
 // Prometheus options

--- a/server/nativeapi/image_upload.go
+++ b/server/nativeapi/image_upload.go
@@ -15,19 +15,19 @@ import (
 
 	"github.com/dustin/go-humanize"
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	_ "golang.org/x/image/webp"
 )
 
-const defaultMaxImageSize = 10 << 20 // 10MB
-
 func maxImageUploadSize() int64 {
 	if size, err := humanize.ParseBytes(conf.Server.MaxImageUploadSize); err == nil && size > 0 {
 		return int64(size)
 	}
-	return defaultMaxImageSize
+	size, _ := humanize.ParseBytes(consts.DefaultMaxImageUploadSize)
+	return int64(size)
 }
 
 func checkImageUploadPermission(w http.ResponseWriter, r *http.Request) bool {
@@ -40,12 +40,12 @@ func checkImageUploadPermission(w http.ResponseWriter, r *http.Request) bool {
 }
 
 func handleImageUpload(saveFn func(ctx context.Context, reader io.Reader, ext string) error) http.HandlerFunc {
+	maxImageSize := maxImageUploadSize()
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		if !checkImageUploadPermission(w, r) {
 			return
 		}
-		maxImageSize := maxImageUploadSize()
 		r.Body = http.MaxBytesReader(w, r.Body, maxImageSize)
 		if err := r.ParseMultipartForm(min(maxImageSize, 10<<20)); err != nil {
 			log.Error(ctx, "Error parsing multipart form", err)

--- a/server/nativeapi/image_upload.go
+++ b/server/nativeapi/image_upload.go
@@ -20,7 +20,14 @@ import (
 	_ "golang.org/x/image/webp"
 )
 
-const maxImageSize = 10 << 20 // 10MB
+const defaultMaxImageSize = 10 << 20 // 10MB
+
+func maxImageUploadSize() int64 {
+	if conf.Server.MaxImageUploadSize > 0 {
+		return conf.Server.MaxImageUploadSize
+	}
+	return defaultMaxImageSize
+}
 
 func checkImageUploadPermission(w http.ResponseWriter, r *http.Request) bool {
 	user, _ := request.UserFrom(r.Context())
@@ -37,6 +44,7 @@ func handleImageUpload(saveFn func(ctx context.Context, reader io.Reader, ext st
 		if !checkImageUploadPermission(w, r) {
 			return
 		}
+		maxImageSize := max(1, maxImageUploadSize())
 		r.Body = http.MaxBytesReader(w, r.Body, maxImageSize)
 		if err := r.ParseMultipartForm(maxImageSize / 2); err != nil {
 			log.Error(ctx, "Error parsing multipart form", err)

--- a/server/nativeapi/image_upload.go
+++ b/server/nativeapi/image_upload.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/dustin/go-humanize"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -23,8 +24,8 @@ import (
 const defaultMaxImageSize = 10 << 20 // 10MB
 
 func maxImageUploadSize() int64 {
-	if conf.Server.MaxImageUploadSize > 0 {
-		return conf.Server.MaxImageUploadSize
+	if size, err := humanize.ParseBytes(conf.Server.MaxImageUploadSize); err == nil && size > 0 {
+		return int64(size)
 	}
 	return defaultMaxImageSize
 }
@@ -44,9 +45,9 @@ func handleImageUpload(saveFn func(ctx context.Context, reader io.Reader, ext st
 		if !checkImageUploadPermission(w, r) {
 			return
 		}
-		maxImageSize := max(1, maxImageUploadSize())
+		maxImageSize := maxImageUploadSize()
 		r.Body = http.MaxBytesReader(w, r.Body, maxImageSize)
-		if err := r.ParseMultipartForm(maxImageSize / 2); err != nil {
+		if err := r.ParseMultipartForm(min(maxImageSize, 10<<20)); err != nil {
 			log.Error(ctx, "Error parsing multipart form", err)
 			http.Error(w, "file too large or invalid form", http.StatusBadRequest)
 			return

--- a/server/nativeapi/image_upload_test.go
+++ b/server/nativeapi/image_upload_test.go
@@ -1,0 +1,34 @@
+package nativeapi
+
+import (
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("maxImageUploadSize", func() {
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+	})
+
+	It("returns the configured size when valid", func() {
+		conf.Server.MaxImageUploadSize = "20MB"
+		Expect(maxImageUploadSize()).To(Equal(int64(20_000_000)))
+	})
+
+	It("returns the default size when config is empty", func() {
+		conf.Server.MaxImageUploadSize = ""
+		Expect(maxImageUploadSize()).To(Equal(int64(10_000_000)))
+	})
+
+	It("returns the default size when config is invalid", func() {
+		conf.Server.MaxImageUploadSize = "not-a-size"
+		Expect(maxImageUploadSize()).To(Equal(int64(10_000_000)))
+	})
+
+	It("parses raw byte values", func() {
+		conf.Server.MaxImageUploadSize = "52428800"
+		Expect(maxImageUploadSize()).To(Equal(int64(52_428_800)))
+	})
+})


### PR DESCRIPTION
### Description
Let `MaxImageUploadSize` be set from config or environment instead of a fixed 10 MB cap. The upload handler still falls back to 10 MB when `MaxImageUploadSize` is not set. This is needed because animated webp files can become fairly large if they have a decent quality.

### Related Issues
navidrome/website documentation update [PR#327](https://github.com/navidrome/website/pull/327)

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Upload a custom playlist image with a size larger than 10 MB (should not work).
2. Set a custom max image upload size larger than the size of the file you want to upload (in `navidrome.toml`)
3. Upload the custom playlist image again (should work now).

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->