### PR TITLE
feat: replace UI scrobble with reportPlayback and redesign NowPlaying panel

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -95,6 +95,7 @@ type configOptions struct {
 	EnableReplayGain                bool
 	EnableCoverAnimation            bool
 	EnableNowPlaying                bool
+	UIPlaybackReportInterval        time.Duration
 	GATrackingID                    string
 	EnableLogRedacting              bool
 	AuthRequestLimit                int
@@ -776,6 +777,7 @@ func setViperDefaults() {
 	viper.SetDefault("enablereplaygain", true)
 	viper.SetDefault("enablecoveranimation", true)
 	viper.SetDefault("enablenowplaying", true)
+	viper.SetDefault("uiplaybackreportinterval", consts.DefaultUIPlaybackReportInterval)
 	viper.SetDefault("enableartworkupload", true)
 	viper.SetDefault("maximageuploadsize", consts.DefaultMaxImageUploadSize)
 	viper.SetDefault("enablesharing", false)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -67,11 +67,12 @@ const (
 	ScanIgnoreFile = ".ndignore"
 	ArtworkFolder  = "artwork"
 
-	PlaceholderArtistArt      = "artist-placeholder.webp"
-	PlaceholderAlbumArt       = "album-placeholder.webp"
-	PlaceholderAvatar         = "logo-192x192.png"
-	DefaultUIVolume           = 100
-	DefaultUISearchDebounceMs = 200
+	PlaceholderArtistArt            = "artist-placeholder.webp"
+	PlaceholderAlbumArt             = "album-placeholder.webp"
+	PlaceholderAvatar               = "logo-192x192.png"
+	DefaultUIVolume                 = 100
+	DefaultUISearchDebounceMs       = 200
+	DefaultUIPlaybackReportInterval = time.Minute
 
 	DefaultHttpClientTimeOut = 10 * time.Second
 

--- a/core/scrobbler/play_tracker.go
+++ b/core/scrobbler/play_tracker.go
@@ -399,7 +399,7 @@ func (p *playTracker) GetNowPlaying(_ context.Context) ([]NowPlayingInfo, error)
 		return b.Start.Compare(a.Start)
 	})
 	for i := range res {
-		if res[i].State == StatePlaying {
+		if res[i].State == StatePlaying || res[i].State == StateStarting {
 			elapsed := time.Since(res[i].LastReport).Milliseconds()
 			estimated := res[i].PositionMs + int64(float64(elapsed)*res[i].PlaybackRate)
 			trackDurationMs := int64(res[i].MediaFile.Duration * 1000)

--- a/core/scrobbler/play_tracker.go
+++ b/core/scrobbler/play_tracker.go
@@ -399,7 +399,7 @@ func (p *playTracker) GetNowPlaying(_ context.Context) ([]NowPlayingInfo, error)
 		return b.Start.Compare(a.Start)
 	})
 	for i := range res {
-		if res[i].State == StatePlaying || res[i].State == StateStarting {
+		if res[i].State == StatePlaying {
 			elapsed := time.Since(res[i].LastReport).Milliseconds()
 			estimated := res[i].PositionMs + int64(float64(elapsed)*res[i].PlaybackRate)
 			trackDurationMs := int64(res[i].MediaFile.Duration * 1000)

--- a/core/scrobbler/play_tracker.go
+++ b/core/scrobbler/play_tracker.go
@@ -240,7 +240,6 @@ func (p *playTracker) ReportPlayback(ctx context.Context, params ReportPlaybackP
 	client := params.ClientName
 
 	now := time.Now()
-	prevCount := p.playMap.Len()
 
 	switch params.State {
 	case StateStarting:
@@ -311,7 +310,7 @@ func (p *playTracker) ReportPlayback(ctx context.Context, params ReportPlaybackP
 		p.playMap.Remove(clientId)
 	}
 
-	if conf.Server.EnableNowPlaying && p.playMap.Len() != prevCount {
+	if conf.Server.EnableNowPlaying {
 		p.broker.SendBroadcastMessage(ctx, &events.NowPlayingCount{Count: p.playMap.Len()})
 	}
 

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -505,7 +505,7 @@ var _ = Describe("PlayTracker", func() {
 				Expect(playing[0].PositionMs).To(Equal(int64(10000)))
 			})
 
-			It("does NOT estimate for starting", func() {
+			It("estimates for starting", func() {
 				err := tracker.ReportPlayback(ctx, ReportPlaybackParams{
 					MediaId: "123", PositionMs: 0, State: "starting", PlaybackRate: 1.0, ClientId: defaultClientId,
 				})
@@ -514,7 +514,7 @@ var _ = Describe("PlayTracker", func() {
 				playing, err := tracker.GetNowPlaying(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(playing).To(HaveLen(1))
-				Expect(playing[0].PositionMs).To(Equal(int64(0)))
+				Expect(playing[0].PositionMs).To(BeNumerically(">=", int64(40)))
 			})
 
 			It("respects playbackRate", func() {

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -371,6 +371,69 @@ var _ = Describe("PlayTracker", func() {
 			Expect(playing).To(HaveLen(2))
 		})
 
+		Describe("SSE broadcast on state change", func() {
+			BeforeEach(func() {
+				eventBroker = &fakeEventBroker{}
+				tracker = newPlayTracker(ds, eventBroker, nil)
+				tracker.(*playTracker).builtinScrobblers["fake"] = fake
+			})
+
+			It("broadcasts NowPlayingCount on every state change", func() {
+				// starting -> count should be 1
+				err := tracker.ReportPlayback(ctx, ReportPlaybackParams{
+					MediaId: "123", PositionMs: 0, State: "starting", PlaybackRate: 1.0, ClientId: defaultClientId,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				evts := eventBroker.getEvents()
+				Expect(evts).To(HaveLen(1))
+				Expect(evts[0].(*events.NowPlayingCount).Count).To(Equal(1))
+
+				// playing -> count should be 1
+				err = tracker.ReportPlayback(ctx, ReportPlaybackParams{
+					MediaId: "123", PositionMs: 10000, State: "playing", PlaybackRate: 1.0, ClientId: defaultClientId,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				evts = eventBroker.getEvents()
+				Expect(evts).To(HaveLen(2))
+				Expect(evts[1].(*events.NowPlayingCount).Count).To(Equal(1))
+
+				// paused -> count should be 1
+				err = tracker.ReportPlayback(ctx, ReportPlaybackParams{
+					MediaId: "123", PositionMs: 30000, State: "paused", PlaybackRate: 1.0, ClientId: defaultClientId,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				evts = eventBroker.getEvents()
+				Expect(evts).To(HaveLen(3))
+				Expect(evts[2].(*events.NowPlayingCount).Count).To(Equal(1))
+
+				// stopped -> count should be 0
+				err = tracker.ReportPlayback(ctx, ReportPlaybackParams{
+					MediaId: "123", PositionMs: 30000, State: "stopped", PlaybackRate: 1.0, ClientId: defaultClientId,
+					IgnoreScrobble: true,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				evts = eventBroker.getEvents()
+				Expect(evts).To(HaveLen(4))
+				Expect(evts[3].(*events.NowPlayingCount).Count).To(Equal(0))
+			})
+
+			It("does NOT broadcast when EnableNowPlaying is false", func() {
+				conf.Server.EnableNowPlaying = false
+				tracker = newPlayTracker(ds, eventBroker, nil)
+				tracker.(*playTracker).builtinScrobblers["fake"] = fake
+
+				err := tracker.ReportPlayback(ctx, ReportPlaybackParams{
+					MediaId: "123", PositionMs: 0, State: "starting", PlaybackRate: 1.0, ClientId: defaultClientId,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				err = tracker.ReportPlayback(ctx, ReportPlaybackParams{
+					MediaId: "123", PositionMs: 10000, State: "playing", PlaybackRate: 1.0, ClientId: defaultClientId,
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(eventBroker.getEvents()).To(BeEmpty())
+			})
+		})
+
 		Describe("auto-scrobble", func() {
 			It("scrobbles on stopped when positionMs >= 50% of track", func() {
 				err := tracker.ReportPlayback(ctx, ReportPlaybackParams{

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -505,7 +505,7 @@ var _ = Describe("PlayTracker", func() {
 				Expect(playing[0].PositionMs).To(Equal(int64(10000)))
 			})
 
-			It("estimates for starting", func() {
+			It("does NOT estimate for starting", func() {
 				err := tracker.ReportPlayback(ctx, ReportPlaybackParams{
 					MediaId: "123", PositionMs: 0, State: "starting", PlaybackRate: 1.0, ClientId: defaultClientId,
 				})
@@ -514,7 +514,7 @@ var _ = Describe("PlayTracker", func() {
 				playing, err := tracker.GetNowPlaying(ctx)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(playing).To(HaveLen(1))
-				Expect(playing[0].PositionMs).To(BeNumerically(">=", int64(40)))
+				Expect(playing[0].PositionMs).To(Equal(int64(0)))
 			})
 
 			It("respects playbackRate", func() {

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -58,6 +58,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 			"uiCoverArtSize":            conf.Server.UICoverArtSize,
 			"enableCoverAnimation":      conf.Server.EnableCoverAnimation,
 			"enableNowPlaying":          conf.Server.EnableNowPlaying,
+			"playbackReportIntervalMs":  conf.Server.UIPlaybackReportInterval.Milliseconds(),
 			"gaTrackingId":              conf.Server.GATrackingID,
 			"losslessFormats":           strings.ToUpper(strings.Join(mime.LosslessFormats, ",")),
 			"devActivityPanel":          conf.Server.DevActivityPanel,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -106,6 +106,7 @@ var _ = Describe("serveIndex", func() {
 		Entry("enableSharing", func() { conf.Server.EnableSharing = true }, "enableSharing", true),
 		Entry("devNewEventStream", func() { conf.Server.DevNewEventStream = true }, "devNewEventStream", true),
 		Entry("extAuthLogoutURL", func() { conf.Server.ExtAuth.LogoutURL = "https://auth.example.com/logout" }, "extAuthLogoutURL", "https://auth.example.com/logout"),
+		Entry("playbackReportIntervalMs", func() { conf.Server.UIPlaybackReportInterval = 30 * time.Second }, "playbackReportIntervalMs", float64(30000)),
 	)
 
 	It("sanitizes entity-encoded welcomeMessage as html", func() {

--- a/server/subsonic/album_lists.go
+++ b/server/subsonic/album_lists.go
@@ -213,11 +213,12 @@ func (api *Router) GetNowPlaying(r *http.Request) (*responses.Subsonic, error) {
 	response.NowPlaying = &responses.NowPlaying{}
 	var i int32
 	response.NowPlaying.Entry = slice.Map(npInfo, func(np scrobbler.NowPlayingInfo) responses.NowPlayingEntry {
+		i++
 		return responses.NowPlayingEntry{
 			Child:        childFromMediaFile(ctx, np.MediaFile),
 			UserName:     np.Username,
 			MinutesAgo:   int32(time.Since(np.Start).Minutes()),
-			PlayerId:     i + 1, // Fake numeric playerId, it does not seem to be used for anything
+			PlayerId:     i,
 			PlayerName:   np.PlayerName,
 			State:        np.State,
 			PositionMs:   np.PositionMs,

--- a/ui/src/actions/serverEvents.js
+++ b/ui/src/actions/serverEvents.js
@@ -2,6 +2,7 @@ export const EVENT_SCAN_STATUS = 'scanStatus'
 export const EVENT_SERVER_START = 'serverStart'
 export const EVENT_REFRESH_RESOURCE = 'refreshResource'
 export const EVENT_NOW_PLAYING_COUNT = 'nowPlayingCount'
+export const EVENT_NOW_PLAYING_COUNT_SYNC = 'nowPlayingCountSync'
 export const EVENT_STREAM_RECONNECTED = 'streamReconnected'
 
 export const processEvent = (type, data) => ({
@@ -15,6 +16,11 @@ export const scanStatusUpdate = (data) => ({
 
 export const nowPlayingCountUpdate = (data) => ({
   type: EVENT_NOW_PLAYING_COUNT,
+  data: data,
+})
+
+export const nowPlayingCountSync = (data) => ({
+  type: EVENT_NOW_PLAYING_COUNT_SYNC,
   data: data,
 })
 

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -170,6 +170,9 @@ const Player = () => {
         e.preventDefault()
         e.returnValue = ''
       }
+    }
+
+    const handlePageHide = () => {
       if (currentTrackIdRef.current && !playerState.current?.isRadio) {
         stoppedRef.current = true
         try {
@@ -185,7 +188,11 @@ const Player = () => {
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+    window.addEventListener('pagehide', handlePageHide)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      window.removeEventListener('pagehide', handlePageHide)
+    }
   }, [playerState, audioInstance])
 
   const defaultOptions = useMemo(

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -268,6 +268,17 @@ const Player = () => {
     [],
   )
 
+  const onAudioSeeked = useCallback(
+    (info) => {
+      if (!info.isRadio && currentTrackId) {
+        const posMs = Math.floor(info.currentTime * 1000)
+        lastPositionMsRef.current = posMs
+        subsonic.reportPlayback(currentTrackId, posMs, 'playing')
+      }
+    },
+    [currentTrackId],
+  )
+
   const onAudioVolumeChange = useCallback(
     // sqrt to compensate for the logarithmic volume
     (volume) => dispatch(setVolume(Math.sqrt(volume))),
@@ -418,6 +429,7 @@ const Player = () => {
         onAudioListsChange={onAudioListsChange}
         onAudioVolumeChange={onAudioVolumeChange}
         onAudioProgress={onAudioProgress}
+        onAudioSeeked={onAudioSeeked}
         onAudioPlay={onAudioPlay}
         onAudioPlayTrackChange={onAudioPlayTrackChange}
         onAudioPause={onAudioPause}

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -176,7 +176,7 @@ const Player = () => {
       if (currentTrackIdRef.current && !playerState.current?.isRadio) {
         stoppedRef.current = true
         try {
-          subsonic.reportPlaybackSync(
+          subsonic.reportPlaybackKeepalive(
             currentTrackIdRef.current,
             lastPositionMsRef.current,
             'stopped',

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -276,7 +276,9 @@ const Player = () => {
           lastPositionMsRef.current = posMs
           const isNewTrack = info.trackId !== currentTrackId
           if (isNewTrack) {
-            subsonic.reportPlayback(info.trackId, posMs, 'starting')
+            subsonic.reportPlayback(info.trackId, posMs, 'starting').then(
+              () => subsonic.reportPlayback(info.trackId, posMs, 'playing'),
+            )
             setCurrentTrackId(info.trackId)
           } else {
             subsonic.reportPlayback(info.trackId, posMs, 'playing')

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -41,9 +41,9 @@ const Player = () => {
   const dataProvider = useDataProvider()
   const playerState = useSelector((state) => state.player)
   const dispatch = useDispatch()
-  const [startTime, setStartTime] = useState(null)
-  const [scrobbled, setScrobbled] = useState(false)
-  const [preloaded, setPreload] = useState(false)
+  const [currentTrackId, setCurrentTrackId] = useState(null)
+  const heartbeatRef = useRef(null)
+  const lastPositionMsRef = useRef(0)
   const [audioInstance, setAudioInstance] = useState(null)
   const isDesktop = useMediaQuery('(min-width:810px)')
   const isMobilePlayer =
@@ -57,6 +57,28 @@ const Player = () => {
   // without re-triggering on every queue/position change
   const playerStateRef = useRef(playerState)
   playerStateRef.current = playerState
+
+  const stopHeartbeat = useCallback(() => {
+    if (heartbeatRef.current) {
+      clearInterval(heartbeatRef.current)
+      heartbeatRef.current = null
+    }
+  }, [])
+
+  const startHeartbeat = useCallback(
+    (trackId) => {
+      stopHeartbeat()
+      if (!trackId || !config.playbackReportIntervalMs) return
+      heartbeatRef.current = setInterval(() => {
+        if (audioInstance) {
+          const posMs = Math.floor(audioInstance.currentTime * 1000)
+          lastPositionMsRef.current = posMs
+          subsonic.reportPlayback(trackId, posMs, 'playing')
+        }
+      }, config.playbackReportIntervalMs)
+    },
+    [stopHeartbeat, audioInstance],
+  )
 
   // Detect browser codec profile and eagerly resolve transcode URLs for the
   // persisted queue once on mount (e.g. after a browser refresh)
@@ -107,6 +129,10 @@ const Player = () => {
     }
   }, [playerState.queue, playerState.savedPlayIndex])
 
+  useEffect(() => {
+    return () => stopHeartbeat()
+  }, [stopHeartbeat])
+
   const visible = authenticated && playerState.queue.length > 0
   const isRadio = playerState.current?.isRadio || false
   const classes = useStyle({
@@ -155,16 +181,22 @@ const Player = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
-      // Check there's a current track and is actually playing/not paused
       if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
+        if (currentTrackId && !playerState.current?.isRadio) {
+          subsonic.reportPlaybackBeacon(
+            currentTrackId,
+            lastPositionMsRef.current,
+            'stopped',
+          )
+        }
         e.preventDefault()
-        e.returnValue = '' // Chrome requires returnValue to be set
+        e.returnValue = ''
       }
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [playerState, audioInstance])
+  }, [playerState, audioInstance, currentTrackId])
 
   const defaultOptions = useMemo(
     () => ({
@@ -227,44 +259,16 @@ const Player = () => {
     [dispatch],
   )
 
-  const nextSong = useCallback(() => {
-    const idx = playerState.queue.findIndex(
-      (item) => item.uuid === playerState.current.uuid,
-    )
-    return idx !== null ? playerState.queue[idx + 1] : null
-  }, [playerState])
-
   const onAudioProgress = useCallback(
     (info) => {
       if (info.ended) {
         document.title = 'Navidrome'
       }
-
-      const progress = (info.currentTime / info.duration) * 100
-      if (isNaN(info.duration) || (progress < 50 && info.currentTime < 240)) {
-        return
-      }
-
-      if (info.isRadio) {
-        return
-      }
-
-      if (!preloaded) {
-        const next = nextSong()
-        if (next != null && !next.isRadio) {
-          // Trigger decision pre-fetch (this also warms the cache)
-          decisionService.prefetchDecisions([next.trackId])
-        }
-        setPreload(true)
-        return
-      }
-
-      if (!scrobbled) {
-        info.trackId && subsonic.scrobble(info.trackId, startTime)
-        setScrobbled(true)
+      if (!info.isRadio && info.currentTime) {
+        lastPositionMsRef.current = Math.floor(info.currentTime * 1000)
       }
     },
-    [startTime, scrobbled, nextSong, preloaded],
+    [],
   )
 
   const onAudioVolumeChange = useCallback(
@@ -275,24 +279,26 @@ const Player = () => {
 
   const onAudioPlay = useCallback(
     (info) => {
-      // Do this to start the context; on chrome-based browsers, the context
-      // will start paused since it is created prior to user interaction
       if (context && context.state !== 'running') {
         context.resume()
       }
 
       dispatch(currentPlaying(info))
-      if (startTime === null) {
-        setStartTime(Date.now())
-      }
       if (info.duration) {
         const song = info.song
         document.title = `${song.title} - ${song.artist} - Navidrome`
         if (!info.isRadio) {
-          const pos = startTime === null ? null : Math.floor(info.currentTime)
-          subsonic.nowPlaying(info.trackId, pos)
+          const posMs = Math.floor(info.currentTime * 1000)
+          lastPositionMsRef.current = posMs
+          const isNewTrack = info.trackId !== currentTrackId
+          if (isNewTrack) {
+            subsonic.reportPlayback(info.trackId, posMs, 'starting')
+            setCurrentTrackId(info.trackId)
+          } else {
+            subsonic.reportPlayback(info.trackId, posMs, 'playing')
+          }
+          startHeartbeat(info.trackId)
         }
-        setPreload(false)
         if (config.gaTrackingId) {
           ReactGA.event({
             category: 'Player',
@@ -309,34 +315,45 @@ const Player = () => {
         }
       }
     },
-    [context, dispatch, showNotifications, startTime],
+    [context, dispatch, showNotifications, currentTrackId, startHeartbeat],
   )
 
   const onAudioPlayTrackChange = useCallback(() => {
-    if (scrobbled) {
-      setScrobbled(false)
+    if (currentTrackId) {
+      subsonic.reportPlayback(currentTrackId, lastPositionMsRef.current, 'stopped')
     }
-    if (startTime !== null) {
-      setStartTime(null)
-    }
-  }, [scrobbled, startTime])
+    stopHeartbeat()
+    setCurrentTrackId(null)
+  }, [currentTrackId, stopHeartbeat])
 
   const onAudioPause = useCallback(
-    (info) => dispatch(currentPlaying(info)),
-    [dispatch],
+    (info) => {
+      dispatch(currentPlaying(info))
+      if (!info.isRadio && currentTrackId) {
+        const posMs = Math.floor(info.currentTime * 1000)
+        lastPositionMsRef.current = posMs
+        subsonic.reportPlayback(currentTrackId, posMs, 'paused')
+      }
+      stopHeartbeat()
+    },
+    [dispatch, currentTrackId, stopHeartbeat],
   )
 
   const onAudioEnded = useCallback(
     (currentPlayId, audioLists, info) => {
-      setScrobbled(false)
-      setStartTime(null)
+      if (currentTrackId && !info.isRadio) {
+        const posMs = Math.floor((info.duration || 0) * 1000)
+        subsonic.reportPlayback(currentTrackId, posMs, 'stopped')
+      }
+      stopHeartbeat()
+      setCurrentTrackId(null)
       dispatch(currentPlaying(info))
       dataProvider
         .getOne('keepalive', { id: info.trackId })
         // eslint-disable-next-line no-console
         .catch((e) => console.log('Keepalive error:', e))
     },
-    [dispatch, dataProvider],
+    [dispatch, dataProvider, currentTrackId, stopHeartbeat],
   )
 
   const onCoverClick = useCallback((mode, audioLists, audioInfo) => {

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -165,6 +165,13 @@ const Player = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
+      if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
+    }
+
+    const handlePageHide = () => {
       if (currentTrackIdRef.current && !playerState.current?.isRadio) {
         subsonic.reportPlaybackBeacon(
           currentTrackIdRef.current,
@@ -172,14 +179,14 @@ const Player = () => {
           'stopped',
         )
       }
-      if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
-        e.preventDefault()
-        e.returnValue = ''
-      }
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload)
-    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+    window.addEventListener('pagehide', handlePageHide)
+    return () => {
+      window.removeEventListener('beforeunload', handleBeforeUnload)
+      window.removeEventListener('pagehide', handlePageHide)
+    }
   }, [playerState, audioInstance])
 
   const defaultOptions = useMemo(

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -267,7 +267,7 @@ const Player = () => {
     if (info.ended) {
       document.title = 'Navidrome'
     }
-    if (!info.isRadio && info.currentTime) {
+    if (!info.isRadio && info.currentTime != null) {
       lastPositionMsRef.current = Math.floor(info.currentTime * 1000)
     }
   }, [])
@@ -277,10 +277,11 @@ const Player = () => {
       if (!info.isRadio && currentTrackId) {
         const posMs = Math.floor(info.currentTime * 1000)
         lastPositionMsRef.current = posMs
-        subsonic.reportPlayback(currentTrackId, posMs, 'playing')
+        const state = audioInstance?.paused ? 'paused' : 'playing'
+        subsonic.reportPlayback(currentTrackId, posMs, state)
       }
     },
-    [currentTrackId],
+    [currentTrackId, audioInstance],
   )
 
   const onAudioVolumeChange = useCallback(

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -63,11 +63,18 @@ const Player = () => {
 
   currentTrackIdRef.current = currentTrackId
 
-  useInterval(() => {
-    if (heartbeatTrackId && !stoppedRef.current) {
-      subsonic.reportPlayback(heartbeatTrackId, lastPositionMsRef.current, 'playing')
-    }
-  }, heartbeatTrackId ? config.playbackReportIntervalMs : null)
+  useInterval(
+    () => {
+      if (heartbeatTrackId && !stoppedRef.current) {
+        subsonic.reportPlayback(
+          heartbeatTrackId,
+          lastPositionMsRef.current,
+          'playing',
+        )
+      }
+    },
+    heartbeatTrackId ? config.playbackReportIntervalMs : null,
+  )
 
   // Detect browser codec profile and eagerly resolve transcode URLs for the
   // persisted queue once on mount (e.g. after a browser refresh)
@@ -256,17 +263,14 @@ const Player = () => {
     [dispatch],
   )
 
-  const onAudioProgress = useCallback(
-    (info) => {
-      if (info.ended) {
-        document.title = 'Navidrome'
-      }
-      if (!info.isRadio && info.currentTime) {
-        lastPositionMsRef.current = Math.floor(info.currentTime * 1000)
-      }
-    },
-    [],
-  )
+  const onAudioProgress = useCallback((info) => {
+    if (info.ended) {
+      document.title = 'Navidrome'
+    }
+    if (!info.isRadio && info.currentTime) {
+      lastPositionMsRef.current = Math.floor(info.currentTime * 1000)
+    }
+  }, [])
 
   const onAudioSeeked = useCallback(
     (info) => {
@@ -300,9 +304,11 @@ const Player = () => {
           lastPositionMsRef.current = posMs
           const isNewTrack = info.trackId !== currentTrackId
           if (isNewTrack) {
-            subsonic.reportPlayback(info.trackId, posMs, 'starting').then(
-              () => subsonic.reportPlayback(info.trackId, posMs, 'playing'),
-            )
+            subsonic
+              .reportPlayback(info.trackId, posMs, 'starting')
+              .then(() =>
+                subsonic.reportPlayback(info.trackId, posMs, 'playing'),
+              )
             setCurrentTrackId(info.trackId)
           } else {
             subsonic.reportPlayback(info.trackId, posMs, 'playing')
@@ -330,7 +336,11 @@ const Player = () => {
 
   const onAudioPlayTrackChange = useCallback(() => {
     if (currentTrackId) {
-      subsonic.reportPlayback(currentTrackId, lastPositionMsRef.current, 'stopped')
+      subsonic.reportPlayback(
+        currentTrackId,
+        lastPositionMsRef.current,
+        'stopped',
+      )
     }
     setHeartbeatTrackId(null)
     setCurrentTrackId(null)
@@ -397,7 +407,11 @@ const Player = () => {
   const onBeforeDestroy = useCallback(() => {
     return new Promise((resolve, reject) => {
       if (currentTrackId && !playerStateRef.current?.current?.isRadio) {
-        subsonic.reportPlayback(currentTrackId, lastPositionMsRef.current, 'stopped')
+        subsonic.reportPlayback(
+          currentTrackId,
+          lastPositionMsRef.current,
+          'stopped',
+        )
       }
       setHeartbeatTrackId(null)
       setCurrentTrackId(null)

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -166,7 +166,7 @@ const Player = () => {
   useEffect(() => {
     const handleBeforeUnload = (e) => {
       if (currentTrackIdRef.current && !playerState.current?.isRadio) {
-        subsonic.reportPlaybackBeacon(
+        subsonic.reportPlaybackSync(
           currentTrackIdRef.current,
           lastPositionMsRef.current,
           'stopped',

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useInterval } from '../common'
 import { useDispatch, useSelector } from 'react-redux'
 import { useMediaQuery } from '@material-ui/core'
 import { ThemeProvider } from '@material-ui/core/styles'
@@ -42,8 +43,9 @@ const Player = () => {
   const playerState = useSelector((state) => state.player)
   const dispatch = useDispatch()
   const [currentTrackId, setCurrentTrackId] = useState(null)
-  const heartbeatRef = useRef(null)
+  const [heartbeatTrackId, setHeartbeatTrackId] = useState(null)
   const lastPositionMsRef = useRef(0)
+  const currentTrackIdRef = useRef(null)
   const [audioInstance, setAudioInstance] = useState(null)
   const isDesktop = useMediaQuery('(min-width:810px)')
   const isMobilePlayer =
@@ -58,27 +60,13 @@ const Player = () => {
   const playerStateRef = useRef(playerState)
   playerStateRef.current = playerState
 
-  const stopHeartbeat = useCallback(() => {
-    if (heartbeatRef.current) {
-      clearInterval(heartbeatRef.current)
-      heartbeatRef.current = null
-    }
-  }, [])
+  currentTrackIdRef.current = currentTrackId
 
-  const startHeartbeat = useCallback(
-    (trackId) => {
-      stopHeartbeat()
-      if (!trackId || !config.playbackReportIntervalMs) return
-      heartbeatRef.current = setInterval(() => {
-        if (audioInstance) {
-          const posMs = Math.floor(audioInstance.currentTime * 1000)
-          lastPositionMsRef.current = posMs
-          subsonic.reportPlayback(trackId, posMs, 'playing')
-        }
-      }, config.playbackReportIntervalMs)
-    },
-    [stopHeartbeat, audioInstance],
-  )
+  useInterval(() => {
+    if (heartbeatTrackId) {
+      subsonic.reportPlayback(heartbeatTrackId, lastPositionMsRef.current, 'playing')
+    }
+  }, heartbeatTrackId ? config.playbackReportIntervalMs : null)
 
   // Detect browser codec profile and eagerly resolve transcode URLs for the
   // persisted queue once on mount (e.g. after a browser refresh)
@@ -129,10 +117,6 @@ const Player = () => {
     }
   }, [playerState.queue, playerState.savedPlayIndex])
 
-  useEffect(() => {
-    return () => stopHeartbeat()
-  }, [stopHeartbeat])
-
   const visible = authenticated && playerState.queue.length > 0
   const isRadio = playerState.current?.isRadio || false
   const classes = useStyle({
@@ -182,9 +166,9 @@ const Player = () => {
   useEffect(() => {
     const handleBeforeUnload = (e) => {
       if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
-        if (currentTrackId && !playerState.current?.isRadio) {
+        if (currentTrackIdRef.current && !playerState.current?.isRadio) {
           subsonic.reportPlaybackBeacon(
-            currentTrackId,
+            currentTrackIdRef.current,
             lastPositionMsRef.current,
             'stopped',
           )
@@ -196,7 +180,7 @@ const Player = () => {
 
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
-  }, [playerState, audioInstance, currentTrackId])
+  }, [playerState, audioInstance])
 
   const defaultOptions = useMemo(
     () => ({
@@ -297,7 +281,7 @@ const Player = () => {
           } else {
             subsonic.reportPlayback(info.trackId, posMs, 'playing')
           }
-          startHeartbeat(info.trackId)
+          setHeartbeatTrackId(info.trackId)
         }
         if (config.gaTrackingId) {
           ReactGA.event({
@@ -315,16 +299,16 @@ const Player = () => {
         }
       }
     },
-    [context, dispatch, showNotifications, currentTrackId, startHeartbeat],
+    [context, dispatch, showNotifications, currentTrackId],
   )
 
   const onAudioPlayTrackChange = useCallback(() => {
     if (currentTrackId) {
       subsonic.reportPlayback(currentTrackId, lastPositionMsRef.current, 'stopped')
     }
-    stopHeartbeat()
+    setHeartbeatTrackId(null)
     setCurrentTrackId(null)
-  }, [currentTrackId, stopHeartbeat])
+  }, [currentTrackId])
 
   const onAudioPause = useCallback(
     (info) => {
@@ -334,9 +318,9 @@ const Player = () => {
         lastPositionMsRef.current = posMs
         subsonic.reportPlayback(currentTrackId, posMs, 'paused')
       }
-      stopHeartbeat()
+      setHeartbeatTrackId(null)
     },
-    [dispatch, currentTrackId, stopHeartbeat],
+    [dispatch, currentTrackId],
   )
 
   const onAudioEnded = useCallback(
@@ -345,7 +329,7 @@ const Player = () => {
         const posMs = Math.floor((info.duration || 0) * 1000)
         subsonic.reportPlayback(currentTrackId, posMs, 'stopped')
       }
-      stopHeartbeat()
+      setHeartbeatTrackId(null)
       setCurrentTrackId(null)
       dispatch(currentPlaying(info))
       dataProvider
@@ -353,7 +337,7 @@ const Player = () => {
         // eslint-disable-next-line no-console
         .catch((e) => console.log('Keepalive error:', e))
     },
-    [dispatch, dataProvider, currentTrackId, stopHeartbeat],
+    [dispatch, dataProvider, currentTrackId],
   )
 
   const onCoverClick = useCallback((mode, audioLists, audioInfo) => {

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -165,14 +165,14 @@ const Player = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
+      if (currentTrackIdRef.current && !playerState.current?.isRadio) {
+        subsonic.reportPlaybackBeacon(
+          currentTrackIdRef.current,
+          lastPositionMsRef.current,
+          'stopped',
+        )
+      }
       if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
-        if (currentTrackIdRef.current && !playerState.current?.isRadio) {
-          subsonic.reportPlaybackBeacon(
-            currentTrackIdRef.current,
-            lastPositionMsRef.current,
-            'stopped',
-          )
-        }
         e.preventDefault()
         e.returnValue = ''
       }
@@ -370,10 +370,15 @@ const Player = () => {
 
   const onBeforeDestroy = useCallback(() => {
     return new Promise((resolve, reject) => {
+      if (currentTrackId && !playerState.current?.isRadio) {
+        subsonic.reportPlayback(currentTrackId, lastPositionMsRef.current, 'stopped')
+      }
+      setHeartbeatTrackId(null)
+      setCurrentTrackId(null)
       dispatch(clearQueue())
       reject()
     })
-  }, [dispatch])
+  }, [dispatch, currentTrackId, playerState.current?.isRadio])
 
   if (!visible) {
     document.title = 'Navidrome'

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -165,16 +165,20 @@ const Player = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
-      if (currentTrackIdRef.current && !playerState.current?.isRadio) {
-        subsonic.reportPlaybackSync(
-          currentTrackIdRef.current,
-          lastPositionMsRef.current,
-          'stopped',
-        )
-      }
       if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
         e.preventDefault()
         e.returnValue = ''
+      }
+      if (currentTrackIdRef.current && !playerState.current?.isRadio) {
+        try {
+          subsonic.reportPlaybackSync(
+            currentTrackIdRef.current,
+            lastPositionMsRef.current,
+            'stopped',
+          )
+        } catch {
+          // Sync XHR may be blocked; ignore
+        }
       }
     }
 

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -396,7 +396,7 @@ const Player = () => {
 
   const onBeforeDestroy = useCallback(() => {
     return new Promise((resolve, reject) => {
-      if (currentTrackId && !playerState.current?.isRadio) {
+      if (currentTrackId && !playerStateRef.current?.current?.isRadio) {
         subsonic.reportPlayback(currentTrackId, lastPositionMsRef.current, 'stopped')
       }
       setHeartbeatTrackId(null)
@@ -404,7 +404,7 @@ const Player = () => {
       dispatch(clearQueue())
       reject()
     })
-  }, [dispatch, currentTrackId, playerState.current?.isRadio])
+  }, [dispatch, currentTrackId])
 
   if (!visible) {
     document.title = 'Navidrome'

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -165,13 +165,6 @@ const Player = () => {
 
   useEffect(() => {
     const handleBeforeUnload = (e) => {
-      if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
-        e.preventDefault()
-        e.returnValue = ''
-      }
-    }
-
-    const handlePageHide = () => {
       if (currentTrackIdRef.current && !playerState.current?.isRadio) {
         subsonic.reportPlaybackBeacon(
           currentTrackIdRef.current,
@@ -179,14 +172,14 @@ const Player = () => {
           'stopped',
         )
       }
+      if (playerState.current?.uuid && audioInstance && !audioInstance.paused) {
+        e.preventDefault()
+        e.returnValue = ''
+      }
     }
 
     window.addEventListener('beforeunload', handleBeforeUnload)
-    window.addEventListener('pagehide', handlePageHide)
-    return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload)
-      window.removeEventListener('pagehide', handlePageHide)
-    }
+    return () => window.removeEventListener('beforeunload', handleBeforeUnload)
   }, [playerState, audioInstance])
 
   const defaultOptions = useMemo(

--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -46,6 +46,7 @@ const Player = () => {
   const [heartbeatTrackId, setHeartbeatTrackId] = useState(null)
   const lastPositionMsRef = useRef(0)
   const currentTrackIdRef = useRef(null)
+  const stoppedRef = useRef(false)
   const [audioInstance, setAudioInstance] = useState(null)
   const isDesktop = useMediaQuery('(min-width:810px)')
   const isMobilePlayer =
@@ -63,7 +64,7 @@ const Player = () => {
   currentTrackIdRef.current = currentTrackId
 
   useInterval(() => {
-    if (heartbeatTrackId) {
+    if (heartbeatTrackId && !stoppedRef.current) {
       subsonic.reportPlayback(heartbeatTrackId, lastPositionMsRef.current, 'playing')
     }
   }, heartbeatTrackId ? config.playbackReportIntervalMs : null)
@@ -170,6 +171,7 @@ const Player = () => {
         e.returnValue = ''
       }
       if (currentTrackIdRef.current && !playerState.current?.isRadio) {
+        stoppedRef.current = true
         try {
           subsonic.reportPlaybackSync(
             currentTrackIdRef.current,
@@ -177,7 +179,7 @@ const Player = () => {
             'stopped',
           )
         } catch {
-          // Sync XHR may be blocked; ignore
+          // fetch/sendBeacon may throw; ignore
         }
       }
     }

--- a/ui/src/config.js
+++ b/ui/src/config.js
@@ -33,6 +33,7 @@ const defaultConfig = {
   enableExternalServices: true,
   enableCoverAnimation: true,
   enableNowPlaying: true,
+  playbackReportIntervalMs: 60000,
   devShowArtistPage: true,
   devUIShowConfig: true,
   devNewEventStream: false,

--- a/ui/src/dataProvider/httpClient.js
+++ b/ui/src/dataProvider/httpClient.js
@@ -7,7 +7,7 @@ import { removeHomeCache } from '../utils/removeHomeCache'
 
 const customAuthorizationHeader = 'X-ND-Authorization'
 const clientUniqueIdHeader = 'X-ND-Client-Unique-Id'
-const clientUniqueId = uuidv4()
+export const clientUniqueId = uuidv4()
 
 const httpClient = (url, options = {}) => {
   url = baseUrl(url)

--- a/ui/src/dataProvider/httpClient.js
+++ b/ui/src/dataProvider/httpClient.js
@@ -6,7 +6,7 @@ import { jwtDecode } from 'jwt-decode'
 import { removeHomeCache } from '../utils/removeHomeCache'
 
 const customAuthorizationHeader = 'X-ND-Authorization'
-const clientUniqueIdHeader = 'X-ND-Client-Unique-Id'
+export const clientUniqueIdHeader = 'X-ND-Client-Unique-Id'
 export const clientUniqueId = uuidv4()
 
 const httpClient = (url, options = {}) => {

--- a/ui/src/dataProvider/index.js
+++ b/ui/src/dataProvider/index.js
@@ -1,6 +1,6 @@
-import httpClient from './httpClient'
+import httpClient, { clientUniqueId } from './httpClient'
 import wrapperDataProvider from './wrapperDataProvider'
 
-export { httpClient }
+export { httpClient, clientUniqueId }
 
 export default wrapperDataProvider

--- a/ui/src/dataProvider/index.js
+++ b/ui/src/dataProvider/index.js
@@ -1,6 +1,6 @@
-import httpClient, { clientUniqueId } from './httpClient'
+import httpClient, { clientUniqueId, clientUniqueIdHeader } from './httpClient'
 import wrapperDataProvider from './wrapperDataProvider'
 
-export { httpClient, clientUniqueId }
+export { httpClient, clientUniqueId, clientUniqueIdHeader }
 
 export default wrapperDataProvider

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useSelector, useDispatch } from 'react-redux'
 import { useTranslate, Link, useNotify } from 'react-admin'
@@ -183,10 +183,17 @@ NowPlayingButton.propTypes = {
 
 // NowPlayingItem component - Discord-style card layout
 const NowPlayingItem = React.memo(
-  ({ nowPlayingEntry, onLinkClick, getArtistLink }) => {
+  ({ nowPlayingEntry, onLinkClick, getArtistLink, tick }) => {
     const classes = useStyles()
     const isPaused = nowPlayingEntry.state === 'paused'
-    const positionSec = (nowPlayingEntry.positionMs || 0) / 1000
+    const isPlaying =
+      nowPlayingEntry.state === 'playing' ||
+      nowPlayingEntry.state === 'starting'
+    const basePositionMs = nowPlayingEntry.positionMs || 0
+    const interpolatedMs = isPlaying ? basePositionMs + tick * 1000 : basePositionMs
+    const durationMs = (nowPlayingEntry.duration || 0) * 1000
+    const positionMs = durationMs > 0 ? Math.min(interpolatedMs, durationMs) : interpolatedMs
+    const positionSec = positionMs / 1000
     const durationSec = nowPlayingEntry.duration || 0
     const progress =
       durationSec > 0 ? (positionSec / durationSec) * 100 : 0
@@ -285,11 +292,12 @@ NowPlayingItem.propTypes = {
   }).isRequired,
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
+  tick: PropTypes.number.isRequired,
 }
 
 // NowPlayingList component - handles the popover content
 const NowPlayingList = React.memo(
-  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink }) => {
+  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink, tick }) => {
     const classes = useStyles({ entryCount: entries.length })
     const translate = useTranslate()
 
@@ -321,6 +329,7 @@ const NowPlayingList = React.memo(
                     nowPlayingEntry={nowPlayingEntry}
                     onLinkClick={onLinkClick}
                     getArtistLink={getArtistLink}
+                    tick={tick}
                   />
                 ))}
               </List>
@@ -341,6 +350,7 @@ NowPlayingList.propTypes = {
   entries: PropTypes.arrayOf(PropTypes.object).isRequired,
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
+  tick: PropTypes.number.isRequired,
 }
 
 // Main NowPlayingPanel component
@@ -360,6 +370,7 @@ const NowPlayingPanel = () => {
 
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
+  const [tick, setTick] = useState(0)
   const open = Boolean(anchorEl)
 
   const handleMenuOpen = useCallback((event) => {
@@ -393,6 +404,7 @@ const NowPlayingPanel = () => {
           if (data.status === 'ok') {
             const nowPlayingEntries = data.nowPlaying?.entry || []
             setEntries(nowPlayingEntries)
+            setTick(0)
             // Also update the count in Redux store
             dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
           } else {
@@ -419,6 +431,12 @@ const NowPlayingPanel = () => {
     if (open && serverUp) fetchList()
   }, [count, open, fetchList, serverUp])
 
+  // Tick every second when open to animate progress bars
+  useInterval(
+    () => setTick((t) => t + 1),
+    open ? 1000 : null,
+  )
+
   // Periodic refresh when panel is open (10 seconds)
   useInterval(
     () => {
@@ -443,6 +461,7 @@ const NowPlayingPanel = () => {
         open={open}
         onClose={handleMenuClose}
         entries={entries}
+        tick={tick}
         onLinkClick={handleLinkClick}
         getArtistLink={getArtistLink}
       />

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -403,39 +403,37 @@ const NowPlayingPanel = () => {
   }, [])
 
   const fetchTimerRef = useRef(null)
-  const doFetch = useCallback(
-    () =>
-      subsonic
-        .getNowPlaying()
-        .then((resp) => resp.json['subsonic-response'])
-        .then((data) => {
-          if (data.status === 'ok') {
-            const nowPlayingEntries = data.nowPlaying?.entry || []
-            const fetchTime = Date.now()
-            setEntries(
-              nowPlayingEntries.map((e) => ({ ...e, _fetchedAt: fetchTime })),
-            )
-            dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
-          } else {
-            throw new Error(
-              data.error?.message || 'Failed to fetch now playing data',
-            )
-          }
+  const doFetchRef = useRef()
+  doFetchRef.current = () =>
+    subsonic
+      .getNowPlaying()
+      .then((resp) => resp.json['subsonic-response'])
+      .then((data) => {
+        if (data.status === 'ok') {
+          const nowPlayingEntries = data.nowPlaying?.entry || []
+          const fetchTime = Date.now()
+          setEntries(
+            nowPlayingEntries.map((e) => ({ ...e, _fetchedAt: fetchTime })),
+          )
+          dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
+        } else {
+          throw new Error(
+            data.error?.message || 'Failed to fetch now playing data',
+          )
+        }
+      })
+      .catch((error) => {
+        notify('ra.page.error', 'warning', {
+          messageArgs: { error: error.message || 'Unknown error' },
         })
-        .catch((error) => {
-          notify('ra.page.error', 'warning', {
-            messageArgs: { error: error.message || 'Unknown error' },
-          })
-        }),
-    [dispatch, notify],
-  )
+      })
   const fetchList = useCallback(() => {
     if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current)
     fetchTimerRef.current = setTimeout(() => {
       fetchTimerRef.current = null
-      doFetch()
+      doFetchRef.current()
     }, 300)
-  }, [doFetch])
+  }, [])
 
   // Initialize count and entries on mount, and refresh on server/stream changes
   useEffect(() => {

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -328,9 +328,9 @@ const NowPlayingList = React.memo(
                 dense
                 aria-label={translate('nowPlaying.title')}
               >
-                {entries.map((nowPlayingEntry, idx) => (
+                {entries.map((nowPlayingEntry) => (
                   <NowPlayingItem
-                    key={`${nowPlayingEntry.username}-${nowPlayingEntry.playerName}-${idx}`}
+                    key={`${nowPlayingEntry.username}-${nowPlayingEntry.playerName}`}
                     nowPlayingEntry={nowPlayingEntry}
                     onLinkClick={onLinkClick}
                     getArtistLink={getArtistLink}
@@ -384,7 +384,6 @@ const NowPlayingPanel = () => {
 
   const handleMenuClose = useCallback(() => {
     setAnchorEl(null)
-    setEntries([])
   }, [])
 
   // Close panel when link is clicked on small screens
@@ -431,6 +430,12 @@ const NowPlayingPanel = () => {
       fetchTimerRef.current = null
       doFetchRef.current()
     }, 300)
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current)
+    }
   }, [])
 
   // Initialize count and entries on mount, and refresh on server/stream changes

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -18,7 +18,7 @@ import {
   useTheme,
   useMediaQuery,
 } from '@material-ui/core'
-import { FaRegCirclePlay, FaPlay, FaPause } from 'react-icons/fa6'
+import { FaRegCirclePlay, FaPause } from 'react-icons/fa6'
 import subsonic from '../subsonic'
 import { useInterval } from '../common'
 import { nowPlayingCountUpdate } from '../actions'
@@ -181,7 +181,6 @@ NowPlayingButton.propTypes = {
   onClick: PropTypes.func.isRequired,
 }
 
-// NowPlayingItem component - Discord-style card layout
 const NowPlayingItem = React.memo(
   ({ nowPlayingEntry, onLinkClick, getArtistLink, now }) => {
     const classes = useStyles()
@@ -197,15 +196,13 @@ const NowPlayingItem = React.memo(
       : basePositionMs
     const durationMs = (nowPlayingEntry.duration || 0) * 1000
     const clampedMs = Math.max(0, interpolatedMs)
-    const positionMs = durationMs > 0 ? Math.min(clampedMs, durationMs) : clampedMs
+    const positionMs =
+      durationMs > 0 ? Math.min(clampedMs, durationMs) : clampedMs
     const positionSec = positionMs / 1000
     const durationSec = nowPlayingEntry.duration || 0
-    const progress =
-      durationSec > 0 ? (positionSec / durationSec) * 100 : 0
-    const artistId =
-      nowPlayingEntry.albumArtistId || nowPlayingEntry.artistId
-    const artistName =
-      nowPlayingEntry.albumArtist || nowPlayingEntry.artist
+    const progress = durationSec > 0 ? (positionSec / durationSec) * 100 : 0
+    const artistId = nowPlayingEntry.albumArtistId || nowPlayingEntry.artistId
+    const artistName = nowPlayingEntry.albumArtist || nowPlayingEntry.artist
 
     return (
       <ListItem className={classes.listItem}>
@@ -222,16 +219,17 @@ const NowPlayingItem = React.memo(
               loading="lazy"
             />
           </Link>
-          <div className={classes.stateOverlay}>
-            {isPaused ? (
+          {isPaused && (
+            <div className={classes.stateOverlay}>
               <FaPause className={classes.stateIcon} />
-            ) : (
-              <FaPlay className={classes.stateIcon} />
-            )}
-          </div>
+            </div>
+          )}
         </div>
         <div className={classes.entryContent}>
-          <Typography className={classes.trackTitle} title={nowPlayingEntry.title}>
+          <Typography
+            className={classes.trackTitle}
+            title={nowPlayingEntry.title}
+          >
             {nowPlayingEntry.title}
           </Typography>
           {artistId ? (
@@ -247,7 +245,10 @@ const NowPlayingItem = React.memo(
               {artistName}
             </Typography>
           )}
-          <Typography className={classes.trackDetail} title={nowPlayingEntry.album}>
+          <Typography
+            className={classes.trackDetail}
+            title={nowPlayingEntry.album}
+          >
             {nowPlayingEntry.album}
           </Typography>
           <div className={classes.progressRow}>
@@ -447,10 +448,7 @@ const NowPlayingPanel = () => {
   }, [lastUpdate, open, fetchList, serverUp])
 
   // Update current time every second when open to animate progress bars
-  useInterval(
-    () => setNow(Date.now()),
-    open ? 1000 : null,
-  )
+  useInterval(() => setNow(Date.now()), open ? 1000 : null)
 
   // Periodic refresh when panel is open (10 seconds)
   useInterval(

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -401,13 +401,10 @@ const NowPlayingPanel = () => {
       : `/album?filter={"artist_id":"${artistId}"}&order=ASC&sort=max_year&displayedFilters={"compilation":true}&perPage=15`
   }, [])
 
-  const lastFetchRef = useRef(0)
-  const fetchList = useCallback(
-    () => {
-      const fetchNow = Date.now()
-      if (fetchNow - lastFetchRef.current < 1000) return Promise.resolve()
-      lastFetchRef.current = fetchNow
-      return subsonic
+  const fetchTimerRef = useRef(null)
+  const doFetch = useCallback(
+    () =>
+      subsonic
         .getNowPlaying()
         .then((resp) => resp.json['subsonic-response'])
         .then((data) => {
@@ -428,10 +425,16 @@ const NowPlayingPanel = () => {
           notify('ra.page.error', 'warning', {
             messageArgs: { error: error.message || 'Unknown error' },
           })
-        })
-    },
+        }),
     [dispatch, notify],
   )
+  const fetchList = useCallback(() => {
+    if (fetchTimerRef.current) clearTimeout(fetchTimerRef.current)
+    fetchTimerRef.current = setTimeout(() => {
+      fetchTimerRef.current = null
+      doFetch()
+    }, 300)
+  }, [doFetch])
 
   // Initialize count and entries on mount, and refresh on server/stream changes
   useEffect(() => {

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -183,7 +183,7 @@ NowPlayingButton.propTypes = {
 
 // NowPlayingItem component - Discord-style card layout
 const NowPlayingItem = React.memo(
-  ({ nowPlayingEntry, onLinkClick, getArtistLink, tick }) => {
+  ({ nowPlayingEntry, onLinkClick, getArtistLink, fetchedAt }) => {
     const classes = useStyles()
     const isPaused = nowPlayingEntry.state === 'paused'
     const isPlaying =
@@ -191,7 +191,10 @@ const NowPlayingItem = React.memo(
       nowPlayingEntry.state === 'starting'
     const basePositionMs = nowPlayingEntry.positionMs || 0
     const rate = nowPlayingEntry.playbackRate || 1
-    const interpolatedMs = isPlaying ? basePositionMs + tick * 1000 * rate : basePositionMs
+    const elapsedSinceFetch = Date.now() - fetchedAt
+    const interpolatedMs = isPlaying
+      ? basePositionMs + elapsedSinceFetch * rate
+      : basePositionMs
     const durationMs = (nowPlayingEntry.duration || 0) * 1000
     const positionMs = durationMs > 0 ? Math.min(interpolatedMs, durationMs) : interpolatedMs
     const positionSec = positionMs / 1000
@@ -293,12 +296,12 @@ NowPlayingItem.propTypes = {
   }).isRequired,
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
-  tick: PropTypes.number.isRequired,
+  fetchedAt: PropTypes.number.isRequired,
 }
 
 // NowPlayingList component - handles the popover content
 const NowPlayingList = React.memo(
-  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink, tick }) => {
+  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink, fetchedAt }) => {
     const classes = useStyles({ entryCount: entries.length })
     const translate = useTranslate()
 
@@ -330,7 +333,7 @@ const NowPlayingList = React.memo(
                     nowPlayingEntry={nowPlayingEntry}
                     onLinkClick={onLinkClick}
                     getArtistLink={getArtistLink}
-                    tick={tick}
+                    fetchedAt={fetchedAt}
                   />
                 ))}
               </List>
@@ -351,7 +354,7 @@ NowPlayingList.propTypes = {
   entries: PropTypes.arrayOf(PropTypes.object).isRequired,
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
-  tick: PropTypes.number.isRequired,
+  fetchedAt: PropTypes.number.isRequired,
 }
 
 // Main NowPlayingPanel component
@@ -371,7 +374,8 @@ const NowPlayingPanel = () => {
 
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
-  const [tick, setTick] = useState(0)
+  const [, setRenderTick] = useState(0)
+  const fetchedAtRef = useRef(Date.now())
   const open = Boolean(anchorEl)
 
   const handleMenuOpen = useCallback((event) => {
@@ -405,7 +409,7 @@ const NowPlayingPanel = () => {
           if (data.status === 'ok') {
             const nowPlayingEntries = data.nowPlaying?.entry || []
             setEntries(nowPlayingEntries)
-            setTick(0)
+            fetchedAtRef.current = Date.now()
             // Also update the count in Redux store
             dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
           } else {
@@ -432,9 +436,9 @@ const NowPlayingPanel = () => {
     if (open && serverUp) fetchList()
   }, [count, open, fetchList, serverUp])
 
-  // Tick every second when open to animate progress bars
+  // Force re-render every second when open to animate progress bars
   useInterval(
-    () => setTick((t) => t + 1),
+    () => setRenderTick((t) => t + 1),
     open ? 1000 : null,
   )
 
@@ -462,7 +466,7 @@ const NowPlayingPanel = () => {
         open={open}
         onClose={handleMenuClose}
         entries={entries}
-        tick={tick}
+        fetchedAt={fetchedAtRef.current}
         onLinkClick={handleLinkClick}
         getArtistLink={getArtistLink}
       />

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -183,7 +183,7 @@ NowPlayingButton.propTypes = {
 
 // NowPlayingItem component - Discord-style card layout
 const NowPlayingItem = React.memo(
-  ({ nowPlayingEntry, onLinkClick, getArtistLink, now, fetchedAt }) => {
+  ({ nowPlayingEntry, onLinkClick, getArtistLink, now }) => {
     const classes = useStyles()
     const isPaused = nowPlayingEntry.state === 'paused'
     const isPlaying =
@@ -191,7 +191,7 @@ const NowPlayingItem = React.memo(
       nowPlayingEntry.state === 'starting'
     const basePositionMs = nowPlayingEntry.positionMs || 0
     const rate = nowPlayingEntry.playbackRate || 1
-    const elapsedSinceFetch = now - fetchedAt
+    const elapsedSinceFetch = now - (nowPlayingEntry._fetchedAt || now)
     const interpolatedMs = isPlaying
       ? basePositionMs + elapsedSinceFetch * rate
       : basePositionMs
@@ -297,12 +297,11 @@ NowPlayingItem.propTypes = {
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
   now: PropTypes.number.isRequired,
-  fetchedAt: PropTypes.number.isRequired,
 }
 
 // NowPlayingList component - handles the popover content
 const NowPlayingList = React.memo(
-  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink, now, fetchedAt }) => {
+  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink, now }) => {
     const classes = useStyles({ entryCount: entries.length })
     const translate = useTranslate()
 
@@ -335,7 +334,6 @@ const NowPlayingList = React.memo(
                     onLinkClick={onLinkClick}
                     getArtistLink={getArtistLink}
                     now={now}
-                    fetchedAt={fetchedAt}
                   />
                 ))}
               </List>
@@ -357,7 +355,6 @@ NowPlayingList.propTypes = {
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
   now: PropTypes.number.isRequired,
-  fetchedAt: PropTypes.number.isRequired,
 }
 
 // Main NowPlayingPanel component
@@ -377,7 +374,6 @@ const NowPlayingPanel = () => {
 
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
-  const [fetchedAt, setFetchedAt] = useState(Date.now())
   const [now, setNow] = useState(Date.now())
   const open = Boolean(anchorEl)
 
@@ -412,9 +408,9 @@ const NowPlayingPanel = () => {
           if (data.status === 'ok') {
             const nowPlayingEntries = data.nowPlaying?.entry || []
             const fetchTime = Date.now()
-            setEntries(nowPlayingEntries)
-            setFetchedAt(fetchTime)
-            setNow(fetchTime)
+            setEntries(
+              nowPlayingEntries.map((e) => ({ ...e, _fetchedAt: fetchTime })),
+            )
             // Also update the count in Redux store
             dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
           } else {
@@ -472,7 +468,6 @@ const NowPlayingPanel = () => {
         onClose={handleMenuClose}
         entries={entries}
         now={now}
-        fetchedAt={fetchedAt}
         onLinkClick={handleLinkClick}
         getArtistLink={getArtistLink}
       />

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -196,7 +196,8 @@ const NowPlayingItem = React.memo(
       ? basePositionMs + elapsedSinceFetch * rate
       : basePositionMs
     const durationMs = (nowPlayingEntry.duration || 0) * 1000
-    const positionMs = durationMs > 0 ? Math.min(interpolatedMs, durationMs) : interpolatedMs
+    const clampedMs = Math.max(0, interpolatedMs)
+    const positionMs = durationMs > 0 ? Math.min(clampedMs, durationMs) : clampedMs
     const positionSec = positionMs / 1000
     const durationSec = nowPlayingEntry.duration || 0
     const progress =

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
 import { useSelector, useDispatch } from 'react-redux'
 import { useTranslate, Link, useNotify } from 'react-admin'
@@ -401,9 +401,13 @@ const NowPlayingPanel = () => {
       : `/album?filter={"artist_id":"${artistId}"}&order=ASC&sort=max_year&displayedFilters={"compilation":true}&perPage=15`
   }, [])
 
+  const lastFetchRef = useRef(0)
   const fetchList = useCallback(
-    () =>
-      subsonic
+    () => {
+      const now = Date.now()
+      if (now - lastFetchRef.current < 1000) return Promise.resolve()
+      lastFetchRef.current = now
+      return subsonic
         .getNowPlaying()
         .then((resp) => resp.json['subsonic-response'])
         .then((data) => {
@@ -413,7 +417,6 @@ const NowPlayingPanel = () => {
             setEntries(
               nowPlayingEntries.map((e) => ({ ...e, _fetchedAt: fetchTime })),
             )
-            // Also update the count in Redux store
             dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
           } else {
             throw new Error(
@@ -425,7 +428,8 @@ const NowPlayingPanel = () => {
           notify('ra.page.error', 'warning', {
             messageArgs: { error: error.message || 'Unknown error' },
           })
-        }),
+        })
+    },
     [dispatch, notify],
   )
 

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
-import { useSelector, useDispatch } from 'react-redux'
+import { useSelector } from 'react-redux'
 import { useTranslate, Link, useNotify } from 'react-admin'
 import {
   Popover,
@@ -21,7 +21,6 @@ import {
 import { FaRegCirclePlay, FaPause } from 'react-icons/fa6'
 import subsonic from '../subsonic'
 import { useInterval } from '../common'
-import { nowPlayingCountUpdate } from '../actions'
 import { formatDuration } from '../utils'
 import config from '../config'
 
@@ -361,7 +360,6 @@ NowPlayingList.propTypes = {
 
 // Main NowPlayingPanel component
 const NowPlayingPanel = () => {
-  const dispatch = useDispatch()
   const count = useSelector((state) => state.activity.nowPlayingCount)
   const lastUpdate = useSelector((state) => state.activity.nowPlayingLastUpdate)
   const streamReconnected = useSelector(
@@ -415,7 +413,6 @@ const NowPlayingPanel = () => {
           setEntries(
             nowPlayingEntries.map((e) => ({ ...e, _fetchedAt: fetchTime })),
           )
-          dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
         } else {
           throw new Error(
             data.error?.message || 'Failed to fetch now playing data',
@@ -466,7 +463,7 @@ const NowPlayingPanel = () => {
 
   return (
     <div>
-      <NowPlayingButton count={count} onClick={handleMenuOpen} />
+      <NowPlayingButton count={entries.length || count} onClick={handleMenuOpen} />
       <NowPlayingList
         anchorEl={anchorEl}
         open={open}

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -183,7 +183,7 @@ NowPlayingButton.propTypes = {
 
 // NowPlayingItem component - Discord-style card layout
 const NowPlayingItem = React.memo(
-  ({ nowPlayingEntry, onLinkClick, getArtistLink, fetchedAt }) => {
+  ({ nowPlayingEntry, onLinkClick, getArtistLink, now, fetchedAt }) => {
     const classes = useStyles()
     const isPaused = nowPlayingEntry.state === 'paused'
     const isPlaying =
@@ -191,7 +191,7 @@ const NowPlayingItem = React.memo(
       nowPlayingEntry.state === 'starting'
     const basePositionMs = nowPlayingEntry.positionMs || 0
     const rate = nowPlayingEntry.playbackRate || 1
-    const elapsedSinceFetch = Date.now() - fetchedAt
+    const elapsedSinceFetch = now - fetchedAt
     const interpolatedMs = isPlaying
       ? basePositionMs + elapsedSinceFetch * rate
       : basePositionMs
@@ -296,12 +296,13 @@ NowPlayingItem.propTypes = {
   }).isRequired,
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
+  now: PropTypes.number.isRequired,
   fetchedAt: PropTypes.number.isRequired,
 }
 
 // NowPlayingList component - handles the popover content
 const NowPlayingList = React.memo(
-  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink, fetchedAt }) => {
+  ({ anchorEl, open, onClose, entries, onLinkClick, getArtistLink, now, fetchedAt }) => {
     const classes = useStyles({ entryCount: entries.length })
     const translate = useTranslate()
 
@@ -333,6 +334,7 @@ const NowPlayingList = React.memo(
                     nowPlayingEntry={nowPlayingEntry}
                     onLinkClick={onLinkClick}
                     getArtistLink={getArtistLink}
+                    now={now}
                     fetchedAt={fetchedAt}
                   />
                 ))}
@@ -354,6 +356,7 @@ NowPlayingList.propTypes = {
   entries: PropTypes.arrayOf(PropTypes.object).isRequired,
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,
+  now: PropTypes.number.isRequired,
   fetchedAt: PropTypes.number.isRequired,
 }
 
@@ -374,7 +377,7 @@ const NowPlayingPanel = () => {
 
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
-  const [, setRenderTick] = useState(0)
+  const [now, setNow] = useState(Date.now())
   const fetchedAtRef = useRef(Date.now())
   const open = Boolean(anchorEl)
 
@@ -436,9 +439,9 @@ const NowPlayingPanel = () => {
     if (open && serverUp) fetchList()
   }, [count, open, fetchList, serverUp])
 
-  // Force re-render every second when open to animate progress bars
+  // Update current time every second when open to animate progress bars
   useInterval(
-    () => setRenderTick((t) => t + 1),
+    () => setNow(Date.now()),
     open ? 1000 : null,
   )
 
@@ -466,6 +469,7 @@ const NowPlayingPanel = () => {
         open={open}
         onClose={handleMenuClose}
         entries={entries}
+        now={now}
         fetchedAt={fetchedAtRef.current}
         onLinkClick={handleLinkClick}
         getArtistLink={getArtistLink}

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -9,29 +9,28 @@ import {
   Tooltip,
   List,
   ListItem,
-  ListItemText,
-  ListItemAvatar,
   Avatar,
   Badge,
   Card,
   CardContent,
   Typography,
+  LinearProgress,
   useTheme,
   useMediaQuery,
 } from '@material-ui/core'
-import { FaRegCirclePlay } from 'react-icons/fa6'
+import { FaRegCirclePlay, FaPlay, FaPause } from 'react-icons/fa6'
 import subsonic from '../subsonic'
 import { useInterval } from '../common'
 import { nowPlayingCountUpdate } from '../actions'
+import { formatDuration } from '../utils'
 import config from '../config'
 
 const useStyles = makeStyles((theme) => ({
   button: { color: 'inherit' },
   list: {
-    width: '30em',
+    width: '26em',
     maxHeight: (props) => {
-      // Calculate height for up to 4 entries before scrolling
-      const entryHeight = 80
+      const entryHeight = 100
       const maxEntries = Math.min(props.entryCount || 0, 4)
       return maxEntries > 0 ? `${maxEntries * entryHeight}px` : '12em'
     },
@@ -42,41 +41,110 @@ const useStyles = makeStyles((theme) => ({
     padding: 0,
   },
   cardContent: {
-    padding: `${theme.spacing(1)}px !important`, // Minimal padding, override default
+    padding: `${theme.spacing(1)}px !important`,
     '&:last-child': {
-      paddingBottom: `${theme.spacing(1)}px !important`, // Override Material-UI's last-child padding
+      paddingBottom: `${theme.spacing(1)}px !important`,
     },
   },
   listItem: {
-    paddingTop: theme.spacing(0.5),
-    paddingBottom: theme.spacing(0.5),
-    paddingLeft: theme.spacing(1),
-    paddingRight: theme.spacing(1),
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing(1.5),
+    padding: theme.spacing(1),
+  },
+  avatarContainer: {
+    position: 'relative',
+    flexShrink: 0,
+    width: theme.spacing(8),
+    height: theme.spacing(8),
   },
   avatar: {
-    width: theme.spacing(6),
-    height: theme.spacing(6),
+    width: '100%',
+    height: '100%',
     cursor: 'pointer',
+    borderRadius: theme.spacing(0.5),
     '&:hover': {
       opacity: 0.8,
     },
+  },
+  stateOverlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    width: '100%',
+    height: '100%',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.45)',
+    borderRadius: theme.spacing(0.5),
+    pointerEvents: 'none',
+  },
+  stateIcon: {
+    color: 'rgba(255, 255, 255, 0.85)',
+    fontSize: 18,
+  },
+  entryContent: {
+    flex: 1,
+    minWidth: 0,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(0.25),
+  },
+  trackTitle: {
+    fontWeight: 600,
+    fontSize: '0.875rem',
+    lineHeight: 1.3,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  trackDetail: {
+    fontSize: '0.75rem',
+    color: theme.palette.text.secondary,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  artistLink: {
+    cursor: 'pointer',
+    color: theme.palette.text.secondary,
+    fontSize: '0.75rem',
+    '&:hover': {
+      textDecoration: 'underline',
+    },
+  },
+  progressRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0.75),
+    marginTop: theme.spacing(0.5),
+  },
+  progressTime: {
+    fontSize: '0.65rem',
+    color: theme.palette.text.secondary,
+    fontVariantNumeric: 'tabular-nums',
+    flexShrink: 0,
+  },
+  progressBar: {
+    flex: 1,
+    height: 3,
+    borderRadius: 2,
+    backgroundColor: theme.palette.action.disabledBackground,
+    '& .MuiLinearProgress-bar': {
+      borderRadius: 2,
+    },
+  },
+  userInfo: {
+    fontSize: '0.65rem',
+    color: theme.palette.text.disabled,
+    marginTop: theme.spacing(0.25),
   },
   badge: {
     '& .MuiBadge-badge': {
       backgroundColor: theme.palette.primary.main,
       color: theme.palette.primary.contrastText,
     },
-  },
-  artistLink: {
-    cursor: 'pointer',
-    '&:hover': {
-      textDecoration: 'underline',
-    },
-  },
-  primaryText: {
-    display: 'flex',
-    alignItems: 'center',
-    flexWrap: 'wrap',
   },
 }))
 
@@ -113,15 +181,23 @@ NowPlayingButton.propTypes = {
   onClick: PropTypes.func.isRequired,
 }
 
-// NowPlayingItem component - individual list item
+// NowPlayingItem component - Discord-style card layout
 const NowPlayingItem = React.memo(
   ({ nowPlayingEntry, onLinkClick, getArtistLink }) => {
     const classes = useStyles()
-    const translate = useTranslate()
+    const isPaused = nowPlayingEntry.state === 'paused'
+    const positionSec = (nowPlayingEntry.positionMs || 0) / 1000
+    const durationSec = nowPlayingEntry.duration || 0
+    const progress =
+      durationSec > 0 ? (positionSec / durationSec) * 100 : 0
+    const artistId =
+      nowPlayingEntry.albumArtistId || nowPlayingEntry.artistId
+    const artistName =
+      nowPlayingEntry.albumArtist || nowPlayingEntry.artist
 
     return (
       <ListItem key={nowPlayingEntry.playerId} className={classes.listItem}>
-        <ListItemAvatar>
+        <div className={classes.avatarContainer}>
           <Link
             to={`/album/${nowPlayingEntry.albumId}/show`}
             onClick={onLinkClick}
@@ -134,30 +210,54 @@ const NowPlayingItem = React.memo(
               loading="lazy"
             />
           </Link>
-        </ListItemAvatar>
-        <ListItemText
-          primary={
-            <div className={classes.primaryText}>
-              {nowPlayingEntry.albumArtistId || nowPlayingEntry.artistId ? (
-                <Link
-                  to={getArtistLink(
-                    nowPlayingEntry.albumArtistId || nowPlayingEntry.artistId,
-                  )}
-                  className={classes.artistLink}
-                  onClick={onLinkClick}
-                >
-                  {nowPlayingEntry.albumArtist || nowPlayingEntry.artist}
-                </Link>
-              ) : (
-                <span>
-                  {nowPlayingEntry.albumArtist || nowPlayingEntry.artist}
-                </span>
-              )}
-              &nbsp;-&nbsp;{nowPlayingEntry.title}
-            </div>
-          }
-          secondary={`${nowPlayingEntry.username}${nowPlayingEntry.playerName ? ` (${nowPlayingEntry.playerName})` : ''} • ${translate('nowPlaying.minutesAgo', { smart_count: nowPlayingEntry.minutesAgo })}`}
-        />
+          <div className={classes.stateOverlay}>
+            {isPaused ? (
+              <FaPause className={classes.stateIcon} />
+            ) : (
+              <FaPlay className={classes.stateIcon} />
+            )}
+          </div>
+        </div>
+        <div className={classes.entryContent}>
+          <Typography className={classes.trackTitle} title={nowPlayingEntry.title}>
+            {nowPlayingEntry.title}
+          </Typography>
+          {artistId ? (
+            <Link
+              to={getArtistLink(artistId)}
+              className={classes.artistLink}
+              onClick={onLinkClick}
+            >
+              {artistName}
+            </Link>
+          ) : (
+            <Typography className={classes.trackDetail}>
+              {artistName}
+            </Typography>
+          )}
+          <Typography className={classes.trackDetail} title={nowPlayingEntry.album}>
+            {nowPlayingEntry.album}
+          </Typography>
+          <div className={classes.progressRow}>
+            <span className={classes.progressTime}>
+              {formatDuration(positionSec)}
+            </span>
+            <LinearProgress
+              className={classes.progressBar}
+              variant="determinate"
+              value={Math.min(progress, 100)}
+            />
+            <span className={classes.progressTime}>
+              {formatDuration(durationSec)}
+            </span>
+          </div>
+          <Typography className={classes.userInfo}>
+            {nowPlayingEntry.username}
+            {nowPlayingEntry.playerName
+              ? ` (${nowPlayingEntry.playerName})`
+              : ''}
+          </Typography>
+        </div>
       </ListItem>
     )
   },
@@ -178,8 +278,10 @@ NowPlayingItem.propTypes = {
     title: PropTypes.string.isRequired,
     username: PropTypes.string.isRequired,
     playerName: PropTypes.string,
-    minutesAgo: PropTypes.number.isRequired,
     album: PropTypes.string,
+    state: PropTypes.string,
+    positionMs: PropTypes.number,
+    duration: PropTypes.number,
   }).isRequired,
   onLinkClick: PropTypes.func.isRequired,
   getArtistLink: PropTypes.func.isRequired,

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -472,10 +472,7 @@ const NowPlayingPanel = () => {
 
   return (
     <div>
-      <NowPlayingButton
-        count={count}
-        onClick={handleMenuOpen}
-      />
+      <NowPlayingButton count={count} onClick={handleMenuOpen} />
       <NowPlayingList
         anchorEl={anchorEl}
         open={open}

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -190,7 +190,8 @@ const NowPlayingItem = React.memo(
       nowPlayingEntry.state === 'playing' ||
       nowPlayingEntry.state === 'starting'
     const basePositionMs = nowPlayingEntry.positionMs || 0
-    const interpolatedMs = isPlaying ? basePositionMs + tick * 1000 : basePositionMs
+    const rate = nowPlayingEntry.playbackRate || 1
+    const interpolatedMs = isPlaying ? basePositionMs + tick * 1000 * rate : basePositionMs
     const durationMs = (nowPlayingEntry.duration || 0) * 1000
     const positionMs = durationMs > 0 ? Math.min(interpolatedMs, durationMs) : interpolatedMs
     const positionSec = positionMs / 1000

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react'
+import React, { useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { useSelector, useDispatch } from 'react-redux'
 import { useTranslate, Link, useNotify } from 'react-admin'
@@ -377,8 +377,8 @@ const NowPlayingPanel = () => {
 
   const [anchorEl, setAnchorEl] = useState(null)
   const [entries, setEntries] = useState([])
+  const [fetchedAt, setFetchedAt] = useState(Date.now())
   const [now, setNow] = useState(Date.now())
-  const fetchedAtRef = useRef(Date.now())
   const open = Boolean(anchorEl)
 
   const handleMenuOpen = useCallback((event) => {
@@ -411,8 +411,10 @@ const NowPlayingPanel = () => {
         .then((data) => {
           if (data.status === 'ok') {
             const nowPlayingEntries = data.nowPlaying?.entry || []
+            const fetchTime = Date.now()
             setEntries(nowPlayingEntries)
-            fetchedAtRef.current = Date.now()
+            setFetchedAt(fetchTime)
+            setNow(fetchTime)
             // Also update the count in Redux store
             dispatch(nowPlayingCountUpdate({ count: nowPlayingEntries.length }))
           } else {
@@ -470,7 +472,7 @@ const NowPlayingPanel = () => {
         onClose={handleMenuClose}
         entries={entries}
         now={now}
-        fetchedAt={fetchedAtRef.current}
+        fetchedAt={fetchedAt}
         onLinkClick={handleLinkClick}
         getArtistLink={getArtistLink}
       />

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -30,8 +30,8 @@ const useStyles = makeStyles((theme) => ({
   list: {
     width: '26em',
     maxHeight: (props) => {
-      const entryHeight = 100
-      const maxEntries = Math.min(props.entryCount || 0, 4)
+      const entryHeight = 120
+      const maxEntries = Math.min(props.entryCount || 0, 3)
       return maxEntries > 0 ? `${maxEntries * entryHeight}px` : '12em'
     },
     overflowY: 'auto',

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -207,7 +207,7 @@ const NowPlayingItem = React.memo(
       nowPlayingEntry.albumArtist || nowPlayingEntry.artist
 
     return (
-      <ListItem key={nowPlayingEntry.playerId} className={classes.listItem}>
+      <ListItem className={classes.listItem}>
         <div className={classes.avatarContainer}>
           <Link
             to={`/album/${nowPlayingEntry.albumId}/show`}
@@ -327,9 +327,9 @@ const NowPlayingList = React.memo(
                 dense
                 aria-label={translate('nowPlaying.title')}
               >
-                {entries.map((nowPlayingEntry) => (
+                {entries.map((nowPlayingEntry, idx) => (
                   <NowPlayingItem
-                    key={nowPlayingEntry.playerId}
+                    key={`${nowPlayingEntry.username}-${nowPlayingEntry.playerName}-${idx}`}
                     nowPlayingEntry={nowPlayingEntry}
                     onLinkClick={onLinkClick}
                     getArtistLink={getArtistLink}

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -384,6 +384,7 @@ const NowPlayingPanel = () => {
 
   const handleMenuClose = useCallback(() => {
     setAnchorEl(null)
+    setEntries([])
   }, [])
 
   // Close panel when link is clicked on small screens

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react'
 import PropTypes from 'prop-types'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { useTranslate, Link, useNotify } from 'react-admin'
 import {
   Popover,
@@ -21,6 +21,7 @@ import {
 import { FaRegCirclePlay, FaPause } from 'react-icons/fa6'
 import subsonic from '../subsonic'
 import { useInterval } from '../common'
+import { nowPlayingCountSync } from '../actions'
 import { formatDuration } from '../utils'
 import config from '../config'
 
@@ -360,6 +361,7 @@ NowPlayingList.propTypes = {
 
 // Main NowPlayingPanel component
 const NowPlayingPanel = () => {
+  const dispatch = useDispatch()
   const count = useSelector((state) => state.activity.nowPlayingCount)
   const lastUpdate = useSelector((state) => state.activity.nowPlayingLastUpdate)
   const streamReconnected = useSelector(
@@ -413,6 +415,7 @@ const NowPlayingPanel = () => {
           setEntries(
             nowPlayingEntries.map((e) => ({ ...e, _fetchedAt: fetchTime })),
           )
+          dispatch(nowPlayingCountSync({ count: nowPlayingEntries.length }))
         } else {
           throw new Error(
             data.error?.message || 'Failed to fetch now playing data',
@@ -470,7 +473,7 @@ const NowPlayingPanel = () => {
   return (
     <div>
       <NowPlayingButton
-        count={entries.length || count}
+        count={count}
         onClick={handleMenuOpen}
       />
       <NowPlayingList

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -404,9 +404,9 @@ const NowPlayingPanel = () => {
   const lastFetchRef = useRef(0)
   const fetchList = useCallback(
     () => {
-      const now = Date.now()
-      if (now - lastFetchRef.current < 1000) return Promise.resolve()
-      lastFetchRef.current = now
+      const fetchNow = Date.now()
+      if (fetchNow - lastFetchRef.current < 1000) return Promise.resolve()
+      lastFetchRef.current = fetchNow
       return subsonic
         .getNowPlaying()
         .then((resp) => resp.json['subsonic-response'])

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -361,6 +361,7 @@ NowPlayingList.propTypes = {
 const NowPlayingPanel = () => {
   const dispatch = useDispatch()
   const count = useSelector((state) => state.activity.nowPlayingCount)
+  const lastUpdate = useSelector((state) => state.activity.nowPlayingLastUpdate)
   const streamReconnected = useSelector(
     (state) => state.activity.streamReconnected,
   )
@@ -432,10 +433,10 @@ const NowPlayingPanel = () => {
     if (serverUp) fetchList()
   }, [fetchList, serverUp, streamReconnected])
 
-  // Refresh when count changes from WebSocket events (if panel is open)
+  // Refresh when NowPlaying updates from SSE events (if panel is open)
   useEffect(() => {
     if (open && serverUp) fetchList()
-  }, [count, open, fetchList, serverUp])
+  }, [lastUpdate, open, fetchList, serverUp])
 
   // Update current time every second when open to animate progress bars
   useInterval(

--- a/ui/src/layout/NowPlayingPanel.jsx
+++ b/ui/src/layout/NowPlayingPanel.jsx
@@ -464,7 +464,10 @@ const NowPlayingPanel = () => {
 
   return (
     <div>
-      <NowPlayingButton count={entries.length || count} onClick={handleMenuOpen} />
+      <NowPlayingButton
+        count={entries.length || count}
+        onClick={handleMenuOpen}
+      />
       <NowPlayingList
         anchorEl={anchorEl}
         open={open}

--- a/ui/src/layout/NowPlayingPanel.test.jsx
+++ b/ui/src/layout/NowPlayingPanel.test.jsx
@@ -70,7 +70,12 @@ describe('<NowPlayingPanel />', () => {
     )
   }
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   beforeEach(() => {
+    vi.useFakeTimers()
     vi.clearAllMocks()
     mockUseMediaQuery.mockReturnValue(false) // Default to large screen
 
@@ -105,10 +110,8 @@ describe('<NowPlayingPanel />', () => {
       </Provider>,
     )
 
-    // Wait for initial fetch to complete
-    await waitFor(() => {
-      expect(subsonic.getNowPlaying).toHaveBeenCalled()
-    })
+    // Advance past debounce and flush promises
+    await vi.advanceTimersByTimeAsync(500)
 
     fireEvent.click(screen.getByRole('button'))
     await waitFor(() => {
@@ -128,21 +131,18 @@ describe('<NowPlayingPanel />', () => {
       </Provider>,
     )
 
-    // Wait for initial fetch to complete
-    await waitFor(() => {
-      expect(subsonic.getNowPlaying).toHaveBeenCalled()
-    })
+    await vi.advanceTimersByTimeAsync(500)
 
     fireEvent.click(screen.getByRole('button'))
     await waitFor(() => {
       expect(
-        screen.getByText('u1 (Chrome Browser) • nowPlaying.minutesAgo'),
+        screen.getByText('u1 (Chrome Browser)'),
       ).toBeInTheDocument()
     })
   })
 
   it('handles entries without player name', async () => {
-    subsonic.getNowPlaying.mockResolvedValueOnce({
+    subsonic.getNowPlaying.mockResolvedValue({
       json: {
         'subsonic-response': {
           status: 'ok',
@@ -170,19 +170,16 @@ describe('<NowPlayingPanel />', () => {
       </Provider>,
     )
 
-    // Wait for initial fetch to complete
-    await waitFor(() => {
-      expect(subsonic.getNowPlaying).toHaveBeenCalled()
-    })
+    await vi.advanceTimersByTimeAsync(500)
 
     fireEvent.click(screen.getByRole('button'))
     await waitFor(() => {
-      expect(screen.getByText('u1 • nowPlaying.minutesAgo')).toBeInTheDocument()
+      expect(screen.getByText('u1')).toBeInTheDocument()
     })
   })
 
   it('shows empty message when no entries', async () => {
-    subsonic.getNowPlaying.mockResolvedValueOnce({
+    subsonic.getNowPlaying.mockResolvedValue({
       json: {
         'subsonic-response': { status: 'ok', nowPlaying: { entry: [] } },
       },
@@ -194,10 +191,7 @@ describe('<NowPlayingPanel />', () => {
       </Provider>,
     )
 
-    // Wait for initial fetch
-    await waitFor(() => {
-      expect(subsonic.getNowPlaying).toHaveBeenCalled()
-    })
+    await vi.advanceTimersByTimeAsync(500)
 
     fireEvent.click(screen.getByRole('button'))
     await waitFor(() => {
@@ -215,10 +209,7 @@ describe('<NowPlayingPanel />', () => {
       </Provider>,
     )
 
-    // Wait for initial fetch to complete
-    await waitFor(() => {
-      expect(subsonic.getNowPlaying).toHaveBeenCalled()
-    })
+    await vi.advanceTimersByTimeAsync(500)
 
     // Open the panel
     fireEvent.click(screen.getByRole('button'))
@@ -268,7 +259,9 @@ describe('<NowPlayingPanel />', () => {
     expect(subsonic.getNowPlaying).not.toHaveBeenCalled()
   })
 
-  it('does not double-fetch on server reconnection', () => {
+  it('does not double-fetch on server reconnection', async () => {
+    vi.useFakeTimers()
+
     const initialStore = createMockStore({
       nowPlayingCount: 1,
       serverStart: { startTime: null }, // Server initially down
@@ -295,8 +288,13 @@ describe('<NowPlayingPanel />', () => {
       </Provider>,
     )
 
+    // Advance past the debounce window
+    vi.advanceTimersByTime(500)
+
     // Should only make one call despite both serverUp and streamReconnected changing
     expect(subsonic.getNowPlaying).toHaveBeenCalledTimes(1)
+
+    vi.useRealTimers()
   })
 
   it('skips polling when server is down', () => {

--- a/ui/src/layout/NowPlayingPanel.test.jsx
+++ b/ui/src/layout/NowPlayingPanel.test.jsx
@@ -135,9 +135,7 @@ describe('<NowPlayingPanel />', () => {
 
     fireEvent.click(screen.getByRole('button'))
     await waitFor(() => {
-      expect(
-        screen.getByText('u1 (Chrome Browser)'),
-      ).toBeInTheDocument()
+      expect(screen.getByText('u1 (Chrome Browser)')).toBeInTheDocument()
     })
   })
 

--- a/ui/src/reducers/activityReducer.js
+++ b/ui/src/reducers/activityReducer.js
@@ -17,6 +17,7 @@ const initialState = {
   },
   serverStart: { version: config.version },
   nowPlayingCount: 0,
+  nowPlayingLastUpdate: 0,
   streamReconnected: 0, // Timestamp of last reconnection
 }
 
@@ -45,7 +46,7 @@ export const activityReducer = (previousState = initialState, payload) => {
         },
       }
     case EVENT_NOW_PLAYING_COUNT:
-      return { ...previousState, nowPlayingCount: data.count }
+      return { ...previousState, nowPlayingCount: data.count, nowPlayingLastUpdate: Date.now() }
     case EVENT_STREAM_RECONNECTED:
       return { ...previousState, streamReconnected: Date.now() }
     default:

--- a/ui/src/reducers/activityReducer.js
+++ b/ui/src/reducers/activityReducer.js
@@ -46,7 +46,11 @@ export const activityReducer = (previousState = initialState, payload) => {
         },
       }
     case EVENT_NOW_PLAYING_COUNT:
-      return { ...previousState, nowPlayingCount: data.count, nowPlayingLastUpdate: Date.now() }
+      return {
+        ...previousState,
+        nowPlayingCount: data.count,
+        nowPlayingLastUpdate: Date.now(),
+      }
     case EVENT_STREAM_RECONNECTED:
       return { ...previousState, streamReconnected: Date.now() }
     default:

--- a/ui/src/reducers/activityReducer.js
+++ b/ui/src/reducers/activityReducer.js
@@ -3,6 +3,7 @@ import {
   EVENT_SCAN_STATUS,
   EVENT_SERVER_START,
   EVENT_NOW_PLAYING_COUNT,
+  EVENT_NOW_PLAYING_COUNT_SYNC,
   EVENT_STREAM_RECONNECTED,
 } from '../actions'
 import config from '../config'
@@ -51,6 +52,8 @@ export const activityReducer = (previousState = initialState, payload) => {
         nowPlayingCount: data.count,
         nowPlayingLastUpdate: Date.now(),
       }
+    case EVENT_NOW_PLAYING_COUNT_SYNC:
+      return { ...previousState, nowPlayingCount: data.count }
     case EVENT_STREAM_RECONNECTED:
       return { ...previousState, streamReconnected: Date.now() }
     default:

--- a/ui/src/reducers/activityReducer.test.js
+++ b/ui/src/reducers/activityReducer.test.js
@@ -18,6 +18,7 @@ describe('activityReducer', () => {
     },
     serverStart: { version: config.version },
     nowPlayingCount: 0,
+    nowPlayingLastUpdate: 0,
     streamReconnected: 0,
   }
 
@@ -131,6 +132,20 @@ describe('activityReducer', () => {
     }
     const newState = activityReducer(initialState, action)
     expect(newState.nowPlayingCount).toEqual(5)
+  })
+
+  it('handles EVENT_NOW_PLAYING_COUNT with nowPlayingLastUpdate', () => {
+    const action = {
+      type: EVENT_NOW_PLAYING_COUNT,
+      data: { count: 3 },
+    }
+    const beforeTimestamp = Date.now()
+    const newState = activityReducer(initialState, action)
+    const afterTimestamp = Date.now()
+
+    expect(newState.nowPlayingCount).toEqual(3)
+    expect(newState.nowPlayingLastUpdate).toBeGreaterThanOrEqual(beforeTimestamp)
+    expect(newState.nowPlayingLastUpdate).toBeLessThanOrEqual(afterTimestamp)
   })
 
   it('handles EVENT_STREAM_RECONNECTED', () => {

--- a/ui/src/reducers/activityReducer.test.js
+++ b/ui/src/reducers/activityReducer.test.js
@@ -144,7 +144,9 @@ describe('activityReducer', () => {
     const afterTimestamp = Date.now()
 
     expect(newState.nowPlayingCount).toEqual(3)
-    expect(newState.nowPlayingLastUpdate).toBeGreaterThanOrEqual(beforeTimestamp)
+    expect(newState.nowPlayingLastUpdate).toBeGreaterThanOrEqual(
+      beforeTimestamp,
+    )
     expect(newState.nowPlayingLastUpdate).toBeLessThanOrEqual(afterTimestamp)
   })
 

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -1,5 +1,9 @@
 import { baseUrl } from '../utils'
-import { httpClient, clientUniqueId, clientUniqueIdHeader } from '../dataProvider'
+import {
+  httpClient,
+  clientUniqueId,
+  clientUniqueIdHeader,
+} from '../dataProvider'
 
 const url = (command, id, options) => {
   const username = localStorage.getItem('username')

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -37,25 +37,16 @@ const url = (command, id, options) => {
 
 const ping = () => httpClient(url('ping'))
 
+const reportPlaybackUrl = (mediaId, positionMs, state) =>
+  url('reportPlayback', null, { mediaId, mediaType: 'song', positionMs, state })
+
 const reportPlayback = (mediaId, positionMs, state) =>
-  httpClient(
-    url('reportPlayback', null, {
-      mediaId,
-      mediaType: 'song',
-      positionMs,
-      state,
-    }),
-  )
+  httpClient(reportPlaybackUrl(mediaId, positionMs, state))
 
 const reportPlaybackBeacon = (mediaId, positionMs, state) => {
-  const beaconUrl = url('reportPlayback', null, {
-    mediaId,
-    mediaType: 'song',
-    positionMs,
-    state,
-  })
-  if (beaconUrl) {
-    navigator.sendBeacon(baseUrl(beaconUrl))
+  const u = reportPlaybackUrl(mediaId, positionMs, state)
+  if (u) {
+    navigator.sendBeacon(baseUrl(u))
   }
 }
 

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -37,16 +37,27 @@ const url = (command, id, options) => {
 
 const ping = () => httpClient(url('ping'))
 
-const scrobble = (id, time, submission = true, position = null) =>
+const reportPlayback = (mediaId, positionMs, state) =>
   httpClient(
-    url('scrobble', id, {
-      ...(submission && time && { time }),
-      submission,
-      ...(!submission && position !== null && { position }),
+    url('reportPlayback', null, {
+      mediaId,
+      mediaType: 'song',
+      positionMs,
+      state,
     }),
   )
 
-const nowPlaying = (id, position = null) => scrobble(id, null, false, position)
+const reportPlaybackBeacon = (mediaId, positionMs, state) => {
+  const beaconUrl = url('reportPlayback', null, {
+    mediaId,
+    mediaType: 'song',
+    positionMs,
+    state,
+  })
+  if (beaconUrl) {
+    navigator.sendBeacon(baseUrl(beaconUrl))
+  }
+}
 
 const star = (id) => httpClient(url('star', id))
 
@@ -132,8 +143,8 @@ const streamUrl = (id, options) => {
 export default {
   url,
   ping,
-  scrobble,
-  nowPlaying,
+  reportPlayback,
+  reportPlaybackBeacon,
   download,
   star,
   unstar,

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -43,10 +43,12 @@ const reportPlaybackUrl = (mediaId, positionMs, state) =>
 const reportPlayback = (mediaId, positionMs, state) =>
   httpClient(reportPlaybackUrl(mediaId, positionMs, state))
 
-const reportPlaybackBeacon = (mediaId, positionMs, state) => {
+const reportPlaybackSync = (mediaId, positionMs, state) => {
   const u = reportPlaybackUrl(mediaId, positionMs, state)
   if (u) {
-    navigator.sendBeacon(baseUrl(u))
+    const xhr = new XMLHttpRequest()
+    xhr.open('GET', baseUrl(u), false)
+    xhr.send()
   }
 }
 
@@ -135,7 +137,7 @@ export default {
   url,
   ping,
   reportPlayback,
-  reportPlaybackBeacon,
+  reportPlaybackSync,
   download,
   star,
   unstar,

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -46,9 +46,12 @@ const reportPlayback = (mediaId, positionMs, state) =>
 const reportPlaybackSync = (mediaId, positionMs, state) => {
   const u = reportPlaybackUrl(mediaId, positionMs, state)
   if (u) {
-    const xhr = new XMLHttpRequest()
-    xhr.open('GET', baseUrl(u), false)
-    xhr.send()
+    const fullUrl = baseUrl(u)
+    try {
+      fetch(fullUrl, { keepalive: true })
+    } catch {
+      navigator.sendBeacon(fullUrl)
+    }
   }
 }
 

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -46,15 +46,10 @@ const reportPlayback = (mediaId, positionMs, state) =>
 const reportPlaybackSync = (mediaId, positionMs, state) => {
   const u = reportPlaybackUrl(mediaId, positionMs, state)
   if (u) {
-    const fullUrl = baseUrl(u)
-    try {
-      fetch(fullUrl, {
-        keepalive: true,
-        headers: { [clientUniqueIdHeader]: clientUniqueId },
-      })
-    } catch {
-      navigator.sendBeacon(fullUrl)
-    }
+    fetch(baseUrl(u), {
+      keepalive: true,
+      headers: { [clientUniqueIdHeader]: clientUniqueId },
+    })
   }
 }
 

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -1,5 +1,5 @@
 import { baseUrl } from '../utils'
-import { httpClient } from '../dataProvider'
+import { httpClient, clientUniqueId } from '../dataProvider'
 
 const url = (command, id, options) => {
   const username = localStorage.getItem('username')
@@ -48,7 +48,10 @@ const reportPlaybackSync = (mediaId, positionMs, state) => {
   if (u) {
     const fullUrl = baseUrl(u)
     try {
-      fetch(fullUrl, { keepalive: true })
+      fetch(fullUrl, {
+        keepalive: true,
+        headers: { 'X-ND-Client-Unique-Id': clientUniqueId },
+      })
     } catch {
       navigator.sendBeacon(fullUrl)
     }

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -1,5 +1,5 @@
 import { baseUrl } from '../utils'
-import { httpClient, clientUniqueId } from '../dataProvider'
+import { httpClient, clientUniqueId, clientUniqueIdHeader } from '../dataProvider'
 
 const url = (command, id, options) => {
   const username = localStorage.getItem('username')
@@ -50,7 +50,7 @@ const reportPlaybackSync = (mediaId, positionMs, state) => {
     try {
       fetch(fullUrl, {
         keepalive: true,
-        headers: { 'X-ND-Client-Unique-Id': clientUniqueId },
+        headers: { [clientUniqueIdHeader]: clientUniqueId },
       })
     } catch {
       navigator.sendBeacon(fullUrl)

--- a/ui/src/subsonic/index.js
+++ b/ui/src/subsonic/index.js
@@ -43,7 +43,7 @@ const reportPlaybackUrl = (mediaId, positionMs, state) =>
 const reportPlayback = (mediaId, positionMs, state) =>
   httpClient(reportPlaybackUrl(mediaId, positionMs, state))
 
-const reportPlaybackSync = (mediaId, positionMs, state) => {
+const reportPlaybackKeepalive = (mediaId, positionMs, state) => {
   const u = reportPlaybackUrl(mediaId, positionMs, state)
   if (u) {
     fetch(baseUrl(u), {
@@ -138,7 +138,7 @@ export default {
   url,
   ping,
   reportPlayback,
-  reportPlaybackSync,
+  reportPlaybackKeepalive,
   download,
   star,
   unstar,

--- a/ui/src/subsonic/index.test.js
+++ b/ui/src/subsonic/index.test.js
@@ -194,3 +194,35 @@ describe('getAvatarUrl', () => {
     expect(url).toContain('username=john')
   })
 })
+
+describe('reportPlayback', () => {
+  beforeEach(() => {
+    const localStorageMock = {
+      getItem: vi.fn((key) => {
+        const values = {
+          username: 'testuser',
+          'subsonic-token': 'testtoken',
+          'subsonic-salt': 'testsalt',
+        }
+        return values[key] || null
+      }),
+    }
+    Object.defineProperty(window, 'localStorage', { value: localStorageMock })
+  })
+
+  it('should call httpClient with reportPlayback URL and correct parameters', async () => {
+    // reportPlayback uses httpClient internally, which is imported from dataProvider
+    // We need to verify the URL is constructed correctly
+    const url = subsonic.url('reportPlayback', null, {
+      mediaId: 'song-123',
+      mediaType: 'song',
+      positionMs: 5000,
+      state: 'playing',
+    })
+    expect(url).toContain('reportPlayback')
+    expect(url).toContain('mediaId=song-123')
+    expect(url).toContain('mediaType=song')
+    expect(url).toContain('positionMs=5000')
+    expect(url).toContain('state=playing')
+  })
+})

--- a/ui/src/subsonic/index.test.js
+++ b/ui/src/subsonic/index.test.js
@@ -210,9 +210,7 @@ describe('reportPlayback', () => {
     Object.defineProperty(window, 'localStorage', { value: localStorageMock })
   })
 
-  it('should call httpClient with reportPlayback URL and correct parameters', async () => {
-    // reportPlayback uses httpClient internally, which is imported from dataProvider
-    // We need to verify the URL is constructed correctly
+  it('should construct reportPlayback URL with correct parameters', () => {
     const url = subsonic.url('reportPlayback', null, {
       mediaId: 'song-123',
       mediaType: 'song',


### PR DESCRIPTION
## Description

Replace the UI's `/rest/scrobble` calls with `/rest/reportPlayback`, moving all scrobble decisions to the backend. The UI now reports playback state transitions (`starting` → `playing` → `paused` → `stopped`) and the server decides when to scrobble.

Also redesigns the NowPlaying panel with a Discord-style layout: album art with pause overlay, track/artist/album info, and a live progress bar with client-side interpolation.

## Screenshots

<img width="491" height="291" alt="Screenshot 2026-05-01 at 2 03 26 PM" src="https://github.com/user-attachments/assets/18fbd01a-8f88-4b3c-acfb-007bf6c423bc" />


## Related Issues

_None_

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

## How to Test

1. `make dev` — play a song, open NowPlaying panel
2. Verify progress bar advances smoothly, pause shows overlay on artwork
3. Skip tracks, seek — verify instant NowPlaying updates
4. Close tab while playing — verify entry is removed
5. Check Network tab: no `/rest/scrobble`, only `reportPlayback` with correct states

## Additional Notes

- `/rest/scrobble` endpoint unchanged — third-party Subsonic clients still work
- New server config `UIPlaybackReportInterval` (default `1m`) controls heartbeat frequency
- SSE broadcasts on state changes for instant NowPlaying updates; panel falls back to 10s polling when SSE is unavailable
