### PR TITLE
fix(ui): start new album from track 1 after closing player

### DIFF
--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -164,13 +164,15 @@ const reduceSetVolume = (state, { data: { volume } }) => {
 }
 
 const reduceSyncQueue = (state, { data: { audioInfo, audioLists } }) => {
-  // Only keep clear and playIndex alive when there is an actual pending
-  // track switch (playIndex differs from savedPlayIndex). This lets
-  // PLAYER_PLAY_TRACKS selections survive the sync, while allowing
-  // PLAYER_PLAY_NEXT (which sets playIndex to the current track) to
-  // reset immediately and avoid restarting playback.
+  // Keep clear and playIndex alive when there is a pending track switch.
+  // A switch is pending when playIndex is set AND either:
+  //   - playIndex differs from savedPlayIndex, OR
+  //   - clear is true (a new queue was loaded, e.g. after clearQueue + playTracks)
+  // The clear check handles the edge case where both playIndex and
+  // savedPlayIndex are 0 (close player then play a new album from track 1).
   const hasPendingSwitch =
-    state.playIndex != null && state.playIndex !== state.savedPlayIndex
+    state.playIndex != null &&
+    (state.clear || state.playIndex !== state.savedPlayIndex)
   return {
     ...state,
     queue: audioLists,

--- a/ui/src/reducers/playerReducer.test.js
+++ b/ui/src/reducers/playerReducer.test.js
@@ -96,6 +96,88 @@ describe('playerReducer', () => {
     })
   })
 
+  describe('play new album after closing player (issue #5440)', () => {
+    it('SYNC_QUEUE preserves pending playIndex=0 after clearQueue', () => {
+      // Scenario: user plays album A, advances to track 3, closes player,
+      // then plays album B. After clearQueue, savedPlayIndex=0.
+      // PLAYER_PLAY_TRACKS sets playIndex=0. SYNC_QUEUE must NOT clear it.
+      const stateAfterClearThenPlay = {
+        queue: [
+          { trackId: 'b1', uuid: 'u1', name: 'B Song 1' },
+          { trackId: 'b2', uuid: 'u2', name: 'B Song 2' },
+          { trackId: 'b3', uuid: 'u3', name: 'B Song 3' },
+        ],
+        current: {},
+        playIndex: 0,
+        savedPlayIndex: 0, // reset by clearQueue
+        clear: true,
+        volume: 1,
+      }
+
+      const action = {
+        type: PLAYER_SYNC_QUEUE,
+        data: {
+          audioInfo: {},
+          audioLists: stateAfterClearThenPlay.queue,
+        },
+      }
+      const result = playerReducer(stateAfterClearThenPlay, action)
+      expect(result.playIndex).toBe(0)
+      expect(result.clear).toBe(true)
+    })
+
+    it('CURRENT for wrong track preserves pending playIndex=0 after clearQueue', () => {
+      // The music player fires onAudioPlay for the old track (at index 3)
+      // before switching to the new track at index 0.
+      const stateAfterClearThenPlay = {
+        queue: [
+          { trackId: 'b1', uuid: 'u1', name: 'B Song 1' },
+          { trackId: 'b2', uuid: 'u2', name: 'B Song 2' },
+          { trackId: 'b3', uuid: 'u3', name: 'B Song 3' },
+          { trackId: 'b4', uuid: 'u4', name: 'B Song 4' },
+        ],
+        current: {},
+        playIndex: 0,
+        savedPlayIndex: 0,
+        clear: true,
+        volume: 1,
+      }
+
+      // Player reports track at index 3 as current (stale callback)
+      const action = {
+        type: PLAYER_CURRENT,
+        data: { uuid: 'u4', name: 'B Song 4', volume: 1 },
+      }
+      const result = playerReducer(stateAfterClearThenPlay, action)
+      expect(result.playIndex).toBe(0)
+      expect(result.clear).toBe(true)
+    })
+
+    it('CURRENT for correct track consumes pending playIndex=0', () => {
+      const stateAfterClearThenPlay = {
+        queue: [
+          { trackId: 'b1', uuid: 'u1', name: 'B Song 1' },
+          { trackId: 'b2', uuid: 'u2', name: 'B Song 2' },
+        ],
+        current: {},
+        playIndex: 0,
+        savedPlayIndex: 0,
+        clear: true,
+        volume: 1,
+      }
+
+      // Player confirms it switched to track at index 0
+      const action = {
+        type: PLAYER_CURRENT,
+        data: { uuid: 'u1', name: 'B Song 1', volume: 1 },
+      }
+      const result = playerReducer(stateAfterClearThenPlay, action)
+      expect(result.playIndex).toBeUndefined()
+      expect(result.clear).toBe(false)
+      expect(result.savedPlayIndex).toBe(0)
+    })
+  })
+
   describe('PLAYER_REFRESH_QUEUE', () => {
     it('clamps negative savedPlayIndex to 0', () => {
       const state = {


### PR DESCRIPTION
### Description

When a user played an album, advanced a few tracks, closed the player (X button), then played a different album, playback started mid-album at the previous track index instead of track 1.

The root cause was in `reduceSyncQueue`: the `hasPendingSwitch` check compared `playIndex` against `savedPlayIndex` to decide whether a track switch was still pending. After `clearQueue`, both values reset to `0`. When `playTracks` then set `playIndex=0` for the new album, the comparison `0 !== 0` was `false`, so `PLAYER_SYNC_QUEUE` prematurely cleared the pending `playIndex` and `clear` flags before the music player library could act on them. The library's internal state retained the old track position.

The fix adds `state.clear` as an additional signal that a track switch is pending, since `clear=true` means a new queue was just loaded (e.g., by `PLAYER_PLAY_TRACKS`). This correctly preserves the pending state for the edge case where both `playIndex` and `savedPlayIndex` are `0`.

### Related Issues

Fixes #5440

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Play any album with multiple tracks
2. Advance to track 3 or 4 using the next button
3. Close the player by clicking the X button in the bottom right
4. Navigate to a different album and click the Play button
5. **Expected:** The new album starts playing from track 1
6. **Before fix:** The new album started at the track index from step 2

### Additional Notes

The one-line logic change is in `reduceSyncQueue`'s `hasPendingSwitch` condition. The existing `playIndex !== savedPlayIndex` check is preserved — the fix only adds `state.clear` as an OR condition, so all other playback flows (Play Next, Play Later, track switching while playing) are unaffected.
