### PR TITLE
Add outbound proxy support for HTTP clients

### DIFF
--- a/adapters/deezer/deezer.go
+++ b/adapters/deezer/deezer.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
@@ -13,6 +12,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/slice"
 )
 
@@ -34,9 +34,7 @@ func deezerConstructor(dataStore model.DataStore) agents.Interface {
 		dataStore: dataStore,
 		languages: conf.Server.Deezer.Languages,
 	}
-	httpClient := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	httpClient := httpclient.New()
 	cachedHttpClient := cache.NewHTTPClient(httpClient, consts.DefaultHttpClientTimeOut)
 	agent.client = newClient(cachedHttpClient)
 	return agent

--- a/adapters/lastfm/agent.go
+++ b/adapters/lastfm/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"golang.org/x/net/html"
 )
 
@@ -59,9 +60,7 @@ func lastFMConstructor(ds model.DataStore) *lastfmAgent {
 		secret:      conf.Server.LastFM.Secret,
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 	}
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New()
 	chc := cache.NewHTTPClient(hc, consts.DefaultHttpClientTimeOut)
 	l.httpClient = chc
 	l.client = newClient(l.apiKey, l.secret, chc)

--- a/adapters/lastfm/auth_router.go
+++ b/adapters/lastfm/auth_router.go
@@ -12,12 +12,12 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/navidrome/navidrome/conf"
-	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/agents"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/req"
 )
 
@@ -41,9 +41,7 @@ func NewRouter(ds model.DataStore) *Router {
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 	}
 	r.Handler = r.routes()
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New()
 	r.client = newClient(r.apiKey, r.secret, hc)
 	return r
 }

--- a/adapters/listenbrainz/agent.go
+++ b/adapters/listenbrainz/agent.go
@@ -3,7 +3,6 @@ package listenbrainz
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
@@ -12,6 +11,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/slice"
 )
 
@@ -33,9 +33,7 @@ func listenBrainzConstructor(ds model.DataStore) *listenBrainzAgent {
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 		baseURL:     conf.Server.ListenBrainz.BaseURL,
 	}
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New()
 	chc := cache.NewHTTPClient(hc, consts.DefaultHttpClientTimeOut)
 	l.client = newClient(l.baseURL, chc)
 	return l

