### PR TITLE
fix: split html sanitization from plaintext handling

### DIFF
--- a/core/external/provider.go
+++ b/core/external/provider.go
@@ -508,7 +508,7 @@ func (e *provider) callGetBiography(ctx context.Context, agent agents.ArtistBiog
 	if err != nil {
 		return
 	}
-	bio = str.SanitizeHTML(bio)
+	bio = str.SanitizeText(bio)
 	bio = strings.ReplaceAll(bio, "\n", " ")
 	artist.Biography = strings.ReplaceAll(bio, "<a ", "<a target='_blank' ")
 }

--- a/core/external/provider.go
+++ b/core/external/provider.go
@@ -508,7 +508,7 @@ func (e *provider) callGetBiography(ctx context.Context, agent agents.ArtistBiog
 	if err != nil {
 		return
 	}
-	bio = str.SanitizeText(bio)
+	bio = str.SanitizeHTML(bio)
 	bio = strings.ReplaceAll(bio, "\n", " ")
 	artist.Biography = strings.ReplaceAll(bio, "<a ", "<a target='_blank' ")
 }

--- a/core/external/provider_updateartistinfo_test.go
+++ b/core/external/provider_updateartistinfo_test.go
@@ -105,6 +105,29 @@ var _ = Describe("Provider - UpdateArtistInfo", func() {
 		ag.AssertExpectations(GinkgoT())
 	})
 
