### PR TITLE
ci: run Go tests on Windows

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -120,6 +120,69 @@ jobs:
           go build -o ndpgen .
           ./ndpgen --help
 
+  go-windows:
+    name: Test Go code (Windows)
+    runs-on: windows-2022
+    continue-on-error: true   # remove after soak period (Task 6)
+    env:
+      FFMPEG_VERSION: "7.1"
+      FFMPEG_REPOSITORY: navidrome/ffmpeg-windows-builds
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: mingw-w64-x86_64-gcc
+          update: false
+
+      - name: Add mingw64 to PATH
+        shell: bash
+        run: echo "C:/msys64/mingw64/bin" >> $GITHUB_PATH
+
+      - name: Cache ffmpeg
+        id: ffmpeg-cache
+        uses: actions/cache@v4
+        with:
+          path: C:\ffmpeg
+          key: ffmpeg-${{ env.FFMPEG_VERSION }}-win64
+
+      - name: Download ffmpeg
+        if: steps.ffmpeg-cache.outputs.cache-hit != 'true'
+        shell: pwsh
+        run: |
+          $asset = "ffmpeg-n${env:FFMPEG_VERSION}-latest-win64-gpl-${env:FFMPEG_VERSION}"
+          $url = "https://github.com/${env:FFMPEG_REPOSITORY}/releases/download/latest/$asset.zip"
+          Invoke-WebRequest -Uri $url -OutFile ffmpeg.zip
+          Expand-Archive ffmpeg.zip -DestinationPath C:\ffmpeg-extracted
+          New-Item -ItemType Directory -Force -Path C:\ffmpeg\bin | Out-Null
+          Copy-Item "C:\ffmpeg-extracted\$asset\bin\ffmpeg.exe"  C:\ffmpeg\bin
+          Copy-Item "C:\ffmpeg-extracted\$asset\bin\ffprobe.exe" C:\ffmpeg\bin
+
+      - name: Add ffmpeg to PATH
+        shell: bash
+        run: echo "C:/ffmpeg/bin" >> $GITHUB_PATH
+
+      - name: Verify toolchain
+        shell: pwsh
+        run: |
+          go version
+          gcc --version
+          ffmpeg -version
+          ffprobe -version
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Compile all packages (smoke test)
+        env:
+          CGO_ENABLED: "1"
+        run: go build -tags netgo,sqlite_fts5 ./...
+
   js:
     name: Test JS code
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -180,11 +180,19 @@ jobs:
         shell: bash
         run: go mod download
 
-      - name: Compile all packages (smoke test)
+      - name: Test
         shell: bash
         env:
           CGO_ENABLED: "1"
-        run: go build -tags netgo,sqlite_fts5 ./...
+        run: go test -shuffle=on -tags netgo,sqlite_fts5 ./... -v
+
+      - name: Test ndpgen
+        shell: pwsh
+        run: |
+          cd plugins\cmd\ndpgen
+          go test -shuffle=on -v
+          go build -o ndpgen.exe .
+          .\ndpgen.exe --help
 
   js:
     name: Test JS code

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -123,7 +123,6 @@ jobs:
   go-windows:
     name: Test Go code (Windows)
     runs-on: windows-2022
-    continue-on-error: true   # remove after soak period (Task 7)
     env:
       FFMPEG_VERSION: "7.1"
       FFMPEG_REPOSITORY: navidrome/ffmpeg-windows-builds
@@ -258,7 +257,7 @@ jobs:
 
   build:
     name: Build
