### PR TITLE
fix(ui): prevent autoplay when clearing the play queue

### DIFF
--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -210,6 +210,7 @@ const Player = () => {
       audioLists: playerState.queue.map((item) => item),
       playIndex: playerState.playIndex,
       autoPlay:
+        playerState.queue.length > 0 &&
         playerState.autoPlay !== false &&
         (playerState.clear || playerState.playIndex === 0),
       clearPriorAudioLists: playerState.clear,


### PR DESCRIPTION
### Description

When clearing the play queue (via the destroy/trash button), the first song would restart playing instead of stopping. This was caused by the `autoPlay` option being computed as `true` even when the queue was empty.

The root cause: `reduceClearQueue` resets state to `initialState` which has no `autoPlay` field, so `playerState.autoPlay` is `undefined`. The expression `undefined !== false` evaluates to `true`, which combined with `clear: true` made `autoPlay` resolve to `true`. This told the music player library to auto-play, triggering a race condition where `audio.play()` was called before internal state was fully cleared.

The fix adds a `queue.length > 0` guard to the `autoPlay` calculation, ensuring it is never `true` when the queue is empty.

### Related Issues

Fixes #5331

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Play multiple songs (select several from the Songs list and click "Play Now")
2. While music is playing, click the destroy/close button (X) on the player
3. **Expected**: Playback stops completely, player disappears, page title resets to "Navidrome"
4. **Before fix**: The first song would restart playing, visible as the page title changing back to the song name
5. After clearing, click play on new songs to verify normal playback still auto-starts correctly
6. Refresh the page while music is playing — verify the queue is restored but does NOT auto-play

### Additional Notes

The bug was introduced by the transcode integration (957130ca3) which added the `autoPlay !== false` guard for the `PLAYER_REFRESH_QUEUE` action but didn't account for `PLAYER_CLEAR_QUEUE` resetting that field to `undefined`. The fix is deliberately placed as a catch-all guard in the `options` memo rather than in the reducer, since `autoPlay: true` with an empty queue is never semantically correct.
