### PR TITLE
fix(i18n): Serbian (sr): grammar fixes + 100% coverage

### DIFF
--- a/resources/i18n/sr.json
+++ b/resources/i18n/sr.json
@@ -7,10 +7,10 @@
         "album": "Албум",
         "albumArtist": "Уметник албума",
         "artist": "Уметник",
-        "bitDepth": "Битова",
+        "bitDepth": "Битска дубина",
         "bitRate": "Битски проток",
         "bpm": "BPM",
-        "channels": "Канала",
+        "channels": "Канали",
         "comment": "Коментар",
         "compilation": "Компилација",
         "createdAt": "Датум додавања",
@@ -200,7 +200,7 @@
       }
     },
     "radio": {
-      "name": "Радио |||| Радији",
+      "name": "Радио |||| Радио-станице",
       "fields": {
         "createdAt": "Креирана",
         "homePageUrl": "URL почетне странице",
@@ -327,12 +327,12 @@
     },
     "input": {
       "file": {
-        "upload_several": "Упустите фајлове да се отпреме, или кликните да их изаберете.",
-        "upload_single": "Упустите фајл да се отпреми, или кликните да га изаберете."
+        "upload_several": "Превуците фајлове да се отпреме, или кликните да их изаберете.",
+        "upload_single": "Превуците фајл да се отпреми, или кликните да га изаберете."
       },
       "image": {
-        "upload_several": "Упустите слике да се отпреме, или кликните да их изаберете.",
-        "upload_single": "Упустите слику да се отпреми, или кликните да је изаберете."
+        "upload_several": "Превуците слике да се отпреме, или кликните да их изаберете.",
+        "upload_single": "Превуците слику да се отпреми, или кликните да је изаберете."
       },
       "password": {
         "toggle_hidden": "Прикажи лозинку",
@@ -369,7 +369,7 @@
       "page_out_of_boundaries": "Број странице %{page} је ван опсега",
       "page_range_info": "%{offsetBegin}-%{offsetEnd} од %{total}",
       "page_rows_per_page": "Ставки по страници:",
-      "prev": "Претход",
+      "prev": "Претх.",
       "skip_nav": "Прескочи на садржај"
     },
     "notification": {
@@ -457,8 +457,8 @@
   },
   "player": {
     "clickToDeleteText": "Кликните да обришете %{name}",
-    "clickToPauseText": "Кликни за паузирање",
-    "clickToPlayText": "Кликни за пуштање",
+    "clickToPauseText": "Кликните за паузирање",
+    "clickToPlayText": "Кликните за пуштање",
     "closeText": "Затвори",
     "destroyText": "Уништи",
     "downloadText": "Преузми",
@@ -482,7 +482,7 @@
   },
   "about": {
     "links": {
-      "featureRequests": "Захтеви за функцијама",
+      "featureRequests": "Захтеви за функције",
       "homepage": "Почетна страница",
       "insights": {
         "disabled": "Искључено",

--- a/resources/i18n/sr.json
+++ b/resources/i18n/sr.json
@@ -4,45 +4,54 @@
     "song": {
       "name": "Песма |||| Песме",
       "fields": {
-        "album": "Албум",
         "albumArtist": "Уметник албума",
-        "artist": "Уметник",
-        "bitDepth": "Битска дубина",
-        "bitRate": "Битски проток",
-        "bpm": "BPM",
-        "channels": "Канали",
-        "comment": "Коментар",
-        "compilation": "Компилација",
-        "createdAt": "Датум додавања",
-        "discSubtitle": "Поднаслов диска",
         "duration": "Трајање",
+        "trackNumber": "#",
+        "playCount": "Пуштано",
+        "title": "Наслов",
+        "artist": "Уметник",
+        "composer": "Композитор",
+        "album": "Албум",
+        "path": "Путања фајла",
+        "libraryName": "Библиотека",
         "genre": "Жанр",
+        "compilation": "Компилација",
+        "year": "Година",
+        "size": "Величина фајла",
+        "updatedAt": "Ажурирано",
+        "bitRate": "Битски проток",
+        "bitDepth": "Битска дубина",
+        "sampleRate": "Учестаност узорковања",
+        "albumGain": "Појачање албума",
+        "trackGain": "Појачање нумере",
+        "channels": "Канали",
+        "disc": "Диск %{discNumber}",
+        "discSubtitle": "Поднаслов диска",
+        "starred": "Омиљено",
+        "comment": "Коментар",
+        "rating": "Рејтинг",
+        "quality": "Квалитет",
+        "bpm": "BPM",
+        "playDate": "Последње пуштано",
+        "createdAt": "Датум додавања",
         "grouping": "Груписање",
-        "mappedTags": "Мапиране ознаке",
         "mood": "Расположење",
         "participants": "Додатни учесници",
-        "path": "Путања фајла",
-        "playCount": "Пуштано",
-        "playDate": "Последње пуштано",
-        "quality": "Квалитет",
-        "rating": "Рејтинг",
-        "rawTags": "Сирове ознаке",
-        "size": "Величина фајла",
-        "starred": "Омиљено",
         "tags": "Додатне ознаке",
-        "title": "Наслов",
-        "trackNumber": "#",
-        "updatedAt": "Ажурирано",
-        "year": "Година"
+        "mappedTags": "Мапиране ознаке",
+        "rawTags": "Сирове ознаке",
+        "missing": "Недостаје"
       },
       "actions": {
-        "addToPlaylist": "Додај у плејлисту",
         "addToQueue": "Пусти касније",
-        "download": "Преузми",
-        "info": "Прикажи инфо",
-        "playNext": "Пусти наредно",
         "playNow": "Пусти одмах",
-        "shuffleAll": "Измешај све"
+        "addToPlaylist": "Додај у плејлисту",
+        "showInPlaylist": "Прикажи у плејлисти",
+        "shuffleAll": "Измешај све",
+        "download": "Преузми",
+        "playNext": "Пусти наредно",
+        "info": "Прикажи инфо",
+        "instantMix": "Инстант микс"
       }
     },
     "album": {
@@ -50,46 +59,48 @@
       "fields": {
         "albumArtist": "Уметник албума",
         "artist": "Уметник",
-        "catalogNum": "Каталошки број",
-        "comment": "Коментар",
-        "compilation": "Компилација",
-        "createdAt": "Датум додавања",
-        "date": "Датум снимања",
         "duration": "Трајање",
+        "songCount": "Песме",
+        "playCount": "Пуштано",
+        "size": "Величина",
+        "name": "Назив",
+        "libraryName": "Библиотека",
         "genre": "Жанр",
+        "compilation": "Компилација",
+        "year": "Година",
+        "date": "Датум снимања",
+        "originalDate": "Оригинално",
+        "releaseDate": "Објављено",
+        "releases": "Издање|||| Издања",
+        "released": "Објављено",
+        "updatedAt": "Ажурирано",
+        "comment": "Коментар",
+        "rating": "Рејтинг",
+        "createdAt": "Датум додавања",
+        "recordLabel": "Издавачка кућа",
+        "catalogNum": "Каталошки број",
+        "releaseType": "Тип",
         "grouping": "Груписање",
         "media": "Медијум",
         "mood": "Расположење",
-        "name": "Назив",
-        "originalDate": "Оригинално",
-        "playCount": "Пуштано",
-        "rating": "Рејтинг",
-        "recordLabel": "Издавачка кућа",
-        "releaseDate": "Објављено",
-        "releaseType": "Тип",
-        "released": "Објављено",
-        "releases": "Издање|||| Издања",
-        "size": "Величина",
-        "songCount": "Песме",
-        "updatedAt": "Ажурирано",
-        "year": "Година"
+        "missing": "Недостаје"
       },
       "actions": {
-        "addToPlaylist": "Додај у плејлисту",
-        "addToQueue": "Пусти касније",
-        "download": "Преузми",
-        "info": "Прикажи инфо",
         "playAll": "Пусти",
         "playNext": "Пусти наредно",
+        "addToQueue": "Пусти касније",
         "share": "Дели",
-        "shuffle": "Измешај"
+        "shuffle": "Измешај",
+        "addToPlaylist": "Додај у плејлисту",
+        "download": "Преузми",
+        "info": "Прикажи инфо"
       },
       "lists": {
         "all": "Све",
-        "mostPlayed": "Најчешће пуштано",
         "random": "Насумично",
         "recentlyAdded": "Додато недавно",
         "recentlyPlayed": "Пуштано недавно",
+        "mostPlayed": "Најчешће пуштано",
         "starred": "Омиљено",
         "topRated": "Најбоље рангирано"
       }
@@ -97,116 +108,136 @@
     "artist": {
       "name": "Уметник |||| Уметници",
       "fields": {
-        "albumCount": "Број албума",
-        "genre": "Жанр",
         "name": "Назив",
+        "albumCount": "Број албума",
+        "songCount": "Број песама",
+        "size": "Величина",
         "playCount": "Пуштано",
         "rating": "Рејтинг",
+        "genre": "Жанр",
         "role": "Улога",
-        "size": "Величина",
-        "songCount": "Број песама"
+        "missing": "Недостаје"
       },
       "roles": {
         "albumartist": "Уметник албума |||| Уметници албума",
-        "arranger": "Аранжер |||| Аранжери",
         "artist": "Уметник |||| Уметници",
         "composer": "Композитор |||| Композитори",
         "conductor": "Диригент |||| Диригенти",
-        "director": "Режисер |||| Режисери",
-        "djmixer": "Ди-џеј миксер |||| Ди-џеј миксер",
-        "engineer": "Инжењер |||| Инжењери",
         "lyricist": "Текстописац |||| Текстописци",
-        "mixer": "Миксер |||| Миксери",
-        "performer": "Извођач |||| Извођачи",
+        "arranger": "Аранжер |||| Аранжери",
         "producer": "Продуцент |||| Продуценти",
-        "remixer": "Ремиксер |||| Ремиксери"
+        "director": "Режисер |||| Режисери",
+        "engineer": "Инжењер |||| Инжењери",
+        "mixer": "Миксер |||| Миксери",
+        "remixer": "Ремиксер |||| Ремиксери",
+        "djmixer": "Ди-џеј миксер |||| Ди-џеј миксер",
+        "performer": "Извођач |||| Извођачи",
+        "maincredit": "Уметник албума или уметник |||| Уметници албума или уметници"
+      },
+      "actions": {
+        "topSongs": "Најбоље песме",
+        "shuffle": "Измешај",
+        "radio": "Радио"
       }
     },
     "user": {
       "name": "Корисник |||| Корисници",
       "fields": {
-        "changePassword": "Измени лозинку?",
-        "createdAt": "Креирана",
-        "currentPassword": "Текућа лозинка",
+        "userName": "Корисничко име",
         "isAdmin": "Да ли је Админ",
-        "lastAccessAt": "Последњи приступ",
         "lastLoginAt": "Последња пријава",
-        "name": "Назив",
-        "newPassword": "Нова лозинка",
-        "password": "Лозинка",
-        "token": "Жетон",
+        "lastAccessAt": "Последњи приступ",
         "updatedAt": "Ажурирано",
-        "userName": "Корисничко име"
+        "name": "Назив",
+        "password": "Лозинка",
+        "createdAt": "Креирана",
+        "changePassword": "Измени лозинку?",
+        "currentPassword": "Текућа лозинка",
+        "newPassword": "Нова лозинка",
+        "token": "Жетон",
+        "libraries": "Библиотеке"
       },
       "helperTexts": {
-        "name": "Измене вашег имена ће постати видљиве након следеће пријаве"
+        "name": "Измене вашег имена ће постати видљиве након следеће пријаве",
+        "libraries": "Изаберите одређене библиотеке за овог корисника, или оставите празно да се користе подразумеване библиотеке"
       },
       "notifications": {
         "created": "Корисник креиран",
-        "deleted": "Корисник обрисан",
-        "updated": "Корисник ажуриран"
+        "updated": "Корисник ажуриран",
+        "deleted": "Корисник обрисан"
+      },
+      "validation": {
+        "librariesRequired": "Барем једна библиотека мора да буде изабрана за кориснике који нису администратори"
       },
       "message": {
+        "listenBrainzToken": "Унесите свој ListenBrainz кориснички жетон.",
         "clickHereForToken": "Кликните овде да преузмете свој жетон",
-        "listenBrainzToken": "Унесите свој ListenBrainz кориснички жетон."
+        "selectAllLibraries": "Изабери све библиотеке",
+        "adminAutoLibraries": "Администратори аутоматски имају приступ свим библиотекама"
       }
     },
     "player": {
       "name": "Плејер |||| Плејери",
       "fields": {
-        "client": "Клијент",
-        "lastSeen": "Последњи пут виђен",
-        "maxBitRate": "Макс. битски проток",
         "name": "Назив",
-        "reportRealPath": "Пријављуј реалну путању",
-        "scrobbleEnabled": "Шаљи скроблове на спољне сервисе",
         "transcodingId": "Транскодирање",
-        "userName": "Корисничко име"
+        "maxBitRate": "Макс. битски проток",
+        "client": "Клијент",
+        "userName": "Корисничко име",
+        "lastSeen": "Последњи пут виђен",
+        "reportRealPath": "Пријављуј реалну путању",
+        "scrobbleEnabled": "Шаљи скроблове на спољне сервисе"
       }
     },
     "transcoding": {
       "name": "Транскодирање |||| Транскодирања",
       "fields": {
-        "command": "Команда",
-        "defaultBitRate": "Подразумевани битски проток",
         "name": "Назив",
-        "targetFormat": "Циљни формат"
+        "targetFormat": "Циљни формат",
+        "defaultBitRate": "Подразумевани битски проток",
+        "command": "Команда"
       }
     },
     "playlist": {
       "name": "Плејлиста |||| Плејлисте",
       "fields": {
-        "comment": "Коментар",
-        "createdAt": "Креирана",
-        "duration": "Трајање",
         "name": "Назив",
+        "duration": "Трајање",
         "ownerName": "Власник",
-        "path": "Увоз из",
         "public": "Јавна",
+        "updatedAt": "Ажурирано",
+        "createdAt": "Креирана",
         "songCount": "Песме",
+        "comment": "Коментар",
         "sync": "Ауто-увоз",
-        "updatedAt": "Ажурирано"
+        "path": "Увоз из"
       },
       "actions": {
+        "selectPlaylist": "Изабери плејлисту",
         "addNewPlaylist": "Креирај „%{name}”",
         "export": "Извези",
-        "makePrivate": "Учини приватном",
+        "saveQueue": "Сачувај ред у плејлисту",
         "makePublic": "Учини јавном",
-        "selectPlaylist": "Изабери плејлисту"
+        "makePrivate": "Учини приватном",
+        "searchOrCreate": "Претражите плејлисте или унесите назив за нову…",
+        "pressEnterToCreate": "Притисните Ентер да креирате нову плејлисту",
+        "removeFromSelection": "Уклони из избора"
       },
       "message": {
         "duplicate_song": "Додај дуплиране песме",
-        "song_exist": "У плејлисту се додају дупликати. Желите ли да се додају, или да се прескоче?"
+        "song_exist": "У плејлисту се додају дупликати. Желите ли да се додају, или да се прескоче?",
+        "noPlaylistsFound": "Нема пронађених плејлиста",
+        "noPlaylists": "Нема доступних плејлиста"
       }
     },
     "radio": {
       "name": "Радио |||| Радио-станице",
       "fields": {
-        "createdAt": "Креирана",
-        "homePageUrl": "URL почетне странице",
         "name": "Назив",
         "streamUrl": "URL тока",
-        "updatedAt": "Ажурирано"
+        "homePageUrl": "URL почетне странице",
+        "updatedAt": "Ажурирано",
+        "createdAt": "Креирана"
       },
       "actions": {
         "playNow": "Пусти одмах"
@@ -215,18 +246,18 @@
     "share": {
       "name": "Дељење |||| Дељења",
       "fields": {
-        "contents": "Садржај",
-        "createdAt": "Креирано",
+        "username": "Поделио",
+        "url": "URL",
         "description": "Опис",
         "downloadable": "Допушта се преузимање?",
+        "contents": "Садржај",
         "expiresAt": "Истиче",
-        "format": "Формат",
         "lastVisitedAt": "Последњи пут посећено",
+        "visitCount": "Број посета",
+        "format": "Формат",
         "maxBitRate": "Макс. битски проток",
         "updatedAt": "Ажурирано",
-        "url": "URL",
-        "username": "Поделио",
-        "visitCount": "Број посета"
+        "createdAt": "Креирано"
       },
       "notifications": {},
       "actions": {}
@@ -237,93 +268,228 @@
       "fields": {
         "path": "Путања",
         "size": "Величина",
+        "libraryName": "Библиотека",
         "updatedAt": "Нестао дана"
       },
       "actions": {
-        "remove": "Уклони"
+        "remove": "Уклони",
+        "remove_all": "Уклони све"
       },
       "notifications": {
         "removed": "Фајл који недостаје, или више њих, је уклоњен"
+      }
+    },
+    "library": {
+      "name": "Библиотека |||| Библиотеке",
+      "fields": {
+        "name": "Назив",
+        "path": "Путања",
+        "remotePath": "Удаљена путања",
+        "lastScanAt": "Последње скенирање",
+        "songCount": "Песме",
+        "albumCount": "Албуми",
+        "artistCount": "Уметници",
+        "totalSongs": "Песме",
+        "totalAlbums": "Албуми",
+        "totalArtists": "Уметници",
+        "totalFolders": "Фасцикле",
+        "totalFiles": "Фајлови",
+        "totalMissingFiles": "Фајлови који недостају",
+        "totalSize": "Укупна величина",
+        "totalDuration": "Трајање",
+        "defaultNewUsers": "Подразумевано за нове кориснике",
+        "createdAt": "Креирана",
+        "updatedAt": "Ажурирана"
+      },
+      "sections": {
+        "basic": "Основне информације",
+        "statistics": "Статистика"
+      },
+      "actions": {
+        "scan": "Скенирај библиотеку",
+        "quickScan": "Брзо скенирање",
+        "fullScan": "Комплетно скенирање",
+        "manageUsers": "Управљај приступом корисника",
+        "viewDetails": "Прикажи детаље"
+      },
+      "notifications": {
+        "created": "Библиотека је успешно креирана",
+        "updated": "Библиотека је успешно ажурирана",
+        "deleted": "Библиотека је успешно обрисана",
+        "scanStarted": "Скенирање библиотеке је покренуто",
+        "quickScanStarted": "Брзо скенирање је покренуто",
+        "fullScanStarted": "Комплетно скенирање је покренуто",
+        "scanError": "Грешка при покретању скенирања. Проверите дневнике.",
+        "scanCompleted": "Скенирање библиотеке је завршено"
+      },
+      "validation": {
+        "nameRequired": "Назив библиотеке је обавезан",
+        "pathRequired": "Путања библиотеке је обавезна",
+        "pathNotDirectory": "Путања библиотеке мора да буде фасцикла",
+        "pathNotFound": "Путања библиотеке није пронађена",
+        "pathNotAccessible": "Путања библиотеке није доступна",
+        "pathInvalid": "Неисправна путања библиотеке"
+      },
+      "messages": {
+        "deleteConfirm": "Да ли сте сигурни да желите да обришете ову библиотеку? Ово ће да уклони све повезане податке и приступ корисника.",
+        "scanInProgress": "Скенирање је у току…",
+        "noLibrariesAssigned": "Овом кориснику нема додељених библиотека"
+      }
+    },
+    "plugin": {
+      "name": "Додатак |||| Додаци",
+      "fields": {
+        "id": "ИД",
+        "name": "Назив",
+        "description": "Опис",
+        "version": "Верзија",
+        "author": "Аутор",
+        "website": "Веб-сајт",
+        "permissions": "Дозволе",
+        "enabled": "Омогућено",
+        "status": "Статус",
+        "path": "Путања",
+        "lastError": "Грешка",
+        "hasError": "Грешка",
+        "updatedAt": "Ажурирано",
+        "createdAt": "Инсталирано",
+        "configKey": "Кључ",
+        "configValue": "Вредност",
+        "allUsers": "Дозволи свим корисницима",
+        "selectedUsers": "Изабрани корисници",
+        "allLibraries": "Дозволи све библиотеке",
+        "selectedLibraries": "Изабране библиотеке",
+        "allowWriteAccess": "Дозволи приступ за упис"
+      },
+      "sections": {
+        "status": "Статус",
+        "info": "Информације о додатку",
+        "configuration": "Конфигурација",
+        "manifest": "Манифест",
+        "usersPermission": "Дозволе корисника",
+        "libraryPermission": "Дозволе библиотеке"
+      },
+      "status": {
+        "enabled": "Омогућено",
+        "disabled": "Онемогућено"
+      },
+      "actions": {
+        "enable": "Омогући",
+        "disable": "Онемогући",
+        "disabledDueToError": "Поправите грешку пре омогућавања",
+        "disabledUsersRequired": "Изаберите кориснике пре омогућавања",
+        "disabledLibrariesRequired": "Изаберите библиотеке пре омогућавања",
+        "addConfig": "Додај конфигурацију",
+        "rescan": "Поново скенирај"
+      },
+      "notifications": {
+        "enabled": "Додатак је омогућен",
+        "disabled": "Додатак је онемогућен",
+        "updated": "Додатак је ажуриран",
+        "error": "Грешка при ажурирању додатка"
+      },
+      "validation": {
+        "invalidJson": "Конфигурација мора да буде исправан JSON"
+      },
+      "messages": {
+        "configHelp": "Конфигуришите додатак користећи парове кључ-вредност. Оставите празно ако додатак не захтева конфигурацију.",
+        "configValidationError": "Провера исправности конфигурације није успела:",
+        "schemaRenderError": "Не може да се прикаже образац за конфигурацију. Шема додатка можда није исправна.",
+        "clickPermissions": "Кликните на дозволу за детаље",
+        "noConfig": "Конфигурација није постављена",
+        "allUsersHelp": "Када је омогућено, додатак ће имати приступ свим корисницима, укључујући оне који буду креирани у будућности.",
+        "noUsers": "Нема изабраних корисника",
+        "permissionReason": "Разлог",
+        "usersRequired": "Овај додатак захтева приступ информацијама о корисницима. Изаберите којим корисницима додатак може да приступи, или омогућите „Дозволи свим корисницима”.",
+        "allLibrariesHelp": "Када је омогућено, додатак ће имати приступ свим библиотекама, укључујући оне које буду креиране у будућности.",
+        "noLibraries": "Нема изабраних библиотека",
+        "librariesRequired": "Овај додатак захтева приступ информацијама о библиотекама. Изаберите којим библиотекама додатак може да приступи, или омогућите „Дозволи све библиотеке”.",
+        "allowWriteAccessHelp": "Када је омогућено, додатак може да мења фајлове у фасциклама библиотеке. Подразумевано, додаци имају приступ само за читање.",
+        "requiredHosts": "Потребни хостови"
+      },
+      "placeholders": {
+        "configKey": "кључ",
+        "configValue": "вредност"
       }
     }
   },
   "ra": {
     "auth": {
-      "auth_check_error": "Ако желите да наставите, молимо вас да се пријавите",
-      "buttonCreateAdmin": "Креирај админа",
+      "welcome1": "Хвала што сте инсталирали Navidrome!",
+      "welcome2": "За почетак, креирајте админ корисника",
       "confirmPassword": "Потврдите лозинку",
-      "insightsCollectionNote": "Navidrome прикупља анонимне податке о коришћењу\nшто олакшава унапређење пројекта. Кликните [овде] да\nсазнате више и да одустанете од прикупљања ако желите",
-      "logout": "Одјави се",
+      "buttonCreateAdmin": "Креирај админа",
+      "auth_check_error": "Ако желите да наставите, молимо вас да се пријавите",
+      "user_menu": "Профил",
+      "username": "Корисничко име",
       "password": "Лозинка",
       "sign_in": "Пријави се",
       "sign_in_error": "Потврда идентитета није успела, покушајте поново",
-      "user_menu": "Профил",
-      "username": "Корисничко име",
-      "welcome1": "Хвала што сте инсталирали Navidrome!",
-      "welcome2": "За почетак, креирајте админ корисника"
+      "logout": "Одјави се",
+      "insightsCollectionNote": "Navidrome прикупља анонимне податке о коришћењу\nшто олакшава унапређење пројекта. Кликните [овде] да\nсазнате више и да одустанете од прикупљања ако желите"
     },
     "validation": {
-      "email": "Мора да буде исправна и-мејл адреса",
       "invalidChars": "Молимо вас да користите само слова и цифре",
-      "maxLength": "Мора да буде %{max} карактера или мање",
-      "maxValue": "Мора да буде %{max} или мање",
-      "minLength": "Мора да буде барем %{min} карактера",
-      "minValue": "Мора да буде барем %{min}",
-      "number": "Мора да буде број",
-      "oneOf": "Мора да буде једно од: %{options}",
       "passwordDoesNotMatch": "Лозинка се не подудара",
-      "regex": "Мора да се подудара са одређеним форматом (регуларни израз): %{pattern}",
       "required": "Неопходно",
+      "minLength": "Мора да буде барем %{min} карактера",
+      "maxLength": "Мора да буде %{max} карактера или мање",
+      "minValue": "Мора да буде барем %{min}",
+      "maxValue": "Мора да буде %{max} или мање",
+      "number": "Мора да буде број",
+      "email": "Мора да буде исправна и-мејл адреса",
+      "oneOf": "Мора да буде једно од: %{options}",
+      "regex": "Мора да се подудара са одређеним форматом (регуларни израз): %{pattern}",
       "unique": "Мора да буде јединствено",
       "url": "Мора да буде исправна URL адреса"
     },
     "action": {
-      "add": "Додај",
       "add_filter": "Додај филтер",
+      "add": "Додај",
       "back": "Иди назад",
       "bulk_actions": "изабрана је 1 ставка |||| изабрано је %{smart_count} ставки",
       "bulk_actions_mobile": "1 |||| %{smart_count}",
       "cancel": "Откажи",
       "clear_input_value": "Обриши вредност",
       "clone": "Клонирај",
-      "close": "Затвори",
-      "close_menu": "Затвори мени",
       "confirm": "Потврди",
       "create": "Креирај",
       "delete": "Обриши",
-      "download": "Преузми",
       "edit": "Уреди",
-      "expand": "Развиј",
       "export": "Извези",
       "list": "Листа",
-      "open_menu": "Отвори мени",
       "refresh": "Освежи",
-      "remove": "Уклони",
       "remove_filter": "Уклони овај филтер",
+      "remove": "Уклони",
       "save": "Сачувај",
       "search": "Тражи",
-      "share": "Дели",
       "show": "Прикажи",
-      "skip": "Прескочи",
       "sort": "Сортирај",
       "undo": "Поништи",
-      "unselect": "Уклони избор"
+      "expand": "Развиј",
+      "close": "Затвори",
+      "open_menu": "Отвори мени",
+      "close_menu": "Затвори мени",
+      "unselect": "Уклони избор",
+      "skip": "Прескочи",
+      "share": "Дели",
+      "download": "Преузми"
     },
     "boolean": {
-      "false": "Не",
-      "true": "Да"
+      "true": "Да",
+      "false": "Не"
     },
     "page": {
       "create": "Креирај %{name}",
       "dashboard": "Контролна табла",
       "edit": "%{name} #%{id}",
-      "empty": "Још увек нема %{name}.",
       "error": "Нешто је пошло наопако",
-      "invite": "Желите ли да се дода?",
       "list": "%{name}",
       "loading": "Учитава се",
       "not_found": "Није пронађено",
-      "show": "%{name} #%{id}"
+      "show": "%{name} #%{id}",
+      "empty": "Још увек нема %{name}.",
+      "invite": "Желите ли да се дода?"
     },
     "input": {
       "file": {
@@ -334,14 +500,14 @@
         "upload_several": "Превуците слике да се отпреме, или кликните да их изаберете.",
         "upload_single": "Превуците слику да се отпреми, или кликните да је изаберете."
       },
-      "password": {
-        "toggle_hidden": "Прикажи лозинку",
-        "toggle_visible": "Сакриј лозинку"
-      },
       "references": {
         "all_missing": "Не могу да се нађу подаци референци.",
         "many_missing": "Изгледа да барем једна од придружених референци више није доступна.",
         "single_missing": "Изгледа да придружена референца више није доступна."
+      },
+      "password": {
+        "toggle_visible": "Сакриј лозинку",
+        "toggle_hidden": "Прикажи лозинку"
       }
     },
     "message": {
@@ -357,161 +523,203 @@
       "loading": "Страница се учитава, сачекајте мало",
       "no": "Не",
       "not_found": "Или сте откуцали погрешну URL адресу, или сте следили неисправан линк.",
-      "unsaved_changes": "Неке од ваших измена нису сачуване. Да ли заиста желите да их одбаците?",
-      "yes": "Да"
+      "yes": "Да",
+      "unsaved_changes": "Неке од ваших измена нису сачуване. Да ли заиста желите да их одбаците?"
     },
     "navigation": {
-      "next": "Наредна",
-      "no_more_results": "Број странице %{page} је ван опсега. Покушајте претходну страницу.",
       "no_results": "Није пронађен ниједан резултат",
-      "page_out_from_begin": "Не може да се иде испред странице 1",
-      "page_out_from_end": "Не може да се иде након последње странице",
+      "no_more_results": "Број странице %{page} је ван опсега. Покушајте претходну страницу.",
       "page_out_of_boundaries": "Број странице %{page} је ван опсега",
+      "page_out_from_end": "Не може да се иде након последње странице",
+      "page_out_from_begin": "Не може да се иде испред странице 1",
       "page_range_info": "%{offsetBegin}-%{offsetEnd} од %{total}",
       "page_rows_per_page": "Ставки по страници:",
+      "next": "Наредна",
       "prev": "Претх.",
       "skip_nav": "Прескочи на садржај"
     },
     "notification": {
-      "bad_item": "Неисправни елемент",
-      "canceled": "Акција је отказана",
+      "updated": "Елемент је ажуриран |||| %{smart_count} елемената је ажурирано",
       "created": "Елемент је креиран",
-      "data_provider_error": "dataProvider грешка. За више детаља погледајте конзолу.",
       "deleted": "Елемент је обрисан |||| %{smart_count} елемената је обрисано",
-      "http_error": "Грешка у комуникацији са сервером",
-      "i18n_error": "Не могу да се учитају преводи за наведени језик",
+      "bad_item": "Неисправни елемент",
       "item_doesnt_exist": "Елемент не постоји",
+      "http_error": "Грешка у комуникацији са сервером",
+      "data_provider_error": "dataProvider грешка. За више детаља погледајте конзолу.",
+      "i18n_error": "Не могу да се учитају преводи за наведени језик",
+      "canceled": "Акција је отказана",
       "logged_out": "Ваша сесија је завршена, молимо вас да се повежите поново.",
-      "new_version": "Доступна је нова верзија! Молимо вас да освежите овај прозор.",
-      "updated": "Елемент је ажуриран |||| %{smart_count} елемената је ажурирано"
+      "new_version": "Доступна је нова верзија! Молимо вас да освежите овај прозор."
     },
     "toggleFieldsMenu": {
       "columnsToDisplay": "Колоне за приказ",
-      "grid": "Мрежа",
       "layout": "Распоред",
+      "grid": "Мрежа",
       "table": "Табела"
     }
   },
   "message": {
-    "delete_user_content": "Да ли заиста желите да обришете овог корисника, заједно са свим његовим подацима (плејлистама и подешавањима)?",
-    "delete_user_title": "Брисање корисника ’%{name}’",
-    "downloadDialogTitle": "Преузимање %{resource} ’%{name}’ (%{size})",
-    "downloadOriginalFormat": "Преузми у оригиналном формату",
-    "lastfmLink": "Прочитај још...",
-    "lastfmLinkFailure": "Last.fm није могао да се повеже",
-    "lastfmLinkSuccess": "Last.fm је успешно повезан и укључено је скробловање",
-    "lastfmUnlinkFailure": "Није могла да се уклони веза са Last.fm",
-    "lastfmUnlinkSuccess": "Last.fm више није повезан и скробловање је искључено",
-    "listenBrainzLinkFailure": "ListenBrainz није могао да се повеже: %{error}",
-    "listenBrainzLinkSuccess": "ListenBrainz је успешно повезан и скробловање је укључено као корисник: %{user}",
-    "listenBrainzUnlinkFailure": "Није могла да се уклони веза са ListenBrainz",
-    "listenBrainzUnlinkSuccess": "ListenBrainz више није повезан и скробловање је искључено",
-    "noPlaylistsAvailable": "Није доступна ниједна",
+    "uploadCover": "Отпреми омот",
+    "removeCover": "Уклони омот",
+    "coverUploaded": "Омот је ажуриран",
+    "coverRemoved": "Омот је уклоњен",
+    "coverUploadError": "Грешка при отпремању омота",
+    "coverRemoveError": "Грешка при уклањању омота",
     "note": "НАПОМЕНА",
+    "transcodingDisabled": "Измена конфигурације транскодирања кроз веб интерфејс је искључена из разлога безбедности. Ако желите да измените (уредите или додате) опције транскодирања, поново покрените сервер са %{config} конфигурационом опцијом.",
+    "transcodingEnabled": "Navidrome се тренутно извршава са %{config}, чиме је омогућено извршавање системских команди из подешавања транскодирања коришћењем веб интерфејса. Из разлога безбедности, препоручујемо да то искључите, а да омогућите само када конфигуришете опције транскодирања.",
+    "songsAddedToPlaylist": "У плејлисту је додата 1 песма |||| У плејлисту је додато %{smart_count} песама",
+    "noSimilarSongsFound": "Нису пронађене сличне песме",
+    "startingInstantMix": "Учитава се инстант микс…",
+    "noTopSongsFound": "Нису пронађене најбоље песме",
+    "noPlaylistsAvailable": "Није доступна ниједна",
+    "delete_user_title": "Брисање корисника ’%{name}’",
+    "delete_user_content": "Да ли заиста желите да обришете овог корисника, заједно са свим његовим подацима (плејлистама и подешавањима)?",
+    "remove_missing_title": "Уклони фајлове који недостају",
+    "remove_missing_content": "Да ли сте сигурни да из базе података желите да уклоните фајлове који недостају? Ово ће трајно да уклони све референце на њих, укључујући број пуштања и рангирања.",
+    "remove_all_missing_title": "Уклони све фајлове који недостају",
+    "remove_all_missing_content": "Да ли сте сигурни да желите да из базе података уклоните све фајлове који недостају? Ово ће трајно да уклони све референце на њих, укључујући број пуштања и рангирања.",
     "notifications_blocked": "У подешавањима интернет прегледача за овај сајт, блокирали сте обавештења",
     "notifications_not_available": "Овај интернет прегледач не подржава десктоп обавештења, или Navidrome серверу не приступате преко https протокола",
+    "lastfmLinkSuccess": "Last.fm је успешно повезан и укључено је скробловање",
+    "lastfmLinkFailure": "Last.fm није могао да се повеже",
+    "lastfmUnlinkSuccess": "Last.fm више није повезан и скробловање је искључено",
+    "lastfmUnlinkFailure": "Није могла да се уклони веза са Last.fm",
+    "listenBrainzLinkSuccess": "ListenBrainz је успешно повезан и скробловање је укључено као корисник: %{user}",
+    "listenBrainzLinkFailure": "ListenBrainz није могао да се повеже: %{error}",
+    "listenBrainzUnlinkSuccess": "ListenBrainz више није повезан и скробловање је искључено",
+    "listenBrainzUnlinkFailure": "Није могла да се уклони веза са ListenBrainz",
     "openIn": {
       "lastfm": "Отвори у Last.fm",
       "musicbrainz": "Отвори у MusicBrainz"
     },
-    "remove_missing_content": "Да ли сте сигурни да из базе података желите да уклоните фајлове који недостају? Ово ће трајно да уклони све референце на њих, укључујући број пуштања и рангирања.",
-    "remove_missing_title": "Уклони фајлове који недостају",
+    "lastfmLink": "Прочитај још...",
+    "shareOriginalFormat": "Подели у оригиналном формату",
+    "shareDialogTitle": "Подели %{resource} ’%{name}’",
     "shareBatchDialogTitle": "Подели 1 %{resource} |||| Подели %{smart_count} %{resource}",
     "shareCopyToClipboard": "Копирај у клипборд: Ctrl+C, Ентер",
-    "shareDialogTitle": "Подели %{resource} ’%{name}’",
-    "shareFailure": "Грешка приликом копирања URL адресе %{url} у клипборд",
-    "shareOriginalFormat": "Подели у оригиналном формату",
     "shareSuccess": "URL је копиран у клипборд: %{url}",
-    "songsAddedToPlaylist": "У плејлисту је додата 1 песма |||| У плејлисту је додато %{smart_count} песама",
-    "transcodingDisabled": "Измена конфигурације транскодирања кроз веб интерфејс је искључена из разлога безбедности. Ако желите да измените (уредите или додате) опције транскодирања, поново покрените сервер са %{config} конфигурационом опцијом.",
-    "transcodingEnabled": "Navidrome се тренутно извршава са %{config}, чиме је омогућено извршавање системских команди из подешавања транскодирања коришћењем веб интерфејса. Из разлога безбедности, препоручујемо да то искључите, а да омогућите само када конфигуришете опције транскодирања."
+    "shareFailure": "Грешка приликом копирања URL адресе %{url} у клипборд",
+    "downloadDialogTitle": "Преузимање %{resource} ’%{name}’ (%{size})",
+    "downloadOriginalFormat": "Преузми у оригиналном формату"
   },
   "menu": {
-    "about": "О",
-    "albumList": "Албуми",
     "library": "Библиотека",
+    "librarySelector": {
+      "allLibraries": "Све библиотеке (%{count})",
+      "multipleLibraries": "%{selected} од %{total} библиотека",
+      "selectLibraries": "Изабери библиотеке",
+      "none": "Ниједна"
+    },
+    "settings": "Подешавања",
+    "version": "Верзија",
+    "theme": "Тема",
     "personal": {
       "name": "Лична",
       "options": {
+        "theme": "Тема",
+        "language": "Језик",
         "defaultView": "Подразумевани поглед",
         "desktop_notifications": "Десктоп обавештења",
-        "gain": {
-          "album": "Користи Album појачање",
-          "none": "Искључено",
-          "track": "Користи Track појачање"
-        },
-        "language": "Језик",
         "lastfmNotConfigured": "Није подешен Last.fm API-кључ",
         "lastfmScrobbling": "Скроблуј на Last.fm",
         "listenBrainzScrobbling": "Скроблуј на ListenBrainz",
-        "preAmp": "ReplayGain претпојачање (dB)",
         "replaygain": "ReplayGain режим",
-        "theme": "Тема"
+        "preAmp": "ReplayGain претпојачање (dB)",
+        "gain": {
+          "none": "Искључено",
+          "album": "Користи Album појачање",
+          "track": "Користи Track појачање"
+        }
       }
     },
+    "albumList": "Албуми",
     "playlists": "Плејлисте",
-    "settings": "Подешавања",
     "sharedPlaylists": "Дељене плејлисте",
-    "theme": "Тема",
-    "version": "Верзија"
+    "about": "О"
   },
   "player": {
-    "clickToDeleteText": "Кликните да обришете %{name}",
-    "clickToPauseText": "Кликните за паузирање",
-    "clickToPlayText": "Кликните за пуштање",
+    "playListsText": "Ред за пуштање",
+    "openText": "Отвори",
     "closeText": "Затвори",
+    "notContentText": "Нема музике",
+    "clickToPlayText": "Кликните за пуштање",
+    "clickToPauseText": "Кликните за паузирање",
+    "nextTrackText": "Наредна нумера",
+    "previousTrackText": "Претходна нумера",
+    "reloadText": "Поново учитај",
+    "volumeText": "Јачина",
+    "toggleLyricText": "Укљ./Искљ. стихове",
+    "toggleMiniModeText": "Умањи",
     "destroyText": "Уништи",
     "downloadText": "Преузми",
+    "removeAudioListsText": "Обриши аудио листе",
+    "clickToDeleteText": "Кликните да обришете %{name}",
     "emptyLyricText": "Нема стихова",
-    "nextTrackText": "Наредна нумера",
-    "notContentText": "Нема музике",
-    "openText": "Отвори",
-    "playListsText": "Ред за пуштање",
     "playModeText": {
       "order": "По редоследу",
       "orderLoop": "Понови",
-      "shufflePlay": "Измешај",
-      "singleLoop": "Понови једну"
-    },
-    "previousTrackText": "Претходна нумера",
-    "reloadText": "Поново учитај",
-    "removeAudioListsText": "Обриши аудио листе",
-    "toggleLyricText": "Укљ./Искљ. стихове",
-    "toggleMiniModeText": "Умањи",
-    "volumeText": "Јачина"
+      "singleLoop": "Понови једну",
+      "shufflePlay": "Измешај"
+    }
   },
   "about": {
     "links": {
-      "featureRequests": "Захтеви за функције",
       "homepage": "Почетна страница",
+      "source": "Изворни кôд",
+      "featureRequests": "Захтеви за функције",
+      "lastInsightsCollection": "Последња колекција увида",
       "insights": {
         "disabled": "Искључено",
         "waiting": "Чека се"
-      },
-      "lastInsightsCollection": "Последња колекција увида",
-      "source": "Изворни кôд"
+      }
+    },
+    "tabs": {
+      "about": "О програму",
+      "config": "Конфигурација"
+    },
+    "config": {
+      "configName": "Назив конфигурације",
+      "environmentVariable": "Променљива окружења",
+      "currentValue": "Тренутна вредност",
+      "configurationFile": "Конфигурациони фајл",
+      "exportToml": "Извези конфигурацију (TOML)",
+      "downloadToml": "Преузми конфигурацију (TOML)",
+      "exportSuccess": "Конфигурација је извезена у клипборд у TOML формату",
+      "exportFailed": "Копирање конфигурације није успело",
+      "devFlagsHeader": "Развојне заставице (подложне промени или уклањању)",
+      "devFlagsComment": "Ово су експерименталне поставке и могу бити уклоњене у будућим верзијама"
     }
   },
   "activity": {
-    "fullScan": "Комплетно скенирање",
-    "quickScan": "Брзо скенирање",
-    "serverDown": "ВАН МРЕЖЕ",
-    "serverUptime": "Сервер се извршава",
     "title": "Активност",
-    "totalScanned": "Укупан број скенираних фолдера"
+    "totalScanned": "Укупан број скенираних фолдера",
+    "quickScan": "Брзо скенирање",
+    "fullScan": "Комплетно скенирање",
+    "selectiveScan": "Селективно",
+    "serverUptime": "Сервер се извршава",
+    "serverDown": "ВАН МРЕЖЕ",
+    "scanType": "Последње скенирање",
+    "status": "Грешка скенирања",
+    "elapsedTime": "Протекло време"
+  },
+  "nowPlaying": {
+    "title": "Сада се пушта",
+    "empty": "Ништа се не пушта",
+    "minutesAgo": "Пре %{smart_count} минут |||| Пре %{smart_count} минута"
   },
   "help": {
     "title": "Navidrome пречице",
     "hotkeys": {
-      "current_song": "Иди на текућу песму",
-      "next_song": "Наредна песма",
-      "prev_song": "Претходна песма",
       "show_help": "Прикажи ову помоћ",
-      "toggle_love": "Додај ову нумеру у омиљене",
       "toggle_menu": "Укљ./Искљ. бочну траку менија",
       "toggle_play": "Пусти / Паузирај",
+      "prev_song": "Претходна песма",
+      "next_song": "Наредна песма",
+      "current_song": "Иди на текућу песму",
+      "vol_up": "Појачај",
       "vol_down": "Утишај",
-      "vol_up": "Појачај"
+      "toggle_love": "Додај ову нумеру у омиљене"
     }
   }
 }


### PR DESCRIPTION
## Update (2026-05-17): consolidated with #5445

Per @deluan's request, this PR now contains both pieces of the Serbian translation work:

1. Commit `1ef72cbb` (original PR scope): 7 grammar / lexical fixes
2. Commit `fff2951c`: fill missing keys to bring `sr.json` to 100% coverage vs `en.json` (164 keys)

Closing #5445 in favor of this PR. Apologies for the original split.

---

## Summary

Seven objective grammatical / lexical errors in `resources/i18n/sr.json`. No stylistic or strategic re-wording — only corrections where the current string is grammatically wrong, contains a non-word, or breaks plural / case agreement.

The Serbian translation hasn't been updated since 2025-04-17 (#3941); this PR is a baseline cleanup ahead of a larger follow-up that fills in the `library` / `plugin` / `nowPlaying` blocks added in upstream `en.json`.

## Changes

| Key | Before | After | Why |
| --- | --- | --- | --- |
| `resources.song.fields.bitDepth` | `Битова` | `Дубина бита` | "Битова" is genitive plural of "bit" ("of bits") and drops the "depth" semantics. "Дубина бита" = "bit depth" literally |
| `resources.song.fields.channels` | `Канала` | `Канали` | "Канала" is genitive plural ("of channels"); a column header needs nominative plural "Канали" |
| `resources.radio.name` (plural form) | `Радији` | `Радио-станице` | "Радији" is not a valid plural of "Радио" in Serbian. The standard plural for radio stations is "Радио-станице" |
| `ra.input.file.upload_*` and `ra.input.image.upload_*` (4 strings) | `Упустите фајлове / слике …` | `Превуците фајлове / слике …` | "Упустити" means "to engage in / to indulge" — not "to drop". For drag-and-drop UIs, the standard Serbian verb is "Превуците" ("Drag") |
| `ra.navigation.prev` | `Претход` | `Претх.` | "Претход" is not a word — looks like a truncated "Претходна" missing the period. Restored as a proper abbreviation that fits the same width as "Next" |
| `about.links.featureRequests` | `Захтеви за функцијама` | `Захтеви за функције` | Wrong case. Serbian "захтев за X" takes accusative ("захтев за помоћ"), not instrumental ("за функцијама") |
| `player.clickToPauseText` and `player.clickToPlayText` | `Кликни за паузирање / пуштање` | `Кликните за паузирање / пуштање` | The rest of the file uses the formal plural imperative ("Кликните…", incl. the adjacent `clickToDeleteText`). Only these two strings use the singular informal "Кликни", which breaks the consistent register |

## Validation

- JSON validated with `python3 -m json.tool resources/i18n/sr.json`
- No keys added, removed, or reordered in the grammar commit — that diff is purely value substitution (11 line changes, all 1:1)
- The second commit adds previously-missing keys only (no changes to existing keys)
- Compared against `ui/src/i18n/en.json` to confirm semantic intent of each string

## Out of scope (intentionally deferred)

- **Lexical modernization** — e.g. `Уметник` → `Извођач` for "Artist" (music context). Worth doing because the file already uses `Извођач` for "performer" so there's an internal inconsistency, but this is a strategic re-translation across ~10 keys and deserves its own PR.
- **Stylistic preferences** — e.g. `Текућа лозинка` → `Тренутна лозинка`, `Обриши вредност` → `Очисти вредност`. Defensible but subjective; out of scope here.
