### PR TITLE
chore(ci): update GitHub Actions to latest major versions

### DIFF
--- a/.github/actions/prepare-docker/action.yml
+++ b/.github/actions/prepare-docker/action.yml
@@ -53,13 +53,13 @@ runs:
 
     - name: Login to Docker Hub
       if: inputs.hub_username != '' && inputs.hub_password != ''
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ inputs.hub_username }}
         password: ${{ inputs.hub_password }}
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -67,11 +67,11 @@ runs:
 
     - name: Set up Docker Buildx
       id: buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Extract metadata for Docker image
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         labels: |
           maintainer=deluan@navidrome.org

--- a/.github/actions/prepare-docker/action.yml
+++ b/.github/actions/prepare-docker/action.yml
@@ -73,6 +73,7 @@ runs:
       id: meta
       uses: docker/metadata-action@v6
       with:
+        token: ${{ inputs.github_token }}
         labels: |
           maintainer=deluan@navidrome.org
         images: |

--- a/.github/workflows/download-link-on-pr.yml
+++ b/.github/workflows/download-link-on-pr.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v3
+      - uses: actions/github-script@v7
         with:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml
@@ -19,7 +19,7 @@ jobs:
             const pull_user_id = ${{github.event.sender.id}};
 
             const issue_number = await (async () => {
-              const pulls = await github.pulls.list({owner, repo});
+              const pulls = await github.rest.pulls.list({owner, repo});
               for await (const {data} of github.paginate.iterator(pulls)) {
                 for (const pull of data) {
                   if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
@@ -34,7 +34,7 @@ jobs:
               return core.error(`No matching pull request found`);
             }
 
-            const {data: {artifacts}} = await github.actions.listWorkflowRunArtifacts({owner, repo, run_id});
+            const {data: {artifacts}} = await github.rest.actions.listWorkflowRunArtifacts({owner, repo, run_id});
             if (!artifacts.length) {
               return core.error(`No artifacts found`);
             }
@@ -43,12 +43,12 @@ jobs:
               body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
             }
 
-            const {data: comments} = await github.issues.listComments({repo, owner, issue_number});
+            const {data: comments} = await github.rest.issues.listComments({repo, owner, issue_number});
             const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
             if (existing_comment) {
               core.info(`Updating comment ${existing_comment.id}`);
-              await github.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});
+              await github.rest.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});
             } else {
               core.info(`Creating a comment`);
-              await github.issues.createComment({repo, owner, issue_number, body});
+              await github.rest.issues.createComment({repo, owner, issue_number, body});
             }

--- a/.github/workflows/download-link-on-pr.yml
+++ b/.github/workflows/download-link-on-pr.yml
@@ -19,8 +19,7 @@ jobs:
             const pull_user_id = ${{github.event.sender.id}};
 
             const issue_number = await (async () => {
-              const pulls = await github.rest.pulls.list({owner, repo});
-              for await (const {data} of github.paginate.iterator(pulls)) {
+              for await (const {data} of github.paginate.iterator(github.rest.pulls.list, {owner, repo})) {
                 for (const pull of data) {
                   if (pull.head.sha === pull_head_sha && pull.user.id === pull_user_id) {
                     return pull.number;

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -145,7 +145,7 @@ jobs:
 
       - name: Cache ffmpeg
         id: ffmpeg-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: C:\ffmpeg
           key: ffmpeg-${{ env.FFMPEG_VERSION }}-win64

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,7 @@ jobs:
             This pull request has been automatically locked since there
             has not been any recent activity after it was closed.
             Please open a new issue for related bugs.
-      - uses: actions/stale@v9
+      - uses: actions/stale@v10
         with:
           operations-per-run: 999
           days-before-issue-stale: 180


### PR DESCRIPTION
### Description

Update GitHub Actions used in CI/CD workflows to their latest major versions. This ensures we stay current with security patches, performance improvements, and Node.js runtime support.

**Actions updated:**
- `actions/cache` v4 → v5
- `actions/github-script` v3 → v7 (+ migrated Octokit calls to `github.rest.*` namespace)
- `actions/stale` v9 → v10
- `docker/login-action` v3 → v4
- `docker/setup-buildx-action` v3 → v4
- `docker/metadata-action` v5 → v6

All other actions were already on their latest major versions.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI dependency update

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. CI pipeline runs on this PR will validate all workflow changes
2. The `download-link-on-pr` workflow will be tested when CI completes and posts the artifact download comment
3. Docker build/push actions will be validated in the build job
