### PR TITLE
chore(deps): upgrade Go to 1.26

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 		"dockerfile": "Dockerfile",
 		"args": {
 			// Update the VARIANT arg to pick a version of Go: 1, 1.15, 1.14
-			"VARIANT": "1.25",
+			"VARIANT": "1.26",
 			// Options
 			"INSTALL_NODE": "true",
 			"NODE_VERSION": "v24"

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,6 +64,10 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
@@ -98,6 +102,10 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
 
       - name: Download dependencies
         run: go mod download

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=ui /build /build
 
 ########################################################################################################################
 ### Build Navidrome binary for Docker image (dynamic musl, enables native libwebp via dlopen)
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25-alpine AS build-alpine
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.26-alpine AS build-alpine
 COPY --from=xx / /
 
 ARG TARGETPLATFORM
@@ -82,7 +82,7 @@ EOT
 
 ########################################################################################################################
 ### Build Navidrome binary for standalone distribution (static glibc, cross-compiled)
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.25-trixie AS base
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.26-trixie AS base
 RUN apt-get update && apt-get install -y clang lld
 COPY --from=xx / /
 WORKDIR /workspace

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/navidrome/navidrome
 
-go 1.25.0
+go 1.26.0
 
 // Fork to implement raw tags support
 replace go.senan.xyz/taglib => github.com/deluan/go-taglib v0.0.0-20260407173416-cf47afbaa67a


### PR DESCRIPTION
### Description

Upgrades the main Navidrome module to **Go 1.26**:

- `go.mod`: `go 1.25.0` → `go 1.26.0` (no `toolchain` directive; no 1.26 language features are used yet — this is a routine floor bump).
- `Dockerfile`: both build stages (`build-alpine` and `base`) bumped from `golang:1.25-*` to `golang:1.26-*`. Tag existence on `public.ecr.aws/docker/library/golang` verified.
- `.devcontainer/devcontainer.json`: `VARIANT` bumped `1.25` → `1.26`. Confirmed `mcr.microsoft.com/vscode/devcontainers/go:1.26` exists before committing.
- `.github/workflows/pipeline.yml`: added an explicit `actions/setup-go@v6` step (with `go-version-file: go.mod`) to both the `go-lint` and `go` jobs.

**Why the CI setup-go addition:** The `golangci/golangci-lint-action` docs state that starting with v4.0.0 the action requires an explicit `actions/setup-go` step before it runs. The current pipeline at `@v9` worked only because `ubuntu-latest` happened to ship a compatible Go in its tools cache. Without `setup-go`, there's a window between this PR merging and GitHub updating the runner image where CI could break. Pinning the Go version to `go.mod` via `setup-go` removes that risk and matches every official `golangci-lint-action` example.

**Explicitly out of scope:** The plugin sub-modules under `plugins/` (19 `go.mod` files) and the `ndpgen` template/tests still declare `go 1.25`. They are independent Go modules, are not traversed by `go test ./...` at the repo root, and don't block this upgrade. Bumping them should be a separate, deliberate PR.

### Related Issues
<!-- None -->

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Toolchain upgrade (Go 1.25 → 1.26) + CI hardening

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

_(No new tests: this is a toolchain version bump with no behavior change. The existing suite exercises everything that the new Go version could affect.)_

### How to Test

1. Check out the branch with Go 1.26 installed (`go version` should report `go1.26.x`).
2. Run `go mod tidy` — diff should be empty (only the `go 1.26.0` directive line, already committed).
3. Run `make wire` — no diff should appear in generated files.
4. Run `make test` — the full Go suite should pass.
5. (Optional, slow) `docker build --target binary .` — confirms the `golang:1.26-alpine` and `golang:1.26-trixie` tags resolve on `public.ecr.aws`.
6. Watch the CI pipeline after push: the `go-lint` and `go` jobs should both pick up Go 1.26 via the new `setup-go` step, and the 11-platform Docker build matrix should succeed against `golang:1.26-*`.

### Screenshots / Demos (if applicable)
<!-- N/A -->

### Additional Notes

- **Plugin-main version skew is intentional.** Plugins stay on `go 1.25` while main moves to `go 1.26`. This is safe: plugin sub-modules are independent, and the PDK surface they import doesn't rely on any Go 1.26-only APIs. A follow-up PR can align them once we're ready.
- **Runner tools-cache lag risk is mitigated.** Even if `ubuntu-latest` hasn't picked up Go 1.26 yet, the new `actions/setup-go@v6` step downloads whatever version `go.mod` declares, so CI is independent of the runner image schedule.
- **Local verification done** on `darwin/arm64` with `go1.26.0`: `go mod tidy` (clean), `make wire` (clean), `make format` (clean), `make lint` (`0 issues`), `make test` (all pass).
