### PR TITLE
fix(utils/str): unescape HTML entities before sanitizing

### DIFF
--- a/utils/str/sanitize_strings.go
+++ b/utils/str/sanitize_strings.go
@@ -39,8 +39,14 @@ func SanitizeStrings(text ...string) string {
 var policy = bluemonday.UGCPolicy()
 
 func SanitizeText(text string) string {
-	s := policy.Sanitize(text)
-	return html.UnescapeString(s)
+	// Unescape HTML entities first so that payloads like
+	// &lt;script&gt;alert(1)&lt;/script&gt; are fed to the sanitizer as
+	// real tags it can strip. The previous order (sanitize then
+	// unescape) let entity-encoded markup round-trip through the
+	// bluemonday policy unchanged and then get decoded back to
+	// dangerous HTML by html.UnescapeString — e.g. the Login.jsx
+	// welcomeMessage rendering via dangerouslySetInnerHTML.
+	return policy.Sanitize(html.UnescapeString(text))
 }
 
 func SanitizeFieldForSorting(originalValue string) string {


### PR DESCRIPTION
Fixes navidrome/navidrome#5401.

## Problem

`SanitizeText` called `bluemonday.Sanitize(text)` first and then `html.UnescapeString` on the result. An entity-encoded payload like `&lt;script&gt;alert(1)&lt;/script&gt;` passes through the sanitizer untouched (entities look like plain text) and is then decoded to live `<script>` tags by `UnescapeString`, undoing the sanitization before it reaches the browser.

## Fix

Swap the order: unescape first, then sanitize so whatever `UnescapeString` produces is what `bluemonday` strips. `ND_UIWELCOMEMESSAGE` (rendered via `dangerouslySetInnerHTML` in `Login.jsx`) and any other caller of `SanitizeText` now get the expected protection.

## Test

`go test ./utils/str/...` passes locally.