### PR TITLE
fix(subsonic): always emit required `created` field on AlbumID3

### DIFF
--- a/db/migrations/20260410201914_fix_zero_album_created_at.sql
+++ b/db/migrations/20260410201914_fix_zero_album_created_at.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+
+-- Backfill album.created_at for rows poisoned by early scanner versions or
+-- propagated via CopyAttributes during metadata-driven ID changes. Prefer the
+-- oldest valid birth_time from the album's media files, fall back to updated_at.
+UPDATE album
+SET created_at = COALESCE(
+    (SELECT MIN(birth_time)
+     FROM media_file
+     WHERE media_file.album_id = album.id
+       AND birth_time IS NOT NULL
+       AND birth_time != ''
+       AND birth_time NOT LIKE '0001-%'),
+    updated_at
+)
+WHERE created_at IS NULL
+   OR created_at = ''
+   OR created_at LIKE '0001-%';
+
+-- +goose Down
+
+SELECT 1;

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -361,6 +361,9 @@ func older(t1, t2 time.Time) time.Time {
 	if t1.IsZero() {
 		return t2
 	}
+	if t2.IsZero() {
+		return t1
+	}
 	if t1.After(t2) {
 		return t2
 	}

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -119,6 +119,20 @@ var _ = Describe("MediaFiles", func() {
 						Expect(a.MinYear).To(Equal(1999))
 					})
 				})
