### PR TITLE
fix(artwork): return imagesUpdatedAt in LastUpdated when disc or album coverart changes

### DIFF
--- a/core/artwork/artwork_internal_test.go
+++ b/core/artwork/artwork_internal_test.go
@@ -7,9 +7,9 @@ import (
 	"image/jpeg"
 	"image/png"
 	"io"
-
 	"os"
 	"path/filepath"
+	"time"
 
 	_ "github.com/gen2brain/webp"
 
@@ -145,6 +145,43 @@ var _ = Describe("Artwork", func() {
 				Entry(nil, "front.* , cover.*, embedded ,folder.*", "tests/fixtures/artist/an-album/front.png"),
 				Entry(nil, " embedded , front.* , cover.*,folder.*", "tests/fixtures/artist/an-album/test.mp3"),
 			)
+		})
+		Context("LastUpdated returns the correct timestamp", func() {
+			It("returns album UpdatedAt when imagesUpdatedAt is older", func() {
+				// Set up album with recent UpdatedAt but folder with older ImagesUpdatedAt
+				now := time.Now().Truncate(time.Second)
+				albumOld := model.Album{ID: "old-album", Name: "Old Album", UpdatedAt: now, FolderIDs: []string{"folder1"}}
+				folderRepo.result = []model.Folder{{
+					Path:            "tests/fixtures/artist/an-album",
+					ImagesUpdatedAt: now.Add(-1 * time.Hour), // older than album.UpdatedAt
+					ImageFiles:      []string{"cover.jpg"},
+				}}
+				ds.Album(ctx).(*tests.MockAlbumRepo).SetData(model.Albums{albumOld})
+				ds.MediaFile(ctx).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{})
+
+				ar, err := newAlbumArtworkReader(ctx, aw, albumOld.CoverArtID(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ar.LastUpdated()).To(Equal(now)) // should return album.UpdatedAt (now)
+			})
+			It("returns imagesUpdatedAt when it is newer than album UpdatedAt", func() {
+				// Set up album with old UpdatedAt but folder with recent ImagesUpdatedAt
+				// This simulates the case where cover art was updated but no media files changed
+				now := time.Now().Truncate(time.Second)
+				albumOld := model.Album{ID: "old-album2", Name: "Old Album 2", UpdatedAt: now.Add(-24 * time.Hour), FolderIDs: []string{"folder1"}}
+				newerImagesUpdatedAt := now.Add(-1 * time.Hour) // cover art was updated 1 hour ago
+				folderRepo.result = []model.Folder{{
+					Path:            "tests/fixtures/artist/an-album",
+					ImagesUpdatedAt: newerImagesUpdatedAt,
+					ImageFiles:      []string{"cover.jpg"},
+				}}
+				ds.Album(ctx).(*tests.MockAlbumRepo).SetData(model.Albums{albumOld})
+				ds.MediaFile(ctx).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{})
+
+				ar, err := newAlbumArtworkReader(ctx, aw, albumOld.CoverArtID(), nil)
+				Expect(err).ToNot(HaveOccurred())
+				// Should return imagesUpdatedAt (newer), not album.UpdatedAt (older)
+				Expect(ar.LastUpdated()).To(Equal(newerImagesUpdatedAt))
+			})
 		})
 	})
 	Describe("artistArtworkReader", func() {

--- a/core/artwork/artwork_internal_test.go
+++ b/core/artwork/artwork_internal_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	_ "github.com/gen2brain/webp"
-
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/log"
@@ -146,42 +145,25 @@ var _ = Describe("Artwork", func() {
 				Entry(nil, " embedded , front.* , cover.*,folder.*", "tests/fixtures/artist/an-album/test.mp3"),
 			)
 		})
-		Context("LastUpdated returns the correct timestamp", func() {
-			It("returns album UpdatedAt when imagesUpdatedAt is older", func() {
-				// Set up album with recent UpdatedAt but folder with older ImagesUpdatedAt
-				now := time.Now().Truncate(time.Second)
-				albumOld := model.Album{ID: "old-album", Name: "Old Album", UpdatedAt: now, FolderIDs: []string{"folder1"}}
-				folderRepo.result = []model.Folder{{
-					Path:            "tests/fixtures/artist/an-album",
-					ImagesUpdatedAt: now.Add(-1 * time.Hour), // older than album.UpdatedAt
-					ImageFiles:      []string{"cover.jpg"},
-				}}
-				ds.Album(ctx).(*tests.MockAlbumRepo).SetData(model.Albums{albumOld})
-				ds.MediaFile(ctx).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{})
+		Context("LastUpdated", func() {
+			// Regression test for #5377: LastUpdated feeds the HTTP Last-Modified header.
+			// It must return max(album.UpdatedAt, ImagesUpdatedAt) so browsers revalidate
+			// cached cover art when only the image file changes.
+			now := time.Now().Truncate(time.Second)
+			DescribeTable("returns the max of album.UpdatedAt and ImagesUpdatedAt",
+				func(albumUpdatedAt, imagesUpdatedAt, expected time.Time) {
+					album := model.Album{ID: "al1", UpdatedAt: albumUpdatedAt}
+					folderRepo.result = []model.Folder{{ImagesUpdatedAt: imagesUpdatedAt}}
+					ds.Album(ctx).(*tests.MockAlbumRepo).SetData(model.Albums{album})
 
-				ar, err := newAlbumArtworkReader(ctx, aw, albumOld.CoverArtID(), nil)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(ar.LastUpdated()).To(Equal(now)) // should return album.UpdatedAt (now)
-			})
-			It("returns imagesUpdatedAt when it is newer than album UpdatedAt", func() {
-				// Set up album with old UpdatedAt but folder with recent ImagesUpdatedAt
-				// This simulates the case where cover art was updated but no media files changed
-				now := time.Now().Truncate(time.Second)
-				albumOld := model.Album{ID: "old-album2", Name: "Old Album 2", UpdatedAt: now.Add(-24 * time.Hour), FolderIDs: []string{"folder1"}}
-				newerImagesUpdatedAt := now.Add(-1 * time.Hour) // cover art was updated 1 hour ago
-				folderRepo.result = []model.Folder{{
-					Path:            "tests/fixtures/artist/an-album",
-					ImagesUpdatedAt: newerImagesUpdatedAt,
-					ImageFiles:      []string{"cover.jpg"},
-				}}
-				ds.Album(ctx).(*tests.MockAlbumRepo).SetData(model.Albums{albumOld})
-				ds.MediaFile(ctx).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{})
-
-				ar, err := newAlbumArtworkReader(ctx, aw, albumOld.CoverArtID(), nil)
-				Expect(err).ToNot(HaveOccurred())
-				// Should return imagesUpdatedAt (newer), not album.UpdatedAt (older)
-				Expect(ar.LastUpdated()).To(Equal(newerImagesUpdatedAt))
-			})
+					ar, err := newAlbumArtworkReader(ctx, aw, album.CoverArtID(), nil)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ar.LastUpdated()).To(Equal(expected))
+				},
+				Entry("album newer than images", now, now.Add(-1*time.Hour), now),
+				Entry("images newer than album", now.Add(-24*time.Hour), now.Add(-1*time.Hour), now.Add(-1*time.Hour)),
+				Entry("equal timestamps", now, now, now),
+			)
 		})
 	})
 	Describe("artistArtworkReader", func() {

--- a/core/artwork/artwork_internal_test.go
+++ b/core/artwork/artwork_internal_test.go
@@ -166,6 +166,31 @@ var _ = Describe("Artwork", func() {
 			)
 		})
 	})
