### PR TITLE
fix(playlists): allow toggling auto-import and avoid unnecessary artwork reloads

### DIFF
--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -3,9 +3,11 @@ package playlists
 import (
 	"context"
 	"errors"
+	"reflect"
 
 	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/criteria"
 	"github.com/navidrome/navidrome/model/request"
 )
 
@@ -77,7 +79,7 @@ func (s *playlists) savePlaylist(ctx context.Context, pls *model.Playlist) (stri
 
 // updatePlaylistEntity updates playlist metadata with permission checks.
 // Used by the REST API wrapper.
-func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity *model.Playlist, cols ...string) error {
+func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity *model.Playlist, _ ...string) error {
 	current, err := s.checkWritable(ctx, id)
 	if err != nil {
 		switch {
@@ -93,15 +95,45 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 	if !usr.IsAdmin && entity.OwnerID != "" && entity.OwnerID != current.OwnerID {
 		return rest.ErrPermissionDenied
 	}
-	// Apply ownership change (admin only)
-	if entity.OwnerID != "" {
-		current.OwnerID = entity.OwnerID
+
+	contentChanged := entity.Name != current.Name ||
+		entity.Comment != current.Comment ||
+		(entity.OwnerID != "" && entity.OwnerID != current.OwnerID) ||
+		!rulesEqual(current.Rules, entity.Rules)
+
+	if contentChanged {
+		if entity.OwnerID != "" {
+			current.OwnerID = entity.OwnerID
+		}
+		current.Rules = entity.Rules
+		if current.Path != "" {
+			current.Sync = entity.Sync
+		}
+		return s.updateMetadata(ctx, s.ds, current, &entity.Name, &entity.Comment, &entity.Public)
 	}
-	// Apply smart playlist rules update
-	current.Rules = entity.Rules
-	// Apply sync toggle only for file-backed playlists
-	if current.Path != "" {
+
+	// Only sync/public changed — skip updatedAt so cover art URLs stay stable
+	var cols []string
+	if current.Path != "" && current.Sync != entity.Sync {
 		current.Sync = entity.Sync
+		cols = append(cols, "sync")
 	}
-	return s.updateMetadata(ctx, s.ds, current, &entity.Name, &entity.Comment, &entity.Public)
+	if current.Public != entity.Public {
+		current.Public = entity.Public
+		cols = append(cols, "public")
+	}
+	if len(cols) == 0 {
+		return nil
+	}
+	return s.ds.Playlist(ctx).Put(current, cols...)
+}
+
+func rulesEqual(a, b *criteria.Criteria) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return reflect.DeepEqual(a, b)
 }

--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -106,7 +106,7 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 			current.OwnerID = entity.OwnerID
 		}
 		current.Rules = entity.Rules
-		if current.Path != "" {
+		if current.Path != "" && current.Sync != entity.Sync {
 			current.Sync = entity.Sync
 		}
 		return s.updateMetadata(ctx, s.ds, current, &entity.Name, &entity.Comment, &entity.Public)
@@ -129,7 +129,7 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 }
 
 func rulesEqual(a, b *criteria.Criteria) bool {
-	if a == nil && b == nil {
+	if a == b {
 		return true
 	}
 	if a == nil || b == nil {

--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -99,5 +99,9 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 	}
 	// Apply smart playlist rules update
 	current.Rules = entity.Rules
+	// Apply sync toggle only for file-backed playlists
+	if current.Path != "" {
+		current.Sync = entity.Sync
+	}
 	return s.updateMetadata(ctx, s.ds, current, &entity.Name, &entity.Comment, &entity.Public)
 }

--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -34,8 +34,8 @@ func (r *playlistRepositoryWrapper) Save(entity any) (string, error) {
 	return r.service.savePlaylist(r.ctx, entity.(*model.Playlist))
 }
 
-func (r *playlistRepositoryWrapper) Update(id string, entity any, cols ...string) error {
-	return r.service.updatePlaylistEntity(r.ctx, id, entity.(*model.Playlist), cols...)
+func (r *playlistRepositoryWrapper) Update(id string, entity any, _ ...string) error {
+	return r.service.updatePlaylistEntity(r.ctx, id, entity.(*model.Playlist))
 }
 
 func (r *playlistRepositoryWrapper) Delete(id string) error {
@@ -79,7 +79,7 @@ func (s *playlists) savePlaylist(ctx context.Context, pls *model.Playlist) (stri
 
 // updatePlaylistEntity updates playlist metadata with permission checks.
 // Used by the REST API wrapper.
-func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity *model.Playlist, _ ...string) error {
+func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity *model.Playlist) error {
 	current, err := s.checkWritable(ctx, id)
 	if err != nil {
 		switch {

--- a/core/playlists/rest_adapter_test.go
+++ b/core/playlists/rest_adapter_test.go
@@ -142,6 +142,38 @@ var _ = Describe("REST Adapter", func() {
 				Expect(mockPlsRepo.Last.Rules).To(Equal(newRules))
 			})
 
+			It("allows toggling sync for file-backed playlists", func() {
+				mockPlsRepo.Data["file-pls"] = &model.Playlist{
+					ID:      "file-pls",
+					Name:    "File Playlist",
+					OwnerID: "user-1",
+					Path:    "/music/playlist.m3u",
+					Sync:    true,
+				}
+				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+				repo = ps.NewRepository(ctx).(rest.Persistable)
+				pls := &model.Playlist{Name: "File Playlist", Sync: false}
+				err := repo.Update("file-pls", pls)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mockPlsRepo.Last.Sync).To(BeFalse())
+			})
+
+			It("does not allow setting sync on non-file-backed playlists", func() {
+				mockPlsRepo.Data["manual-pls"] = &model.Playlist{
+					ID:      "manual-pls",
+					Name:    "Manual Playlist",
+					OwnerID: "user-1",
+					Path:    "",
+					Sync:    false,
+				}
+				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+				repo = ps.NewRepository(ctx).(rest.Persistable)
+				pls := &model.Playlist{Name: "Manual Playlist", Sync: true}
+				err := repo.Update("manual-pls", pls)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mockPlsRepo.Last.Sync).To(BeFalse())
+			})
+
 			It("returns rest.ErrNotFound when playlist doesn't exist", func() {
 				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 				repo = ps.NewRepository(ctx).(rest.Persistable)

--- a/core/playlists/rest_adapter_test.go
+++ b/core/playlists/rest_adapter_test.go
@@ -143,12 +143,14 @@ var _ = Describe("REST Adapter", func() {
 			})
 
 			It("allows toggling sync for file-backed playlists", func() {
+				originalTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
 				mockPlsRepo.Data["file-pls"] = &model.Playlist{
-					ID:      "file-pls",
-					Name:    "File Playlist",
-					OwnerID: "user-1",
-					Path:    "/music/playlist.m3u",
-					Sync:    true,
+					ID:        "file-pls",
+					Name:      "File Playlist",
+					OwnerID:   "user-1",
+					Path:      "/music/playlist.m3u",
+					Sync:      true,
+					UpdatedAt: originalTime,
 				}
 				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 				repo = ps.NewRepository(ctx).(rest.Persistable)
@@ -156,6 +158,7 @@ var _ = Describe("REST Adapter", func() {
 				err := repo.Update("file-pls", pls)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(mockPlsRepo.Last.Sync).To(BeFalse())
+				Expect(mockPlsRepo.Last.UpdatedAt).To(Equal(originalTime))
 			})
 
 			It("does not allow setting sync on non-file-backed playlists", func() {
@@ -171,6 +174,41 @@ var _ = Describe("REST Adapter", func() {
 				pls := &model.Playlist{Name: "Manual Playlist", Sync: true}
 				err := repo.Update("manual-pls", pls)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(mockPlsRepo.Last).To(BeNil())
+			})
+
+			It("does not bump updatedAt when only public changes", func() {
+				originalTime := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+				mockPlsRepo.Data["pls-pub"] = &model.Playlist{
+					ID:        "pls-pub",
+					Name:      "My Playlist",
+					OwnerID:   "user-1",
+					Public:    false,
+					UpdatedAt: originalTime,
+				}
+				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+				repo = ps.NewRepository(ctx).(rest.Persistable)
+				pls := &model.Playlist{Name: "My Playlist", Public: true}
+				err := repo.Update("pls-pub", pls)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mockPlsRepo.Last.Public).To(BeTrue())
+				Expect(mockPlsRepo.Last.UpdatedAt).To(Equal(originalTime))
+			})
+
+			It("bumps updatedAt when name changes along with sync", func() {
+				mockPlsRepo.Data["file-pls2"] = &model.Playlist{
+					ID:      "file-pls2",
+					Name:    "Old Name",
+					OwnerID: "user-1",
+					Path:    "/music/playlist.m3u",
+					Sync:    true,
+				}
+				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+				repo = ps.NewRepository(ctx).(rest.Persistable)
+				pls := &model.Playlist{Name: "New Name", Sync: false}
+				err := repo.Update("file-pls2", pls)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mockPlsRepo.Last.Name).To(Equal("New Name"))
 				Expect(mockPlsRepo.Last.Sync).To(BeFalse())
 			})
 

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -123,7 +123,7 @@ type PlaylistRepository interface {
 	ResourceRepository
 	CountAll(options ...QueryOptions) (int64, error)
 	Exists(id string) (bool, error)
-	Put(pls *Playlist) error
+	Put(pls *Playlist, cols ...string) error
 	Get(id string) (*Playlist, error)
 	GetWithTracks(id string, refreshSmartPlaylist, includeMissing bool) (*Playlist, error)
 	GetAll(options ...QueryOptions) (Playlists, error)

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -97,8 +97,12 @@ func (r *playlistRepository) Delete(id string) error {
 	return r.delete(And{Eq{"id": id}, r.userFilter()})
 }
 
-func (r *playlistRepository) Put(p *model.Playlist) error {
+func (r *playlistRepository) Put(p *model.Playlist, cols ...string) error {
 	pls := dbPlaylist{Playlist: *p}
+	if len(cols) > 0 {
+		_, err := r.put(pls.ID, pls, cols...)
+		return err
+	}
 	if pls.ID == "" {
 		pls.CreatedAt = time.Now()
 	}

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -100,6 +100,9 @@ func (r *playlistRepository) Delete(id string) error {
 func (r *playlistRepository) Put(p *model.Playlist, cols ...string) error {
 	pls := dbPlaylist{Playlist: *p}
 	if len(cols) > 0 {
+		if pls.ID == "" {
+			return errors.New("playlist id is required for partial update")
+		}
 		_, err := r.put(pls.ID, pls, cols...)
 		return err
 	}

--- a/tests/mock_playlist_repo.go
+++ b/tests/mock_playlist_repo.go
@@ -45,7 +45,7 @@ func (m *MockPlaylistRepo) GetWithTracks(id string, _, _ bool) (*model.Playlist,
 	return m.Get(id)
 }
 
-func (m *MockPlaylistRepo) Put(pls *model.Playlist) error {
+func (m *MockPlaylistRepo) Put(pls *model.Playlist, _ ...string) error {
 	if m.Err {
 		return errors.New("error")
 	}


### PR DESCRIPTION
### Description

Fixes the playlist Auto-import (sync) toggle in the UI, which was completely non-functional — the backend silently discarded the field on every update.

Additionally, toggling `sync` or `public` no longer bumps `updatedAt`, which prevents unnecessary cover art reloads in the UI. The frontend uses `updatedAt` as a cache-buster for artwork URLs, so changing it on non-content updates caused a visual flicker as images re-fetched.

**Approach:**
- `PlaylistRepository.Put()` now accepts optional `cols ...string` — when specified, only those columns are written without touching `updatedAt`
- `updatePlaylistEntity` distinguishes content-affecting changes (name, comment, rules, owner → bumps `updatedAt`) from metadata-only toggles (sync, public → preserves `updatedAt`)

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Start the dev server (`make dev`)
2. Navigate to **Playlists** in the UI
3. Toggle the **Auto-import** switch on a file-backed playlist
4. Verify the toggle persists (stays in the new state after page refresh)
5. Verify the playlist cover art does **not** flash/reload when toggling
6. Toggle **Public** and verify the same behavior (no artwork reload)
7. Edit a playlist **name** and verify `updatedAt` does change (artwork may reload — this is correct)

### Additional Notes

- The `Put(pls, cols...)` extension is backward-compatible — all existing callers pass no columns and get unchanged behavior
- `sync` can only be toggled on file-backed playlists (those with a `Path`); non-file-backed playlists ignore the field
- The Subsonic `Changed` field (mapped from `updatedAt`) correctly updates for content changes (name/comment/rules) but stays stable for visibility/sync toggles, which Subsonic clients don't consume