+	It("preserves decoded plain text in biography storage", func() {
+		originalArtist := &model.Artist{
+			ID:   "ar-encoded-bio",
+			Name: "Encoded Bio Artist",
+		}
+		mockArtistRepo.SetData(model.Artists{*originalArtist})
+
+		expectedMBID := "mbid-encoded-bio"
+		expectedBio := "R&amp;B"
+
+		ag.On("GetArtistMBID", ctx, "ar-encoded-bio", "Encoded Bio Artist").Return(expectedMBID, nil).Once()
+		ag.On("GetArtistImages", ctx, "ar-encoded-bio", "Encoded Bio Artist", expectedMBID).Return(nil, nil).Maybe()
+		ag.On("GetArtistBiography", ctx, "ar-encoded-bio", "Encoded Bio Artist", expectedMBID).Return(expectedBio, nil).Once()
+		ag.On("GetArtistURL", ctx, "ar-encoded-bio", "Encoded Bio Artist", expectedMBID).Return("", nil).Maybe()
+		ag.On("GetSimilarArtists", ctx, "ar-encoded-bio", "Encoded Bio Artist", expectedMBID, 100).Return(nil, nil).Maybe()
+
+		updatedArtist, err := p.UpdateArtistInfo(ctx, "ar-encoded-bio", 10, false)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updatedArtist).NotTo(BeNil())
+		Expect(updatedArtist.Biography).To(Equal("R&B"))
+	})
+
 	It("returns cached info when artist exists and info is not expired", func() {
 		now := time.Now()
 		originalArtist := &model.Artist{

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -45,7 +45,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"variousArtistsId":          consts.VariousArtistsID,
 			"baseURL":                   str.SanitizeText(strings.TrimSuffix(conf.Server.BasePath, "/")),
 			"loginBackgroundURL":        str.SanitizeText(conf.Server.UILoginBackgroundURL),
-			"welcomeMessage":            str.SanitizeText(conf.Server.UIWelcomeMessage),
+			"welcomeMessage":            str.SanitizeHTML(conf.Server.UIWelcomeMessage),
 			"maxSidebarPlaylists":       conf.Server.MaxSidebarPlaylists,
 			"enableTranscodingConfig":   conf.Server.EnableTranscodingConfig,
 			"enableDownloads":           conf.Server.EnableDownloads,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -108,6 +108,18 @@ var _ = Describe("serveIndex", func() {
 		Entry("extAuthLogoutURL", func() { conf.Server.ExtAuth.LogoutURL = "https://auth.example.com/logout" }, "extAuthLogoutURL", "https://auth.example.com/logout"),
 	)
 
+	It("sanitizes entity-encoded welcomeMessage as html", func() {
+		conf.Server.UIWelcomeMessage = `&lt;img src=x onerror=alert(1)&gt;&lt;b&gt;Hello&lt;/b&gt;`
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		serveIndex(ds, fs, nil)(w, r)
+
+		config := extractAppConfig(w.Body.String())
+		Expect(config).To(HaveKey("welcomeMessage"))
+		Expect(config["welcomeMessage"]).To(Equal(`<img src="x"><b>Hello</b>`))
+	})
+
 	DescribeTable("sets other UI configuration values",
 		func(configKey string, expectedValueFunc func() any) {
 			r := httptest.NewRequest("GET", "/index.html", nil)

--- a/utils/str/sanitize_strings.go
+++ b/utils/str/sanitize_strings.go
@@ -43,6 +43,10 @@ func SanitizeText(text string) string {
 	return html.UnescapeString(s)
 }
 
+func SanitizeHTML(text string) string {
+	return policy.Sanitize(html.UnescapeString(text))
+}
+
 func SanitizeFieldForSorting(originalValue string) string {
 	v := strings.TrimSpace(sanitize.Accents(originalValue))
 	return Clear(strings.ToLower(v))

--- a/utils/str/sanitize_strings.go
+++ b/utils/str/sanitize_strings.go
@@ -38,11 +38,16 @@ func SanitizeStrings(text ...string) string {
 
 var policy = bluemonday.UGCPolicy()
 
+// SanitizeText unescapes the input string before sanitizing it as text.
+// This should be used for fields rendered as plain text in the UI (e.g. lyrics, song titles, artist names)
 func SanitizeText(text string) string {
 	s := policy.Sanitize(text)
 	return html.UnescapeString(s)
 }
 
+// SanitizeHTML unescapes the input string before sanitizing it as HTML.
+// This should be used for fields rendered as HTML by clients (e.g. biographies, welcome messages)
+// to prevent XSS bypasses via entity-encoded tags.
 func SanitizeHTML(text string) string {
 	return policy.Sanitize(html.UnescapeString(text))
 }

--- a/utils/str/sanitize_strings_test.go
+++ b/utils/str/sanitize_strings_test.go
@@ -64,6 +64,35 @@ var _ = Describe("Sanitize Strings", func() {
 		})
 	})
 
+	Describe("SanitizeText", func() {
+		It("preserves decoded plaintext", func() {
+			Expect(str.SanitizeText("Tom &amp; Jerry")).To(Equal("Tom & Jerry"))
+			Expect(str.SanitizeText("Tom & Jerry")).To(Equal("Tom & Jerry"))
+		})
+
+		It("keeps entity-encoded html readable", func() {
+			Expect(str.SanitizeText(`&lt;b&gt;ok&lt;/b&gt;`)).To(Equal("<b>ok</b>"))
+		})
+	})
+
+	Describe("SanitizeHTML", func() {
+		It("removes dangerous content from raw html", func() {
+			sanitized := str.SanitizeHTML(`<img src=x onerror=alert(1)><script>alert(2)</script><b>ok</b>`)
+
+			Expect(sanitized).To(ContainSubstring("<b>ok</b>"))
+			Expect(sanitized).ToNot(ContainSubstring("onerror"))
+			Expect(sanitized).ToNot(ContainSubstring("<script"))
+		})
+
+		It("removes dangerous content from entity-encoded html", func() {
+			sanitized := str.SanitizeHTML(`&lt;img src=x onerror=alert(1)&gt;&lt;script&gt;alert(2)&lt;/script&gt;&lt;b&gt;ok&lt;/b&gt;`)
+
+			Expect(sanitized).To(ContainSubstring("<b>ok</b>"))
+			Expect(sanitized).ToNot(ContainSubstring("onerror"))
+			Expect(sanitized).ToNot(ContainSubstring("<script"))
+		})
+	})
+
 	Describe("SanitizeFieldForSortingNoArticle", func() {
 		BeforeEach(func() {
 			conf.Server.IgnoredArticles = "The O"


### PR DESCRIPTION
### Description
This PR fixes the XSS reported in #5401 without changing the longstanding plain-text behavior of `SanitizeText`.

The root cause was that HTML-entity-encoded input could pass through `SanitizeText`, then get decoded after sanitization and become active markup at render time. Instead of changing `SanitizeText` globally, this patch adds a dedicated `SanitizeHTML` helper for values that are intended to be rendered as HTML, and switches the affected HTML sinks to use it.

This keeps lyrics, comments, and other plain-text callers on the existing `SanitizeText` semantics while ensuring `welcomeMessage` and artist biographies sanitize entity-encoded HTML safely.

### Related Issues
Fixes #5401

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Set `ND_UIWELCOMEMESSAGE='&lt;img src=x onerror=alert(1)&gt;&lt;b&gt;Hello&lt;/b&gt;'` and start Navidrome.
2. Open the login page.
3. Confirm no script executes and the welcome message renders as sanitized HTML.
4. Run `make test`, `make lint`, and verify the new sanitizer tests pass.
5. Verify plain-text consumers still preserve decoded text semantics, for example `Tom &amp; Jerry` remaining `Tom & Jerry` through `SanitizeText`.

### Additional Notes
The fix intentionally splits HTML sanitization from plain-text handling. A global unescape-first change in `SanitizeText` would have changed lyrics/comment behavior by re-encoding plain-text ampersands, so only the actual HTML-rendered paths now use `SanitizeHTML`.
