### PR TITLE
fix(ui): handle network errors for externalized auth session expiry

### DIFF
--- a/ui/src/authProvider.js
+++ b/ui/src/authProvider.js
@@ -87,10 +87,8 @@ const authProvider = {
     }
     if (config.extAuthLogoutURL && isNetworkError(error)) {
       const now = Date.now()
-      const lastReload = parseInt(
-        sessionStorage.getItem('ext-auth-reload-ts') || '0',
-        10,
-      )
+      const lastReload =
+        Number(sessionStorage.getItem('ext-auth-reload-ts')) || 0
       if (now - lastReload > 30000) {
         sessionStorage.setItem('ext-auth-reload-ts', String(now))
         removeItems()

--- a/ui/src/authProvider.js
+++ b/ui/src/authProvider.js
@@ -26,6 +26,11 @@ function storeAuthenticationInfo(authInfo) {
   localStorage.setItem('is-authenticated', 'true')
 }
 
+const isNetworkError = (error) => {
+  const msg = error?.message || ''
+  return msg === 'Failed to fetch' || msg.includes('NetworkError')
+}
+
 const authProvider = {
   login: ({ username, password }) => {
     let url = baseUrl('/auth/login')
@@ -53,10 +58,7 @@ const authProvider = {
         return response
       })
       .catch((error) => {
-        if (
-          error.message === 'Failed to fetch' ||
-          error.stack === 'TypeError: Failed to fetch'
-        ) {
+        if (isNetworkError(error)) {
           throw new Error('errors.network_error')
         }
 
@@ -78,10 +80,23 @@ const authProvider = {
       ? Promise.resolve()
       : Promise.reject(),
 
-  checkError: ({ status }) => {
-    if (status === 401) {
+  checkError: (error) => {
+    if (error?.status === 401) {
       removeItems()
       return Promise.reject()
+    }
+    if (config.extAuthLogoutURL && isNetworkError(error)) {
+      const now = Date.now()
+      const lastReload = parseInt(
+        sessionStorage.getItem('ext-auth-reload-ts') || '0',
+        10,
+      )
+      if (now - lastReload > 30000) {
+        sessionStorage.setItem('ext-auth-reload-ts', String(now))
+        removeItems()
+        window.location.reload()
+        return new Promise(() => {})
+      }
     }
     return Promise.resolve()
   },

--- a/ui/src/authProvider.test.js
+++ b/ui/src/authProvider.test.js
@@ -1,4 +1,4 @@
-import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'
+import { describe, it, beforeEach, afterEach, expect } from 'vitest'
 import config from './config'
 import authProvider from './authProvider'
 

--- a/ui/src/authProvider.test.js
+++ b/ui/src/authProvider.test.js
@@ -66,10 +66,7 @@ describe('authProvider', () => {
 
     it('does not reload-loop within 30 seconds', async () => {
       config.extAuthLogoutURL = 'https://auth.example.com/logout'
-      sessionStorage.setItem(
-        'ext-auth-reload-ts',
-        String(Date.now() - 10000),
-      )
+      sessionStorage.setItem('ext-auth-reload-ts', String(Date.now() - 10000))
       await expect(
         authProvider.checkError(new TypeError('Failed to fetch')),
       ).resolves.toBeUndefined()
@@ -78,10 +75,7 @@ describe('authProvider', () => {
 
     it('allows reload again after 30 seconds', () => {
       config.extAuthLogoutURL = 'https://auth.example.com/logout'
-      sessionStorage.setItem(
-        'ext-auth-reload-ts',
-        String(Date.now() - 31000),
-      )
+      sessionStorage.setItem('ext-auth-reload-ts', String(Date.now() - 31000))
       try {
         authProvider.checkError(new TypeError('Failed to fetch'))
       } catch {

--- a/ui/src/authProvider.test.js
+++ b/ui/src/authProvider.test.js
@@ -1,0 +1,106 @@
+import { describe, it, beforeEach, afterEach, vi, expect } from 'vitest'
+import config from './config'
+import authProvider from './authProvider'
+
+describe('authProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    sessionStorage.clear()
+    localStorage.setItem('is-authenticated', 'true')
+    localStorage.setItem('token', 'test-token')
+    localStorage.setItem('userId', 'test-user')
+    localStorage.setItem('role', 'admin')
+    config.extAuthLogoutURL = ''
+  })
+
+  afterEach(() => {
+    config.extAuthLogoutURL = ''
+  })
+
+  describe('checkError', () => {
+    it('rejects and clears storage on 401', async () => {
+      await expect(authProvider.checkError({ status: 401 })).rejects.toBe(
+        undefined,
+      )
+      expect(localStorage.getItem('is-authenticated')).toBeNull()
+    })
+
+    it('resolves on non-401 HTTP errors', async () => {
+      await expect(
+        authProvider.checkError({ status: 500 }),
+      ).resolves.toBeUndefined()
+      expect(localStorage.getItem('is-authenticated')).toBe('true')
+    })
+
+    it('resolves on network error without extAuth configured', async () => {
+      config.extAuthLogoutURL = ''
+      await expect(
+        authProvider.checkError(new TypeError('Failed to fetch')),
+      ).resolves.toBeUndefined()
+      expect(localStorage.getItem('is-authenticated')).toBe('true')
+    })
+
+    it('clears auth and sets reload guard on TypeError with extAuth', () => {
+      config.extAuthLogoutURL = 'https://auth.example.com/logout'
+      // window.location.reload throws in jsdom, so we catch it
+      try {
+        authProvider.checkError(new TypeError('Failed to fetch'))
+      } catch {
+        // jsdom "Not implemented: navigation" is expected
+      }
+      expect(localStorage.getItem('is-authenticated')).toBeNull()
+      expect(sessionStorage.getItem('ext-auth-reload-ts')).not.toBeNull()
+    })
+
+    it('clears auth on Firefox NetworkError with extAuth', () => {
+      config.extAuthLogoutURL = 'https://auth.example.com/logout'
+      const error = new Error('NetworkError when attempting to fetch resource')
+      try {
+        authProvider.checkError(error)
+      } catch {
+        // jsdom "Not implemented: navigation" is expected
+      }
+      expect(localStorage.getItem('is-authenticated')).toBeNull()
+      expect(sessionStorage.getItem('ext-auth-reload-ts')).not.toBeNull()
+    })
+
+    it('does not reload-loop within 30 seconds', async () => {
+      config.extAuthLogoutURL = 'https://auth.example.com/logout'
+      sessionStorage.setItem(
+        'ext-auth-reload-ts',
+        String(Date.now() - 10000),
+      )
+      await expect(
+        authProvider.checkError(new TypeError('Failed to fetch')),
+      ).resolves.toBeUndefined()
+      expect(localStorage.getItem('is-authenticated')).toBe('true')
+    })
+
+    it('allows reload again after 30 seconds', () => {
+      config.extAuthLogoutURL = 'https://auth.example.com/logout'
+      sessionStorage.setItem(
+        'ext-auth-reload-ts',
+        String(Date.now() - 31000),
+      )
+      try {
+        authProvider.checkError(new TypeError('Failed to fetch'))
+      } catch {
+        // jsdom "Not implemented: navigation" is expected
+      }
+      expect(localStorage.getItem('is-authenticated')).toBeNull()
+      const ts = parseInt(sessionStorage.getItem('ext-auth-reload-ts'), 10)
+      expect(Date.now() - ts).toBeLessThan(5000)
+    })
+  })
+
+  describe('checkAuth', () => {
+    it('resolves when authenticated', async () => {
+      await expect(authProvider.checkAuth()).resolves.toBeUndefined()
+    })
+
+    it('rejects when not authenticated', async () => {
+      localStorage.removeItem('is-authenticated')
+      await expect(authProvider.checkAuth()).rejects.toBe(undefined)
+    })
+  })
+})

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -14,6 +14,9 @@ const localStorageMock = (function () {
     setItem: function (key, value) {
       store[key] = value.toString()
     },
+    removeItem: function (key) {
+      delete store[key]
+    },
     clear: function () {
       store = {}
     },


### PR DESCRIPTION
### Description

When using externalized authentication (reverse proxy with Authentik, Authelia, etc.), expired proxy sessions cause the proxy to redirect API requests to its login page. The browser's `fetch()` follows this redirect but hits a CORS error, throwing a `TypeError` ("NetworkError when attempting to fetch resource" in Firefox, "Failed to fetch" in Chrome) instead of returning an HTTP 401.

The existing `authProvider.checkError` only handled `status === 401`, so these network-level errors were displayed as vague "NetworkError" notifications with no way to recover except manually reloading the page.

This PR enhances `checkError` to detect network errors when `extAuthLogoutURL` is configured, clear the auth state, and reload the page so the proxy can redirect to the auth provider. A sessionStorage-based 30-second cooldown guard prevents infinite reload loops if the auth provider itself is unreachable.

Also extracts a shared `isNetworkError` helper to deduplicate the network error detection logic that was already present inline in the `login` method.

### Related Issues

Fixes #5458

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Configure externalized auth with a reverse proxy (e.g. Caddy + Authentik) as described in the [docs](https://www.navidrome.org/docs/usage/integration/authentication/#configuration)
2. Log in via external auth and keep the tab open
3. Let the external auth credentials expire
4. Try to use Navidrome (via the existing tab)
5. **Before**: Vague "NetworkError when attempting to fetch resource" notification
6. **After**: Page reloads automatically, proxy redirects to auth provider login

For regular (non-externalized) auth setups:
1. Log in with correct credentials → works normally
2. Log out → redirects to login page
3. Log in with wrong credentials → shows error on login page
4. All existing behavior is preserved (the new code path is gated behind `config.extAuthLogoutURL`)

### Additional Notes

- The reload-loop guard uses `sessionStorage` (cleared on tab close) with a 30-second cooldown to prevent thrashing if the auth provider is also down
- The never-resolving `Promise` returned after calling `reload()` prevents React Admin from processing further actions during the page reload
- Fixed a pre-existing gap in `setupTests.js` where the localStorage mock was missing `removeItem`