--- a/adapters/listenbrainz/auth_router.go
+++ b/adapters/listenbrainz/auth_router.go
@@ -10,12 +10,12 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/navidrome/navidrome/conf"
-	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/agents"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/utils/httpclient"
 )
 
 type sessionKeysRepo interface {
@@ -37,9 +37,7 @@ func NewRouter(ds model.DataStore) *Router {
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 	}
 	r.Handler = r.routes()
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New()
 	r.client = newClient(conf.Server.ListenBrainz.BaseURL, hc)
 	return r
 }

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -103,6 +103,7 @@ type configOptions struct {
 	ExtAuth                         extAuthOptions
 	Plugins                         pluginsOptions
 	HTTPHeaders                     httpHeaderOptions   `json:",omitzero"`
+	Proxy                           proxyOptions        `json:",omitzero"`
 	Prometheus                      prometheusOptions   `json:",omitzero"`
 	Scanner                         scannerOptions      `json:",omitzero"`
 	Jukebox                         jukeboxOptions      `json:",omitzero"`
@@ -208,6 +209,10 @@ type listenBrainzOptions struct {
 
 type httpHeaderOptions struct {
 	FrameOptions string
+}
+
+type proxyOptions struct {
+	URL string
 }
 
 type prometheusOptions struct {
@@ -381,6 +386,7 @@ func Load(noConfigDump bool) {
 		validatePlaylistsPath,
 		validatePurgeMissingOption,
 		validateMaxImageUploadSize,
+		validateProxyURL("Proxy.URL", Server.Proxy.URL),
 		validateURL("ExtAuth.LogoutURL", Server.ExtAuth.LogoutURL),
 	)
 	if err != nil {
@@ -672,6 +678,29 @@ func validateURL(optionName, optionURL string) func() error {
 	}
 }
 
+// validateProxyURL checks if the provided proxy URL is valid and has one of the
+// supported proxy schemes.
+func validateProxyURL(optionName, optionURL string) func() error {
+	return func() error {
+		if optionURL == "" {
+			return nil
+		}
+		u, err := url.Parse(optionURL)
+		if err != nil {
+			return fmt.Errorf("invalid %s %q: %w", optionName, optionURL, err)
+		}
+		switch u.Scheme {
+		case "http", "https", "socks5", "socks5h":
+		default:
+			return fmt.Errorf("invalid scheme for %s: '%s'. Only 'http', 'https', 'socks5', and 'socks5h' are allowed", optionName, u.Scheme)
+		}
+		if u.Host == "" || u.Opaque != "" {
+			return fmt.Errorf("invalid %s: '%s'. A full proxy URL with a non-empty host is required", optionName, optionURL)
+		}
+		return nil
+	}
+}
+
 func normalizeSearchBackend(value string) string {
 	v := strings.ToLower(strings.TrimSpace(value))
 	switch v {
@@ -829,6 +858,7 @@ func setViperDefaults() {
 	viper.SetDefault("listenbrainz.trackalgorithm", consts.DefaultListenBrainzTrackAlgorithm)
 	viper.SetDefault("enablescrobblehistory", true)
 	viper.SetDefault("httpheaders.frameoptions", "DENY")
+	viper.SetDefault("proxy.url", "")
 	viper.SetDefault("backup.path", "")
 	viper.SetDefault("backup.schedule", "")
 	viper.SetDefault("backup.count", 0)

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -100,6 +100,31 @@ var _ = Describe("Configuration", func() {
 		})
 	})
 
+	Describe("ValidateProxyURL", func() {
+		DescribeTable("accepts supported proxy URLs",
+			func(input string) {
+				fn := conf.ValidateProxyURL("Proxy.URL", input)
+				Expect(fn()).To(Succeed())
+			},
+			Entry("empty URL", ""),
+			Entry("http proxy", "http://proxy.example.com:8080"),
+			Entry("https proxy", "https://proxy.example.com:8443"),
+			Entry("socks5 proxy", "socks5://proxy.example.com:1080"),
+			Entry("socks5h proxy", "socks5h://proxy.example.com:1080"),
+			Entry("proxy with auth", "http://user:pass@proxy.example.com:8080"),
+		)
+
+		DescribeTable("rejects invalid proxy URLs",
+			func(input string, expected string) {
+				fn := conf.ValidateProxyURL("Proxy.URL", input)
+				Expect(fn()).To(MatchError(ContainSubstring(expected)))
+			},
+			Entry("unsupported scheme", "ftp://proxy.example.com", "invalid scheme"),
+			Entry("missing host", "http:///path", "non-empty host is required"),
+			Entry("opaque URL", "socks5:user:pass@proxy.example.com:1080", "non-empty host is required"),
+		)
+	})
+
 	DescribeTable("NormalizeSearchBackend",
 		func(input, expected string) {
 			Expect(conf.NormalizeSearchBackend(input)).To(Equal(expected))

--- a/conf/export_test.go
+++ b/conf/export_test.go
@@ -10,6 +10,8 @@ var ParseLanguages = parseLanguages
 
 var ValidateURL = validateURL
 
+var ValidateProxyURL = validateProxyURL
+
 var NormalizeSearchBackend = normalizeSearchBackend
 
 var ToPascalCase = toPascalCase

--- a/core/artwork/sources.go
+++ b/core/artwork/sources.go
@@ -21,6 +21,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/resources"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"go.senan.xyz/taglib"
 )
 
@@ -188,7 +189,7 @@ func fromAlbumExternalSource(ctx context.Context, al model.Album, provider exter
 }
 
 func fromURL(ctx context.Context, imageUrl *url.URL) (io.ReadCloser, string, error) {
-	hc := http.Client{Timeout: 5 * time.Second}
+	hc := httpclient.NewWithTimeout(5 * time.Second)
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, imageUrl.String(), nil)
 	req.Header.Set("User-Agent", consts.HTTPUserAgent)
 	resp, err := hc.Do(req) //nolint:gosec

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -25,6 +25,7 @@ import (
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/plugins"
 	"github.com/navidrome/navidrome/server/events"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/singleton"
 )
 
@@ -94,9 +95,7 @@ func (c *insightsCollector) sendInsights(ctx context.Context) {
 		log.Trace(ctx, "No users found, skipping Insights data collection")
 		return
 	}
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New()
 	data := c.collect(ctx)
 	if data == nil {
 		return

--- a/plugins/host_httpclient.go
+++ b/plugins/host_httpclient.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/plugins/host"
+	"github.com/navidrome/navidrome/utils/httpclient"
 )
 
 const (
@@ -46,7 +47,7 @@ func newHTTPService(pluginName string, permission *HTTPPermission) *httpServiceI
 		requiredHosts: requiredHosts,
 	}
 	svc.client = &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: httpclient.Transport(),
 		// Timeout is set per-request via context deadline, not here.
 		// CheckRedirect validates hosts and enforces redirect limits.
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/server/backgrounds/handler.go
+++ b/server/backgrounds/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/random"
 	"gopkg.in/yaml.v3"
 )
@@ -29,13 +30,15 @@ const (
 )
 
 type Handler struct {
-	httpClient *cache.HTTPClient
-	cache      cache.FileCache
+	listClient  *cache.HTTPClient
+	imageClient *http.Client
+	cache       cache.FileCache
 }
 
 func NewHandler() *Handler {
 	h := &Handler{}
-	h.httpClient = cache.NewHTTPClient(&http.Client{Timeout: 5 * time.Second}, imageListTTL)
+	h.listClient = cache.NewHTTPClient(httpclient.NewWithTimeout(5*time.Second), imageListTTL)
+	h.imageClient = httpclient.NewWithTimeout(imageRequestTimeout)
 	h.cache = cache.NewFileCache(imageCacheDir, imageCacheSize, imageCacheDir, imageCacheMaxItems, h.serveImage)
 	go func() {
 		_, _ = h.getImageList(log.NewContext(context.Background()))
@@ -78,9 +81,8 @@ func (h *Handler) serveImage(ctx context.Context, item cache.Item) (io.Reader, e
 	if image == "" {
 		return nil, errors.New("empty image name")
 	}
-	c := http.Client{Timeout: imageRequestTimeout}
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, imageURL(image), nil)
-	resp, err := c.Do(req) //nolint:bodyclose,gosec // No need to close resp.Body, it will be closed via the CachedStream wrapper
+	resp, err := h.imageClient.Do(req) //nolint:bodyclose,gosec // No need to close resp.Body, it will be closed via the CachedStream wrapper
 	if errors.Is(err, context.DeadlineExceeded) {
 		defaultImage, _ := base64.StdEncoding.DecodeString(consts.DefaultUILoginBackgroundOffline)
 		return strings.NewReader(string(defaultImage)), nil
@@ -112,7 +114,7 @@ func (h *Handler) getImageList(ctx context.Context) ([]string, error) {
 	start := time.Now()
 
 	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, imageListURL, nil)
-	resp, err := h.httpClient.Do(req)
+	resp, err := h.listClient.Do(req)
 	if err != nil {
 		log.Warn(ctx, "Could not get background images from image service", err)
 		return nil, err

--- a/server/nativeapi/config.go
+++ b/server/nativeapi/config.go
@@ -30,6 +30,7 @@ var sensitiveFieldsPartialMask = []string{
 var sensitiveFieldsFullMask = []string{
 	"DevAutoCreateAdminPassword",
 	"PasswordEncryptionKey",
+	"Proxy.URL",
 	"Prometheus.Password",
 }
 

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Config API", func() {
 				conf.Server.PasswordEncryptionKey = "encryptionkey789"
 				conf.Server.DevAutoCreateAdminPassword = "adminpassword123"
 				conf.Server.Prometheus.Password = "prometheuspass"
+				conf.Server.Proxy.URL = "http://user:secret@proxy.example.com:8080"
 
 				req := createAuthenticatedConfigRequest(adminToken)
 				w := httptest.NewRecorder()
@@ -106,6 +107,11 @@ var _ = Describe("Config API", func() {
 				prometheus, ok := resp.Config["Prometheus"].(map[string]any)
 				Expect(ok).To(BeTrue())
 				Expect(prometheus["Password"]).To(Equal("****"))
+
+				// Check Proxy.URL (fully masked because it may include credentials)
+				proxyConfig, ok := resp.Config["Proxy"].(map[string]any)
+				Expect(ok).To(BeTrue())
+				Expect(proxyConfig["URL"]).To(Equal("****"))
 			})
 
 			It("handles empty sensitive values", func() {

--- a/utils/httpclient/httpclient.go
+++ b/utils/httpclient/httpclient.go
@@ -1,0 +1,59 @@
+package httpclient
+
+import (
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/log"
+)
+
+var (
+	mu          sync.Mutex
+	cachedURL   string
+	cachedValue *http.Transport
+)
+
+func Transport() *http.Transport {
+	mu.Lock()
+	defer mu.Unlock()
+
+	currentURL := conf.Server.Proxy.URL
+	if cachedValue != nil && cachedURL == currentURL {
+		return cachedValue
+	}
+	if cachedValue != nil {
+		cachedValue.CloseIdleConnections()
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = nil
+
+	if currentURL != "" {
+		proxyURL, err := url.Parse(currentURL)
+		if err != nil {
+			// Config validation should prevent this, but keep runtime behavior safe.
+			log.Error("Invalid Proxy.URL configured for outbound HTTP transport", err)
+		} else {
+			transport.Proxy = http.ProxyURL(proxyURL)
+		}
+	}
+
+	cachedURL = currentURL
+	cachedValue = transport
+	return cachedValue
+}
+
+func New() *http.Client {
+	return NewWithTimeout(consts.DefaultHttpClientTimeOut)
+}
+
+func NewWithTimeout(timeout time.Duration) *http.Client {
+	return &http.Client{
+		Timeout:   timeout,
+		Transport: Transport(),
+	}
+}

--- a/utils/httpclient/httpclient_test.go
+++ b/utils/httpclient/httpclient_test.go
@@ -1,0 +1,224 @@
+package httpclient
+
+import (
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/consts"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHTTPClient(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTP Client Suite")
+}
+
+var _ = Describe("Transport", func() {
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.Proxy.URL = ""
+	})
+
+	It("memoizes the shared transport for the same proxy URL", func() {
+		first := Transport()
+		second := Transport()
+
+		Expect(second).To(BeIdenticalTo(first))
+	})
+
+	It("does not configure a proxy when Proxy.URL is empty", func() {
+		Expect(Transport().Proxy).To(BeNil())
+	})
+
+	It("returns the configured proxy URL for requests", func() {
+		conf.Server.Proxy.URL = "socks5://user:pass@proxy.example.com:1080"
+
+		req := httptest.NewRequest(http.MethodGet, "https://example.com", nil)
+		proxyURL, err := Transport().Proxy(req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(proxyURL.String()).To(Equal("socks5://user:pass@proxy.example.com:1080"))
+		Expect(proxyURL.User.Username()).To(Equal("user"))
+		password, ok := proxyURL.User.Password()
+		Expect(ok).To(BeTrue())
+		Expect(password).To(Equal("pass"))
+	})
+})
+
+var _ = Describe("New", func() {
+	var (
+		proxy *httptest.Server
+		rec   *proxyRecorder
+	)
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.Proxy.URL = ""
+		proxy, rec = newProxyServer()
+		DeferCleanup(proxy.Close)
+	})
+
+	It("routes outbound HTTP requests through the configured proxy", func() {
+		backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, "proxied-http")
+		}))
+		DeferCleanup(backend.Close)
+
+		conf.Server.Proxy.URL = proxy.URL
+		client := NewWithTimeout(2 * time.Second)
+
+		resp, err := client.Get(backend.URL)
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(body)).To(Equal("proxied-http"))
+		Expect(rec.absoluteRequests()).To(ContainElement(backend.URL + "/"))
+	})
+
+	It("routes outbound HTTPS requests through the configured proxy", func() {
+		backend := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = io.WriteString(w, "proxied-https")
+		}))
+		DeferCleanup(backend.Close)
+
+		conf.Server.Proxy.URL = proxy.URL
+		transport := Transport().Clone()
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		client := &http.Client{
+			Timeout:   2 * time.Second,
+			Transport: transport,
+		}
+
+		resp, err := client.Get(backend.URL)
+		Expect(err).ToNot(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(body)).To(Equal("proxied-https"))
+		Expect(rec.connectRequests()).To(ContainElement(backend.Listener.Addr().String()))
+	})
+})
+
+var _ = Describe("NewWithTimeout", func() {
+	It("uses the default outbound timeout in New", func() {
+		Expect(New().Timeout).To(Equal(consts.DefaultHttpClientTimeOut))
+	})
+
+	It("allows overriding the default timeout", func() {
+		Expect(NewWithTimeout(5 * time.Second).Timeout).To(Equal(5 * time.Second))
+	})
+})
+
+type proxyRecorder struct {
+	mu       sync.Mutex
+	absolute []string
+	connects []string
+}
+
+func (p *proxyRecorder) addAbsolute(rawURL string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.absolute = append(p.absolute, rawURL)
+}
+
+func (p *proxyRecorder) addConnect(host string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.connects = append(p.connects, host)
+}
+
+func (p *proxyRecorder) absoluteRequests() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.absolute))
+	copy(out, p.absolute)
+	return out
+}
+
+func (p *proxyRecorder) connectRequests() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.connects))
+	copy(out, p.connects)
+	return out
+}
+
+func newProxyServer() (*httptest.Server, *proxyRecorder) {
+	recorder := &proxyRecorder{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodConnect {
+			recorder.addConnect(r.Host)
+			handleConnect(w, r)
+			return
+		}
+
+		recorder.addAbsolute(r.URL.String())
+
+		req := r.Clone(r.Context())
+		req.RequestURI = ""
+
+		transport := http.DefaultTransport.(*http.Transport).Clone()
+		transport.Proxy = nil
+
+		resp, err := transport.RoundTrip(req)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadGateway)
+			return
+		}
+		defer resp.Body.Close()
+
+		for key, values := range resp.Header {
+			for _, value := range values {
+				w.Header().Add(key, value)
+			}
+		}
+		w.WriteHeader(resp.StatusCode)
+		_, _ = io.Copy(w, resp.Body)
+	}))
+	return server, recorder
+}
+
+func handleConnect(w http.ResponseWriter, r *http.Request) {
+	targetConn, err := net.DialTimeout("tcp", r.Host, 2*time.Second)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	hijacker, ok := w.(http.Hijacker)
+	if !ok {
+		targetConn.Close()
+		http.Error(w, "hijacking not supported", http.StatusInternalServerError)
+		return
+	}
+
+	clientConn, _, err := hijacker.Hijack()
+	if err != nil {
+		targetConn.Close()
+		http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		return
+	}
+
+	_, _ = fmt.Fprint(clientConn, "HTTP/1.1 200 Connection Established\r\n\r\n")
+
+	go proxyCopy(targetConn, clientConn)
+	go proxyCopy(clientConn, targetConn)
+}
+
+func proxyCopy(dst net.Conn, src net.Conn) {
+	defer dst.Close()
+	defer src.Close()
+	_, _ = io.Copy(dst, src)
+}

