### PR TITLE
fix(ui): add Rescan button to plugin list empty state

### DIFF
--- a/ui/src/plugin/PluginList.jsx
+++ b/ui/src/plugin/PluginList.jsx
@@ -2,6 +2,7 @@ import React, { useMemo, useState, useCallback } from 'react'
 import {
   Button,
   Datagrid,
+  Empty,
   TextField,
   TopToolbar,
   useNotify,
@@ -10,7 +11,13 @@ import {
   useTranslate,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
-import { useMediaQuery, Tooltip, Chip, Typography } from '@material-ui/core'
+import {
+  useMediaQuery,
+  Tooltip,
+  Chip,
+  Typography,
+  Box,
+} from '@material-ui/core'
 import { MdError, MdRefresh } from 'react-icons/md'
 import { List, DateField, SimpleList, useResourceRefresh } from '../common'
 import { httpClient } from '../dataProvider'
@@ -72,7 +79,7 @@ const ManifestField = ({ source }) => {
   return <Typography variant="body2">{manifest[source] || '-'}</Typography>
 }
 
-const PluginListActions = () => {
+const RescanButton = () => {
   const translate = useTranslate()
   const notify = useNotify()
   const refresh = useRefresh()
@@ -93,16 +100,33 @@ const PluginListActions = () => {
   }, [notify, refresh])
 
   return (
+    <Button
+      onClick={handleRescan}
+      disabled={loading}
+      label={translate('resources.plugin.actions.rescan')}
+      data-testid="rescan-button"
+    >
+      <MdRefresh />
+    </Button>
+  )
+}
+
+const PluginListActions = () => {
+  return (
     <TopToolbar>
-      <Button
-        onClick={handleRescan}
-        disabled={loading}
-        label={translate('resources.plugin.actions.rescan')}
-        data-testid="rescan-button"
-      >
-        <MdRefresh />
-      </Button>
+      <RescanButton />
     </TopToolbar>
+  )
+}
+
+const PluginEmpty = () => {
+  return (
+    <>
+      <Empty />
+      <Box textAlign="center" mt={2}>
+        <RescanButton />
+      </Box>
+    </>
   )
 }
 
@@ -118,6 +142,7 @@ const PluginList = (props) => {
       exporter={false}
       bulkActionButtons={false}
       actions={<PluginListActions />}
+      empty={<PluginEmpty />}
     >
       {isXsmall ? (
         <SimpleList

--- a/ui/src/plugin/PluginList.jsx
+++ b/ui/src/plugin/PluginList.jsx
@@ -80,7 +80,6 @@ const ManifestField = ({ source }) => {
 }
 
 const RescanButton = () => {
-  const translate = useTranslate()
   const notify = useNotify()
   const refresh = useRefresh()
   const [loading, setLoading] = useState(false)
@@ -103,7 +102,7 @@ const RescanButton = () => {
     <Button
       onClick={handleRescan}
       disabled={loading}
-      label={translate('resources.plugin.actions.rescan')}
+      label="resources.plugin.actions.rescan"
       data-testid="rescan-button"
     >
       <MdRefresh />

--- a/ui/src/plugin/PluginList.test.jsx
+++ b/ui/src/plugin/PluginList.test.jsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 const mockNotify = vi.fn()
@@ -99,15 +105,13 @@ describe('PluginList', () => {
   it('renders the rescan button in the toolbar', () => {
     render(<PluginList />)
     const toolbar = screen.getByTestId('top-toolbar')
-    expect(
-      toolbar.querySelector('[data-testid="rescan-button"]'),
-    ).toBeInTheDocument()
+    expect(within(toolbar).getByTestId('rescan-button')).toBeInTheDocument()
   })
 
   it('calls rescan endpoint when rescan button is clicked', async () => {
     render(<PluginList />)
     const toolbar = screen.getByTestId('top-toolbar')
-    const rescanButton = toolbar.querySelector('[data-testid="rescan-button"]')
+    const rescanButton = within(toolbar).getByTestId('rescan-button')
 
     fireEvent.click(rescanButton)
 
@@ -121,7 +125,7 @@ describe('PluginList', () => {
   it('calls refresh after successful rescan', async () => {
     render(<PluginList />)
     const toolbar = screen.getByTestId('top-toolbar')
-    const rescanButton = toolbar.querySelector('[data-testid="rescan-button"]')
+    const rescanButton = within(toolbar).getByTestId('rescan-button')
 
     fireEvent.click(rescanButton)
 
@@ -135,7 +139,7 @@ describe('PluginList', () => {
 
     render(<PluginList />)
     const toolbar = screen.getByTestId('top-toolbar')
-    const rescanButton = toolbar.querySelector('[data-testid="rescan-button"]')
+    const rescanButton = within(toolbar).getByTestId('rescan-button')
 
     fireEvent.click(rescanButton)
 
@@ -150,17 +154,13 @@ describe('PluginList', () => {
     render(<PluginList />)
     const emptyState = screen.getByTestId('empty-state')
     expect(emptyState).toBeInTheDocument()
-    expect(
-      emptyState.querySelector('[data-testid="rescan-button"]'),
-    ).toBeInTheDocument()
+    expect(within(emptyState).getByTestId('rescan-button')).toBeInTheDocument()
   })
 
   it('empty state rescan button triggers rescan', async () => {
     render(<PluginList />)
     const emptyState = screen.getByTestId('empty-state')
-    const rescanButton = emptyState.querySelector(
-      '[data-testid="rescan-button"]',
-    )
+    const rescanButton = within(emptyState).getByTestId('rescan-button')
 
     fireEvent.click(rescanButton)
 

--- a/ui/src/plugin/PluginList.test.jsx
+++ b/ui/src/plugin/PluginList.test.jsx
@@ -34,6 +34,7 @@ vi.mock('react-admin', async () => {
     TopToolbar: ({ children }) => (
       <div data-testid="top-toolbar">{children}</div>
     ),
+    Empty: () => <div data-testid="ra-empty">No resources</div>,
     Datagrid: ({ children }) => <div data-testid="datagrid">{children}</div>,
     TextField: ({ source }) => <span data-testid={`text-${source}`} />,
   }
@@ -42,9 +43,10 @@ vi.mock('react-admin', async () => {
 // Mock common components
 vi.mock('../common', async () => {
   return {
-    List: ({ children, actions, ...props }) => (
+    List: ({ children, actions, empty, ...props }) => (
       <div data-testid="list">
         {actions}
+        {empty && <div data-testid="empty-state">{empty}</div>}
         {children}
       </div>
     ),
@@ -94,14 +96,18 @@ describe('PluginList', () => {
     expect(screen.getByTestId('datagrid')).toBeInTheDocument()
   })
 
-  it('renders the rescan button', () => {
+  it('renders the rescan button in the toolbar', () => {
     render(<PluginList />)
-    expect(screen.getByTestId('rescan-button')).toBeInTheDocument()
+    const toolbar = screen.getByTestId('top-toolbar')
+    expect(
+      toolbar.querySelector('[data-testid="rescan-button"]'),
+    ).toBeInTheDocument()
   })
 
   it('calls rescan endpoint when rescan button is clicked', async () => {
     render(<PluginList />)
-    const rescanButton = screen.getByTestId('rescan-button')
+    const toolbar = screen.getByTestId('top-toolbar')
+    const rescanButton = toolbar.querySelector('[data-testid="rescan-button"]')
 
     fireEvent.click(rescanButton)
 
@@ -114,7 +120,8 @@ describe('PluginList', () => {
 
   it('calls refresh after successful rescan', async () => {
     render(<PluginList />)
-    const rescanButton = screen.getByTestId('rescan-button')
+    const toolbar = screen.getByTestId('top-toolbar')
+    const rescanButton = toolbar.querySelector('[data-testid="rescan-button"]')
 
     fireEvent.click(rescanButton)
 
@@ -127,13 +134,39 @@ describe('PluginList', () => {
     mockHttpClient.mockRejectedValue(new Error('Network error'))
 
     render(<PluginList />)
-    const rescanButton = screen.getByTestId('rescan-button')
+    const toolbar = screen.getByTestId('top-toolbar')
+    const rescanButton = toolbar.querySelector('[data-testid="rescan-button"]')
 
     fireEvent.click(rescanButton)
 
     await waitFor(() => {
       expect(mockNotify).toHaveBeenCalledWith('Network error', {
         type: 'warning',
+      })
+    })
+  })
+
+  it('renders a rescan button in the empty state', () => {
+    render(<PluginList />)
+    const emptyState = screen.getByTestId('empty-state')
+    expect(emptyState).toBeInTheDocument()
+    expect(
+      emptyState.querySelector('[data-testid="rescan-button"]'),
+    ).toBeInTheDocument()
+  })
+
+  it('empty state rescan button triggers rescan', async () => {
+    render(<PluginList />)
+    const emptyState = screen.getByTestId('empty-state')
+    const rescanButton = emptyState.querySelector(
+      '[data-testid="rescan-button"]',
+    )
+
+    fireEvent.click(rescanButton)
+
+    await waitFor(() => {
+      expect(mockHttpClient).toHaveBeenCalledWith('/api/plugin/rescan', {
+        method: 'POST',
       })
     })
   })


### PR DESCRIPTION
### Description

When no plugins are installed and the plugin folder watcher fails to detect new plugins, the user has no way to trigger a rescan — the Rescan button in the toolbar disappears when React Admin renders its empty state page.

This PR extracts the rescan logic into a shared `RescanButton` component and adds a custom empty state (`PluginEmpty`) that renders React Admin's default `<Empty />` layout with the Rescan button appended below it.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works
- [x] All existing and new tests pass

### How to Test

1. Enable plugins in config (`EnablePlugins = true`)
2. Ensure the plugins folder is empty (no `.wasm` files)
3. Navigate to the Plugins page in the admin UI
4. Verify the empty state shows React Admin's default empty page with a Rescan button below it
5. Click the Rescan button — it should call the rescan endpoint and refresh the list

### Additional Notes

- Extracted `RescanButton` as a shared component used by both `PluginListActions` (toolbar) and `PluginEmpty` (empty state)
- No new i18n keys needed — reuses the existing `resources.plugin.actions.rescan` key and React Admin's default empty page text