### PR TITLE
feat: playlist permissions / collaborative playlists

### DIFF
--- a/.github/workflows/validate-translations.sh
+++ b/.github/workflows/validate-translations.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # validate-translations.sh
 # 

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ AGENTS.md
 openspec/
 go.work*
 .worktrees/
+.direnv/

--- a/core/playlists/permissions.go
+++ b/core/playlists/permissions.go
@@ -1,0 +1,63 @@
+package playlists
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+func (s *playlists) GetPermissionsForPlaylist(ctx context.Context, playlistID string) (model.PlaylistPermissions, error) {
+	if _, err := s.checkWritable(ctx, playlistID); err != nil {
+		return nil, err
+	}
+
+	playlistPermissions, err := s.ds.Playlist(ctx).Permissions(playlistID).GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return playlistPermissions, nil
+}
+
+var userPermissions = []model.Permission{model.PermissionEditor, model.PermissionViewer}
+
+// AddPermission grants the user the provided permission on the playlist.
+// If the user is already granted a permission on the playlist, consecutive calls override the current permission.
+func (s *playlists) AddPermission(ctx context.Context, playlistID string, userID string, permission model.Permission) error {
+	playlist, err := s.checkWritable(ctx, playlistID)
+	if err != nil {
+		return err
+	}
+
+	if userID == playlist.OwnerID {
+		return fmt.Errorf("%w: playlist owner must not be added to the playlist", model.ErrValidation)
+
+	}
+
+	if !slices.Contains(userPermissions, permission) {
+		return fmt.Errorf("%w: permission %q not supported, possible values %q", model.ErrValidation, permission, userPermissions)
+	}
+
+	if _, err := s.ds.User(ctx).Get(userID); err != nil {
+		return fmt.Errorf("failed validating existence of user with ID %q: %w", userID, err)
+	}
+
+	return s.ds.Playlist(ctx).Permissions(playlistID).Put(userID, permission)
+}
+
+// RemovePermission removes the granted permission of the user from the playlist.
+func (s *playlists) RemovePermission(ctx context.Context, playlistID string, userID string) error {
+	_, err := s.checkWritable(ctx, playlistID)
+	if err != nil {
+		return err
+	}
+
+	if _, err := s.ds.User(ctx).Get(userID); err != nil {
+		return fmt.Errorf("validating existence of user with ID %q: %w", userID, err)
+	}
+
+	// TODO: check if the Delete actually did something (might not be needed as the api response already tells the users if the set of permissions changed)
+	return s.ds.Playlist(ctx).Permissions(playlistID).Delete(userID)
+}

