### PR TITLE
fix(provider): add starred preference to song matching - #5371

### DIFF
--- a/core/external/provider_matching.go
+++ b/core/external/provider_matching.go
@@ -254,10 +254,11 @@ type matchScore struct {
 	durationProximity float64 // 0.0-1.0 (closer duration = higher, 1.0 if unknown)
 	albumSimilarity   float64 // 0.0-1.0 (Jaro-Winkler), used as tiebreaker
 	specificityLevel  int     // 0-5 (higher = more specific metadata match)
+	starred           bool    // prefer starred tracks as tiebreaker
 }
 
 // betterThan returns true if this score beats another.
-// Comparison order: title similarity > duration proximity > specificity level > album similarity
+// Comparison order: title similarity > duration proximity > specificity level > starred > album similarity
 func (s matchScore) betterThan(other matchScore) bool {
 	if s.titleSimilarity != other.titleSimilarity {
 		return s.titleSimilarity > other.titleSimilarity
@@ -267,6 +268,9 @@ func (s matchScore) betterThan(other matchScore) bool {
 	}
 	if s.specificityLevel != other.specificityLevel {
 		return s.specificityLevel > other.specificityLevel
+	}
+	if s.starred != other.starred {
+		return s.starred
 	}
 	return s.albumSimilarity > other.albumSimilarity
 }
@@ -401,6 +405,7 @@ func (e *provider) findBestMatch(q songQuery, tracks model.MediaFiles, threshold
 			durationProximity: durationProximity(q.durationMs, mf.Duration),
 			albumSimilarity:   albumSim,
 			specificityLevel:  computeSpecificityLevel(q, mf, threshold),
+			starred:           mf.Starred,
 		}
 
 		if score.betterThan(bestScore) {

--- a/core/external/provider_matching_test.go
+++ b/core/external/provider_matching_test.go
@@ -456,6 +456,56 @@ var _ = Describe("Provider - Song Matching", func() {
 				Expect(songs[0].ID).To(Equal("exact"))
 			})
 		})
+
+		Context("with starred tiebreaking", func() {
+			It("prefers starred track when scores are otherwise equal", func() {
+				conf.Server.SimilarSongsMatchThreshold = 85
+
+				returnedSongs := []agents.Song{
+					{Name: "Paranoid Android", Artist: "Radiohead"},
+				}
+				starredTrack := model.MediaFile{
+					ID: "starred", Title: "Paranoid Android", Artist: "Radiohead", Album: "OK Computer",
+					Annotations: model.Annotations{Starred: true},
+				}
+				unstarredTrack := model.MediaFile{
+					ID: "unstarred", Title: "Paranoid Android", Artist: "Radiohead", Album: "OK Computer",
+				}
+
+				// unstarred is listed first but starred should win
+				setupSimilarSongsExpectations(returnedSongs, model.MediaFiles{unstarredTrack, starredTrack})
+
+				songs, err := provider.SimilarSongs(ctx, "track-1", 5)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(songs).To(HaveLen(1))
+				Expect(songs[0].ID).To(Equal("starred"))
+			})
+
+			It("still picks higher title similarity track even if it is not starred", func() {
+				conf.Server.SimilarSongsMatchThreshold = 85
+
+				returnedSongs := []agents.Song{
+					{Name: "Paranoid Android", Artist: "Radiohead"},
+				}
+				exactUnstarred := model.MediaFile{
+					ID: "exact", Title: "Paranoid Android", Artist: "Radiohead",
+				}
+				fuzzyStarred := model.MediaFile{
+					ID: "fuzzy-starred", Title: "Paranoid Android - Remastered", Artist: "Radiohead",
+					Annotations: model.Annotations{Starred: true},
+				}
+
+				setupSimilarSongsExpectations(returnedSongs, model.MediaFiles{fuzzyStarred, exactUnstarred})
+
+				songs, err := provider.SimilarSongs(ctx, "track-1", 5)
+
+				Expect(err).ToNot(HaveOccurred())
+				Expect(songs).To(HaveLen(1))
+				// Title similarity wins over starred
+				Expect(songs[0].ID).To(Equal("exact"))
+			})
+		})
 	})
 
 	Describe("Duration matching", func() {


### PR DESCRIPTION
### Description
Song matching wasn't considering starred status, so you'd get inconsistent results when multiple tracks had the same title and artist. Added starred as a tiebreaker in the scoring logic so starred tracks win when everything else matches.

### Related Issues
Fixes #5371

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Run the provider matching tests. The new test case verifies that when you have two identical songs except one is starred, it returns the starred one as the best match. All tests pass locally.

### Screenshots / Demos (if applicable)
N/A

### Additional Notes
Minimal fix focused on the tiebreaker logic, no breaking changes.