### PR TITLE
fix(ui): show album tile actions on keyboard focus - #4836

### DIFF
--- a/ui/src/album/AlbumGridView.jsx
+++ b/ui/src/album/AlbumGridView.jsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles(
     tileBar: {
       transition: 'all 150ms ease-out',
       opacity: 0,
+      pointerEvents: 'none',
       textAlign: 'left',
       background:
         'linear-gradient(to top, rgba(0,0,0,0.7) 0%,rgba(0,0,0,0.4) 70%,rgba(0,0,0,0) 100%)',
@@ -80,6 +81,7 @@ const useStyles = makeStyles(
       textDecoration: 'none',
       '&:hover $tileBar, &:focus-within $tileBar': {
         opacity: 1,
+        pointerEvents: 'auto',
       },
     },
     albumLink: {

--- a/ui/src/album/AlbumGridView.jsx
+++ b/ui/src/album/AlbumGridView.jsx
@@ -78,7 +78,7 @@ const useStyles = makeStyles(
       position: 'relative',
       display: 'block',
       textDecoration: 'none',
-      '&:hover $tileBar': {
+      '&:hover $tileBar, &:focus-within $tileBar': {
         opacity: 1,
       },
     },


### PR DESCRIPTION
Closes #4836

## Description

Album grid tiles host the play / favorite / context-menu buttons inside a `GridListTileBar` that has `opacity: 0` by default. The bar only becomes visible via `&:hover $tileBar { opacity: 1 }` on the wrapping `<Link>`.

This caused two related issues:

1. **Accessibility (the reported bug, #4836)**: keyboard users tabbing through the album grid never saw a focus state on the focused tile and couldn't discover the play / favorite / context-menu buttons without a mouse.

2. **Pre-existing UX issue**: even when invisible (`opacity: 0`), the tileBar and its buttons stayed interactive. Clicking the cover area near the bottom could accidentally trigger the invisible Play or Menu button instead of navigating to the album page.

## Fix

Two small CSS changes in `ui/src/album/AlbumGridView.jsx`:

**1. Make the bar visible on keyboard focus, not just mouse hover**

```diff
       '&:hover $tileBar': {
+      '&:hover $tileBar, &:focus-within $tileBar': {
         opacity: 1,
+        pointerEvents: 'auto',
       },
```

`:focus-within` matches when the `<Link>` itself or any descendant (the play / favorite / context-menu button) has focus, so it covers both tabbing onto the tile and advancing focus into the action buttons.

**2. Disable pointer events while the bar is invisible**

```diff
     tileBar: {
       transition: 'all 150ms ease-out',
       opacity: 0,
+      pointerEvents: 'none',
       textAlign: 'left',
       ...
     },
```

The bar starts with `pointer-events: none` so it cannot intercept clicks while invisible, and the hover/focus rule above restores `pointer-events: auto` whenever the bar is shown. This was added per review feedback from @gemini-code-assist after the first commit.

Mouse hover behavior is unchanged. No new dependencies. No behavioral change for users who navigate with a mouse on a tile that is already revealed.

## Test plan

- [x] Tab through the album grid — tile bar becomes visible on the focused album
- [x] Move focus to the play / favorite / context buttons — bar stays visible
- [x] Move focus to a different tile — previous tile's bar fades out, new tile's bar fades in
- [x] Click the album cover (away from action buttons) → navigates to the album page (no longer triggers the invisible Play/Menu)
- [x] Click on the visible Play / Menu buttons → still works as expected
- [x] Mouse hover continues to work as before