-    needs: [js, go, go-lint, i18n-lint, git-version, check-push-enabled]
+    needs: [js, go, go-windows, go-lint, i18n-lint, git-version, check-push-enabled]
     strategy:
       matrix:
         platform: [ linux/amd64, linux/arm64, linux/arm/v5, linux/arm/v6, linux/arm/v7, linux/386, linux/riscv64, darwin/amd64, darwin/arm64, windows/amd64, windows/386 ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -123,7 +123,7 @@ jobs:
   go-windows:
     name: Test Go code (Windows)
     runs-on: windows-2022
-    continue-on-error: true   # remove after soak period (Task 6)
+    continue-on-error: true   # remove after soak period (Task 7)
     env:
       FFMPEG_VERSION: "7.1"
       FFMPEG_REPOSITORY: navidrome/ffmpeg-windows-builds

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -171,14 +171,17 @@ jobs:
         shell: pwsh
         run: |
           go version
+          where.exe gcc
           gcc --version
           ffmpeg -version
           ffprobe -version
 
       - name: Download dependencies
+        shell: bash
         run: go mod download
 
       - name: Compile all packages (smoke test)
+        shell: bash
         env:
           CGO_ENABLED: "1"
         run: go build -tags netgo,sqlite_fts5 ./...

--- a/adapters/gotaglib/gotaglib_test.go
+++ b/adapters/gotaglib/gotaglib_test.go
@@ -3,6 +3,7 @@ package gotaglib
 import (
 	"io/fs"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/navidrome/navidrome/utils"
@@ -213,6 +214,9 @@ var _ = Describe("Extractor", func() {
 			// Only run permission tests if we are not root
 			RegularUserContext("when run without root privileges", func() {
 				BeforeEach(func() {
+					if runtime.GOOS == "windows" {
+						Skip("not supported on Windows: uses Unix file permission bits")
+					}
 					// Use root fs for absolute paths in temp directory
 					e = &extractor{fs: os.DirFS("/")}
 					accessForbiddenFile = utils.TempFileName("access_forbidden-", ".mp3")

--- a/adapters/gotaglib/gotaglib_test.go
+++ b/adapters/gotaglib/gotaglib_test.go
@@ -3,9 +3,9 @@ package gotaglib
 import (
 	"io/fs"
 	"os"
-	"runtime"
 	"strings"
 
+	"github.com/navidrome/navidrome/tests"
 	"github.com/navidrome/navidrome/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -214,9 +214,7 @@ var _ = Describe("Extractor", func() {
 			// Only run permission tests if we are not root
 			RegularUserContext("when run without root privileges", func() {
 				BeforeEach(func() {
-					if runtime.GOOS == "windows" {
-						Skip("not supported on Windows: uses Unix file permission bits")
-					}
+					tests.SkipOnWindows("uses Unix file permission bits")
 					// Use root fs for absolute paths in temp directory
 					e = &extractor{fs: os.DirFS("/")}
 					accessForbiddenFile = utils.TempFileName("access_forbidden-", ".mp3")

--- a/core/artwork/artwork_internal_test.go
+++ b/core/artwork/artwork_internal_test.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	_ "github.com/gen2brain/webp"
@@ -81,9 +80,7 @@ var _ = Describe("Artwork", func() {
 				})
 			})
 			It("returns embed cover", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-				}
+				tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 				aw, err := newAlbumArtworkReader(ctx, aw, alOnlyEmbed.CoverArtID(), nil)
 				Expect(err).ToNot(HaveOccurred())
 				_, path, err := aw.Reader(ctx)
@@ -107,9 +104,7 @@ var _ = Describe("Artwork", func() {
 				})
 			})
 			It("returns external cover", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-				}
+				tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 				folderRepo.result = []model.Folder{{
 					Path:       "tests/fixtures/artist/an-album",
 					ImageFiles: []string{"front.png"},
@@ -140,9 +135,7 @@ var _ = Describe("Artwork", func() {
 			})
 			DescribeTable("CoverArtPriority",
 				func(priority string, expected string) {
-					if runtime.GOOS == "windows" {
-						Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-					}
+					tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 					conf.Server.CoverArtPriority = priority
 					aw, err := newAlbumArtworkReader(ctx, aw, alMultipleCovers.CoverArtID(), nil)
 					Expect(err).ToNot(HaveOccurred())
@@ -220,9 +213,7 @@ var _ = Describe("Artwork", func() {
 			})
 			DescribeTable("ArtistArtPriority",
 				func(priority string, expected string) {
-					if runtime.GOOS == "windows" {
-						Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-					}
+					tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 					conf.Server.ArtistArtPriority = priority
 					aw, err := newArtistArtworkReader(ctx, aw, arMultipleCovers.CoverArtID(), nil)
 					Expect(err).ToNot(HaveOccurred())
@@ -260,9 +251,7 @@ var _ = Describe("Artwork", func() {
 				})
 			})
 			It("returns embed cover", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-				}
+				tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 				aw, err := newMediafileArtworkReader(ctx, aw, mfWithEmbed.CoverArtID())
 				Expect(err).ToNot(HaveOccurred())
 				_, path, err := aw.Reader(ctx)
@@ -270,9 +259,7 @@ var _ = Describe("Artwork", func() {
 				Expect(path).To(Equal("tests/fixtures/test.mp3"))
 			})
 			It("returns embed cover if successfully extracted by ffmpeg", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-				}
+				tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 				aw, err := newMediafileArtworkReader(ctx, aw, mfCorruptedCover.CoverArtID())
 				Expect(err).ToNot(HaveOccurred())
 				r, path, err := aw.Reader(ctx)

--- a/core/artwork/artwork_internal_test.go
+++ b/core/artwork/artwork_internal_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	_ "github.com/gen2brain/webp"
@@ -80,6 +81,9 @@ var _ = Describe("Artwork", func() {
 				})
 			})
 			It("returns embed cover", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+				}
 				aw, err := newAlbumArtworkReader(ctx, aw, alOnlyEmbed.CoverArtID(), nil)
 				Expect(err).ToNot(HaveOccurred())
 				_, path, err := aw.Reader(ctx)
@@ -103,6 +107,9 @@ var _ = Describe("Artwork", func() {
 				})
 			})
 			It("returns external cover", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+				}
 				folderRepo.result = []model.Folder{{
 					Path:       "tests/fixtures/artist/an-album",
 					ImageFiles: []string{"front.png"},
@@ -133,6 +140,9 @@ var _ = Describe("Artwork", func() {
 			})
 			DescribeTable("CoverArtPriority",
 				func(priority string, expected string) {
+					if runtime.GOOS == "windows" {
+						Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+					}
 					conf.Server.CoverArtPriority = priority
 					aw, err := newAlbumArtworkReader(ctx, aw, alMultipleCovers.CoverArtID(), nil)
 					Expect(err).ToNot(HaveOccurred())
@@ -210,6 +220,9 @@ var _ = Describe("Artwork", func() {
 			})
 			DescribeTable("ArtistArtPriority",
 				func(priority string, expected string) {
+					if runtime.GOOS == "windows" {
+						Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+					}
 					conf.Server.ArtistArtPriority = priority
 					aw, err := newArtistArtworkReader(ctx, aw, arMultipleCovers.CoverArtID(), nil)
 					Expect(err).ToNot(HaveOccurred())
@@ -247,6 +260,9 @@ var _ = Describe("Artwork", func() {
 				})
 			})
 			It("returns embed cover", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+				}
 				aw, err := newMediafileArtworkReader(ctx, aw, mfWithEmbed.CoverArtID())
 				Expect(err).ToNot(HaveOccurred())
 				_, path, err := aw.Reader(ctx)
@@ -254,6 +270,9 @@ var _ = Describe("Artwork", func() {
 				Expect(path).To(Equal("tests/fixtures/test.mp3"))
 			})
 			It("returns embed cover if successfully extracted by ffmpeg", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+				}
 				aw, err := newMediafileArtworkReader(ctx, aw, mfCorruptedCover.CoverArtID())
 				Expect(err).ToNot(HaveOccurred())
 				r, path, err := aw.Reader(ctx)

--- a/core/artwork/reader_artist_test.go
+++ b/core/artwork/reader_artist_test.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -62,9 +62,7 @@ var _ = Describe("artistArtworkReader", func() {
 
 		When("artist has only one album", func() {
 			It("returns the parent folder", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-				}
+				tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 				paths = []string{
 					filepath.FromSlash("/music/artist/album1"),
 				}
@@ -90,9 +88,7 @@ var _ = Describe("artistArtworkReader", func() {
 
 		When("the album paths contain same prefix", func() {
 			It("returns the common prefix", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
-				}
+				tests.SkipOnWindows("artwork path handling (#TBD-path-sep-artwork)")
 				paths = []string{
 					filepath.FromSlash("/music/artist/album1"),
 					filepath.FromSlash("/music/artist/album2"),

--- a/core/artwork/reader_artist_test.go
+++ b/core/artwork/reader_artist_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -61,6 +62,9 @@ var _ = Describe("artistArtworkReader", func() {
 
 		When("artist has only one album", func() {
 			It("returns the parent folder", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+				}
 				paths = []string{
 					filepath.FromSlash("/music/artist/album1"),
 				}
@@ -86,6 +90,9 @@ var _ = Describe("artistArtworkReader", func() {
 
 		When("the album paths contain same prefix", func() {
 			It("returns the common prefix", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: artwork path handling (#TBD-path-sep-artwork)")
+				}
 				paths = []string{
 					filepath.FromSlash("/music/artist/album1"),
 					filepath.FromSlash("/music/artist/album2"),

--- a/core/common_test.go
+++ b/core/common_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -41,6 +42,9 @@ var _ = Describe("common.go", func() {
 		})
 
 		It("returns the absolute path when library exists", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-core)")
+			}
 			ctx := context.Background()
 			abs := AbsolutePath(ctx, ds, libId, path)
 			Expect(abs).To(Equal("/library/root/music/file.mp3"))

--- a/core/common_test.go
+++ b/core/common_test.go
@@ -2,7 +2,6 @@ package core
 
 import (
 	"context"
-	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -42,9 +41,7 @@ var _ = Describe("common.go", func() {
 		})
 
 		It("returns the absolute path when library exists", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-core)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-core)")
 			ctx := context.Background()
 			abs := AbsolutePath(ctx, ds, libId, path)
 			Expect(abs).To(Equal("/library/root/music/file.mp3"))

--- a/core/lyrics/lyrics_test.go
+++ b/core/lyrics/lyrics_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -93,6 +94,9 @@ var _ = Describe("sources", func() {
 			var accessForbiddenFile string
 
 			BeforeEach(func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: uses Unix file permission bits")
+				}
 				accessForbiddenFile = utils.TempFileName("access_forbidden-", ".mp3")
 
 				f, err := os.OpenFile(accessForbiddenFile, os.O_WRONLY|os.O_CREATE, 0222)

--- a/core/lyrics/lyrics_test.go
+++ b/core/lyrics/lyrics_test.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"runtime"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core/lyrics"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/gg"
 	. "github.com/onsi/ginkgo/v2"
@@ -94,9 +94,7 @@ var _ = Describe("sources", func() {
 			var accessForbiddenFile string
 
 			BeforeEach(func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: uses Unix file permission bits")
-				}
+				tests.SkipOnWindows("uses Unix file permission bits")
 				accessForbiddenFile = utils.TempFileName("access_forbidden-", ".mp3")
 
 				f, err := os.OpenFile(accessForbiddenFile, os.O_WRONLY|os.O_CREATE, 0222)

--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -199,9 +200,7 @@ var _ = Describe("MPV", func() {
 		})
 
 		It("executes MPV command and captures arguments correctly", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: mpv binary not available in CI (#TBD-mpv-windows)")
-			}
+			tests.SkipOnWindows("mpv binary not available in CI (#TBD-mpv-windows)")
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -229,9 +228,7 @@ var _ = Describe("MPV", func() {
 		})
 
 		It("handles file paths with spaces", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: mpv binary not available in CI (#TBD-mpv-windows)")
-			}
+			tests.SkipOnWindows("mpv binary not available in CI (#TBD-mpv-windows)")
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -259,9 +256,7 @@ var _ = Describe("MPV", func() {
 			})
 
 			It("passes all snapcast arguments correctly", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: mpv binary not available in CI (#TBD-mpv-windows)")
-				}
+				tests.SkipOnWindows("mpv binary not available in CI (#TBD-mpv-windows)")
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 

--- a/core/playback/mpv/mpv_test.go
+++ b/core/playback/mpv/mpv_test.go
@@ -199,6 +199,9 @@ var _ = Describe("MPV", func() {
 		})
 
 		It("executes MPV command and captures arguments correctly", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: mpv binary not available in CI (#TBD-mpv-windows)")
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -226,6 +229,9 @@ var _ = Describe("MPV", func() {
 		})
 
 		It("handles file paths with spaces", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: mpv binary not available in CI (#TBD-mpv-windows)")
+			}
 			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 
@@ -253,6 +259,9 @@ var _ = Describe("MPV", func() {
 			})
 
 			It("passes all snapcast arguments correctly", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: mpv binary not available in CI (#TBD-mpv-windows)")
+				}
 				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 				defer cancel()
 

--- a/core/playlists/import_test.go
+++ b/core/playlists/import_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -183,6 +184,9 @@ var _ = Describe("Playlists - Import", func() {
 			})
 
 			It("rejects #EXTALBUMARTURL with absolute path outside library boundaries", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: relies on Unix /etc filesystem")
+				}
 				tmpDir := GinkgoT().TempDir()
 
 				m3u := "#EXTALBUMARTURL:/etc/passwd\ntest.mp3\n"
@@ -320,6 +324,9 @@ var _ = Describe("Playlists - Import", func() {
 				Expect(pls.Rules.Expression).To(BeAssignableToTypeOf(criteria.All{}))
 			})
 			It("returns an error if the playlist is not well-formed", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: line-ending differences affect JSON error offset")
+				}
 				_, err := ps.ImportFile(ctx, folder, "invalid_json.nsp")
 				Expect(err.Error()).To(ContainSubstring("line 19, column 1: invalid character '\\n'"))
 			})
@@ -347,6 +354,9 @@ var _ = Describe("Playlists - Import", func() {
 
 		DescribeTable("Playlist filename Unicode normalization (regression fix-playlist-filename-normalization)",
 			func(storedForm, filesystemForm string) {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: /tmp hardcoded in test")
+				}
 				// Use Polish characters that decompose: ó (U+00F3) -> o + combining acute (U+006F + U+0301)
 				plsNameNFC := "Piosenki_Polskie_zółć" // NFC form (composed)
 				plsNameNFD := norm.NFD.String(plsNameNFC)
@@ -821,6 +831,9 @@ var _ = Describe("Playlists - Import", func() {
 		})
 
 		It("returns true if folder is in PlaylistsPath", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-playlists)")
+			}
 			conf.Server.PlaylistsPath = "other/**:playlists/**"
 			Expect(playlists.InPath(folder)).To(BeTrue())
 		})

--- a/core/playlists/import_test.go
+++ b/core/playlists/import_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -184,9 +183,7 @@ var _ = Describe("Playlists - Import", func() {
 			})
 
 			It("rejects #EXTALBUMARTURL with absolute path outside library boundaries", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: relies on Unix /etc filesystem")
-				}
+				tests.SkipOnWindows("relies on Unix /etc filesystem")
 				tmpDir := GinkgoT().TempDir()
 
 				m3u := "#EXTALBUMARTURL:/etc/passwd\ntest.mp3\n"
@@ -324,9 +321,7 @@ var _ = Describe("Playlists - Import", func() {
 				Expect(pls.Rules.Expression).To(BeAssignableToTypeOf(criteria.All{}))
 			})
 			It("returns an error if the playlist is not well-formed", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: line-ending differences affect JSON error offset")
-				}
+				tests.SkipOnWindows("line-ending differences affect JSON error offset")
 				_, err := ps.ImportFile(ctx, folder, "invalid_json.nsp")
 				Expect(err.Error()).To(ContainSubstring("line 19, column 1: invalid character '\\n'"))
 			})
@@ -354,9 +349,7 @@ var _ = Describe("Playlists - Import", func() {
 
 		DescribeTable("Playlist filename Unicode normalization (regression fix-playlist-filename-normalization)",
 			func(storedForm, filesystemForm string) {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: /tmp hardcoded in test")
-				}
+				tests.SkipOnWindows("/tmp hardcoded in test")
 				// Use Polish characters that decompose: ó (U+00F3) -> o + combining acute (U+006F + U+0301)
 				plsNameNFC := "Piosenki_Polskie_zółć" // NFC form (composed)
 				plsNameNFD := norm.NFD.String(plsNameNFC)
@@ -831,9 +824,7 @@ var _ = Describe("Playlists - Import", func() {
 		})
 
 		It("returns true if folder is in PlaylistsPath", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-playlists)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-playlists)")
 			conf.Server.PlaylistsPath = "other/**:playlists/**"
 			Expect(playlists.InPath(folder)).To(BeTrue())
 		})

--- a/core/playlists/parse_m3u_test.go
+++ b/core/playlists/parse_m3u_test.go
@@ -2,7 +2,6 @@ package playlists
 
 import (
 	"context"
-	"runtime"
 
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
@@ -16,9 +15,7 @@ var _ = Describe("libraryMatcher", func() {
 	ctx := context.Background()
 
 	BeforeEach(func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: path separator bug (#TBD-path-sep-playlists)")
-		}
+		tests.SkipOnWindows("path separator bug (#TBD-path-sep-playlists)")
 		mockLibRepo = &tests.MockLibraryRepo{}
 		ds = &tests.MockDataStore{
 			MockedLibrary: mockLibRepo,
@@ -200,9 +197,7 @@ var _ = Describe("pathResolver", func() {
 	ctx := context.Background()
 
 	BeforeEach(func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: path separator bug (#TBD-path-sep-playlists)")
-		}
+		tests.SkipOnWindows("path separator bug (#TBD-path-sep-playlists)")
 		mockLibRepo = &tests.MockLibraryRepo{}
 		ds = &tests.MockDataStore{
 			MockedLibrary: mockLibRepo,

--- a/core/playlists/parse_m3u_test.go
+++ b/core/playlists/parse_m3u_test.go
@@ -2,6 +2,7 @@ package playlists
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
@@ -15,6 +16,9 @@ var _ = Describe("libraryMatcher", func() {
 	ctx := context.Background()
 
 	BeforeEach(func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: path separator bug (#TBD-path-sep-playlists)")
+		}
 		mockLibRepo = &tests.MockLibraryRepo{}
 		ds = &tests.MockDataStore{
 			MockedLibrary: mockLibRepo,
@@ -196,6 +200,9 @@ var _ = Describe("pathResolver", func() {
 	ctx := context.Background()
 
 	BeforeEach(func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: path separator bug (#TBD-path-sep-playlists)")
+		}
 		mockLibRepo = &tests.MockLibraryRepo{}
 		ds = &tests.MockDataStore{
 			MockedLibrary: mockLibRepo,

--- a/core/storage/local/local_test.go
+++ b/core/storage/local/local_test.go
@@ -44,6 +44,12 @@ var _ = Describe("LocalStorage", func() {
 	})
 
 	Describe("newLocalStorage", func() {
+		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
+			}
+		})
+
 		Context("with valid path", func() {
 			It("should create a localStorage instance with correct path", func() {
 				u, err := url.Parse("file://" + tempDir)
@@ -166,6 +172,12 @@ var _ = Describe("LocalStorage", func() {
 	})
 
 	Describe("localStorage.FS", func() {
+		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
+			}
+		})
+
 		Context("with existing directory", func() {
 			It("should return a localFS instance", func() {
 				u, err := url.Parse("file://" + tempDir)
@@ -199,6 +211,9 @@ var _ = Describe("LocalStorage", func() {
 		var testFile string
 
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
+			}
 			// Create a test file
 			testFile = filepath.Join(tempDir, "test.mp3")
 			err := os.WriteFile(testFile, []byte("test data"), 0600)
@@ -380,6 +395,9 @@ var _ = Describe("LocalStorage", func() {
 
 	Describe("Storage registration", func() {
 		It("should register localStorage for file scheme", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
+			}
 			// This tests the init() function indirectly
 			storage, err := storage.For("file://" + tempDir)
 			Expect(err).ToNot(HaveOccurred())

--- a/core/storage/local/local_test.go
+++ b/core/storage/local/local_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/storage"
 	"github.com/navidrome/navidrome/model/metadata"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -45,9 +46,7 @@ var _ = Describe("LocalStorage", func() {
 
 	Describe("newLocalStorage", func() {
 		BeforeEach(func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-storage-local)")
 		})
 
 		Context("with valid path", func() {
@@ -173,9 +172,7 @@ var _ = Describe("LocalStorage", func() {
 
 	Describe("localStorage.FS", func() {
 		BeforeEach(func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-storage-local)")
 		})
 
 		Context("with existing directory", func() {
@@ -211,9 +208,7 @@ var _ = Describe("LocalStorage", func() {
 		var testFile string
 
 		BeforeEach(func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-storage-local)")
 			// Create a test file
 			testFile = filepath.Join(tempDir, "test.mp3")
 			err := os.WriteFile(testFile, []byte("test data"), 0600)
@@ -395,9 +390,7 @@ var _ = Describe("LocalStorage", func() {
 
 	Describe("Storage registration", func() {
 		It("should register localStorage for file scheme", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage-local)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-storage-local)")
 			// This tests the init() function indirectly
 			storage, err := storage.For("file://" + tempDir)
 			Expect(err).ToNot(HaveOccurred())

--- a/core/storage/storage_test.go
+++ b/core/storage/storage_test.go
@@ -4,9 +4,9 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -55,9 +55,7 @@ var _ = Describe("Storage", func() {
 			Expect(s.(*fakeLocalStorage).u.Path).To(Equal("/tmp"))
 		})
 		It("should return a file implementation for a relative folder", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-storage)")
 			s, err := For("tmp")
 			Expect(err).ToNot(HaveOccurred())
 			cwd, _ := os.Getwd()

--- a/core/storage/storage_test.go
+++ b/core/storage/storage_test.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -54,6 +55,9 @@ var _ = Describe("Storage", func() {
 			Expect(s.(*fakeLocalStorage).u.Path).To(Equal("/tmp"))
 		})
 		It("should return a file implementation for a relative folder", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-storage)")
+			}
 			s, err := For("tmp")
 			Expect(err).ToNot(HaveOccurred())
 			cwd, _ := os.Getwd()

--- a/model/folder_test.go
+++ b/model/folder_test.go
@@ -3,6 +3,7 @@ package model_test
 import (
 	"path"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/model"
@@ -66,6 +67,9 @@ var _ = Describe("Folder", func() {
 
 		When("the folder has multiple subdirs", func() {
 			It("should return the correct folder ID", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
+				}
 				folderPath := filepath.FromSlash("/music/rock/metal")
 				expectedID := id.NewHash("1:rock/metal")
 				Expect(model.FolderID(lib, folderPath)).To(Equal(expectedID))
@@ -75,6 +79,9 @@ var _ = Describe("Folder", func() {
 
 	Describe("NewFolder", func() {
 		It("should create a new SubFolder with the correct attributes", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
+			}
 			folderPath := filepath.FromSlash("rock/metal")
 			folder := model.NewFolder(lib, folderPath)
 

--- a/model/folder_test.go
+++ b/model/folder_test.go
@@ -3,11 +3,11 @@ package model_test
 import (
 	"path"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -67,9 +67,7 @@ var _ = Describe("Folder", func() {
 
 		When("the folder has multiple subdirs", func() {
 			It("should return the correct folder ID", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
-				}
+				tests.SkipOnWindows("path separator bug (#TBD-path-sep-model)")
 				folderPath := filepath.FromSlash("/music/rock/metal")
 				expectedID := id.NewHash("1:rock/metal")
 				Expect(model.FolderID(lib, folderPath)).To(Equal(expectedID))
@@ -79,9 +77,7 @@ var _ = Describe("Folder", func() {
 
 	Describe("NewFolder", func() {
 		It("should create a new SubFolder with the correct attributes", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-model)")
 			folderPath := filepath.FromSlash("rock/metal")
 			folder := model.NewFolder(lib, folderPath)
 

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -1,12 +1,12 @@
 package model_test
 
 import (
-	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	. "github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -448,8 +448,8 @@ var _ = Describe("MediaFiles", func() {
 
 			DescribeTable("generates correct output",
 				func(absolutePaths bool, expectedContent string) {
-					if runtime.GOOS == "windows" && absolutePaths {
-						Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
+					if absolutePaths {
+						tests.SkipOnWindows("path separator bug (#TBD-path-sep-model)")
 					}
 					result := mfs.ToM3U8("Multi Track", absolutePaths)
 					Expect(result).To(Equal(expectedContent))
@@ -471,9 +471,7 @@ var _ = Describe("MediaFiles", func() {
 
 		Context("path variations", func() {
 			It("handles different path structures", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
-				}
+				tests.SkipOnWindows("path separator bug (#TBD-path-sep-model)")
 				mfs = MediaFiles{
 					{Title: "Root", Artist: "Artist", Duration: 60, Path: "song.mp3", LibraryPath: "/lib"},
 					{Title: "Nested", Artist: "Artist", Duration: 60, Path: "deep/nested/song.mp3", LibraryPath: "/lib"},

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -1,6 +1,7 @@
 package model_test
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -447,6 +448,9 @@ var _ = Describe("MediaFiles", func() {
 
 			DescribeTable("generates correct output",
 				func(absolutePaths bool, expectedContent string) {
+					if runtime.GOOS == "windows" && absolutePaths {
+						Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
+					}
 					result := mfs.ToM3U8("Multi Track", absolutePaths)
 					Expect(result).To(Equal(expectedContent))
 				},
@@ -467,6 +471,9 @@ var _ = Describe("MediaFiles", func() {
 
 		Context("path variations", func() {
 			It("handles different path structures", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
+				}
 				mfs = MediaFiles{
 					{Title: "Root", Artist: "Artist", Duration: 60, Path: "song.mp3", LibraryPath: "/lib"},
 					{Title: "Nested", Artist: "Artist", Duration: 60, Path: "deep/nested/song.mp3", LibraryPath: "/lib"},

--- a/model/metadata/map_mediafile_test.go
+++ b/model/metadata/map_mediafile_test.go
@@ -3,6 +3,7 @@ package metadata_test
 import (
 	"encoding/json"
 	"os"
+	"runtime"
 	"sort"
 
 	"github.com/navidrome/navidrome/model"
@@ -21,6 +22,9 @@ var _ = Describe("ToMediaFile", func() {
 	)
 
 	BeforeEach(func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: flaky on Windows (#TBD-flake-metadata-tempfile)")
+		}
 		_, filePath, _ := tests.TempFile(GinkgoT(), "test", ".mp3")
 		fileInfo, _ := os.Stat(filePath)
 		props = metadata.Info{

--- a/model/metadata/map_mediafile_test.go
+++ b/model/metadata/map_mediafile_test.go
@@ -3,7 +3,6 @@ package metadata_test
 import (
 	"encoding/json"
 	"os"
-	"runtime"
 	"sort"
 
 	"github.com/navidrome/navidrome/model"
@@ -22,9 +21,6 @@ var _ = Describe("ToMediaFile", func() {
 	)
 
 	BeforeEach(func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: flaky on Windows (#TBD-flake-metadata-tempfile)")
-		}
 		_, filePath, _ := tests.TempFile(GinkgoT(), "test", ".mp3")
 		fileInfo, _ := os.Stat(filePath)
 		props = metadata.Info{

--- a/model/metadata/map_participants_test.go
+++ b/model/metadata/map_participants_test.go
@@ -2,7 +2,6 @@ package metadata_test
 
 import (
 	"os"
-	"runtime"
 
 	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/consts"
@@ -24,9 +23,6 @@ var _ = Describe("Participants", func() {
 	)
 
 	BeforeEach(func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: flaky on Windows (#TBD-flake-metadata-tempfile)")
-		}
 		_, filePath, _ := tests.TempFile(GinkgoT(), "test", ".mp3")
 		fileInfo, _ := os.Stat(filePath)
 		mbid1 = uuid.NewString()

--- a/model/metadata/map_participants_test.go
+++ b/model/metadata/map_participants_test.go
@@ -2,6 +2,7 @@ package metadata_test
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/google/uuid"
 	"github.com/navidrome/navidrome/consts"
@@ -23,6 +24,9 @@ var _ = Describe("Participants", func() {
 	)
 
 	BeforeEach(func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: flaky on Windows (#TBD-flake-metadata-tempfile)")
+		}
 		_, filePath, _ := tests.TempFile(GinkgoT(), "test", ".mp3")
 		fileInfo, _ := os.Stat(filePath)
 		mbid1 = uuid.NewString()

--- a/model/metadata/persistent_ids_test.go
+++ b/model/metadata/persistent_ids_test.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"runtime"
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
@@ -79,6 +80,9 @@ var _ = Describe("getPID", func() {
 		})
 		When("field is folder", func() {
 			It("should return the pid", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path separator bug (#TBD-path-sep-metadata)")
+				}
 				spec := "folder|title"
 				md.tags = map[model.TagName][]string{"title": {"title"}}
 				mf.Path = "/path/to/file.mp3"

--- a/model/metadata/persistent_ids_test.go
+++ b/model/metadata/persistent_ids_test.go
@@ -1,12 +1,12 @@
 package metadata
 
 import (
-	"runtime"
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -80,9 +80,7 @@ var _ = Describe("getPID", func() {
 		})
 		When("field is folder", func() {
 			It("should return the pid", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path separator bug (#TBD-path-sep-metadata)")
-				}
+				tests.SkipOnWindows("path separator bug (#TBD-path-sep-metadata)")
 				spec := "folder|title"
 				md.tags = map[model.TagName][]string{"title": {"title"}}
 				mf.Path = "/path/to/file.mp3"

--- a/model/playlist_test.go
+++ b/model/playlist_test.go
@@ -1,6 +1,8 @@
 package model_test
 
 import (
+	"runtime"
+
 	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -27,6 +29,9 @@ var _ = Describe("Playlist", func() {
 			}
 		})
 		It("generates the correct M3U format", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
+			}
 			expected := `#EXTM3U
 #PLAYLIST:Mellow sunset
 #EXTINF:378,Morcheeba feat. Kurt Wagner - What New York Couples Fight About

--- a/model/playlist_test.go
+++ b/model/playlist_test.go
@@ -1,9 +1,8 @@
 package model_test
 
 import (
-	"runtime"
-
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -29,9 +28,7 @@ var _ = Describe("Playlist", func() {
 			}
 		})
 		It("generates the correct M3U format", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-model)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-model)")
 			expected := `#EXTM3U
 #PLAYLIST:Mellow sunset
 #EXTINF:378,Morcheeba feat. Kurt Wagner - What New York Couples Fight About

--- a/persistence/folder_repository_test.go
+++ b/persistence/folder_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -99,6 +100,9 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("includes all child folders when querying parent", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
+				}
 				// Create a parent folder with multiple children
 				parent := model.NewFolder(testLib, "TestParent/Music")
 				child1 := model.NewFolder(testLib, "TestParent/Music/Rock/Queen")
@@ -120,6 +124,9 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("excludes children from other libraries", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
+				}
 				// Create parent in testLib
 				parent := model.NewFolder(testLib, "TestIsolation/Parent")
 				child := model.NewFolder(testLib, "TestIsolation/Parent/Child")
@@ -145,6 +152,9 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("excludes missing children when querying parent", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
+				}
 				// Create parent and children, mark one as missing
 				parent := model.NewFolder(testLib, "TestMissingChild/Parent")
 				child1 := model.NewFolder(testLib, "TestMissingChild/Parent/Child1")
@@ -165,6 +175,9 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("handles mix of existing and non-existing target paths", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
+				}
 				// Create folders for one path but not the other
 				existingParent := model.NewFolder(testLib, "TestMixed/Exists")
 				existingChild := model.NewFolder(testLib, "TestMixed/Exists/Child")

--- a/persistence/folder_repository_test.go
+++ b/persistence/folder_repository_test.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime"
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/pocketbase/dbx"
@@ -100,9 +100,7 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("includes all child folders when querying parent", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
-				}
+				tests.SkipOnWindows("path storage (#TBD-path-sep-persistence)")
 				// Create a parent folder with multiple children
 				parent := model.NewFolder(testLib, "TestParent/Music")
 				child1 := model.NewFolder(testLib, "TestParent/Music/Rock/Queen")
@@ -124,9 +122,7 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("excludes children from other libraries", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
-				}
+				tests.SkipOnWindows("path storage (#TBD-path-sep-persistence)")
 				// Create parent in testLib
 				parent := model.NewFolder(testLib, "TestIsolation/Parent")
 				child := model.NewFolder(testLib, "TestIsolation/Parent/Child")
@@ -152,9 +148,7 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("excludes missing children when querying parent", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
-				}
+				tests.SkipOnWindows("path storage (#TBD-path-sep-persistence)")
 				// Create parent and children, mark one as missing
 				parent := model.NewFolder(testLib, "TestMissingChild/Parent")
 				child1 := model.NewFolder(testLib, "TestMissingChild/Parent/Child1")
@@ -175,9 +169,7 @@ var _ = Describe("FolderRepository", func() {
 			})
 
 			It("handles mix of existing and non-existing target paths", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path storage (#TBD-path-sep-persistence)")
-				}
+				tests.SkipOnWindows("path storage (#TBD-path-sep-persistence)")
 				// Create folders for one path but not the other
 				existingParent := model.NewFolder(testLib, "TestMixed/Exists")
 				existingChild := model.NewFolder(testLib, "TestMixed/Exists/Child")

--- a/persistence/library_repository_test.go
+++ b/persistence/library_repository_test.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -52,6 +53,9 @@ var _ = Describe("LibraryRepository", func() {
 
 		Context("when ID is non-zero and record exists", func() {
 			It("updates the existing record", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: flaky on Windows (#TBD-flake-persistence)")
+				}
 				// First create a library
 				lib := &model.Library{
 					ID:   0,

--- a/persistence/library_repository_test.go
+++ b/persistence/library_repository_test.go
@@ -2,7 +2,7 @@ package persistence
 
 import (
 	"context"
-	"runtime"
+	"time"
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -53,9 +53,6 @@ var _ = Describe("LibraryRepository", func() {
 
 		Context("when ID is non-zero and record exists", func() {
 			It("updates the existing record", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: flaky on Windows (#TBD-flake-persistence)")
-				}
 				// First create a library
 				lib := &model.Library{
 					ID:   0,
@@ -67,6 +64,11 @@ var _ = Describe("LibraryRepository", func() {
 
 				originalID := lib.ID
 				originalCreatedAt := lib.CreatedAt
+
+				// Ensure the update's timestamp is strictly greater than the
+				// create's timestamp on platforms with coarse clock resolution
+				// (Windows' time.Now() is millisecond-granular).
+				time.Sleep(2 * time.Millisecond)
 
 				// Now update it
 				lib.Name = "Updated Library"

--- a/plugins/config_validation_test.go
+++ b/plugins/config_validation_test.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package plugins
 
 import (

--- a/plugins/manager_loader_test.go
+++ b/plugins/manager_loader_test.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package plugins
 
 import (

--- a/plugins/manager_test.go
+++ b/plugins/manager_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package plugins
 
 import (

--- a/plugins/manager_watcher_test.go
+++ b/plugins/manager_watcher_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package plugins
 
 import (

--- a/plugins/metadata_agent_test.go
+++ b/plugins/metadata_agent_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package plugins
 
 import (

--- a/plugins/migrate_test.go
+++ b/plugins/migrate_test.go
@@ -1,5 +1,3 @@
-//go:build !windows
-
 package plugins
 
 import (

--- a/plugins/plugins_suite_windows_test.go
+++ b/plugins/plugins_suite_windows_test.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package plugins
+
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestPlugins(t *testing.T) {
+	tests.Init(t, false)
+	log.SetLevel(log.LevelFatal)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Plugins Suite")
+}
+
+var _ = BeforeEach(func() {
+	if true {
+		Skip("not supported on Windows: plugin runtime (#TBD-plugins-windows)")
+	}
+})

--- a/plugins/plugins_suite_windows_test.go
+++ b/plugins/plugins_suite_windows_test.go
@@ -11,15 +11,13 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// Runs the subset of plugin specs compiled on Windows (files without the
+// //go:build !windows tag): capabilities, manager_cache, manager_plugin,
+// manifest, package. WASM-runtime-dependent specs live in !windows-tagged
+// files and aren't reached here.
 func TestPlugins(t *testing.T) {
 	tests.Init(t, false)
 	log.SetLevel(log.LevelFatal)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Plugins Suite")
 }
-
-var _ = BeforeEach(func() {
-	if true {
-		Skip("not supported on Windows: plugin runtime (#TBD-plugins-windows)")
-	}
-})

--- a/scanner/phase_4_playlists_test.go
+++ b/scanner/phase_4_playlists_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 
 	"github.com/navidrome/navidrome/conf"
@@ -112,9 +111,7 @@ var _ = Describe("phasePlaylists", func() {
 		})
 
 		It("reports an error if there is an error reading files", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: relies on Unix /etc filesystem")
-			}
+			tests.SkipOnWindows("relies on Unix /etc filesystem")
 			progress := make(chan *ProgressInfo)
 			state.progress = progress
 			folder := &model.Folder{Path: "/invalid/path"}

--- a/scanner/phase_4_playlists_test.go
+++ b/scanner/phase_4_playlists_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 
 	"github.com/navidrome/navidrome/conf"
@@ -111,6 +112,9 @@ var _ = Describe("phasePlaylists", func() {
 		})
 
 		It("reports an error if there is an error reading files", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: relies on Unix /etc filesystem")
+			}
 			progress := make(chan *ProgressInfo)
 			state.progress = progress
 			folder := &model.Folder{Path: "/invalid/path"}

--- a/scanner/scanner_multilibrary_test.go
+++ b/scanner/scanner_multilibrary_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
-	"runtime"
 	"testing/fstest"
 	"time"
 
@@ -44,9 +43,7 @@ var _ = Describe("Scanner - Multi-Library", Ordered, func() {
 	}
 
 	BeforeAll(func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: SQLite file lock blocks TempDir cleanup (#TBD-path-sep-scanner)")
-		}
+		tests.SkipOnWindows("SQLite file lock blocks TempDir cleanup (#TBD-path-sep-scanner)")
 		ctx = request.WithUser(GinkgoT().Context(), model.User{ID: "123", IsAdmin: true})
 		tmpDir := GinkgoT().TempDir()
 		conf.Server.DbPath = filepath.Join(tmpDir, "test-scanner-multilibrary.db?_journal_mode=WAL")

--- a/scanner/scanner_multilibrary_test.go
+++ b/scanner/scanner_multilibrary_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"runtime"
 	"testing/fstest"
 	"time"
 
@@ -43,6 +44,9 @@ var _ = Describe("Scanner - Multi-Library", Ordered, func() {
 	}
 
 	BeforeAll(func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: SQLite file lock blocks TempDir cleanup (#TBD-path-sep-scanner)")
+		}
 		ctx = request.WithUser(GinkgoT().Context(), model.User{ID: "123", IsAdmin: true})
 		tmpDir := GinkgoT().TempDir()
 		conf.Server.DbPath = filepath.Join(tmpDir, "test-scanner-multilibrary.db?_journal_mode=WAL")

--- a/scanner/scanner_selective_test.go
+++ b/scanner/scanner_selective_test.go
@@ -39,6 +39,12 @@ var _ = Describe("ScanFolders", Ordered, func() {
 		conf.Server.DbPath = filepath.Join(tmpDir, "test-selective-scan.db?_journal_mode=WAL")
 		log.Warn("Using DB at " + conf.Server.DbPath)
 		db.Db().SetMaxOpenConns(1)
+		// Close the DB before Ginkgo's TempDir cleanup runs (LIFO). Required on
+		// Windows where open SQLite handles hold file locks that block removal;
+		// harmless on other OSes.
+		DeferCleanup(func() {
+			db.Close(ctx)
+		})
 	})
 
 	BeforeEach(func() {

--- a/scanner/scanner_selective_test.go
+++ b/scanner/scanner_selective_test.go
@@ -3,7 +3,6 @@ package scanner_test
 import (
 	"context"
 	"path/filepath"
-	"runtime"
 	"testing/fstest"
 
 	"github.com/Masterminds/squirrel"
@@ -35,9 +34,7 @@ var _ = Describe("ScanFolders", Ordered, func() {
 	var fsys storagetest.FakeFS
 
 	BeforeAll(func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: SQLite file lock blocks TempDir cleanup (#TBD-path-sep-scanner)")
-		}
+		tests.SkipOnWindows("SQLite file lock blocks TempDir cleanup (#TBD-path-sep-scanner)")
 		ctx = request.WithUser(GinkgoT().Context(), model.User{ID: "123", IsAdmin: true})
 		tmpDir := GinkgoT().TempDir()
 		conf.Server.DbPath = filepath.Join(tmpDir, "test-selective-scan.db?_journal_mode=WAL")

--- a/scanner/scanner_selective_test.go
+++ b/scanner/scanner_selective_test.go
@@ -3,6 +3,7 @@ package scanner_test
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"testing/fstest"
 
 	"github.com/Masterminds/squirrel"
@@ -34,17 +35,14 @@ var _ = Describe("ScanFolders", Ordered, func() {
 	var fsys storagetest.FakeFS
 
 	BeforeAll(func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: SQLite file lock blocks TempDir cleanup (#TBD-path-sep-scanner)")
+		}
 		ctx = request.WithUser(GinkgoT().Context(), model.User{ID: "123", IsAdmin: true})
 		tmpDir := GinkgoT().TempDir()
 		conf.Server.DbPath = filepath.Join(tmpDir, "test-selective-scan.db?_journal_mode=WAL")
 		log.Warn("Using DB at " + conf.Server.DbPath)
 		db.Db().SetMaxOpenConns(1)
-		// Close the DB before Ginkgo's TempDir cleanup runs (LIFO). Required on
-		// Windows where open SQLite handles hold file locks that block removal;
-		// harmless on other OSes.
-		DeferCleanup(func() {
-			db.Close(ctx)
-		})
 	})
 
 	BeforeEach(func() {

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -879,6 +879,9 @@ var _ = Describe("Scanner", Ordered, func() {
 		})
 
 		It("should update artist stats during quick scans when new albums are added", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+			}
 			// Don't use the mocked artist repo for this test - we need the real one
 			ds.MockedArtist = nil
 

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
-	"runtime"
 	"testing/fstest"
 
 	"github.com/Masterminds/squirrel"
@@ -169,9 +168,7 @@ var _ = Describe("Scanner", Ordered, func() {
 			})
 
 			It("should update the album", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-				}
+				tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 				Expect(runScanner(ctx, true)).To(Succeed())
 
 				albums, err := ds.Album(ctx).GetAll(model.QueryOptions{Filters: squirrel.Eq{"album.name": "Help!"}})
@@ -272,9 +269,7 @@ var _ = Describe("Scanner", Ordered, func() {
 		var beatlesMBID = uuid.NewString()
 
 		BeforeEach(func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 			By("Having two MP3 albums")
 			beatles := _t{
 				"artist":               "The Beatles",
@@ -879,9 +874,7 @@ var _ = Describe("Scanner", Ordered, func() {
 		})
 
 		It("should update artist stats during quick scans when new albums are added", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 			// Don't use the mocked artist repo for this test - we need the real one
 			ds.MockedArtist = nil
 

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -272,6 +272,9 @@ var _ = Describe("Scanner", Ordered, func() {
 		var beatlesMBID = uuid.NewString()
 
 		BeforeEach(func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+			}
 			By("Having two MP3 albums")
 			beatles := _t{
 				"artist":               "The Beatles",
@@ -338,9 +341,6 @@ var _ = Describe("Scanner", Ordered, func() {
 		})
 
 		It("detects a file was moved to a different folder", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-			}
 			By("Storing the original ID")
 			original, err := findByPath("The Beatles/Revolver/02 - Eleanor Rigby.mp3")
 			Expect(err).ToNot(HaveOccurred())
@@ -400,9 +400,6 @@ var _ = Describe("Scanner", Ordered, func() {
 		})
 
 		It("detects file format upgrades", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-			}
 			By("Storing the original ID")
 			original, err := findByPath("The Beatles/Revolver/02 - Eleanor Rigby.mp3")
 			Expect(err).ToNot(HaveOccurred())

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path/filepath"
+	"runtime"
 	"testing/fstest"
 
 	"github.com/Masterminds/squirrel"
@@ -393,6 +394,9 @@ var _ = Describe("Scanner", Ordered, func() {
 		})
 
 		It("detects file format upgrades", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+			}
 			By("Storing the original ID")
 			original, err := findByPath("The Beatles/Revolver/02 - Eleanor Rigby.mp3")
 			Expect(err).ToNot(HaveOccurred())

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -338,6 +338,9 @@ var _ = Describe("Scanner", Ordered, func() {
 		})
 
 		It("detects a file was moved to a different folder", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+			}
 			By("Storing the original ID")
 			original, err := findByPath("The Beatles/Revolver/02 - Eleanor Rigby.mp3")
 			Expect(err).ToNot(HaveOccurred())

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -169,6 +169,9 @@ var _ = Describe("Scanner", Ordered, func() {
 			})
 
 			It("should update the album", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+				}
 				Expect(runScanner(ctx, true)).To(Succeed())
 
 				albums, err := ds.Album(ctx).GetAll(model.QueryOptions{Filters: squirrel.Eq{"album.name": "Help!"}})

--- a/scanner/walk_dir_tree_test.go
+++ b/scanner/walk_dir_tree_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing/fstest"
 
 	"github.com/navidrome/navidrome/conf"
@@ -229,6 +230,9 @@ var _ = Describe("walk_dir_tree", func() {
 
 			Context("with symlinks enabled", func() {
 				BeforeEach(func() {
+					if runtime.GOOS == "windows" {
+						Skip("not supported on Windows: symlink semantics")
+					}
 					conf.Server.Scanner.FollowSymlinks = true
 				})
 

--- a/scanner/walk_dir_tree_test.go
+++ b/scanner/walk_dir_tree_test.go
@@ -6,13 +6,13 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing/fstest"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core/storage"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"golang.org/x/sync/errgroup"
@@ -230,9 +230,7 @@ var _ = Describe("walk_dir_tree", func() {
 
 			Context("with symlinks enabled", func() {
 				BeforeEach(func() {
-					if runtime.GOOS == "windows" {
-						Skip("not supported on Windows: symlink semantics")
-					}
+					tests.SkipOnWindows("symlink semantics")
 					conf.Server.Scanner.FollowSymlinks = true
 				})
 

--- a/scanner/watcher_test.go
+++ b/scanner/watcher_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io/fs"
 	"path/filepath"
-	"runtime"
 	"testing/fstest"
 	"time"
 
@@ -390,9 +389,7 @@ var _ = Describe("Watcher", func() {
 			})
 
 			It("should NOT send notification when nested ignored folder is deleted", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-				}
+				tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 				startEventProcessing()
 
 				// Simulate deletion of music/rock/artist/temp (matches **/temp)
@@ -406,9 +403,7 @@ var _ = Describe("Watcher", func() {
 			})
 
 			It("should send notification for non-ignored nested folder", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-				}
+				tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 				startEventProcessing()
 
 				// Simulate change in music/rock/artist (doesn't match any pattern)
@@ -433,9 +428,7 @@ var _ = Describe("Watcher", func() {
 			})
 
 			It("should NOT send notification for file changes in ignored folders", func() {
-				if runtime.GOOS == "windows" {
-					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-				}
+				tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 				startEventProcessing()
 
 				// Simulate file change in rock/_TEMP/file.mp3
@@ -474,17 +467,13 @@ var _ = Describe("resolveFolderPath", func() {
 	})
 
 	It("walks up to parent directory when given a file path", func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-		}
+		tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 		result := resolveFolderPath(mockFS, "artist1/album1/track1.mp3")
 		Expect(result).To(Equal("artist1/album1"))
 	})
 
 	It("walks up multiple levels if needed", func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-		}
+		tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 		result := resolveFolderPath(mockFS, "artist1/album1/nonexistent/file.mp3")
 		Expect(result).To(Equal("artist1/album1"))
 	})
@@ -505,9 +494,7 @@ var _ = Describe("resolveFolderPath", func() {
 	})
 
 	It("handles nested file paths correctly", func() {
-		if runtime.GOOS == "windows" {
-			Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
-		}
+		tests.SkipOnWindows("path separator bug (#TBD-path-sep-scanner)")
 		result := resolveFolderPath(mockFS, "artist1/album2/song.flac")
 		Expect(result).To(Equal("artist1/album2"))
 	})

--- a/scanner/watcher_test.go
+++ b/scanner/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io/fs"
 	"path/filepath"
+	"runtime"
 	"testing/fstest"
 	"time"
 
@@ -389,6 +390,9 @@ var _ = Describe("Watcher", func() {
 			})
 
 			It("should NOT send notification when nested ignored folder is deleted", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+				}
 				startEventProcessing()
 
 				// Simulate deletion of music/rock/artist/temp (matches **/temp)
@@ -402,6 +406,9 @@ var _ = Describe("Watcher", func() {
 			})
 
 			It("should send notification for non-ignored nested folder", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+				}
 				startEventProcessing()
 
 				// Simulate change in music/rock/artist (doesn't match any pattern)
@@ -426,6 +433,9 @@ var _ = Describe("Watcher", func() {
 			})
 
 			It("should NOT send notification for file changes in ignored folders", func() {
+				if runtime.GOOS == "windows" {
+					Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+				}
 				startEventProcessing()
 
 				// Simulate file change in rock/_TEMP/file.mp3
@@ -464,11 +474,17 @@ var _ = Describe("resolveFolderPath", func() {
 	})
 
 	It("walks up to parent directory when given a file path", func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+		}
 		result := resolveFolderPath(mockFS, "artist1/album1/track1.mp3")
 		Expect(result).To(Equal("artist1/album1"))
 	})
 
 	It("walks up multiple levels if needed", func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+		}
 		result := resolveFolderPath(mockFS, "artist1/album1/nonexistent/file.mp3")
 		Expect(result).To(Equal("artist1/album1"))
 	})
@@ -489,6 +505,9 @@ var _ = Describe("resolveFolderPath", func() {
 	})
 
 	It("handles nested file paths correctly", func() {
+		if runtime.GOOS == "windows" {
+			Skip("not supported on Windows: path separator bug (#TBD-path-sep-scanner)")
+		}
 		result := resolveFolderPath(mockFS, "artist1/album2/song.flac")
 		Expect(result).To(Equal("artist1/album2"))
 	})

--- a/server/e2e/e2e_suite_test.go
+++ b/server/e2e/e2e_suite_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -418,6 +419,14 @@ var (
 var _ = BeforeSuite(func() {
 	ctx = request.WithUser(GinkgoT().Context(), adminUser)
 	tmpDir := GinkgoT().TempDir()
+	// On Windows, SQLite holds file locks that prevent temp-dir cleanup.
+	// Register a DeferCleanup (runs in LIFO before the TempDir cleanup) to
+	// close the DB explicitly so the files can be deleted.
+	if runtime.GOOS == "windows" {
+		DeferCleanup(func() {
+			db.Close(GinkgoT().Context())
+		})
+	}
 	dbFilePath = filepath.Join(tmpDir, "test-e2e.db")
 	snapshotPath = filepath.Join(tmpDir, "test-e2e.db.snapshot")
 	conf.Server.DbPath = dbFilePath + "?_journal_mode=WAL"

--- a/server/e2e/e2e_suite_test.go
+++ b/server/e2e/e2e_suite_test.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -419,14 +418,6 @@ var (
 var _ = BeforeSuite(func() {
 	ctx = request.WithUser(GinkgoT().Context(), adminUser)
 	tmpDir := GinkgoT().TempDir()
-	// On Windows, SQLite holds file locks that prevent temp-dir cleanup.
-	// Register a DeferCleanup (runs in LIFO before the TempDir cleanup) to
-	// close the DB explicitly so the files can be deleted.
-	if runtime.GOOS == "windows" {
-		DeferCleanup(func() {
-			db.Close(GinkgoT().Context())
-		})
-	}
 	dbFilePath = filepath.Join(tmpDir, "test-e2e.db")
 	snapshotPath = filepath.Join(tmpDir, "test-e2e.db.snapshot")
 	conf.Server.DbPath = dbFilePath + "?_journal_mode=WAL"
@@ -477,6 +468,13 @@ var _ = BeforeSuite(func() {
 	data, err := os.ReadFile(dbFilePath)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(os.WriteFile(snapshotPath, data, 0600)).To(Succeed())
+})
+
+// Close the database before the suite's TempDir cleanup runs. Required on
+// Windows where open SQLite handles hold file locks that block temp-dir
+// removal; harmless on other OSes.
+var _ = AfterSuite(func() {
+	db.Close(ctx)
 })
 
 // setupTestDB restores the database from the golden snapshot and creates the

--- a/server/nativeapi/translations_test.go
+++ b/server/nativeapi/translations_test.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/resources"
@@ -16,6 +17,9 @@ import (
 var _ = Describe("Translations", func() {
 	Describe("I18n files", func() {
 		It("contains only valid json language files", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: path separator bug (#TBD-path-sep-nativeapi)")
+			}
 			fsys := resources.FS()
 			dir, _ := fsys.Open(consts.I18nFolder)
 			files, _ := dir.(fs.ReadDirFile).ReadDir(-1)

--- a/server/nativeapi/translations_test.go
+++ b/server/nativeapi/translations_test.go
@@ -6,10 +6,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/resources"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -17,9 +17,7 @@ import (
 var _ = Describe("Translations", func() {
 	Describe("I18n files", func() {
 		It("contains only valid json language files", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: path separator bug (#TBD-path-sep-nativeapi)")
-			}
+			tests.SkipOnWindows("path separator bug (#TBD-path-sep-nativeapi)")
 			fsys := resources.FS()
 			dir, _ := fsys.Open(consts.I18nFolder)
 			files, _ := dir.(fs.ReadDirFile).ReadDir(-1)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -30,6 +31,9 @@ var _ = Describe("createUnixSocketFile", func() {
 
 	When("unixSocketPerm is valid", func() {
 		It("updates the permission of the unix socket file and returns nil", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: uses Unix file permission bits")
+			}
 			_, err := createUnixSocketFile(socketPath, "0777")
 			fileInfo, _ := os.Stat(socketPath)
 			actualPermission := fileInfo.Mode().Perm()
@@ -50,6 +54,9 @@ var _ = Describe("createUnixSocketFile", func() {
 
 	When("file already exists", func() {
 		It("recreates the file as a socket with the right permissions", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: uses Unix file permission bits")
+			}
 			_, err := os.Create(socketPath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(os.Chmod(socketPath, os.FileMode(0777))).To(Succeed())

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -31,9 +30,7 @@ var _ = Describe("createUnixSocketFile", func() {
 
 	When("unixSocketPerm is valid", func() {
 		It("updates the permission of the unix socket file and returns nil", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: uses Unix file permission bits")
-			}
+			tests.SkipOnWindows("uses Unix file permission bits")
 			_, err := createUnixSocketFile(socketPath, "0777")
 			fileInfo, _ := os.Stat(socketPath)
 			actualPermission := fileInfo.Mode().Perm()
@@ -54,9 +51,7 @@ var _ = Describe("createUnixSocketFile", func() {
 
 	When("file already exists", func() {
 		It("recreates the file as a socket with the right permissions", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: uses Unix file permission bits")
-			}
+			tests.SkipOnWindows("uses Unix file permission bits")
 			_, err := os.Create(socketPath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(os.Chmod(socketPath, os.FileMode(0777))).To(Succeed())

--- a/server/subsonic/media_annotation_test.go
+++ b/server/subsonic/media_annotation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/core/scrobbler"
@@ -32,6 +33,9 @@ var _ = Describe("MediaAnnotationController", func() {
 
 	Describe("Scrobble", func() {
 		It("submit all scrobbles with only the id", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: flaky on Windows (#TBD-flake-time-resolution-subsonic)")
+			}
 			submissionTime := time.Now()
 			r := newGetRequest("id=12", "id=34")
 

--- a/server/subsonic/media_annotation_test.go
+++ b/server/subsonic/media_annotation_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"runtime"
 	"time"
 
 	"github.com/navidrome/navidrome/core/scrobbler"
@@ -33,10 +32,9 @@ var _ = Describe("MediaAnnotationController", func() {
 
 	Describe("Scrobble", func() {
 		It("submit all scrobbles with only the id", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: flaky on Windows (#TBD-flake-time-resolution-subsonic)")
-			}
-			submissionTime := time.Now()
+			// Back-date the baseline so the assertion still passes on platforms
+			// with millisecond clock resolution (e.g. Windows).
+			submissionTime := time.Now().Add(-time.Second)
 			r := newGetRequest("id=12", "id=34")
 
 			_, err := router.Scrobble(r)

--- a/tests/test_helpers.go
+++ b/tests/test_helpers.go
@@ -4,13 +4,24 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/navidrome/navidrome/db"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model/id"
+	"github.com/onsi/ginkgo/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 )
+
+// SkipOnWindows marks the current spec (or surrounding BeforeEach) as skipped
+// when running on Windows. The reason is included in the Ginkgo output so the
+// backlog of Windows-skipped tests stays auditable.
+func SkipOnWindows(reason string) {
+	if runtime.GOOS == "windows" {
+		ginkgo.Skip("not supported on Windows: " + reason)
+	}
+}
 
 type testingT interface {
 	TempDir() string

--- a/tests/test_helpers.go
+++ b/tests/test_helpers.go
@@ -20,10 +20,20 @@ func TempFileName(t testingT, prefix, suffix string) string {
 	return filepath.Join(t.TempDir(), prefix+id.NewRandom()+suffix)
 }
 
+// TempFile creates an empty file in t.TempDir() and returns the closed handle.
+// The handle is returned for backward compatibility, but is already closed so
+// callers don't need to. On Windows, leaving the handle open would hold a file
+// lock and block Ginkgo's TempDir cleanup.
 func TempFile(t testingT, prefix, suffix string) (*os.File, string, error) {
 	name := TempFileName(t, prefix, suffix)
 	f, err := os.Create(name)
-	return f, name, err
+	if err != nil {
+		return nil, name, err
+	}
+	if cerr := f.Close(); cerr != nil {
+		return f, name, cerr
+	}
+	return f, name, nil
 }
 
 // ClearDB deletes all tables and data from the database

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -3,7 +3,6 @@ package utils_test
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"github.com/navidrome/navidrome/utils"
@@ -190,12 +189,13 @@ var _ = Describe("FileExists", func() {
 
 	Context("when file is deleted after creation", func() {
 		It("returns false after file deletion", func() {
-			if runtime.GOOS == "windows" {
-				Skip("not supported on Windows: flaky on Windows (#TBD-flake-utils)")
-			}
 			filePath := tempFile.Name()
 			Expect(utils.FileExists(filePath)).To(BeTrue())
 
+			// Close the file before removing it. On Windows, an open handle
+			// holds a file lock and os.Remove fails; closing first makes the
+			// test cross-platform.
+			Expect(tempFile.Close()).To(Succeed())
 			err := os.Remove(filePath)
 			Expect(err).NotTo(HaveOccurred())
 			tempFile = nil // Prevent cleanup attempt

--- a/utils/files_test.go
+++ b/utils/files_test.go
@@ -3,6 +3,7 @@ package utils_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/navidrome/navidrome/utils"
@@ -189,6 +190,9 @@ var _ = Describe("FileExists", func() {
 
 	Context("when file is deleted after creation", func() {
 		It("returns false after file deletion", func() {
+			if runtime.GOOS == "windows" {
+				Skip("not supported on Windows: flaky on Windows (#TBD-flake-utils)")
+			}
 			filePath := tempFile.Name()
 			Expect(utils.FileExists(filePath)).To(BeTrue())
 


### PR DESCRIPTION
## Summary

- Adds a new `go-windows` job to the CI pipeline running the full Go test suite on `windows-2022`.
- Installs gcc via `msys2/setup-msys2` for CGO (required by `mattn/go-sqlite3` with FTS5).
- Downloads ffmpeg from `navidrome/ffmpeg-windows-builds`, matching the version used by `release/wix/build_msi.sh` (`FFMPEG_VERSION=7.1`).
- Introduces a `tests.SkipOnWindows(reason)` helper so Windows-incompatible specs become a single-line skip instead of a 3-line `runtime.GOOS == "windows"` guard.
- Skips tests that aren't Windows-compatible; each skip carries a short reason and (when applicable) a `#TBD-*` slug tracked in #5381.
- `go-windows` is part of `build.needs` — a Windows test failure now blocks the release pipeline.

## Nature of the skipped tests

**No production-code changes in this PR.** The tests that fail on Windows fall into these buckets:

- **Test-side path handling** — tests that hardcode forward-slash expected strings or feed forward-slash keys into `fstest.MapFS`/embedded-FS while the test itself uses `filepath.Join`/`Rel`/`Split` (which return backslashes on Windows). The production code handles OS-native paths correctly; these are assertion/fixture issues in the tests themselves.
- **Runtime gaps** — WASM plugin subprocess tests that can't run on the hosted Windows runner (the `plugins/` package's WASM test plugins are built by `make -C plugins/testdata` which needs a Unix toolchain); mpv tests that use Unix-only mock scripts.
- **Permanent Unix-only** — POSIX perms, symlinks, `/etc/*`, `/tmp` literals, Unix-domain-socket tests.

None of these are user-facing bugs. The value of this PR is the **ongoing Windows signal** in CI so future real regressions are caught promptly.

## Cross-platform fixes applied (not just skips)

During review, four flakes originally skipped on Windows were fixed properly instead:

- `server/subsonic/media_annotation_test.go` — back-dated the `time.Now()` baseline so `BeTemporally(">")` works under millisecond clock resolution.
- `persistence/library_repository_test.go` — brief sleep between `Put` calls so `UpdatedAt > CreatedAt` on low-resolution clocks.
- `utils/files_test.go` — close `tempFile` before `os.Remove` so an open-handle doesn't hold a Windows file lock.
- `tests.TempFile` helper — closes the returned file handle before returning; both callers benefit, ~60 metadata tests re-enabled.

Also, three plugin test files (`config_validation_test.go`, `manager_loader_test.go`, `migrate_test.go`) that had `//go:build !windows` but no WASM/exec/testdata dependency were un-tagged and now run on Windows.

## Coverage on Windows

From the final green Windows run:

- **~3,700 tests passing** on Windows.
- **52 spec-level skips** remaining (≈1.4% of suite) via the new `tests.SkipOnWindows` helper (+ 1 `runtime.GOOS == "windows"` check in `core/ffmpeg/ffmpeg_test.go` that can't use the helper due to an import cycle).
- **18 plugin test files** remain under `//go:build !windows` — they depend on WASM test plugins built by a Unix-only `make` invocation.
- **11 unique `#TBD-*` tracking slugs** remain (10 × test-side path handling, 1 × mpv Windows mock). Tracked in #5381. No `#TBD-flake-*` slugs — all four flakes were fixed during review.

## Testing

- `go-windows` job green on three soak runs before flipping the required flag.
- `go-windows` green on the post-soak blocking-mode commit.
- Existing `go:` (Linux) job still green (the cross-platform test fixes above were verified on macOS locally and Linux in CI).
- Release-pipeline matrix still produces all platform binaries.

Tracking issue: #5381.

## Notes

- `-race` is NOT run on Windows (Linux job already exercises race coverage; adding `-race` on Windows would require a CGO race-aware build).
- Runner pinned to `windows-2022`.
- ffmpeg version pinned via env vars at the top of the job — bump alongside `release/wix/build_msi.sh` when updating ffmpeg.
- Two scanner suites (`ScanFolders`, `Scanner - Multi-Library`) are skipped wholesale on Windows because their `BeforeAll` uses `GinkgoT().TempDir()` + a shared SQLite DB handle; on Windows the DB file lock blocks Ginkgo's TempDir cleanup. `server/e2e` got an explicit `AfterSuite(db.Close)` instead (that suite owns its own DB binary).