+				Context("CreatedAt aggregation", func() {
+					It("ignores zero BirthTime values when computing the oldest", func() {
+						mfs = MediaFiles{
+							{BirthTime: t("2022-12-19 08:30")},
+							{BirthTime: time.Time{}},
+							{BirthTime: t("2022-12-18 10:00")},
+						}
+						Expect(mfs.ToAlbum().CreatedAt).To(Equal(t("2022-12-18 10:00")))
+					})
+					It("returns zero when all BirthTime values are zero", func() {
+						mfs = MediaFiles{{BirthTime: time.Time{}}, {BirthTime: time.Time{}}}
+						Expect(mfs.ToAlbum().CreatedAt).To(BeZero())
+					})
+				})
 			})
 			When("we have multiple songs with same dates", func() {
 				BeforeEach(func() {

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -252,7 +252,17 @@ func (r *albumRepository) CopyAttributes(fromID, toID string, columns ...string)
 	}
 	to := make(map[string]any)
 	for _, col := range columns {
-		to[col] = from[col]
+		v := from[col]
+		// created_at is aggregated from song birth_times and must never be
+		// overwritten with a zero/poisoned value, or it propagates forward on
+		// every metadata-driven album ID change.
+		if col == "created_at" && (!v.Valid || v.String == "" || strings.HasPrefix(v.String, "0001-")) {
+			continue
+		}
+		to[col] = v
+	}
+	if len(to) == 0 {
+		return nil
 	}
 	_, err = r.executeSQL(Update(r.tableName).SetMap(to).Where(Eq{"id": toID}))
 	return err

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -41,6 +41,32 @@ var _ = Describe("AlbumRepository", func() {
 		})
 	})
 
+	Describe("CopyAttributes", func() {
+		var srcTime, dstTime time.Time
+		BeforeEach(func() {
+			srcTime = time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+			dstTime = time.Date(2024, 6, 7, 8, 9, 10, 0, time.UTC)
+			Expect(albumRepo.Put(&model.Album{ID: "copy-src", Name: "src", LibraryID: 1, CreatedAt: srcTime})).To(Succeed())
+			Expect(albumRepo.Put(&model.Album{ID: "copy-dst", Name: "dst", LibraryID: 1, CreatedAt: dstTime})).To(Succeed())
+			Expect(albumRepo.Put(&model.Album{ID: "copy-zero", Name: "zero", LibraryID: 1})).To(Succeed())
+			DeferCleanup(func() {
+				_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": []string{"copy-src", "copy-dst", "copy-zero"}}))
+			})
+		})
+		It("copies a valid created_at from source to destination", func() {
+			Expect(albumRepo.CopyAttributes("copy-src", "copy-dst", "created_at")).To(Succeed())
+			got, err := albumRepo.Get("copy-dst")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.CreatedAt).To(BeTemporally("~", srcTime, time.Second))
+		})
+		It("leaves destination untouched when source created_at is zero", func() {
+			Expect(albumRepo.CopyAttributes("copy-zero", "copy-dst", "created_at")).To(Succeed())
+			got, err := albumRepo.Get("copy-dst")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.CreatedAt).To(BeTemporally("~", dstTime, time.Second))
+		})
+	})
+
 	Describe("GetAll", func() {
 		var GetAll = func(opts ...model.QueryOptions) (model.Albums, error) {
 			albums, err := albumRepo.GetAll(opts...)

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -18,6 +18,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
+	. "github.com/navidrome/navidrome/utils/gg"
 	"github.com/navidrome/navidrome/utils/number"
 	"github.com/navidrome/navidrome/utils/req"
 	"github.com/navidrome/navidrome/utils/slice"
@@ -318,16 +319,18 @@ func sanitizeSlashes(target string) string {
 	return strings.ReplaceAll(target, "/", "_")
 }
 
-// albumCreatedAt returns a non-zero timestamp for the album's `created` field,
-// which is required by the OpenSubsonic spec but may be zero on legacy DB rows.
-func albumCreatedAt(al model.Album) *time.Time {
+// albumCreatedAt returns a best-effort timestamp for the album's `created`
+// field, which is required by the OpenSubsonic spec but may be zero on legacy
+// DB rows. Falls back to UpdatedAt → ImportedAt; can still return zero if all
+// three are unset.
+func albumCreatedAt(al model.Album) time.Time {
 	if !al.CreatedAt.IsZero() {
-		return &al.CreatedAt
+		return al.CreatedAt
 	}
 	if !al.UpdatedAt.IsZero() {
-		return &al.UpdatedAt
+		return al.UpdatedAt
 	}
-	return &al.ImportedAt
+	return al.ImportedAt
 }
 
 func childFromAlbum(ctx context.Context, al model.Album) responses.Child {
@@ -342,7 +345,7 @@ func childFromAlbum(ctx context.Context, al model.Album) responses.Child {
 	child.Year = int32(cmp.Or(al.MaxOriginalYear, al.MaxYear))
 	child.Genre = al.Genre
 	child.CoverArt = al.CoverArtID().String()
-	child.Created = albumCreatedAt(al)
+	child.Created = P(albumCreatedAt(al))
 	child.Parent = al.AlbumArtistID
 	child.ArtistId = al.AlbumArtistID
 	child.Duration = int32(al.Duration)
@@ -434,7 +437,7 @@ func buildAlbumID3(ctx context.Context, album model.Album) responses.AlbumID3 {
 	dir.PlayCount = album.PlayCount
 	dir.Year = int32(cmp.Or(album.MaxOriginalYear, album.MaxYear))
 	dir.Genre = album.Genre
-	dir.Created = albumCreatedAt(album)
+	dir.Created = P(albumCreatedAt(album))
 	if album.Starred {
 		dir.Starred = album.StarredAt
 	}

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
@@ -317,6 +318,18 @@ func sanitizeSlashes(target string) string {
 	return strings.ReplaceAll(target, "/", "_")
 }
 
+// albumCreatedAt returns a non-zero timestamp for the album's `created` field,
+// which is required by the OpenSubsonic spec but may be zero on legacy DB rows.
+func albumCreatedAt(al model.Album) *time.Time {
+	if !al.CreatedAt.IsZero() {
+		return &al.CreatedAt
+	}
+	if !al.UpdatedAt.IsZero() {
+		return &al.UpdatedAt
+	}
+	return &al.ImportedAt
+}
+
 func childFromAlbum(ctx context.Context, al model.Album) responses.Child {
 	child := responses.Child{}
 	child.Id = al.ID
@@ -329,7 +342,7 @@ func childFromAlbum(ctx context.Context, al model.Album) responses.Child {
 	child.Year = int32(cmp.Or(al.MaxOriginalYear, al.MaxYear))
 	child.Genre = al.Genre
 	child.CoverArt = al.CoverArtID().String()
-	child.Created = &al.CreatedAt
+	child.Created = albumCreatedAt(al)
 	child.Parent = al.AlbumArtistID
 	child.ArtistId = al.AlbumArtistID
 	child.Duration = int32(al.Duration)
@@ -421,9 +434,7 @@ func buildAlbumID3(ctx context.Context, album model.Album) responses.AlbumID3 {
 	dir.PlayCount = album.PlayCount
 	dir.Year = int32(cmp.Or(album.MaxOriginalYear, album.MaxYear))
 	dir.Genre = album.Genre
-	if !album.CreatedAt.IsZero() {
-		dir.Created = &album.CreatedAt
-	}
+	dir.Created = albumCreatedAt(album)
 	if album.Starred {
 		dir.Starred = album.StarredAt
 	}

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -571,6 +571,38 @@ var _ = Describe("helpers", func() {
 			})
 		})
 
+		Describe("buildAlbumID3 Created field", func() {
+			It("uses CreatedAt when set", func() {
+				t := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
+				al := model.Album{ID: "a1", Name: "A", CreatedAt: t}
+				dir := buildAlbumID3(ctx, al)
+				Expect(dir.Created).ToNot(BeNil())
+				Expect(*dir.Created).To(Equal(t))
+			})
+
+			It("falls back to UpdatedAt when CreatedAt is zero", func() {
+				updated := time.Date(2019, 5, 6, 7, 8, 9, 0, time.UTC)
+				al := model.Album{ID: "a2", Name: "A", UpdatedAt: updated}
+				dir := buildAlbumID3(ctx, al)
+				Expect(dir.Created).ToNot(BeNil())
+				Expect(*dir.Created).To(Equal(updated))
+			})
+
+			It("falls back to ImportedAt when CreatedAt and UpdatedAt are zero", func() {
+				imported := time.Date(2021, 8, 9, 10, 11, 12, 0, time.UTC)
+				al := model.Album{ID: "a3", Name: "A", ImportedAt: imported}
+				dir := buildAlbumID3(ctx, al)
+				Expect(dir.Created).ToNot(BeNil())
+				Expect(*dir.Created).To(Equal(imported))
+			})
+
+			It("never leaves Created nil even when all timestamps are zero", func() {
+				al := model.Album{ID: "a4", Name: "A"}
+				dir := buildAlbumID3(ctx, al)
+				Expect(dir.Created).ToNot(BeNil())
+			})
+		})
+
 		Describe("EnableAverageRating config", func() {
 			It("excludes averageRating when disabled", func() {
 				conf.Server.Subsonic.EnableAverageRating = false


### PR DESCRIPTION
### Description

Strict OpenSubsonic clients (e.g. [Navic](https://github.com/paigely/Navic) via the `dev.zt64.subsonic:subsonic-client` library) crash with `Field 'created' is required for type 'dev.zt64.subsonic.api.model.Album'` when hitting `search3`, `getAlbum`, or `getAlbumList2` endpoints. The OpenSubsonic spec marks `created` as required on `AlbumID3`, but Navidrome was dropping it whenever the album's `created_at` was zero in the DB.

Investigation against a real ~7k album library found **605 albums (8.7%)** with `created_at = '0001-01-01 00:00:00+00:00'`, despite all their tracks having valid `birth_time` values. This was caused by three separate bugs that compounded:

1. **`buildAlbumID3` / `childFromAlbum`** conditionally emitted `created`, so a zero `CreatedAt` became a missing JSON key that strict clients rejected.
2. **`older()`** in `model/mediafile.go` treated a zero `t2` argument as the minimum, so a single track with missing filesystem birth time could poison the album aggregation.
3. **`CopyAttributes`** in `phase_1_folders.persistAlbum` blindly copied `created_at` from the previous album row on every metadata-driven ID change. Combined with `sql_base_repository.put()` explicitly dropping `created_at` on UPDATE (to preserve first-insert time), a poisoned row could never self-heal on rescans — and bad values propagated forward indefinitely.

Fixes applied in four layers:

- **Render-time fallback** (`server/subsonic/helpers.go`): new `albumCreatedAt` helper used by both `buildAlbumID3` and `childFromAlbum`, always emits `created` with fallback to `UpdatedAt` → `ImportedAt` when `CreatedAt` is zero.
- **Aggregation defense** (`model/mediafile.go`): `older()` now handles a zero `t2` correctly, preventing future zero-poisoning of album `CreatedAt` during `ToAlbum` aggregation.
- **Propagation guard** (`persistence/album_repository.go`): `CopyAttributes` now skips `created_at` when the source value is null / empty / `0001-`-prefixed, so rescans after metadata changes no longer propagate poisoned state forward.
- **Backfill migration** (`db/migrations/20260410201914_fix_zero_album_created_at.sql`): repairs existing broken rows using `MIN(media_file.birth_time)` with `updated_at` fallback, via a single `COALESCE`-based UPDATE.

### Related Issues

Reported upstream at paigely/Navic#159 (external project). This PR is the Navidrome-side fix.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. **Reproduce on an affected library:**
   ```sql
   SELECT COUNT(*) FROM album
   WHERE created_at IS NULL OR created_at = '' OR created_at LIKE '0001-%';
   ```
   On libraries with poisoned rows, this returns a non-zero count.

2. **Query a search3 response** for an affected album's artist and confirm the result JSON now contains `created` for every album:
   ```bash
   curl 'http://localhost:4533/rest/search3.view?query=bowie&f=json&v=1.16.1&c=test&u=USER&p=enc:...' \
     | jq '.["subsonic-response"].searchResult3.album[] | select(.created == null)'
   ```
   Should return no results.

3. **Start the server** to apply the backfill migration, then re-run the query above — the count should be 0 and all affected albums should now have a valid `created_at` derived from the oldest `media_file.birth_time`.

4. **Verify no regression on healthy rows**: snapshot the `album` table before/after the migration and confirm rows with valid `created_at` are untouched.

5. **Run the automated tests:**
   ```bash
   make test PKG=./persistence/...
   make test PKG=./scanner/...
   make test PKG=./server/subsonic/...
   make test PKG=./model/...
   ```
   Added tests:
   - `buildAlbumID3 Created field` — verifies `created` is always emitted with correct fallback order.
   - `CopyAttributes` — verifies zero `created_at` is skipped, non-zero is copied.
   - `ToAlbum` `CreatedAt aggregation` — verifies `older()` correctly ignores zero `BirthTime`.

### Additional Notes

- **Verified against a real DB**: Tested the backfill migration against a copy of a production DB with 605 affected rows. After migration: 0 broken rows, 0 healthy rows touched. The two specific albums that triggered the original Navic report now have valid `created_at` derived from their songs' `birth_time`.
- **Scanner hot path unchanged**: The fix is pushed into `CopyAttributes` itself rather than adding an extra `repo.Get` call at the scanner call site, so the happy path remains 1 SELECT + 1 UPDATE.
- **Narrow column filter**: `CopyAttributes`'s zero-check only applies to `created_at` specifically, not all columns, to avoid surprising future callers copying nullable text columns.
- **Migration down is a no-op**: restoring zero values serves no purpose.
