### PR TITLE
perf: reduce hot-path heap escapes from value-param pointer aliasing

### DIFF
--- a/model/metadata/persistent_ids.go
+++ b/model/metadata/persistent_ids.go
@@ -12,88 +12,85 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
 	"github.com/navidrome/navidrome/utils"
-	"github.com/navidrome/navidrome/utils/slice"
 	"github.com/navidrome/navidrome/utils/str"
 )
 
 type hashFunc = func(...string) string
 
-// createGetPID returns a function that calculates the persistent ID for a given spec, getting the referenced values from the metadata
-// The spec is a pipe-separated list of fields, where each field is a comma-separated list of attributes
-// Attributes can be either tags or some processed values like folder, albumid, albumartistid, etc.
-// For each field, it gets all its attributes values and concatenates them, then hashes the result.
-// If a field is empty, it is skipped and the function looks for the next field.
-type getPIDFunc = func(mf model.MediaFile, md Metadata, spec string, prependLibId bool) string
-
-func createGetPID(hash hashFunc) getPIDFunc {
-	var getPID getPIDFunc
-	getAttr := func(mf model.MediaFile, md Metadata, attr string, prependLibId bool, spec string) string {
-		attr = strings.TrimSpace(strings.ToLower(attr))
-		switch attr {
-		case "albumid":
-			if spec == conf.Server.PID.Album {
-				log.Error("Recursive PID definition detected, ignoring `albumid`", "spec", spec)
-				return ""
+// computePID calculates the persistent ID for a given spec. The spec is a
+// pipe-separated list of fields, where each field is a comma-separated list of
+// attributes. Attributes can be either tags or processed values like folder,
+// albumid, albumartistid, etc. For each field, it gets all its attribute values
+// and concatenates them, then hashes the result. If a field is empty, it is
+// skipped and the function looks for the next field.
+//
+// Taking hash as a parameter (instead of closing over it in a factory) keeps
+// mf on the stack: closing over mf would force the whole ~1KB MediaFile to the
+// heap on every call.
+func computePID(mf model.MediaFile, md Metadata, spec string, prependLibId bool, hash hashFunc) string {
+	switch spec {
+	case "track_legacy":
+		return legacyTrackID(mf, prependLibId)
+	case "album_legacy":
+		return legacyAlbumID(mf, md, prependLibId)
+	}
+	pid := ""
+	fields := strings.SplitSeq(spec, "|")
+	for field := range fields {
+		attributes := strings.Split(field, ",")
+		values := make([]string, len(attributes))
+		hasValue := false
+		for i, attr := range attributes {
+			v := getPIDAttr(mf, md, attr, prependLibId, spec, hash)
+			if v != "" {
+				hasValue = true
 			}
-			return getPID(mf, md, conf.Server.PID.Album, prependLibId)
-		case "folder":
-			return filepath.Dir(mf.Path)
-		case "albumartistid":
-			return hash(str.Clear(strings.ToLower(mf.AlbumArtist)))
-		case "title":
-			return mf.Title
-		case "album":
-			return str.Clear(strings.ToLower(md.String(model.TagAlbum)))
+			values[i] = v
 		}
-		return md.String(model.TagName(attr))
+		if hasValue {
+			pid += strings.Join(values, "\\")
+			break
+		}
 	}
-	getPID = func(mf model.MediaFile, md Metadata, spec string, prependLibId bool) string {
-		pid := ""
-		fields := strings.SplitSeq(spec, "|")
-		for field := range fields {
-			attributes := strings.Split(field, ",")
-			hasValue := false
-			values := slice.Map(attributes, func(attr string) string {
-				v := getAttr(mf, md, attr, prependLibId, spec)
-				if v != "" {
-					hasValue = true
-				}
-				return v
-			})
-			if hasValue {
-				pid += strings.Join(values, "\\")
-				break
-			}
-		}
-		if prependLibId {
-			pid = fmt.Sprintf("%d\\%s", mf.LibraryID, pid)
-		}
-		return hash(pid)
+	if prependLibId {
+		pid = fmt.Sprintf("%d\\%s", mf.LibraryID, pid)
 	}
+	return hash(pid)
+}
 
-	return func(mf model.MediaFile, md Metadata, spec string, prependLibId bool) string {
-		switch spec {
-		case "track_legacy":
-			return legacyTrackID(mf, prependLibId)
-		case "album_legacy":
-			return legacyAlbumID(mf, md, prependLibId)
+func getPIDAttr(mf model.MediaFile, md Metadata, attr string, prependLibId bool, spec string, hash hashFunc) string {
+	attr = strings.TrimSpace(strings.ToLower(attr))
+	switch attr {
+	case "albumid":
+		if spec == conf.Server.PID.Album {
+			log.Error("Recursive PID definition detected, ignoring `albumid`", "spec", spec)
+			return ""
 		}
-		return getPID(mf, md, spec, prependLibId)
+		return computePID(mf, md, conf.Server.PID.Album, prependLibId, hash)
+	case "folder":
+		return filepath.Dir(mf.Path)
+	case "albumartistid":
+		return hash(str.Clear(strings.ToLower(mf.AlbumArtist)))
+	case "title":
+		return mf.Title
+	case "album":
+		return str.Clear(strings.ToLower(md.String(model.TagAlbum)))
 	}
+	return md.String(model.TagName(attr))
 }
 
 func (md Metadata) trackPID(mf model.MediaFile) string {
-	return createGetPID(id.NewHash)(mf, md, conf.Server.PID.Track, true)
+	return computePID(mf, md, conf.Server.PID.Track, true, id.NewHash)
 }
 
 func (md Metadata) albumID(mf model.MediaFile, pidConf string) string {
-	return createGetPID(id.NewHash)(mf, md, pidConf, true)
+	return computePID(mf, md, pidConf, true, id.NewHash)
 }
 
 // BFR Must be configurable?
 func (md Metadata) artistID(name string) string {
 	mf := model.MediaFile{AlbumArtist: name}
-	return createGetPID(id.NewHash)(mf, md, "albumartistid", false)
+	return computePID(mf, md, "albumartistid", false, id.NewHash)
 }
 
 func (md Metadata) mapTrackTitle() string {

--- a/model/metadata/persistent_ids_test.go
+++ b/model/metadata/persistent_ids_test.go
@@ -12,15 +12,16 @@ import (
 
 var _ = Describe("getPID", func() {
 	var (
-		md     Metadata
-		mf     model.MediaFile
-		sum    hashFunc
-		getPID getPIDFunc
+		md  Metadata
+		mf  model.MediaFile
+		sum hashFunc
 	)
+	getPID := func(mf model.MediaFile, md Metadata, spec string, prependLibId bool) string {
+		return computePID(mf, md, spec, prependLibId, sum)
+	}
 
 	BeforeEach(func() {
 		sum = func(s ...string) string { return "(" + strings.Join(s, ",") + ")" }
-		getPID = createGetPID(sum)
 	})
 
 	Context("attributes are tags", func() {

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
+	. "github.com/navidrome/navidrome/utils/gg"
 	"github.com/navidrome/navidrome/utils/number"
 	"github.com/navidrome/navidrome/utils/req"
 	"github.com/navidrome/navidrome/utils/slice"
@@ -215,7 +216,7 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 		child.Path = fakePath(mf)
 	}
 	child.DiscNumber = int32(mf.DiscNumber)
-	child.Created = &mf.BirthTime
+	child.Created = P(mf.BirthTime)
 	child.AlbumId = mf.AlbumID
 	child.ArtistId = mf.ArtistID
 	child.Type = "music"
@@ -391,9 +392,12 @@ func buildDiscSubtitles(a model.Album) []responses.DiscTitle {
 		return nil
 	}
 	var discTitles []responses.DiscTitle
+	// Hoist UpdatedAt to a single stack-local so &updatedAt doesn't force the
+	// whole model.Album parameter onto the heap.
+	updatedAt := a.UpdatedAt
 	for num, title := range a.Discs {
 		artID := model.NewArtworkID(model.KindDiscArtwork,
-			model.DiscArtworkID(a.ID, num), &a.UpdatedAt)
+			model.DiscArtworkID(a.ID, num), &updatedAt)
 		discTitles = append(discTitles, responses.DiscTitle{
 			Disc:     int32(num),
 			Title:    title,


### PR DESCRIPTION
### Description

Three hot-path functions were forcing large value-parameters onto the heap via pointer-to-field aliasing or closure captures. Go's escape analysis can't prove that a pointer aliasing a field of a value parameter stays scoped to the function, so it promotes the *entire* struct to the heap — turning a stack-allocated copy into a per-call GC-tracked allocation.

The pattern was first spotted during review of #5340 ([discussion](https://github.com/navidrome/navidrome/pull/5340#discussion_r3066737911)), where `albumCreatedAt` was returning `*time.Time` aliasing a field of its value receiver and heap-promoting the entire `model.Album` on every call. This PR hunts down the same pattern elsewhere in the codebase.

**Findings fixed:**

1. **`childFromMediaFile`** (`server/subsonic/helpers.go`) — was `child.Created = &mf.BirthTime`, heap-promoting the full ~1KB `model.MediaFile` on every song in search3, getAlbumList2, getAlbum, starred, playlists, bookmarks, jukebox, etc. Now uses `gg.P(mf.BirthTime)`.

2. **`buildDiscSubtitles`** (`server/subsonic/helpers.go`) — was passing `&a.UpdatedAt` to `NewArtworkID` inside a loop, heap-promoting `model.Album` on every album with disc titles. Now hoists `updatedAt := a.UpdatedAt` to a single stack-local outside the loop.

3. **`createGetPID` factory** (`model/metadata/persistent_ids.go`) — returned nested closures that captured `mf model.MediaFile` (992 bytes) by reference. Called three times per track on every scan (trackPID, albumID, artistID), so every scanned track paid three heap allocations of the full `MediaFile` plus closure allocations. Refactored into package-level `computePID` / `getPIDAttr` with explicit `hash` parameter, replacing the inner `slice.Map` callback with an indexed for loop to eliminate the closure-capture of `mf`. The tiny `createGetPID` wrapper was deleted from production and moved into the test file.

**Verification** via `go build -gcflags=-m=2 -tags netgo,sqlite_fts5 ./server/subsonic/ ./model/metadata/`:

- `moved to heap: mf` is gone in `childFromMediaFile` and throughout `persistent_ids.go`.
- `moved to heap: a` is gone in `buildDiscSubtitles`.
- Scanner callers (`map_mediafile.go`, `map_participants.go`) no longer heap-promote their `MediaFile` argument.
- Only the small `time.Time` value escapes via `gg.P(...)` — one 24-byte allocation replacing a ~1KB one.

### Related Issues

Found during code review of #5340 — see [this discussion comment](https://github.com/navidrome/navidrome/pull/5340#discussion_r3066737911).

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Other (please describe): Performance — reduce heap allocations on hot paths

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. **Verify escape analysis** — the authoritative test for this PR:
   ```bash
   go build -gcflags="-m=2" -tags netgo,sqlite_fts5 ./server/subsonic/ ./model/metadata/ 2>&1 \
     | grep -E "moved to heap: (mf|a|album)\b"
   ```
   Before this PR, this prints entries for `childFromMediaFile`, `buildDiscSubtitles`, and `computePID`/`createGetPID`. After this PR, those entries are gone (only the unrelated `childFromAlbum` / `buildAlbumID3` remain — those are fixed by #5340).

2. **Run affected test suites:**
   ```bash
   make test PKG=./server/subsonic/...
   make test PKG=./model/metadata/
   make test PKG=./scanner/...
   ```
   All should pass (123 metadata specs in particular exercise `computePID` via the test-local closure).

3. **Smoke-test a search** against a running server to confirm no behavior change:
   ```bash
   curl -s 'http://localhost:4533/rest/search3.view?query=bowie&f=json&v=1.16.1&c=test&u=USER&p=enc:...' \
     | jq '.["subsonic-response"].searchResult3.song[0]'
   ```

### Additional Notes

- **No behavior change** — these are pure allocation refactors. `childFromMediaFile`'s output still pairs `Created` with the same `BirthTime`; `buildDiscSubtitles`'s artwork IDs are identical; `computePID` produces byte-identical PIDs (same inputs → same hash).
- **The rule of thumb** (worth codifying somewhere): for small helper functions that read a few fields of a large struct, prefer **value-in, value-out** and let callers wrap with `gg.P(...)` if they need a pointer. Any `*T` return aliasing a field of a value parameter, or any closure capturing the parameter, heap-promotes the whole struct.
- **Other escape-analysis hits** in the codebase were investigated and categorized as either (a) unavoidable (DB query fill, range-var address taken intentionally), (b) necessary (returning a pointer to a locally-built struct literal), or (c) real anti-patterns on cold paths (background metadata refresh in `core/external/provider.go`, external artwork fetch closures in `core/artwork/sources.go`) — not worth fixing.
- **Depends on**: nothing, but overlaps conceptually with #5340. The `childFromAlbum`/`buildAlbumID3` escapes remain after this PR because they belong to the #5340 scope.
