### PR TITLE
fix(test): prevent flaky deadlock in throttle backlog test

### DIFF
--- a/server/throttle_backlog_test.go
+++ b/server/throttle_backlog_test.go
@@ -209,7 +209,7 @@ var _ = Describe("ThrottleBacklog", func() {
 // runTwoRequests sends two concurrent requests through a throttled router. The
 // first request holds the token until the second has been dispatched.
 func runTwoRequests(m func(http.Handler) http.Handler) (firstStatus, secondStatus int) {
-	held := make(chan struct{})
+	held := make(chan struct{}, 1)
 	release := make(chan struct{})
 	r := chi.NewRouter()
 	r.Use(m)


### PR DESCRIPTION
### Description

Fix a flaky deadlock in the throttle backlog test that caused the CI pipeline to hang for 10 minutes and fail ([run #25440155108](https://github.com/navidrome/navidrome/actions/runs/25440155108)).

The `held` channel in `runTwoRequests()` was unbuffered, but the handler sends on it via `select/default`. Under CI load (slow 2-core runner, `-race`, `-shuffle=on`, all packages running in parallel), the handler goroutine could be scheduled and reach the `select` before the test goroutine blocked on `<-held`. When this happened, the send silently fell through to `default`, and both goroutines deadlocked permanently — the handler waiting on `<-release` and the test waiting on `<-held`.

Buffering the channel (capacity 1) ensures the send always succeeds regardless of scheduling order.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run `go test -shuffle=on -tags netgo,sqlite_fts5 -race ./server/ -v` — all throttle tests should pass
2. The deadlock was non-deterministic and only reproducible under heavy CI load, so the real verification is that future CI runs no longer hang on this test
