### PR TITLE
(feat) add MbzReleaseGroupID to AlbumID3

### DIFF
--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -476,6 +476,7 @@ func buildOSAlbumID3(ctx context.Context, album model.Album) *responses.OpenSubs
 	dir.IsCompilation = album.Compilation
 	dir.DiscTitles = buildDiscSubtitles(album)
 	dir.ExplicitStatus = mapExplicitStatus(album.ExplicitStatus)
+	dir.MusicBrainzReleaseGroupID = album.MbzReleaseGroupID
 	if len(album.Tags.Values(model.TagAlbumVersion)) > 0 {
 		dir.Version = album.Tags.Values(model.TagAlbumVersion)[0]
 	}

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -261,24 +261,24 @@ type AlbumID3 struct {
 
 type OpenSubsonicAlbumID3 struct {
 	// OpenSubsonic extensions
-	Played              *time.Time          `xml:"played,attr,omitempty"         json:"played,omitempty"`
-	UserRating          int32               `xml:"userRating,attr,omitempty"     json:"userRating"`
-	AverageRating       float64             `xml:"averageRating,attr,omitempty"  json:"averageRating,omitempty"`
-	Genres              Array[ItemGenre]    `xml:"genres,omitempty"              json:"genres"`
-	MusicBrainzId       string              `xml:"musicBrainzId,attr,omitempty"  json:"musicBrainzId"`
-	IsCompilation       bool                `xml:"isCompilation,attr,omitempty"  json:"isCompilation"`
-	SortName            string              `xml:"sortName,attr,omitempty"       json:"sortName"`
-	DiscTitles          Array[DiscTitle]    `xml:"discTitles,omitempty"          json:"discTitles"`
-	OriginalReleaseDate ItemDate            `xml:"originalReleaseDate,omitempty" json:"originalReleaseDate"`
-	ReleaseDate         ItemDate            `xml:"releaseDate,omitempty"         json:"releaseDate"`
-	ReleaseTypes        Array[string]       `xml:"releaseTypes,omitempty"        json:"releaseTypes"`
-	RecordLabels        Array[RecordLabel]  `xml:"recordLabels,omitempty"        json:"recordLabels"`
-	Moods               Array[string]       `xml:"moods,omitempty"               json:"moods"`
-	Artists             Array[ArtistID3Ref] `xml:"artists,omitempty"             json:"artists"`
-	DisplayArtist       string              `xml:"displayArtist,attr,omitempty"  json:"displayArtist"`
-	ExplicitStatus      string              `xml:"explicitStatus,attr,omitempty" json:"explicitStatus"`
-	Version             string              `xml:"version,attr,omitempty"        json:"version"`
-	MusicBrainzReleaseGroupID string `xml:"musicBrainzReleaseGroupId,attr,omitempty" json:"musicBrainzReleaseGroupId,omitempty"`
+	Played                     *time.Time                 `xml:"played,attr,omitempty"                      json:"played,omitempty"`
+	UserRating                 int32                      `xml:"userRating,attr,omitempty"                  json:"userRating"`
+	AverageRating              float64                    `xml:"averageRating,attr,omitempty"               json:"averageRating,omitempty"`
+	Genres                     Array[ItemGenre]           `xml:"genres,omitempty"                           json:"genres"`
+	MusicBrainzId              string                     `xml:"musicBrainzId,attr,omitempty"               json:"musicBrainzId"`
+	MusicBrainzReleaseGroupID  string                     `xml:"musicBrainzReleaseGroupId,attr,omitempty"   json:"musicBrainzReleaseGroupId,omitempty"`
+	IsCompilation              bool                       `xml:"isCompilation,attr,omitempty"               json:"isCompilation"`
+	SortName                   string                     `xml:"sortName,attr,omitempty"                    json:"sortName"`
+	DiscTitles                 Array[DiscTitle]           `xml:"discTitles,omitempty"                       json:"discTitles"`
+	OriginalReleaseDate        ItemDate                   `xml:"originalReleaseDate,omitempty"              json:"originalReleaseDate"`
+	ReleaseDate                ItemDate                   `xml:"releaseDate,omitempty"                      json:"releaseDate"`
+	ReleaseTypes               Array[string]              `xml:"releaseTypes,omitempty"                     json:"releaseTypes"`
+	RecordLabels               Array[RecordLabel]         `xml:"recordLabels,omitempty"                     json:"recordLabels"`
+	Moods                      Array[string]              `xml:"moods,omitempty"                            json:"moods"`
+	Artists                    Array[ArtistID3Ref]        `xml:"artists,omitempty"                          json:"artists"`
+	DisplayArtist              string                     `xml:"displayArtist,attr,omitempty"               json:"displayArtist"`
+	ExplicitStatus             string                     `xml:"explicitStatus,attr,omitempty"              json:"explicitStatus"`
+	Version                    string                     `xml:"version,attr,omitempty"                     json:"version"`
 }
 
 type ArtistWithAlbumsID3 struct {

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -278,6 +278,7 @@ type OpenSubsonicAlbumID3 struct {
 	DisplayArtist       string              `xml:"displayArtist,attr,omitempty"  json:"displayArtist"`
 	ExplicitStatus      string              `xml:"explicitStatus,attr,omitempty" json:"explicitStatus"`
 	Version             string              `xml:"version,attr,omitempty"        json:"version"`
+	MusicBrainzReleaseGroupID string `xml:"musicBrainzReleaseGroupId,attr,omitempty" json:"musicBrainzReleaseGroupId,omitempty"`
 }
 
 type ArtistWithAlbumsID3 struct {


### PR DESCRIPTION
### Description
Hi, I added MbzReleaseGroupID to results of AlbumID3. For me, it is more relevant than MusicBrainzId because in musicbrainz db, songs and album refer to a unique MbzReleaseGroupID. As Said in documentation `Both release groups and releases are "albums" in a general sense. But there is an important difference: a release is something you can buy, such as a CD or a digital download, while a release group embraces the overall concept of an album. `


### Type of Change
- [ X] Extend feature

### Checklist
- [x ] My code follows the project’s coding style
- [x ] I have tested the changes locally

I just add 3 lines of codes, and tested it, it works (not a big commit lol).
Say me if misdoing something.

### How to Test
http://127.0.0.1:4533/rest/getAlbumList2?f=json&type=newest&u=a&p=a&v=1&c=a
http://127.0.0.1:4533/rest/getAlbumList2?&type=newest&u=a&p=a&v=1&c=a


Your Project is awesome, thanks! 