### PR TITLE
fix(artwork): allow shared disc art from unnumbered filenames in single-folder albums

### DIFF
--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -215,18 +215,10 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 }
 
 // fromExternalFile returns a sourceFunc that matches image files against a glob
-// pattern with disc-number-aware filtering.
-//
-// Within a single pattern, a numbered filename whose number equals the target
-// disc always wins over an unnumbered candidate. An unnumbered candidate is
-// returned only as a fallback, and only when:
-//   - the album has multiple folders and the file lives in a folder containing
-//     tracks for this disc (the image belongs to a specific disc); or
-//   - the album has a single folder (the file is shared across every disc).
-//
-// The caller (fromDiscArtPriority) already lowercases the pattern, so this
-// function assumes pattern is lowercase and only lowercases each filename.
+// pattern. A numbered filename whose number equals the target disc wins over
+// any unnumbered candidate; callers must pass a lowercase pattern.
 func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string) sourceFunc {
+	hasWildcard := strings.ContainsRune(pattern, '*')
 	return func() (io.ReadCloser, string, error) {
 		var fallback string
 		for _, file := range d.imgFiles {
@@ -241,21 +233,20 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 				continue
 			}
 
-			if num, hasNum := extractDiscNumber(pattern, name); hasNum {
-				// Numbered filename wins immediately when its number matches.
-				if num != d.discNumber {
-					continue
+			if hasWildcard {
+				if num, hasNum := extractDiscNumber(pattern, name); hasNum {
+					if num != d.discNumber {
+						continue
+					}
+					f, err := os.Open(file)
+					if err != nil {
+						log.Warn(ctx, "Could not open disc art file", "file", file, err)
+						continue
+					}
+					return f, file, nil
 				}
-				f, err := os.Open(file)
-				if err != nil {
-					log.Warn(ctx, "Could not open disc art file", "file", file, err)
-					continue
-				}
-				return f, file, nil
 			}
 
-			// Unnumbered: remember the first viable candidate as a fallback,
-			// but keep scanning for a numbered match that should take precedence.
 			if fallback != "" {
 				continue
 			}
@@ -263,6 +254,11 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 				continue
 			}
 			fallback = file
+			// Literal patterns have no numbered variants to prefer, so
+			// stop as soon as we have a viable fallback.
+			if !hasWildcard {
+				break
+			}
 		}
 
 		if fallback != "" {

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -243,11 +243,6 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 				continue
 			}
 			fallbacks = append(fallbacks, file)
-			// A literal filename can only match one file, so stop as soon
-			// as we have a viable fallback.
-			if isLiteral {
-				break
-			}
 		}
 
 		for _, file := range fallbacks {

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -168,16 +168,17 @@ func (d *discArtworkReader) fromDiscSubtitle(ctx context.Context, subtitle strin
 	}
 }
 
+// globMetaChars lists every metacharacter understood by filepath.Match.
+const globMetaChars = "*?["
+
 // extractDiscNumber parses the disc number from a filename matched by a
-// filepath.Match-style glob pattern. It takes the literal prefix of the
-// pattern (everything before the first '*', '?', or '[' metacharacter),
-// strips it from the filename, and reads the leading digits that follow.
+// filepath.Match-style glob pattern.
 //
 // Both pattern and filename must already be lowercased by the caller, which
 // is also expected to have verified that filepath.Match(pattern, filename)
 // is true before calling this function.
 func extractDiscNumber(pattern, filename string) (int, bool) {
-	metaIdx := strings.IndexAny(pattern, "*?[")
+	metaIdx := strings.IndexAny(pattern, globMetaChars)
 	if metaIdx < 0 {
 		return 0, false
 	}
@@ -186,18 +187,15 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 		return 0, false
 	}
 
-	var digits []byte
-	for i := len(prefix); i < len(filename); i++ {
-		c := filename[i]
-		if c < '0' || c > '9' {
-			break
-		}
-		digits = append(digits, c)
+	start := len(prefix)
+	end := start
+	for end < len(filename) && filename[end] >= '0' && filename[end] <= '9' {
+		end++
 	}
-	if len(digits) == 0 {
+	if end == start {
 		return 0, false
 	}
-	num, err := strconv.Atoi(string(digits))
+	num, err := strconv.Atoi(filename[start:end])
 	if err != nil {
 		return 0, false
 	}
@@ -208,7 +206,7 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 // pattern. A numbered filename whose number equals the target disc wins over
 // any unnumbered candidate; callers must pass a lowercase pattern.
 func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string) sourceFunc {
-	isLiteral := !strings.ContainsAny(pattern, "*?[")
+	isLiteral := !strings.ContainsAny(pattern, globMetaChars)
 	return func() (io.ReadCloser, string, error) {
 		var fallback string
 		for _, file := range d.imgFiles {

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -217,17 +217,18 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 // fromExternalFile returns a sourceFunc that matches image files against a glob
 // pattern with disc-number-aware filtering.
 //
-// Matching rules:
-//   - If a disc number can be extracted from the filename, the file matches only if
-//     the number equals the target disc number.
-//   - If no number is found and this is a multi-folder album, the file matches if
-//     it's in a folder containing tracks for this disc.
-//   - If no number is found and this is a single-folder album, the file matches
-//     for every disc (shared disc art). DiscArtPriority ordering decides whether
-//     a more specific numbered pattern wins.
+// Within a single pattern, a numbered filename whose number equals the target
+// disc always wins over an unnumbered candidate. An unnumbered candidate is
+// returned only as a fallback, and only when:
+//   - the album has multiple folders and the file lives in a folder containing
+//     tracks for this disc (the image belongs to a specific disc); or
+//   - the album has a single folder (the file is shared across every disc).
+//
+// The caller (fromDiscArtPriority) already lowercases the pattern, so this
+// function assumes pattern is lowercase and only lowercases each filename.
 func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string) sourceFunc {
-	pattern = strings.ToLower(pattern)
 	return func() (io.ReadCloser, string, error) {
+		var fallback string
 		for _, file := range d.imgFiles {
 			_, name := filepath.Split(file)
 			name = strings.ToLower(name)
@@ -241,25 +242,36 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 			}
 
 			if num, hasNum := extractDiscNumber(pattern, name); hasNum {
-				// Numbered filename: must match target disc.
+				// Numbered filename wins immediately when its number matches.
 				if num != d.discNumber {
 					continue
 				}
-			} else if d.isMultiFolder {
-				// Unnumbered, multi-folder: match by folder association — the
-				// image lives alongside the tracks of a specific disc.
-				dir := filepath.Dir(file)
-				if !d.discFolders[dir] {
+				f, err := os.Open(file)
+				if err != nil {
+					log.Warn(ctx, "Could not open disc art file", "file", file, err)
 					continue
 				}
+				return f, file, nil
 			}
 
-			f, err := os.Open(file)
-			if err != nil {
-				log.Warn(ctx, "Could not open disc art file", "file", file, err)
+			// Unnumbered: remember the first viable candidate as a fallback,
+			// but keep scanning for a numbered match that should take precedence.
+			if fallback != "" {
 				continue
 			}
-			return f, file, nil
+			if d.isMultiFolder && !d.discFolders[filepath.Dir(file)] {
+				continue
+			}
+			fallback = file
+		}
+
+		if fallback != "" {
+			f, err := os.Open(fallback)
+			if err != nil {
+				log.Warn(ctx, "Could not open disc art file", "file", fallback, err)
+			} else {
+				return f, fallback, nil
+			}
 		}
 		return nil, "", fmt.Errorf("disc %d: pattern '%s' not matched by files", d.discNumber, pattern)
 	}

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -172,10 +172,9 @@ func (d *discArtworkReader) fromDiscSubtitle(ctx context.Context, subtitle strin
 // It finds the portion of the filename that the wildcard matched and parses leading
 // digits as the disc number. Returns (0, false) if the pattern doesn't match or
 // no leading digits are found in the wildcard portion.
+//
+// Both pattern and filename must already be lowercased by the caller.
 func extractDiscNumber(pattern, filename string) (int, bool) {
-	filename = strings.ToLower(filename)
-	pattern = strings.ToLower(pattern)
-
 	matched, err := filepath.Match(pattern, filename)
 	if err != nil || !matched {
 		return 0, false
@@ -227,10 +226,12 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 //     for every disc (shared disc art). DiscArtPriority ordering decides whether
 //     a more specific numbered pattern wins.
 func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string) sourceFunc {
+	pattern = strings.ToLower(pattern)
 	return func() (io.ReadCloser, string, error) {
 		for _, file := range d.imgFiles {
 			_, name := filepath.Split(file)
-			match, err := filepath.Match(pattern, strings.ToLower(name))
+			name = strings.ToLower(name)
+			match, err := filepath.Match(pattern, name)
 			if err != nil {
 				log.Warn(ctx, "Error matching disc art file to pattern", "pattern", pattern, "file", file)
 				continue
@@ -239,7 +240,6 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 				continue
 			}
 
-			// Try to extract disc number from filename
 			if num, hasNum := extractDiscNumber(pattern, name); hasNum {
 				// Numbered filename: must match target disc.
 				if num != d.discNumber {
@@ -253,9 +253,6 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 					continue
 				}
 			}
-			// Unnumbered, single-folder: shared across all discs of the album.
-			// Accept the match; DiscArtPriority order decides whether a more
-			// specific numbered pattern wins.
 
 			f, err := os.Open(file)
 			if err != nil {

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -223,8 +223,9 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 //     the number equals the target disc number.
 //   - If no number is found and this is a multi-folder album, the file matches if
 //     it's in a folder containing tracks for this disc.
-//   - If no number is found and this is a single-folder album, the file is skipped
-//     (ambiguous).
+//   - If no number is found and this is a single-folder album, the file matches
+//     for every disc (shared disc art). DiscArtPriority ordering decides whether
+//     a more specific numbered pattern wins.
 func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string) sourceFunc {
 	return func() (io.ReadCloser, string, error) {
 		for _, file := range d.imgFiles {
@@ -239,22 +240,22 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 			}
 
 			// Try to extract disc number from filename
-			num, hasNum := extractDiscNumber(pattern, name)
-			if hasNum {
-				// File has a disc number — must match target disc
+			if num, hasNum := extractDiscNumber(pattern, name); hasNum {
+				// Numbered filename: must match target disc.
 				if num != d.discNumber {
 					continue
 				}
 			} else if d.isMultiFolder {
-				// No number, multi-folder: match by folder association
+				// Unnumbered, multi-folder: match by folder association — the
+				// image lives alongside the tracks of a specific disc.
 				dir := filepath.Dir(file)
 				if !d.discFolders[dir] {
 					continue
 				}
-			} else {
-				// No number, single-folder: ambiguous, skip
-				continue
 			}
+			// Unnumbered, single-folder: shared across all discs of the album.
+			// Accept the match; DiscArtPriority order decides whether a more
+			// specific numbered pattern wins.
 
 			f, err := os.Open(file)
 			if err != nil {

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -168,45 +168,35 @@ func (d *discArtworkReader) fromDiscSubtitle(ctx context.Context, subtitle strin
 	}
 }
 
-// extractDiscNumber extracts a disc number from a filename based on a glob pattern.
-// It finds the portion of the filename that the wildcard matched and parses leading
-// digits as the disc number. Returns (0, false) if the pattern doesn't match or
-// no leading digits are found in the wildcard portion.
+// extractDiscNumber parses the disc number from a filename matched by a
+// filepath.Match-style glob pattern. It takes the literal prefix of the
+// pattern (everything before the first '*', '?', or '[' metacharacter),
+// strips it from the filename, and reads the leading digits that follow.
 //
-// Both pattern and filename must already be lowercased by the caller.
+// Both pattern and filename must already be lowercased by the caller, which
+// is also expected to have verified that filepath.Match(pattern, filename)
+// is true before calling this function.
 func extractDiscNumber(pattern, filename string) (int, bool) {
-	matched, err := filepath.Match(pattern, filename)
-	if err != nil || !matched {
+	metaIdx := strings.IndexAny(pattern, "*?[")
+	if metaIdx < 0 {
 		return 0, false
 	}
-
-	// Find the prefix before the first '*' in the pattern
-	starIdx := strings.IndexByte(pattern, '*')
-	if starIdx < 0 {
-		return 0, false
-	}
-	prefix := pattern[:starIdx]
-
-	// Strip the prefix from the filename to get the wildcard-matched portion
+	prefix := pattern[:metaIdx]
 	if !strings.HasPrefix(filename, prefix) {
 		return 0, false
 	}
-	remainder := filename[len(prefix):]
 
-	// Extract leading ASCII digits from the remainder
 	var digits []byte
-	for _, r := range remainder {
-		if r >= '0' && r <= '9' {
-			digits = append(digits, byte(r))
-		} else {
+	for i := len(prefix); i < len(filename); i++ {
+		c := filename[i]
+		if c < '0' || c > '9' {
 			break
 		}
+		digits = append(digits, c)
 	}
-
 	if len(digits) == 0 {
 		return 0, false
 	}
-
 	num, err := strconv.Atoi(string(digits))
 	if err != nil {
 		return 0, false
@@ -218,7 +208,7 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 // pattern. A numbered filename whose number equals the target disc wins over
 // any unnumbered candidate; callers must pass a lowercase pattern.
 func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string) sourceFunc {
-	hasWildcard := strings.ContainsRune(pattern, '*')
+	isLiteral := !strings.ContainsAny(pattern, "*?[")
 	return func() (io.ReadCloser, string, error) {
 		var fallback string
 		for _, file := range d.imgFiles {
@@ -233,7 +223,7 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 				continue
 			}
 
-			if hasWildcard {
+			if !isLiteral {
 				if num, hasNum := extractDiscNumber(pattern, name); hasNum {
 					if num != d.discNumber {
 						continue
@@ -254,9 +244,9 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 				continue
 			}
 			fallback = file
-			// Literal patterns have no numbered variants to prefer, so
-			// stop as soon as we have a viable fallback.
-			if !hasWildcard {
+			// A literal filename can only match one file, so stop as soon
+			// as we have a viable fallback.
+			if isLiteral {
 				break
 			}
 		}

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -168,7 +168,11 @@ func (d *discArtworkReader) fromDiscSubtitle(ctx context.Context, subtitle strin
 	}
 }
 
-// globMetaChars lists every metacharacter understood by filepath.Match.
+// globMetaChars holds the substitution metacharacters understood by
+// filepath.Match. The '\' escape character is intentionally excluded:
+// disc art patterns come from user config and never include escaped
+// metachars in practice, and treating '\' as a metachar would misalign
+// the literal-prefix extraction in extractDiscNumber.
 const globMetaChars = "*?["
 
 // extractDiscNumber parses the disc number from a filename matched by a
@@ -208,7 +212,7 @@ func extractDiscNumber(pattern, filename string) (int, bool) {
 func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string) sourceFunc {
 	isLiteral := !strings.ContainsAny(pattern, globMetaChars)
 	return func() (io.ReadCloser, string, error) {
-		var fallback string
+		var fallbacks []string
 		for _, file := range d.imgFiles {
 			_, name := filepath.Split(file)
 			name = strings.ToLower(name)
@@ -235,13 +239,10 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 				}
 			}
 
-			if fallback != "" {
-				continue
-			}
 			if d.isMultiFolder && !d.discFolders[filepath.Dir(file)] {
 				continue
 			}
-			fallback = file
+			fallbacks = append(fallbacks, file)
 			// A literal filename can only match one file, so stop as soon
 			// as we have a viable fallback.
 			if isLiteral {
@@ -249,13 +250,13 @@ func (d *discArtworkReader) fromExternalFile(ctx context.Context, pattern string
 			}
 		}
 
-		if fallback != "" {
-			f, err := os.Open(fallback)
+		for _, file := range fallbacks {
+			f, err := os.Open(file)
 			if err != nil {
-				log.Warn(ctx, "Could not open disc art file", "file", fallback, err)
-			} else {
-				return f, fallback, nil
+				log.Warn(ctx, "Could not open disc art file", "file", file, err)
+				continue
 			}
+			return f, file, nil
 		}
 		return nil, "", fmt.Errorf("disc %d: pattern '%s' not matched by files", d.discNumber, pattern)
 	}

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -170,46 +170,29 @@ var _ = Describe("Disc Artwork Reader", func() {
 			r.Close()
 		})
 
-		It("prefers disc-numbered match over shared unnumbered match within the same pattern", func() {
-			// Natural sort of basenames puts disc < disc1 < disc2, so
-			// disc.jpg appears first in imgFiles. The loop must not return
-			// disc.jpg for disc 2 when disc2.jpg also matches the pattern.
-			f1 := createFile("album/disc.jpg")
-			f2 := createFile("album/disc1.jpg")
-			f3 := createFile("album/disc2.jpg")
-			reader := &discArtworkReader{
-				discNumber:  2,
-				imgFiles:    []string{f1, f2, f3},
-				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
-			}
+		DescribeTable("numbered match wins over shared fallback within a pattern",
+			func(discNumber, expectedIdx int) {
+				files := []string{
+					createFile("album/disc.jpg"),
+					createFile("album/disc1.jpg"),
+					createFile("album/disc2.jpg"),
+				}
+				reader := &discArtworkReader{
+					discNumber:  discNumber,
+					imgFiles:    files,
+					discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+				}
 
-			sf := reader.fromExternalFile(ctx, "disc*.*")
-			r, path, err := sf()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(r).ToNot(BeNil())
-			r.Close()
-			Expect(path).To(Equal(f3))
-		})
-
-		It("falls back to shared unnumbered match when no numbered file matches the target disc", func() {
-			// Disc 3 has no disc3.jpg; disc.jpg should be used as the shared
-			// fallback so a disc without dedicated art still gets something.
-			f1 := createFile("album/disc.jpg")
-			f2 := createFile("album/disc1.jpg")
-			f3 := createFile("album/disc2.jpg")
-			reader := &discArtworkReader{
-				discNumber:  3,
-				imgFiles:    []string{f1, f2, f3},
-				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
-			}
-
-			sf := reader.fromExternalFile(ctx, "disc*.*")
-			r, path, err := sf()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(r).ToNot(BeNil())
-			r.Close()
-			Expect(path).To(Equal(f1))
-		})
+				sf := reader.fromExternalFile(ctx, "disc*.*")
+				r, path, err := sf()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(r).ToNot(BeNil())
+				r.Close()
+				Expect(path).To(Equal(files[expectedIdx]))
+			},
+			Entry("disc 2 picks disc2.jpg over the shared disc.jpg", 2, 2),
+			Entry("disc 3 falls back to disc.jpg when no numbered match exists", 3, 0),
+		)
 
 		It("matches file without number in multi-folder album by folder", func() {
 			f1 := createFile("album/cd1/disc.jpg")

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -131,7 +131,6 @@ var _ = Describe("Disc Artwork Reader", func() {
 				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
 			}
 
-			// Numbered pattern: disc-number filter must still return disc 2.
 			sf := reader.fromExternalFile(ctx, "disc*.*")
 			r, path, err := sf()
 			Expect(err).ToNot(HaveOccurred())
@@ -139,9 +138,6 @@ var _ = Describe("Disc Artwork Reader", func() {
 			r.Close()
 			Expect(path).To(Equal(f3))
 
-			// Unnumbered pattern against the same reader: single-folder shared
-			// disc art branch must still return cover.png even though numbered
-			// files are present in imgFiles.
 			sf = reader.fromExternalFile(ctx, "cover.*")
 			r, path, err = sf()
 			Expect(err).ToNot(HaveOccurred())
@@ -159,7 +155,6 @@ var _ = Describe("Disc Artwork Reader", func() {
 				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
 			}
 
-			// Numbered pattern first → disc1.jpg wins.
 			ff := reader.fromDiscArtPriority(ctx, nil, "disc*.*, cover.*")
 			Expect(ff).To(HaveLen(2))
 			r, path, err := ff[0]()
@@ -167,7 +162,6 @@ var _ = Describe("Disc Artwork Reader", func() {
 			Expect(path).To(Equal(f2))
 			r.Close()
 
-			// Unnumbered pattern first → cover.png wins.
 			ff = reader.fromDiscArtPriority(ctx, nil, "cover.*, disc*.*")
 			Expect(ff).To(HaveLen(2))
 			r, path, err = ff[0]()

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -139,6 +139,32 @@ var _ = Describe("Disc Artwork Reader", func() {
 			Expect(path).To(Equal(f3))
 		})
 
+		It("respects DiscArtPriority order when both numbered and unnumbered patterns match", func() {
+			f1 := createFile("album/cover.png")
+			f2 := createFile("album/disc1.jpg")
+			reader := &discArtworkReader{
+				discNumber:  1,
+				imgFiles:    []string{f1, f2},
+				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+			}
+
+			// Numbered pattern first → disc1.jpg wins.
+			ff := reader.fromDiscArtPriority(ctx, nil, "disc*.*, cover.*")
+			Expect(ff).To(HaveLen(2))
+			r, path, err := ff[0]()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(path).To(Equal(f2))
+			r.Close()
+
+			// Unnumbered pattern first → cover.png wins.
+			ff = reader.fromDiscArtPriority(ctx, nil, "cover.*, disc*.*")
+			Expect(ff).To(HaveLen(2))
+			r, path, err = ff[0]()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(path).To(Equal(f1))
+			r.Close()
+		})
+
 		It("matches file without number in multi-folder album by folder", func() {
 			f1 := createFile("album/cd1/disc.jpg")
 			f2 := createFile("album/cd2/disc.jpg")

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -85,17 +85,20 @@ var _ = Describe("Disc Artwork Reader", func() {
 			Expect(path).To(Equal(f1))
 		})
 
-		It("skips file without number in single-folder album", func() {
-			f1 := createFile("album/disc.jpg")
+		It("matches file without number in single-folder album (shared disc art)", func() {
+			f1 := createFile("album/cover.png")
 			reader := &discArtworkReader{
 				discNumber:  1,
 				imgFiles:    []string{f1},
 				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
 			}
 
-			sf := reader.fromExternalFile(ctx, "disc*.*")
-			r, _, _ := sf()
-			Expect(r).To(BeNil())
+			sf := reader.fromExternalFile(ctx, "cover.*")
+			r, path, err := sf()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r).ToNot(BeNil())
+			r.Close()
+			Expect(path).To(Equal(f1))
 		})
 
 		It("matches file without number in multi-folder album by folder", func() {

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -226,10 +226,10 @@ var _ = Describe("Disc Artwork Reader", func() {
 				r.Close()
 				Expect(path).To(Equal(files[expectedIdx]))
 			},
-			Entry("'?' wildcard, disc 1", "disc?.jpg", 1, 0),
-			Entry("'?' wildcard, disc 2", "disc?.jpg", 2, 1),
-			Entry("character class, disc 1", "disc[0-9].jpg", 1, 0),
-			Entry("character class, disc 2", "disc[0-9].jpg", 2, 1),
+			Entry("disc?.jpg, target disc 1 → disc1.jpg", "disc?.jpg", 1, 0),
+			Entry("disc?.jpg, target disc 2 → disc2.jpg", "disc?.jpg", 2, 1),
+			Entry("disc[0-9].jpg, target disc 1 → disc1.jpg", "disc[0-9].jpg", 1, 0),
+			Entry("disc[0-9].jpg, target disc 2 → disc2.jpg", "disc[0-9].jpg", 2, 1),
 		)
 
 		It("matches file without number in multi-folder album by folder", func() {

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -101,6 +101,26 @@ var _ = Describe("Disc Artwork Reader", func() {
 			Expect(path).To(Equal(f1))
 		})
 
+		It("returns shared disc art for every disc number in single-folder album", func() {
+			f1 := createFile("album/shellac.png")
+			makeReader := func(discNum int) *discArtworkReader {
+				return &discArtworkReader{
+					discNumber:  discNum,
+					imgFiles:    []string{f1},
+					discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+				}
+			}
+
+			for _, disc := range []int{1, 2, 5} {
+				sf := makeReader(disc).fromExternalFile(ctx, "shellac.png")
+				r, path, err := sf()
+				Expect(err).ToNot(HaveOccurred(), "disc %d", disc)
+				Expect(r).ToNot(BeNil())
+				r.Close()
+				Expect(path).To(Equal(f1), "disc %d", disc)
+			}
+		})
+
 		It("matches file without number in multi-folder album by folder", func() {
 			f1 := createFile("album/cd1/disc.jpg")
 			f2 := createFile("album/cd2/disc.jpg")

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -121,6 +121,24 @@ var _ = Describe("Disc Artwork Reader", func() {
 			}
 		})
 
+		It("numbered filename still filters by disc even when unnumbered files exist", func() {
+			f1 := createFile("album/cover.png")
+			f2 := createFile("album/disc1.jpg")
+			f3 := createFile("album/disc2.jpg")
+			reader := &discArtworkReader{
+				discNumber:  2,
+				imgFiles:    []string{f1, f2, f3},
+				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+			}
+
+			sf := reader.fromExternalFile(ctx, "disc*.*")
+			r, path, err := sf()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r).ToNot(BeNil())
+			r.Close()
+			Expect(path).To(Equal(f3))
+		})
+
 		It("matches file without number in multi-folder album by folder", func() {
 			f1 := createFile("album/cd1/disc.jpg")
 			f2 := createFile("album/cd2/disc.jpg")

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -170,6 +170,47 @@ var _ = Describe("Disc Artwork Reader", func() {
 			r.Close()
 		})
 
+		It("prefers disc-numbered match over shared unnumbered match within the same pattern", func() {
+			// Natural sort of basenames puts disc < disc1 < disc2, so
+			// disc.jpg appears first in imgFiles. The loop must not return
+			// disc.jpg for disc 2 when disc2.jpg also matches the pattern.
+			f1 := createFile("album/disc.jpg")
+			f2 := createFile("album/disc1.jpg")
+			f3 := createFile("album/disc2.jpg")
+			reader := &discArtworkReader{
+				discNumber:  2,
+				imgFiles:    []string{f1, f2, f3},
+				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+			}
+
+			sf := reader.fromExternalFile(ctx, "disc*.*")
+			r, path, err := sf()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r).ToNot(BeNil())
+			r.Close()
+			Expect(path).To(Equal(f3))
+		})
+
+		It("falls back to shared unnumbered match when no numbered file matches the target disc", func() {
+			// Disc 3 has no disc3.jpg; disc.jpg should be used as the shared
+			// fallback so a disc without dedicated art still gets something.
+			f1 := createFile("album/disc.jpg")
+			f2 := createFile("album/disc1.jpg")
+			f3 := createFile("album/disc2.jpg")
+			reader := &discArtworkReader{
+				discNumber:  3,
+				imgFiles:    []string{f1, f2, f3},
+				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+			}
+
+			sf := reader.fromExternalFile(ctx, "disc*.*")
+			r, path, err := sf()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r).ToNot(BeNil())
+			r.Close()
+			Expect(path).To(Equal(f1))
+		})
+
 		It("matches file without number in multi-folder album by folder", func() {
 			f1 := createFile("album/cd1/disc.jpg")
 			f2 := createFile("album/cd2/disc.jpg")

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -226,6 +226,33 @@ var _ = Describe("Disc Artwork Reader", func() {
 			Expect(path).To(Equal(f2))
 		})
 
+		It("keeps scanning literal-pattern matches so fallback retry still works", func() {
+			// Guards against an 'early break on first literal match' optimization.
+			// Multiple imgFiles entries can share a basename (symlinks, case-variant
+			// duplicates on case-sensitive filesystems). If the loop breaks after
+			// recording just the first, the fallback retry cannot recover when
+			// that first file is unreadable.
+			f1 := createFile("album/stale/cover.png")
+			f2 := createFile("album/cover.png")
+			Expect(os.Remove(f1)).To(Succeed())
+			reader := &discArtworkReader{
+				discNumber: 1,
+				imgFiles:   []string{f1, f2},
+				discFolders: map[string]bool{
+					filepath.Join(tmpDir, "album"):       true,
+					filepath.Join(tmpDir, "album/stale"): true,
+				},
+				isMultiFolder: true,
+			}
+
+			sf := reader.fromExternalFile(ctx, "cover.png")
+			r, path, err := sf()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r).ToNot(BeNil())
+			r.Close()
+			Expect(path).To(Equal(f2))
+		})
+
 		DescribeTable("filters by disc number for non-'*' wildcard patterns",
 			func(pattern string, discNumber, expectedIdx int) {
 				files := []string{

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Disc Artwork Reader", func() {
 			// Case insensitive (filename already lowered by caller)
 			Entry("Disc1.jpg lowered", "disc*.*", "disc1.jpg", 1, true),
 
-			// Pattern doesn't match
-			Entry("cover.jpg doesn't match disc*.*", "disc*.*", "cover.jpg", 0, false),
+			// HasPrefix guard: filename doesn't share the pattern's literal prefix
+			Entry("cover.jpg with disc*.* (no prefix match)", "disc*.*", "cover.jpg", 0, false),
 
 			// Pattern with no wildcard before dot
 			Entry("front1.jpg with front*.*", "front*.*", "front1.jpg", 1, true),
@@ -206,6 +206,25 @@ var _ = Describe("Disc Artwork Reader", func() {
 			Entry("disc 2 picks disc2.jpg over the shared disc.jpg", 2, 2),
 			Entry("disc 3 falls back to disc.jpg when no numbered match exists", 3, 0),
 		)
+
+		It("tries the next fallback candidate when the first one cannot be opened", func() {
+			f1 := createFile("album/cover.jpg")
+			f2 := createFile("album/cover.png")
+			// Remove f1 so os.Open will fail on it; f2 should still win.
+			Expect(os.Remove(f1)).To(Succeed())
+			reader := &discArtworkReader{
+				discNumber:  1,
+				imgFiles:    []string{f1, f2},
+				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+			}
+
+			sf := reader.fromExternalFile(ctx, "cover.*")
+			r, path, err := sf()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r).ToNot(BeNil())
+			r.Close()
+			Expect(path).To(Equal(f2))
+		})
 
 		DescribeTable("filters by disc number for non-'*' wildcard patterns",
 			func(pattern string, discNumber, expectedIdx int) {

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Disc Artwork Reader", func() {
 			}
 		})
 
-		It("numbered filename still filters by disc even when unnumbered files exist", func() {
+		It("numbered and unnumbered patterns both resolve against the same reader", func() {
 			f1 := createFile("album/cover.png")
 			f2 := createFile("album/disc1.jpg")
 			f3 := createFile("album/disc2.jpg")
@@ -131,12 +131,23 @@ var _ = Describe("Disc Artwork Reader", func() {
 				discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
 			}
 
+			// Numbered pattern: disc-number filter must still return disc 2.
 			sf := reader.fromExternalFile(ctx, "disc*.*")
 			r, path, err := sf()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(r).ToNot(BeNil())
 			r.Close()
 			Expect(path).To(Equal(f3))
+
+			// Unnumbered pattern against the same reader: single-folder shared
+			// disc art branch must still return cover.png even though numbered
+			// files are present in imgFiles.
+			sf = reader.fromExternalFile(ctx, "cover.*")
+			r, path, err = sf()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(r).ToNot(BeNil())
+			r.Close()
+			Expect(path).To(Equal(f1))
 		})
 
 		It("respects DiscArtPriority order when both numbered and unnumbered patterns match", func() {

--- a/core/artwork/reader_disc_test.go
+++ b/core/artwork/reader_disc_test.go
@@ -47,6 +47,19 @@ var _ = Describe("Disc Artwork Reader", func() {
 
 			// Pattern with no wildcard before dot
 			Entry("front1.jpg with front*.*", "front*.*", "front1.jpg", 1, true),
+
+			// '?' single-char wildcard
+			Entry("disc?.jpg with disc1.jpg", "disc?.jpg", "disc1.jpg", 1, true),
+			Entry("disc?.jpg with disc2.jpg", "disc?.jpg", "disc2.jpg", 2, true),
+			Entry("cd??.jpg with cd07.jpg", "cd??.jpg", "cd07.jpg", 7, true),
+
+			// '[...]' character class wildcard
+			Entry("cd[12].jpg with cd1.jpg", "cd[12].jpg", "cd1.jpg", 1, true),
+			Entry("cd[12].jpg with cd2.jpg", "cd[12].jpg", "cd2.jpg", 2, true),
+			Entry("disc[0-9].jpg with disc5.jpg", "disc[0-9].jpg", "disc5.jpg", 5, true),
+
+			// Literal pattern (no wildcard) returns false
+			Entry("shellac.png literal", "shellac.png", "shellac.png", 0, false),
 		)
 	})
 
@@ -192,6 +205,31 @@ var _ = Describe("Disc Artwork Reader", func() {
 			},
 			Entry("disc 2 picks disc2.jpg over the shared disc.jpg", 2, 2),
 			Entry("disc 3 falls back to disc.jpg when no numbered match exists", 3, 0),
+		)
+
+		DescribeTable("filters by disc number for non-'*' wildcard patterns",
+			func(pattern string, discNumber, expectedIdx int) {
+				files := []string{
+					createFile("album/disc1.jpg"),
+					createFile("album/disc2.jpg"),
+				}
+				reader := &discArtworkReader{
+					discNumber:  discNumber,
+					imgFiles:    files,
+					discFolders: map[string]bool{filepath.Join(tmpDir, "album"): true},
+				}
+
+				sf := reader.fromExternalFile(ctx, pattern)
+				r, path, err := sf()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(r).ToNot(BeNil())
+				r.Close()
+				Expect(path).To(Equal(files[expectedIdx]))
+			},
+			Entry("'?' wildcard, disc 1", "disc?.jpg", 1, 0),
+			Entry("'?' wildcard, disc 2", "disc?.jpg", 2, 1),
+			Entry("character class, disc 1", "disc[0-9].jpg", 1, 0),
+			Entry("character class, disc 2", "disc[0-9].jpg", 2, 1),
 		)
 
 		It("matches file without number in multi-folder album by folder", func() {


### PR DESCRIPTION
### Description

`DiscArtPriority` resolution for single-folder multi-disc albums was silently skipping unnumbered image filenames (e.g. `shellac.png`, `cover.png`). The old branch in `core/artwork/reader_disc.go:fromExternalFile` treated unnumbered files in single-folder albums as "ambiguous" and fell through without matching, so a user with a layout like:

```
78rpm Collection/
├── 1-01 - Side A.opus
├── 1-02 - Side B.opus
├── 2-01 - Side A.opus
├── 2-02 - Side B.opus
└── shellac.png
```

…could not use `shellac.png` as disc art for any disc, even with `ND_DISCARTPRIORITY=shellac.png`.

**The fix:** remove the "skip as ambiguous" branch. In a single-folder album an unnumbered filename now matches for every disc as shared disc art. `DiscArtPriority` strict left-to-right ordering — consistent with `CoverArtPriority` — decides whether a more specific numbered pattern wins.

This also activates the `cover.*, folder.*, front.*` entries in the default `DiscArtPriority` (`"disc*.*, cd*.*, cover.*, folder.*, front.*, discsubtitle, embedded"`), which were previously dead code on single-folder albums. Users on defaults who drop a `cover.png` into a single-folder multi-disc album now get shared disc art automatically. The `DiscArtPriority` config hash is already part of the disc artwork cache key, so this is a graceful transition — cached entries expire naturally and new requests get the corrected resolution.

Multi-folder albums (each disc in its own subfolder) were already working via the existing folder-association branch and are untouched by this change.

Also includes a small simplification pass: `strings.ToLower` is now called once per file per pattern instead of three times (`fromExternalFile` matched the lowercased name and then `extractDiscNumber` redundantly re-lowered both pattern and filename). `extractDiscNumber`'s contract now explicitly requires pre-lowercased inputs.

### Related Issues

Related to https://github.com/navidrome/navidrome/discussions/5332#discussioncomment-16526273 (shellac re-releases bundled into one folder)

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Create a single-folder multi-disc album on disk, e.g.:
   ```
   test-album/
   ├── 1-01 - Song A.opus
   ├── 1-02 - Song B.opus
   ├── 2-01 - Song C.opus
   ├── 2-02 - Song D.opus
   └── shellac.png
   ```
   Make sure the track tags have `discnumber=1` and `discnumber=2` set appropriately.
2. Set `ND_DISCARTPRIORITY=shellac.png` (or leave it at the default and drop a `cover.png` into the same folder instead).
3. Run Navidrome and let it scan the album.
4. Open the album in the UI and expand the disc titles.
5. **Expected:** both discs display `shellac.png` (or `cover.png`) as their disc art.
6. Edge case — verify numbered filenames still win when listed first. Add a `disc1.jpg` alongside `shellac.png`, set `ND_DISCARTPRIORITY="disc*.*, shellac.png"`, rescan, and confirm disc 1 shows `disc1.jpg` while disc 2 shows `shellac.png`.
7. Edge case — verify multi-folder albums (one folder per disc, each with its own `shellac.png`) still resolve the correct per-folder image for each disc. This path was untouched but worth a sanity check.

### Screenshots / Demos

_N/A — backend change, visible difference is which image appears for disc art._

### Additional Notes

- **No config migration needed.** The default `DiscArtPriority` value is unchanged; users on defaults simply get the behavior the config string was already promising.
- **Cache invalidation is automatic.** The disc artwork cache key already hashes `conf.Server.DiscArtPriority` (`core/artwork/reader_disc.go:109-116`), so existing cached entries stay valid until their normal expiry, at which point the corrected resolution runs.
- **Production change is ~10 lines** in one function. The rest of the diff is test coverage (one inverted, four new) and one comment/simplification commit.
- The `extractDiscNumber` helper's contract change (caller must pre-lower inputs) is documented in its doc comment. All call sites comply.