+	Describe("discArtworkReader", func() {
+		Context("LastUpdated", func() {
+			// Regression test for #5377: same bug as albumArtworkReader — disc covers
+			// must also revalidate when the image file changes, not only when media files do.
+			now := time.Now().Truncate(time.Second)
+			DescribeTable("returns the max of album.UpdatedAt and ImagesUpdatedAt",
+				func(albumUpdatedAt, imagesUpdatedAt, expected time.Time) {
+					album := model.Album{ID: "al1", UpdatedAt: albumUpdatedAt}
+					folderRepo.result = []model.Folder{{ImagesUpdatedAt: imagesUpdatedAt}}
+					ds.Album(ctx).(*tests.MockAlbumRepo).SetData(model.Albums{album})
+					ds.MediaFile(ctx).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
+						{ID: "mf1", AlbumID: "al1", DiscNumber: 1, Path: "tests/fixtures/test.mp3"},
+					})
+
+					artID := model.NewArtworkID(model.KindDiscArtwork, model.DiscArtworkID("al1", 1), nil)
+					dr, err := newDiscArtworkReader(ctx, aw, artID)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(dr.LastUpdated()).To(Equal(expected))
+				},
+				Entry("album newer than images", now, now.Add(-1*time.Hour), now),
+				Entry("images newer than album", now.Add(-24*time.Hour), now.Add(-1*time.Hour), now.Add(-1*time.Hour)),
+				Entry("equal timestamps", now, now, now),
+			)
+		})
+	})
 	Describe("artistArtworkReader", func() {
 		Context("Multiple covers", func() {
 			BeforeEach(func() {

--- a/core/artwork/reader_album.go
+++ b/core/artwork/reader_album.go
@@ -72,7 +72,7 @@ func (a *albumArtworkReader) Key() string {
 	)
 }
 func (a *albumArtworkReader) LastUpdated() time.Time {
-	return a.album.UpdatedAt
+	return a.lastUpdate
 }
 
 func (a *albumArtworkReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {

--- a/core/artwork/reader_disc.go
+++ b/core/artwork/reader_disc.go
@@ -116,7 +116,7 @@ func (d *discArtworkReader) Key() string {
 }
 
 func (d *discArtworkReader) LastUpdated() time.Time {
-	return d.album.UpdatedAt
+	return d.lastUpdate
 }
 
 func (d *discArtworkReader) Reader(ctx context.Context) (io.ReadCloser, string, error) {


### PR DESCRIPTION
When cover art (cover.jpg) is updated in an album folder, the HTTP Last-Modified header was incorrectly returning album.UpdatedAt (which only tracks media file changes) instead of imagesUpdatedAt (which tracks cover art changes).

This caused browsers to use their cached cover art because the Last-Modified header didn't change, even though the actual cover art image data was new (due to cache key changing based on imagesUpdatedAt).

The fix ensures LastUpdated() returns a.lastUpdate (which is the max of album.UpdatedAt and imagesUpdatedAt) instead of always returning album.UpdatedAt.

Fixes navidrome/navidrome#5377