--- a/core/playlists/permissions.go
+++ b/core/playlists/permissions.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *playlists) GetPermissionsForPlaylist(ctx context.Context, playlistID string) (model.PlaylistPermissions, error) {
-	if _, err := s.checkWritable(ctx, playlistID); err != nil {
+	if _, err := s.checkOwner(ctx, playlistID); err != nil {
 		return nil, err
 	}
 
@@ -26,7 +26,7 @@ var userPermissions = []model.Permission{model.PermissionEditor, model.Permissio
 // AddPermission grants the user the provided permission on the playlist.
 // If the user is already granted a permission on the playlist, consecutive calls override the current permission.
 func (s *playlists) AddPermission(ctx context.Context, playlistID string, userID string, permission model.Permission) error {
-	playlist, err := s.checkWritable(ctx, playlistID)
+	playlist, err := s.checkOwner(ctx, playlistID)
 	if err != nil {
 		return err
 	}
@@ -49,7 +49,7 @@ func (s *playlists) AddPermission(ctx context.Context, playlistID string, userID
 
 // RemovePermission removes the granted permission of the user from the playlist.
 func (s *playlists) RemovePermission(ctx context.Context, playlistID string, userID string) error {
-	_, err := s.checkWritable(ctx, playlistID)
+	_, err := s.checkOwner(ctx, playlistID)
 	if err != nil {
 		return err
 	}

--- a/core/playlists/permissions_test.go
+++ b/core/playlists/permissions_test.go
@@ -1,0 +1,165 @@
+package playlists_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/core/playlists"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/tests"
+)
+
+var _ = Describe("Playlists Permissions", func() {
+	var ds *tests.MockDataStore
+	var ps playlists.Playlists
+	var mockUserRepo *tests.MockedUserRepo
+	var mockPlsRepo *tests.MockPlaylistRepo
+	var mockPermissions *tests.MockPlaylistPermissionRepo
+	ctx := context.Background()
+
+	BeforeEach(func() {
+		mockUserRepo = tests.CreateMockUserRepo()
+		mockPlsRepo = tests.CreateMockPlaylistRepo()
+		ds = &tests.MockDataStore{
+			MockedUser:     mockUserRepo,
+			MockedPlaylist: mockPlsRepo,
+		}
+		ctx = request.WithUser(ctx, model.User{ID: "123"})
+
+		mockUserRepo.Data = map[string]*model.User{
+			"user-1":     {ID: "user-1"},
+			"other-user": {ID: "other-user"},
+		}
+
+		mockPlsRepo.Data = map[string]*model.Playlist{
+			"pls-1": {ID: "pls-1", Name: "My Playlist", OwnerID: "user-1"},
+		}
+		mockPermissions = tests.CreateMockPlaylistPermissionRepo()
+		mockPlsRepo.PermissionsRepo = mockPermissions
+		ps = playlists.NewPlaylists(ds, core.NewImageUploadService())
+	})
+
+	Describe("GetPermissionsForPlaylist", func() {
+		It("allows owner to get permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			perms, err := ps.GetPermissionsForPlaylist(ctx, "pls-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(perms).To(Equal(model.PlaylistPermissions{}))
+		})
+		It("allows admin to get permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "admin", IsAdmin: true})
+			perms, err := ps.GetPermissionsForPlaylist(ctx, "pls-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(perms).To(Equal(model.PlaylistPermissions{}))
+		})
+		It("denies non-owner or non-admin from getting permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "other-user", IsAdmin: false})
+			perms, err := ps.GetPermissionsForPlaylist(ctx, "pls-1")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(perms).To(BeNil())
+		})
+		It("retruns error when playlist not found", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			perms, err := ps.GetPermissionsForPlaylist(ctx, "non-existend-pls")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotFound))
+			Expect(perms).To(BeNil())
+		})
+		Context("with existing permissions", func() {
+			BeforeEach(func() {
+				mockPermissions.Data = map[string]*model.PlaylistPermission{
+					"ignored-1": {Permission: model.PermissionEditor, UserID: "some-user-1", PlaylistID: "pls-1"},
+					"ignored-2": {Permission: model.PermissionViewer, UserID: "some-user-2", PlaylistID: "pls-1"},
+				}
+			})
+			It("returns correct list of permissions", func() {
+				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+				perms, err := ps.GetPermissionsForPlaylist(ctx, "pls-1")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(perms).To(ConsistOf(
+					model.PlaylistPermission{PlaylistID: "pls-1", UserID: "some-user-1", Permission: model.PermissionEditor},
+					model.PlaylistPermission{PlaylistID: "pls-1", UserID: "some-user-2", Permission: model.PermissionViewer},
+				))
+			})
+		})
+	})
+
+	Describe("AddPermission", func() {
+		It("allows owner to add permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.AddPermission(ctx, "pls-1", "other-user", model.PermissionEditor)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mockPermissions.Data).To(Equal(map[string]*model.PlaylistPermission{"other-user": {Permission: model.PermissionEditor}}))
+		})
+		It("allows admin to add permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "admin", IsAdmin: true})
+			err := ps.AddPermission(ctx, "pls-1", "other-user", model.PermissionEditor)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mockPermissions.Data).To(Equal(map[string]*model.PlaylistPermission{"other-user": {Permission: model.PermissionEditor}}))
+		})
+		It("denies non-owner or non-admin from adding permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "other-user", IsAdmin: false})
+			err := ps.AddPermission(ctx, "pls-1", "other-user", model.PermissionEditor)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
+		})
+		It("retruns error when playlist not found", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.AddPermission(ctx, "non-existend-pls", "other-user", model.PermissionEditor)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+		It("retruns error when user to add not found", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.AddPermission(ctx, "pls-1", "non-existent-user", model.PermissionEditor)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotFound))
+			Expect(err).To(MatchError(ContainSubstring("validating existence of user with ID %q", "non-existent-user")))
+		})
+		It("retruns error when permission to add not found", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.AddPermission(ctx, "pls-1", "other-user", "non-existent-perm")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrValidation))
+			Expect(err).To(MatchError(ContainSubstring("permission %q not supported", "non-existent-perm")))
+		})
+	})
+
+	Describe("RemovePermission", func() {
+		It("allows owner to remove permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.RemovePermission(ctx, "pls-1", "other-user")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mockPermissions.Data).To(BeEmpty())
+		})
+		It("allows admin to remove permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "admin", IsAdmin: true})
+			err := ps.RemovePermission(ctx, "pls-1", "other-user")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mockPermissions.Data).To(BeEmpty())
+		})
+		It("denies non-owner or non-admin from removing permissions", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "other-user", IsAdmin: false})
+			err := ps.RemovePermission(ctx, "pls-1", "other-user")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
+		})
+		It("retruns error when playlist not found", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.RemovePermission(ctx, "non-existend-pls", "other-user")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+		It("retruns error when user to add not found", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.RemovePermission(ctx, "pls-1", "non-existent-user")
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+	})
+})

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -167,7 +167,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 	if hasTrackChanges {
 		pls, err = s.checkTracksEditable(ctx, playlistID)
 	} else {
-		pls, err = s.checkOwner(ctx, playlistID)
+		pls, err = s.checkEditor(ctx, playlistID)
 	}
 	if err != nil {
 		return err

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -260,14 +260,32 @@ func (s *playlists) hasEditorPermission(ctx context.Context, playlistID string) 
 
 // checkTracksEditable verifies the user can modify tracks (user is admin / owner or editor + not smart playlist).
 func (s *playlists) checkTracksEditable(ctx context.Context, playlistID string) (*model.Playlist, error) {
-	pls, err := s.checkOwner(ctx, playlistID)
+	pls, err := s.ds.Playlist(ctx).Get(playlistID)
 	if err != nil {
 		return nil, err
 	}
+
 	if pls.IsSmartPlaylist() {
+		// It's a smart playlist, no need to continue with actual permission checks
 		return nil, model.ErrNotAuthorized
 	}
-	return pls, nil
+
+	// First check: is owner / admin?
+	if hasOwnerPermission(ctx, pls) {
+		// User is playlist owner or admin
+		return pls, nil
+	}
+
+	// Second check: has user edit permission on playlist?
+	hasEditorPerms, err := s.hasEditorPermission(ctx, playlistID)
+	if err != nil {
+		return nil, err
+	}
+	if hasEditorPerms {
+		return pls, nil
+	}
+
+	return nil, model.ErrNotAuthorized
 }
 
 // updateMetadata applies optional metadata changes to a playlist and persists it.

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -2,6 +2,7 @@ package playlists
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/bmatcuk/doublestar/v4"
 	"github.com/deluan/rest"
+
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
@@ -209,7 +211,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 func (s *playlists) checkWritable(ctx context.Context, id string) (*model.Playlist, error) {
 	pls, err := s.ds.Playlist(ctx).Get(id)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed getting playlist with ID %q: %w", id, err)
 	}
 	usr, _ := request.UserFrom(ctx)
 	if !usr.IsAdmin && pls.OwnerID != usr.ID {

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -213,11 +213,18 @@ func (s *playlists) checkWritable(ctx context.Context, id string) (*model.Playli
 	if err != nil {
 		return nil, fmt.Errorf("failed getting playlist with ID %q: %w", id, err)
 	}
-	usr, _ := request.UserFrom(ctx)
-	if !usr.IsAdmin && pls.OwnerID != usr.ID {
-		return nil, model.ErrNotAuthorized
+	if hasOwnerPermission(ctx, pls) {
+		return pls, nil
 	}
-	return pls, nil
+	return nil, model.ErrNotAuthorized
+}
+
+func hasOwnerPermission(ctx context.Context, pls *model.Playlist) bool {
+	user, _ := request.UserFrom(ctx)
+	if user.IsAdmin || pls.OwnerID == user.ID {
+		return true
+	}
+	return false
 }
 
 // checkTracksEditable verifies the user can modify tracks (ownership + not smart playlist).

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -49,6 +49,11 @@ type Playlists interface {
 	// REST adapters
 	NewRepository(ctx context.Context) rest.Repository
 	TracksRepository(ctx context.Context, playlistId string, refreshSmartPlaylist bool) rest.Repository
+
+	// Permission Management
+	GetPermissionsForPlaylist(ctx context.Context, playlistID string) (model.PlaylistPermissions, error)
+	AddPermission(ctx context.Context, playlistID string, userID string, permission model.Permission) error
+	RemovePermission(ctx context.Context, playlistID string, userID string) error
 }
 
 // ImageUploadService is a local interface satisfied by core.ImageUploadService.

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -337,6 +337,7 @@ func (s *playlists) ReorderTrack(ctx context.Context, playlistID string, pos int
 // --- Cover art operations ---
 
 func (s *playlists) SetImage(ctx context.Context, playlistID string, reader io.Reader, ext string) error {
+	// TODO: also change to `checkEditor`
 	pls, err := s.checkOwner(ctx, playlistID)
 	if err != nil {
 		return err
@@ -353,6 +354,7 @@ func (s *playlists) SetImage(ctx context.Context, playlistID string, reader io.R
 }
 
 func (s *playlists) RemoveImage(ctx context.Context, playlistID string) error {
+	// TODO: also change to `checkEditor`
 	pls, err := s.checkOwner(ctx, playlistID)
 	if err != nil {
 		return err

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -229,6 +229,35 @@ func hasOwnerPermission(ctx context.Context, pls *model.Playlist) bool {
 	return false
 }
 
+// checkEditor fetches the playlist and verifies the current user is at least editor.
+func (s *playlists) checkEditor(ctx context.Context, playlistID string) (*model.Playlist, error) {
+	pls, err := s.ds.Playlist(ctx).Get(playlistID)
+	if err != nil {
+		return nil, err
+	}
+
+	// First check: is owner / admin?
+	if hasOwnerPermission(ctx, pls) {
+		// User is playlist owner or admin
+		return pls, nil
+	}
+
+	// Second check: has user edit permission on playlist?
+	hasEditorPerms, err := s.hasEditorPermission(ctx, playlistID)
+	if err != nil {
+		return nil, err
+	}
+	if hasEditorPerms {
+		return pls, nil
+	}
+	return nil, model.ErrNotAuthorized
+}
+
+func (s *playlists) hasEditorPermission(ctx context.Context, playlistID string) (bool, error) {
+	usr, _ := request.UserFrom(ctx)
+	return s.ds.Playlist(ctx).Permissions(playlistID).IsUserAllowed(usr.ID, []model.Permission{model.PermissionEditor})
+}
+
 // checkTracksEditable verifies the user can modify tracks (user is admin / owner or editor + not smart playlist).
 func (s *playlists) checkTracksEditable(ctx context.Context, playlistID string) (*model.Playlist, error) {
 	pls, err := s.checkOwner(ctx, playlistID)

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -141,7 +141,7 @@ func (s *playlists) Create(ctx context.Context, playlistId string, name string, 
 }
 
 func (s *playlists) Delete(ctx context.Context, id string) error {
-	pls, err := s.checkWritable(ctx, id)
+	pls, err := s.checkOwner(ctx, id)
 	if err != nil {
 		return err
 	}
@@ -156,6 +156,8 @@ func (s *playlists) Delete(ctx context.Context, id string) error {
 	return s.ds.Playlist(ctx).Delete(id)
 }
 
+// Update updates the playlist metadata & tracks
+// Currently only used for the subsonic API implementation.
 func (s *playlists) Update(ctx context.Context, playlistID string,
 	name *string, comment *string, public *bool,
 	idsToAdd []string, idxToRemove []int) error {
@@ -165,7 +167,7 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 	if hasTrackChanges {
 		pls, err = s.checkTracksEditable(ctx, playlistID)
 	} else {
-		pls, err = s.checkWritable(ctx, playlistID)
+		pls, err = s.checkOwner(ctx, playlistID)
 	}
 	if err != nil {
 		return err
@@ -200,18 +202,18 @@ func (s *playlists) Update(ctx context.Context, playlistID string,
 		if name == nil && comment == nil && public == nil {
 			return nil
 		}
-		// Reuse the playlist from checkWritable (no tracks loaded, so Put only refreshes counters)
+		// Reuse the playlist from checkEditor (no tracks loaded, so Put only refreshes counters)
 		return s.updateMetadata(ctx, tx, pls, name, comment, public)
 	})
 }
 
 // --- Permission helpers ---
 
-// checkWritable fetches the playlist and verifies the current user can modify it.
-func (s *playlists) checkWritable(ctx context.Context, id string) (*model.Playlist, error) {
-	pls, err := s.ds.Playlist(ctx).Get(id)
+// checkOwner fetches the playlist and verifies the current user is the owner or an admin.
+func (s *playlists) checkOwner(ctx context.Context, playlistID string) (*model.Playlist, error) {
+	pls, err := s.ds.Playlist(ctx).Get(playlistID)
 	if err != nil {
-		return nil, fmt.Errorf("failed getting playlist with ID %q: %w", id, err)
+		return nil, fmt.Errorf("failed getting playlist with ID %q: %w", playlistID, err)
 	}
 	if hasOwnerPermission(ctx, pls) {
 		return pls, nil
@@ -227,9 +229,9 @@ func hasOwnerPermission(ctx context.Context, pls *model.Playlist) bool {
 	return false
 }
 
-// checkTracksEditable verifies the user can modify tracks (ownership + not smart playlist).
+// checkTracksEditable verifies the user can modify tracks (user is admin / owner or editor + not smart playlist).
 func (s *playlists) checkTracksEditable(ctx context.Context, playlistID string) (*model.Playlist, error) {
-	pls, err := s.checkWritable(ctx, playlistID)
+	pls, err := s.checkOwner(ctx, playlistID)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +308,7 @@ func (s *playlists) ReorderTrack(ctx context.Context, playlistID string, pos int
 // --- Cover art operations ---
 
 func (s *playlists) SetImage(ctx context.Context, playlistID string, reader io.Reader, ext string) error {
-	pls, err := s.checkWritable(ctx, playlistID)
+	pls, err := s.checkOwner(ctx, playlistID)
 	if err != nil {
 		return err
 	}
@@ -322,7 +324,7 @@ func (s *playlists) SetImage(ctx context.Context, playlistID string, reader io.R
 }
 
 func (s *playlists) RemoveImage(ctx context.Context, playlistID string) error {
-	pls, err := s.checkWritable(ctx, playlistID)
+	pls, err := s.checkOwner(ctx, playlistID)
 	if err != nil {
 		return err
 	}

--- a/core/playlists/playlists_test.go
+++ b/core/playlists/playlists_test.go
@@ -22,10 +22,13 @@ var _ = Describe("Playlists", func() {
 	var ds *tests.MockDataStore
 	var ps playlists.Playlists
 	var mockPlsRepo *tests.MockPlaylistRepo
+	var mockPermissionRepo *tests.MockPlaylistPermissionRepo
 	ctx := context.Background()
 
 	BeforeEach(func() {
 		mockPlsRepo = tests.CreateMockPlaylistRepo()
+		mockPermissionRepo = tests.CreateMockPlaylistPermissionRepo()
+		mockPlsRepo.PermissionsRepo = mockPermissionRepo
 		ds = &tests.MockDataStore{
 			MockedPlaylist: mockPlsRepo,
 			MockedLibrary:  &tests.MockLibraryRepo{},
@@ -138,6 +141,10 @@ var _ = Describe("Playlists", func() {
 				"pls-smart": {ID: "pls-smart", Name: "Smart", OwnerID: "user-1",
 					Rules: &criteria.Criteria{Expression: criteria.Contains{"title": "test"}}},
 			}
+			mockPermissionRepo.Data = map[string]*model.PlaylistPermission{
+				"editor-1": {PlaylistID: "pls-1", UserID: "editor-1", Permission: model.PermissionEditor},
+				"viewer-1": {PlaylistID: "pls-1", UserID: "viewer-1", Permission: model.PermissionViewer},
+			}
 			mockPlsRepo.TracksRepo = mockTracks
 			ps = playlists.NewPlaylists(ds, core.NewImageUploadService())
 		})
@@ -155,8 +162,21 @@ var _ = Describe("Playlists", func() {
 			err := ps.Update(ctx, "pls-other", &newName, nil, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
+		It("allows user with editor permission to update the playlist", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "editor-1", IsAdmin: false})
+			newName := "Updated Name"
+			err := ps.Update(ctx, "pls-1", &newName, nil, nil, nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
 
-		It("denies non-owner, non-admin from updating", func() {
+		It("denies user with viewer permission from updating the playlist", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "viewer-1", IsAdmin: false})
+			newName := "Updated Name"
+			err := ps.Update(ctx, "pls-1", &newName, nil, nil, nil, nil)
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
+		})
+
+		It("denies non-owner, non-admin & non-editor from updating", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "other-user", IsAdmin: false})
 			newName := "Updated Name"
 			err := ps.Update(ctx, "pls-1", &newName, nil, nil, nil, nil)

--- a/core/playlists/playlists_test.go
+++ b/core/playlists/playlists_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Playlists", func() {
 		It("returns error when playlist not found", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.Delete(ctx, "nonexistent")
-			Expect(err).To(Equal(model.ErrNotFound))
+			Expect(err).To(MatchError(model.ErrNotFound))
 		})
 	})
 
@@ -167,7 +167,7 @@ var _ = Describe("Playlists", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			newName := "Updated Name"
 			err := ps.Update(ctx, "nonexistent", &newName, nil, nil, nil, nil)
-			Expect(err).To(Equal(model.ErrNotFound))
+			Expect(err).To(MatchError(model.ErrNotFound))
 		})
 
 		It("denies adding tracks to a smart playlist", func() {
@@ -235,7 +235,7 @@ var _ = Describe("Playlists", func() {
 		It("returns error when playlist not found", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			_, err := ps.AddTracks(ctx, "nonexistent", []string{"song-1"})
-			Expect(err).To(Equal(model.ErrNotFound))
+			Expect(err).To(MatchError(model.ErrNotFound))
 		})
 	})
 
@@ -361,7 +361,7 @@ var _ = Describe("Playlists", func() {
 		It("returns error when playlist not found", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.SetImage(ctx, "nonexistent", strings.NewReader("data"), ".jpg")
-			Expect(err).To(Equal(model.ErrNotFound))
+			Expect(err).To(MatchError(model.ErrNotFound))
 		})
 	})
 
@@ -412,7 +412,7 @@ var _ = Describe("Playlists", func() {
 		It("returns error when playlist not found", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.RemoveImage(ctx, "nonexistent")
-			Expect(err).To(Equal(model.ErrNotFound))
+			Expect(err).To(MatchError(model.ErrNotFound))
 		})
 	})
 })

--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 
 	"github.com/deluan/rest"
+
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
 	"github.com/navidrome/navidrome/model/request"
@@ -80,7 +81,7 @@ func (s *playlists) savePlaylist(ctx context.Context, pls *model.Playlist) (stri
 // updatePlaylistEntity updates playlist metadata with permission checks.
 // Used by the REST API wrapper.
 func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity *model.Playlist) error {
-	current, err := s.checkWritable(ctx, id)
+	current, err := s.checkOwner(ctx, id)
 	if err != nil {
 		switch {
 		case errors.Is(err, model.ErrNotFound):

--- a/db/migrations/20260420000000_add_playlist_permissions.sql
+++ b/db/migrations/20260420000000_add_playlist_permissions.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE TABLE playlist_permissions
+(
+    playlist_id VARCHAR(255) NOT NULL,
+    user_id     VARCHAR(255) NOT NULL,
+    permission  VARCHAR(10) NOT NULL,
+    PRIMARY KEY (playlist_id, user_id),
+    FOREIGN KEY (playlist_id) REFERENCES playlist(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES user(id) ON DELETE CASCADE
+)
+-- +goose StatementEnd
+
+-- +goose Down

--- a/log/redactrus.go
+++ b/log/redactrus.go
@@ -47,7 +47,7 @@ func (h *Hook) Fire(e *logrus.Entry) error {
 			}
 			switch reflect.TypeOf(v).Kind() {
 			case reflect.String:
-				e.Data[k] = re.ReplaceAllString(v.(string), "$1[REDACTED]$2")
+				e.Data[k] = re.ReplaceAllString(reflect.ValueOf(v).String(), "$1[REDACTED]$2")
 				continue
 			case reflect.Map:
 				s := fmt.Sprintf("%+v", v)

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -26,6 +26,9 @@ type Playlist struct {
 	ExternalImageURL string         `structs:"external_image_url" json:"externalImageUrl,omitempty"`
 	CreatedAt        time.Time      `structs:"created_at" json:"createdAt"`
 	UpdatedAt        time.Time      `structs:"updated_at" json:"updatedAt"`
+	// Permission holds the permission the calling uses has on the playlist.
+	// Can be: `owner`, `editor`, `viewer`, `admin`
+	Permission string `structs:"-" json:"permission"`
 
 	// SmartPlaylist attributes
 	Rules       *criteria.Criteria `structs:"rules" json:"rules"`

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -162,3 +162,25 @@ type PlaylistTrackRepository interface {
 	DeleteAll() error
 	Reorder(pos int, newPos int) error
 }
+
+type PlaylistPermission struct {
+	PlaylistID string     `json:"playlistId"`
+	UserID     string     `json:"userId"`
+	Permission Permission `json:"permission"`
+}
+
+type Permission string
+
+const (
+	PermissionEditor Permission = "editor"
+	PermissionViewer Permission = "viewer"
+)
+
+type PlaylistPermissions []PlaylistPermission
+
+type PlaylistPermissionRepository interface {
+	GetAll() (PlaylistPermissions, error)
+	IsUserAllowed(userID string, permissions []Permission) (bool, error)
+	Put(userID string, permission Permission) error
+	Delete(userID string) error
+}

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -131,6 +131,7 @@ type PlaylistRepository interface {
 	Delete(id string) error
 	Tracks(playlistId string, refreshSmartPlaylist bool) PlaylistTrackRepository
 	GetPlaylists(mediaFileId string) (Playlists, error)
+	Permissions(playlistId string) PlaylistPermissionRepository
 }
 
 type PlaylistTrack struct {

--- a/persistence/playlist_permission_repository.go
+++ b/persistence/playlist_permission_repository.go
@@ -1,0 +1,69 @@
+package persistence
+
+import (
+	. "github.com/Masterminds/squirrel"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+type playlistPermissionRepository struct {
+	sqlRepository
+	playlistId string
+}
+
+func (r *playlistRepository) Permissions(playlistId string) model.PlaylistPermissionRepository {
+	p := &playlistPermissionRepository{}
+	p.playlistId = playlistId
+	p.ctx = r.ctx
+	p.db = r.db
+	p.tableName = "playlist_permissions"
+	p.registerModel(&model.PlaylistPermission{}, nil)
+	return p
+}
+
+func (r *playlistPermissionRepository) selectPermissions(options ...model.QueryOptions) SelectBuilder {
+	return r.newSelect(options...).
+		Columns(r.tableName + ".*")
+}
+
+func (r *playlistPermissionRepository) GetAll() (model.PlaylistPermissions, error) {
+	sel := r.selectPermissions().
+		Where(Eq{"playlist_id": r.playlistId})
+
+	var perms model.PlaylistPermissions
+	if err := r.queryAll(sel, &perms); err != nil {
+		return nil, err
+	}
+
+	return perms, nil
+}
+
+func (r *playlistPermissionRepository) IsUserAllowed(userID string, permissions []model.Permission) (bool, error) {
+	permsOr := Or{}
+	for _, perm := range permissions {
+		permsOr = append(permsOr, Eq{"permission": perm})
+	}
+
+	existsQuery := Select("count(*) as exist").From(r.tableName).
+		Where(And{
+			Eq{"playlist_id": r.playlistId},
+			Eq{"user_id": userID},
+			permsOr,
+		})
+	var res struct{ Exist int64 }
+	err := r.queryOne(existsQuery, &res)
+	return res.Exist > 0, err
+}
+
+func (r *playlistPermissionRepository) Put(userID string, permission model.Permission) error {
+	insert := Insert(r.tableName).
+		Columns("playlist_id", "user_id", "permission").
+		Values(r.playlistId, userID, permission).
+		Suffix(`ON CONFLICT(playlist_id, user_id) DO UPDATE SET permission = ?`, permission)
+	_, err := r.executeSQL(insert)
+	return err
+}
+
+func (r *playlistPermissionRepository) Delete(userID string) error {
+	return r.delete(And{Eq{"playlist_id": r.playlistId, "user_id": userID}})
+}

--- a/persistence/playlist_permission_repository_test.go
+++ b/persistence/playlist_permission_repository_test.go
@@ -1,0 +1,81 @@
+package persistence
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+)
+
+var _ = Describe("PlaylistPermissionRepository", Ordered, func() {
+	var (
+		playlistRepo model.PlaylistRepository
+		repo         model.PlaylistPermissionRepository
+	)
+
+	BeforeEach(func() {
+		ctx := log.NewContext(context.Background())
+		ctx = request.WithUser(ctx, adminUser)
+		playlistRepo = NewPlaylistRepository(ctx, GetDBXBuilder())
+
+		repo = playlistRepo.Permissions(testPlaylists[0].ID)
+	})
+
+	Describe("working repo", func() {
+		Describe("No permissions exist yet", func() {
+			It("should return nothing", func() {
+				perms, err := repo.GetAll()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(perms).To(BeEmpty())
+			})
+		})
+		Describe("Create permission", func() {
+			It("should create the permission", func() {
+				Expect(repo.Put(adminUser.ID, model.PermissionEditor)).To(Succeed())
+			})
+		})
+		Describe("There now is a permission", func() {
+			It("should return the permissions", func() {
+				perms, err := repo.GetAll()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(perms).To(Equal(model.PlaylistPermissions{{
+					PlaylistID: testPlaylists[0].ID, UserID: adminUser.ID, Permission: model.PermissionEditor,
+				}}))
+			})
+		})
+		Describe("Test if user is allowed", func() {
+			It("should return true for admin with editor", func() {
+				ok, err := repo.IsUserAllowed(adminUser.ID, []model.Permission{model.PermissionEditor})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeTrue())
+			})
+			It("should return false for admin with viewer", func() {
+				ok, err := repo.IsUserAllowed(adminUser.ID, []model.Permission{model.PermissionViewer})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+			It("should return false for a different user", func() {
+				ok, err := repo.IsUserAllowed("1234567", []model.Permission{model.PermissionEditor})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ok).To(BeFalse())
+			})
+		})
+		Describe("Delete permission", func() {
+			It("should succeed", func() {
+				Expect(repo.Delete(adminUser.ID)).To(Succeed())
+			})
+		})
+		Describe("Permissions are gone", func() {
+			It("should return nothing", func() {
+				perms, err := repo.GetAll()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(perms).To(BeEmpty())
+			})
+		})
+	})
+
+})

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -23,6 +23,7 @@ type playlistRepository struct {
 type dbPlaylist struct {
 	model.Playlist `structs:",flatten"`
 	Rules          sql.NullString `structs:"-"`
+	Permission     sql.NullString `structs:"-"`
 }
 
 func (p *dbPlaylist) PostScan() error {
@@ -166,6 +167,7 @@ func (r *playlistRepository) findBy(sql Sqlizer) (*model.Playlist, error) {
 		return nil, model.ErrNotFound
 	}
 
+	setPermissionField(&pls[0], loggedUser(r.ctx))
 	return &pls[0].Playlist, nil
 }
 
@@ -176,11 +178,34 @@ func (r *playlistRepository) GetAll(options ...model.QueryOptions) (model.Playli
 	if err != nil {
 		return nil, err
 	}
+
+	user := loggedUser(r.ctx)
+
 	playlists := make(model.Playlists, len(res))
 	for i, p := range res {
+		setPermissionField(&p, user)
 		playlists[i] = p.Playlist
 	}
 	return playlists, err
+}
+
+func setPermissionField(dbPls *dbPlaylist, user *model.User) {
+	if dbPls.Playlist.OwnerID == user.ID {
+		dbPls.Playlist.Permission = "owner"
+		return
+	}
+	if user.IsAdmin {
+		dbPls.Playlist.Permission = "admin"
+		return
+	}
+	if dbPls.Permission.Valid {
+		dbPls.Playlist.Permission = dbPls.Permission.String
+		return
+	}
+	if dbPls.Public {
+		dbPls.Playlist.Permission = "viewer"
+		return
+	}
 }
 
 func (r *playlistRepository) GetPlaylists(mediaFileId string) (model.Playlists, error) {
@@ -411,5 +436,7 @@ func (r *playlistRepository) renumber(id string) error {
 }
 
 var _ model.PlaylistRepository = (*playlistRepository)(nil)
+
 var _ rest.Repository = (*playlistRepository)(nil)
+
 var _ rest.Persistable = (*playlistRepository)(nil)

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -158,17 +158,12 @@ func (r *playlistRepository) FindByPath(path string) (*model.Playlist, error) {
 
 func (r *playlistRepository) findBy(sql Sqlizer) (*model.Playlist, error) {
 	sel := r.selectPlaylist().Where(sql)
-	var pls []dbPlaylist
-	err := r.queryAll(sel, &pls)
-	if err != nil {
+	var pls dbPlaylist
+	if err := r.queryOne(sel, &pls); err != nil {
 		return nil, err
 	}
-	if len(pls) == 0 {
-		return nil, model.ErrNotFound
-	}
-
-	setPermissionField(&pls[0], loggedUser(r.ctx))
-	return &pls[0].Playlist, nil
+	setPermissionField(&pls, loggedUser(r.ctx))
+	return &pls.Playlist, nil
 }
 
 func (r *playlistRepository) GetAll(options ...model.QueryOptions) (model.Playlists, error) {

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -74,28 +74,38 @@ func smartPlaylistFilter(string, any) Sqlizer {
 	}
 }
 
-func (r *playlistRepository) userFilter() Sqlizer {
+func (r *playlistRepository) userFilter(sel SelectBuilder) SelectBuilder {
 	user := loggedUser(r.ctx)
 	if user.IsAdmin {
-		return And{}
+		return sel
 	}
-	return Or{
-		Eq{"public": true},
-		Eq{"owner_id": user.ID},
-	}
+	return sel.
+		LeftJoin("playlist_permissions ON playlist.id = playlist_permissions.playlist_id").
+		Where(Or{
+			Eq{"playlist.owner_id": user.ID},
+			Eq{"playlist.public": true},
+			And{
+				Eq{"playlist_permissions.user_id": user.ID},
+				Or{
+					Eq{"permission": model.PermissionEditor},
+					Eq{"permission": model.PermissionViewer},
+				},
+			},
+		}).
+		Columns("playlist_permissions.permission as permission")
 }
 
 func (r *playlistRepository) CountAll(options ...model.QueryOptions) (int64, error) {
-	sq := Select().Where(r.userFilter())
+	sq := r.userFilter(Select())
 	return r.count(sq, options...)
 }
 
 func (r *playlistRepository) Exists(id string) (bool, error) {
-	return r.exists(And{Eq{"id": id}, r.userFilter()})
+	return r.exists(Eq{"id": id})
 }
 
 func (r *playlistRepository) Delete(id string) error {
-	return r.delete(And{Eq{"id": id}, r.userFilter()})
+	return r.delete(Eq{"id": id})
 }
 
 func (r *playlistRepository) Put(p *model.Playlist, cols ...string) error {
@@ -130,7 +140,7 @@ func (r *playlistRepository) Put(p *model.Playlist, cols ...string) error {
 }
 
 func (r *playlistRepository) Get(id string) (*model.Playlist, error) {
-	return r.findBy(And{Eq{"playlist.id": id}, r.userFilter()})
+	return r.findBy(Eq{"playlist.id": id})
 }
 
 func (r *playlistRepository) GetWithTracks(id string, refreshSmartPlaylist, includeMissing bool) (*model.Playlist, error) {
@@ -157,7 +167,7 @@ func (r *playlistRepository) FindByPath(path string) (*model.Playlist, error) {
 }
 
 func (r *playlistRepository) findBy(sql Sqlizer) (*model.Playlist, error) {
-	sel := r.selectPlaylist().Where(sql)
+	sel := r.userFilter(r.selectPlaylist().Where(sql))
 	var pls dbPlaylist
 	if err := r.queryOne(sel, &pls); err != nil {
 		return nil, err
@@ -167,7 +177,7 @@ func (r *playlistRepository) findBy(sql Sqlizer) (*model.Playlist, error) {
 }
 
 func (r *playlistRepository) GetAll(options ...model.QueryOptions) (model.Playlists, error) {
-	sel := r.selectPlaylist(options...).Where(r.userFilter())
+	sel := r.userFilter(r.selectPlaylist(options...))
 	var res []dbPlaylist
 	err := r.queryAll(sel, &res)
 	if err != nil {
@@ -204,9 +214,9 @@ func setPermissionField(dbPls *dbPlaylist, user *model.User) {
 }
 
 func (r *playlistRepository) GetPlaylists(mediaFileId string) (model.Playlists, error) {
-	sel := r.selectPlaylist(model.QueryOptions{Sort: "name"}).
+	sel := r.userFilter(r.selectPlaylist(model.QueryOptions{Sort: "name"})).
 		Join("playlist_tracks on playlist.id = playlist_tracks.playlist_id").
-		Where(And{Eq{"playlist_tracks.media_file_id": mediaFileId}, r.userFilter()})
+		Where(Eq{"playlist_tracks.media_file_id": mediaFileId})
 	var res []dbPlaylist
 	err := r.queryAll(sel, &res)
 	if err != nil {

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -36,11 +36,12 @@ var _ = Describe("PlaylistRepository", func() {
 		It("returns an existing playlist", func() {
 			p, err := repo.Get(plsBest.ID)
 			Expect(err).To(BeNil())
-			// Compare all but Tracks and timestamps
+			// Compare all but tracks, timestamps & permission
 			p2 := *p
 			p2.Tracks = plsBest.Tracks
 			p2.UpdatedAt = plsBest.UpdatedAt
 			p2.CreatedAt = plsBest.CreatedAt
+			p2.Permission = plsBest.Permission
 			Expect(p2).To(Equal(plsBest))
 			// Compare tracks
 			for i := range p.Tracks {

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -143,6 +143,11 @@ func (api *Router) addPlaylistRoute(r chi.Router) {
 			r.Delete("/", rest.Delete(constructor))
 			r.Post("/image", uploadPlaylistImage(api.playlists))
 			r.Delete("/image", deletePlaylistImage(api.playlists))
+			r.Route("/permissions", func(r chi.Router) {
+				r.Get("/", getPlaylistPermissions(api.playlists))
+				r.Post("/", addPlaylistPermission(api.playlists))
+				r.Delete("/", deletePlaylistPermission(api.playlists))
+			})
 		})
 	})
 }

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/deluan/rest"
 	"github.com/go-chi/chi/v5"
+
 	"github.com/navidrome/navidrome/core/playlists"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -239,3 +239,104 @@ func deletePlaylistImage(pls playlists.Playlists) http.HandlerFunc {
 		return pls.RemoveImage(ctx, playlistId)
 	})
 }
+
+func getPlaylistPermissions(pls playlists.Playlists) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		playlistID := chi.URLParamFromCtx(ctx, "id")
+
+		getPlaylistPermissionsHelper(ctx, playlistID, pls, w, r)
+	}
+
+}
+
+func addPlaylistPermission(pls playlists.Playlists) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		playlistID := chi.URLParamFromCtx(ctx, "id")
+
+		var request struct {
+			UserID     string           `json:"userId"`
+			Permission model.Permission `json:"permission"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			log.Error(r.Context(), "Error decoding request", err)
+			http.Error(w, "Invalid request body", http.StatusBadRequest)
+			return
+		}
+
+		if err := pls.AddPermission(ctx, playlistID, request.UserID, request.Permission); err != nil {
+			log.Error(r.Context(), "Error granting user permission on playlist", "playlistID", playlistID, "userID", request.UserID, "permission", request.Permission, err)
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			if errors.Is(err, model.ErrValidation) {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if errors.Is(err, model.ErrNotAuthorized) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
+			http.Error(w, "Failed to add user to playlist", http.StatusInternalServerError)
+			return
+		}
+
+		// Return updated permissions of playlist
+		getPlaylistPermissionsHelper(ctx, playlistID, pls, w, r)
+	}
+}
+
+func deletePlaylistPermission(pls playlists.Playlists) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		playlistID := chi.URLParamFromCtx(ctx, "id")
+
+		userID, err := req.Params(r).String("userId")
+		if errors.Is(err, req.ErrMissingParam) {
+			log.Error(r.Context(), fmt.Sprintf("%q query parameter missing", "userId"))
+			http.Error(w, fmt.Sprintf("%q query parameter missing", "userId"), http.StatusBadRequest)
+			return
+		}
+
+		if err := pls.RemovePermission(ctx, playlistID, userID); err != nil {
+			log.Error(r.Context(), "Error removing playlist permission for user", "playlistID", playlistID, "userID", userID, err)
+			if errors.Is(err, model.ErrNotFound) {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			if errors.Is(err, model.ErrNotAuthorized) {
+				http.Error(w, err.Error(), http.StatusForbidden)
+				return
+			}
+			http.Error(w, "Failed to remove user from playlist", http.StatusInternalServerError)
+			return
+		}
+
+		// Return updated permissions of playlist
+		getPlaylistPermissionsHelper(ctx, playlistID, pls, w, r)
+	}
+}
+
+func getPlaylistPermissionsHelper(ctx context.Context, playlistID string, pls playlists.Playlists, w http.ResponseWriter, r *http.Request) {
+	permissions, err := pls.GetPermissionsForPlaylist(ctx, playlistID)
+	if err != nil {
+		log.Error(r.Context(), "Error getting playlist permissions", "playlistID", playlistID, err)
+		if errors.Is(err, model.ErrNotFound) {
+			http.Error(w, err.Error(), http.StatusNotFound)
+			return
+		}
+		if errors.Is(err, model.ErrNotAuthorized) {
+			http.Error(w, err.Error(), http.StatusForbidden)
+			return
+		}
+		http.Error(w, "Internal server error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(permissions); err != nil {
+		log.Error(r.Context(), "Error encoding playlist permissions", err)
+	}
+}

--- a/tests/mock_playlist_permission_repo.go
+++ b/tests/mock_playlist_permission_repo.go
@@ -1,0 +1,73 @@
+package tests
+
+import (
+	"errors"
+	"slices"
+
+	"github.com/navidrome/navidrome/model"
+)
+
+func CreateMockPlaylistPermissionRepo() *MockPlaylistPermissionRepo {
+	return &MockPlaylistPermissionRepo{
+		Data: make(map[string]*model.PlaylistPermission),
+	}
+}
+
+type MockPlaylistPermissionRepo struct {
+	model.PlaylistPermissionRepository
+	Data map[string]*model.PlaylistPermission // keyed by userID
+	Err  bool
+}
+
+func (m *MockPlaylistPermissionRepo) SetError(setError bool) {
+	m.Err = setError
+}
+
+func (m *MockPlaylistPermissionRepo) GetAll() (model.PlaylistPermissions, error) {
+	if m.Err {
+		return nil, errors.New("error")
+	}
+	if m.Data != nil {
+		perms := make(model.PlaylistPermissions, 0, len(m.Data))
+		for i := range m.Data {
+			perms = append(perms, *m.Data[i])
+		}
+		return perms, nil
+	}
+
+	return nil, model.ErrNotFound
+}
+
+func (m *MockPlaylistPermissionRepo) IsUserAllowed(userID string, permissions []model.Permission) (bool, error) {
+	if m.Err {
+		return false, errors.New("error")
+	}
+	if m.Data != nil {
+		if perm, ok := m.Data[userID]; ok {
+			if slices.Contains(permissions, perm.Permission) {
+				return true, nil
+			}
+		}
+	}
+	return false, nil
+}
+
+func (m *MockPlaylistPermissionRepo) Put(userID string, permission model.Permission) error {
+	if m.Err {
+		return errors.New("error")
+	}
+	if m.Data != nil {
+		m.Data[userID] = &model.PlaylistPermission{Permission: permission}
+	}
+	return nil
+}
+
+func (m *MockPlaylistPermissionRepo) Delete(userID string) error {
+	if m.Err {
+		return errors.New("error")
+	}
+	if m.Data != nil {
+		delete(m.Data, userID)
+	}
+	return nil
+}

--- a/tests/mock_playlist_repo.go
+++ b/tests/mock_playlist_repo.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/deluan/rest"
+
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
 )
@@ -17,12 +18,13 @@ func CreateMockPlaylistRepo() *MockPlaylistRepo {
 
 type MockPlaylistRepo struct {
 	model.PlaylistRepository
-	Data       map[string]*model.Playlist // keyed by ID
-	PathMap    map[string]*model.Playlist // keyed by path
-	Last       *model.Playlist
-	Deleted    []string
-	Err        bool
-	TracksRepo model.PlaylistTrackRepository
+	Data            map[string]*model.Playlist // keyed by ID
+	PathMap         map[string]*model.Playlist // keyed by path
+	Last            *model.Playlist
+	Deleted         []string
+	Err             bool
+	TracksRepo      model.PlaylistTrackRepository
+	PermissionsRepo model.PlaylistPermissionRepository
 }
 
 func (m *MockPlaylistRepo) SetError(err bool) {
@@ -81,6 +83,10 @@ func (m *MockPlaylistRepo) Delete(id string) error {
 
 func (m *MockPlaylistRepo) Tracks(_ string, _ bool) model.PlaylistTrackRepository {
 	return m.TracksRepo
+}
+
+func (m *MockPlaylistRepo) Permissions(_ string) model.PlaylistPermissionRepository {
+	return m.PermissionsRepo
 }
 
 func (m *MockPlaylistRepo) Exists(id string) (bool, error) {

--- a/tests/mock_user_repo.go
+++ b/tests/mock_user_repo.go
@@ -20,8 +20,8 @@ func CreateMockUserRepo() *MockedUserRepo {
 type MockedUserRepo struct {
 	model.UserRepository
 	Error         error
-	Data          map[string]*model.User
-	UserLibraries map[string][]int // userID -> libraryIDs
+	Data          map[string]*model.User // keyed by lower case username
+	UserLibraries map[string][]int       // userID -> libraryIDs
 }
 
 func (u *MockedUserRepo) CountAll(qo ...model.QueryOptions) (int64, error) {


### PR DESCRIPTION
### Description
<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->
This PR adds the possibility (API, UI still missing) to grant users permission (viewer or editor) on playlists.


### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->
- https://github.com/navidrome/navidrome/discussions/2770
- Probably one part of https://github.com/navidrome/navidrome/issues/390

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
<!-- Describe the steps to test your changes. Include setup, commands, and expected results. -->
1. Create a (non public) playlist "test" with the admin user
2. Save the playlist ID
3. Create a new user "test"
4. Save the user ID
5. Get the admin users access token from the browsers local storage via dev tools
6. Grant "test" user "viewer" permission on the "test" playlist:
   - `curl -H "X-Nd-Authorization: Bearer $TOKEN" localhost:4533/api/playlist/bKyx6t5ZQGWZo5cYGqZrGV/permissions -X POST -d '{"permission":"viewer","userId":"Kgh8MmYlkLvxMcBvo1RD7m"}'`
7. Login with the "test" user and see that the "test" playlist is now visible

- With `DELETE` the granted permission can be revoked.
- With an additional `POST` for permission `editor` the existing permission is changed from `viewer` to `editor`.
  - Adding tracks via the UI does not yet work, but via API or subsonic API it's possible.

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->
Because of the amount and size of the required changes, I structured them in small atomic commits.
To make reviewing easier we could even merge this in smaller chunks / dedicated PRs. I would appreciate it if you could let me know how I should split it up.

There are still a few open to-dos / questions:
- [ ] Tests for the new endpoints
- [ ] Possibility to managed playlist permissions in the UI
  - I read in different issues that a big UI rewrite is happening. If it's ok with you we can finish and merge the non UI changes and I can contribute the new UI elements after the rewrite? 
- [ ] Are there any preferences how permission checks should be implemented?
  - I saw multiple places where checks were missing but implicitly handled via SQL "filters". This results in 404 instead of 403. Currently, knowing just a small amount of the code base, it feels a bit inconsistent.

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->