### PR TITLE
fix(scanner): use synthetic admin user on fresh installs to fix scanner phases

### DIFF
--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -205,8 +205,8 @@ func libraryIdFilter(_ string, value any) Sqlizer {
 func (r sqlRepository) applyLibraryFilter(sq SelectBuilder, tableName ...string) SelectBuilder {
 	user := loggedUser(r.ctx)
 
-	// If the user is an admin, or the user ID is empty/invalid (e.g., when no user is logged in), skip the library filter
-	if user.IsAdmin || user.ID == "" || user.ID == invalidUserId {
+	// If the user is an admin, or the user ID is invalid (e.g., when no user is logged in), skip the library filter
+	if user.IsAdmin || user.ID == invalidUserId {
 		return sq
 	}
 

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -205,8 +205,8 @@ func libraryIdFilter(_ string, value any) Sqlizer {
 func (r sqlRepository) applyLibraryFilter(sq SelectBuilder, tableName ...string) SelectBuilder {
 	user := loggedUser(r.ctx)
 
-	// If the user is an admin, or the user ID is invalid (e.g., when no user is logged in), skip the library filter
-	if user.IsAdmin || user.ID == invalidUserId {
+	// If the user is an admin, or the user ID is empty/invalid (e.g., when no user is logged in), skip the library filter
+	if user.IsAdmin || user.ID == "" || user.ID == invalidUserId {
 		return sq
 	}
 

--- a/scanner/phase_4_playlists.go
+++ b/scanner/phase_4_playlists.go
@@ -50,7 +50,7 @@ func (p *phasePlaylists) produce(put func(entry *model.Folder)) error {
 		return nil
 	}
 	u, _ := request.UserFrom(p.ctx)
-	if !u.IsAdmin && u.ID == "" {
+	if u.ID == "" {
 		log.Warn(p.ctx, "Playlists will not be imported, as there are no admin users yet, "+
 			"Please create an admin user first, and then update the playlists for them to be imported")
 		return nil

--- a/scanner/phase_4_playlists.go
+++ b/scanner/phase_4_playlists.go
@@ -50,7 +50,7 @@ func (p *phasePlaylists) produce(put func(entry *model.Folder)) error {
 		return nil
 	}
 	u, _ := request.UserFrom(p.ctx)
-	if !u.IsAdmin {
+	if !u.IsAdmin && u.ID == "" {
 		log.Warn(p.ctx, "Playlists will not be imported, as there are no admin users yet, "+
 			"Please create an admin user first, and then update the playlists for them to be imported")
 		return nil


### PR DESCRIPTION
## Summary

Fixes scanner failing on fresh installs when no admin user exists yet.

**Root cause:** `WithAdminUser` falls back to `model.User{}` (empty ID, not admin) when no admin exists. The scanner needs admin privileges — without `IsAdmin: true`, Phase 2 fails with "permission denied" when purging missing items. But simply setting `IsAdmin: true` caused Phase 4 to attempt playlist import with an empty `OwnerID`, violating FK constraints.

**Fix (two changes):**
1. **`core/auth/auth.go`**: Set `IsAdmin: true` on the fallback user so the scanner has the privileges it needs (library filter bypass, delete permissions, etc.)
2. **`scanner/phase_4_playlists.go`**: Check `u.ID == ""` instead of `!u.IsAdmin` to detect "no real admin exists". The synthetic admin has `IsAdmin: true` but `ID: ""`, so this correctly skips playlist import while allowing everything else.

## Related Issues

Fixes #5456 (together with #5457)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

## Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

## How to Test

1. Start Navidrome with a fresh database (delete existing `navidrome.db`)
2. Point `MusicFolder` at a library with a multi-disc album (per-disc `folder.jpg` + album-root `cover.jpg`)
3. Wait for the scan to complete **without** creating an admin user
4. Verify in the logs: scan completes without errors, playlists are skipped with "no admin users yet" warning
5. Create the admin user and log in
6. **Expected**: Album shows all tracks across all discs; artwork is correct
7. **Before fix**: Scan fails with "permission denied", or album shows only last-scanned disc's tracks and artwork

Verify in the DB:
```sql
SELECT name, folder_ids, song_count FROM album;
```
`folder_ids` should contain all disc folder IDs (not just one), and `song_count` should reflect all tracks.

## Additional Notes

The `!u.IsAdmin` → `u.ID == ""` change in Phase 4 is semantically equivalent for the "no admin" case, but also handles the synthetic admin correctly. `cmd/utils.go` and `core/metrics/insights.go` also call `WithAdminUser` and check `!u.IsAdmin` — with the synthetic admin they would now proceed, but this is acceptable: CLI commands will fail downstream if they need a real user ID, and insights collection does read-only aggregate queries that work fine without a real user.