--- a/utils/httpclient/httpclient_test.go
+++ b/utils/httpclient/httpclient_test.go
@@ -94,7 +94,7 @@ var _ = Describe("New", func() {
 
 		conf.Server.Proxy.URL = proxy.URL
 		transport := Transport().Clone()
-		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+		transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // Test server uses a self-signed certificate.
 		client := &http.Client{
 			Timeout:   2 * time.Second,
 			Transport: transport,
@@ -191,7 +191,7 @@ func newProxyServer() (*httptest.Server, *proxyRecorder) {
 }
 
 func handleConnect(w http.ResponseWriter, r *http.Request) {
-	targetConn, err := net.DialTimeout("tcp", r.Host, 2*time.Second)
+	targetConn, err := net.DialTimeout("tcp", r.Host, 2*time.Second) //nolint:gosec // Test-only proxy forwards to httptest targets.
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadGateway)
 		return


### PR DESCRIPTION
### Description
This PR adds outbound proxy support for Navidrome-owned HTTP clients through a new `Proxy.URL` setting. It introduces a shared `utils/httpclient` helper for proxy-aware transports and updates the current outbound HTTP call sites to use it while preserving caller-specific behavior like plugin redirect handling.

It also validates supported proxy URL schemes, redacts `Proxy.URL` from the config API because it may contain credentials, and adds tests for config loading, proxy validation, and proxied HTTP/HTTPS requests.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Set `Proxy.URL` in `navidrome.toml` or `ND_PROXY_URL` to an `http`, `https`, `socks5`, or `socks5h` proxy URL.
2. Start Navidrome and exercise outbound integrations such as Last.fm, ListenBrainz, Deezer, login background fetches, or the plugin HTTP host service.
3. Verify outbound HTTP/HTTPS requests go through the proxy.
4. Confirm invalid proxy URLs fail startup validation and that the config API redacts `Proxy.URL`.

### Additional Notes
This change is explicit-only: there is no `NO_PROXY` support and no fallback to process proxy environment variables when `Proxy.URL` is unset.