### PR TITLE
Include ID3 Grouping tag in OpenSubsonic responses

### DIFF
--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -266,6 +266,7 @@ func osChildFromMediaFile(ctx context.Context, mf model.MediaFile) *responses.Op
 	child.BitDepth = int32(mf.BitDepth)
 	child.Genres = toItemGenres(mf.Genres)
 	child.Moods = mf.Tags.Values(model.TagMood)
+	child.Groupings = mf.Tags.Values(model.TagGrouping)
 	child.DisplayArtist = mf.Artist
 	child.Artists = artistRefs(mf.Participants[model.RoleArtist])
 	child.DisplayAlbumArtist = mf.AlbumArtist

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -329,6 +329,9 @@ var _ = Describe("helpers", func() {
 				Title:   "Test Song",
 				Artist:  "Test Artist",
 				Comment: "Test Comment",
+				Tags: model.Tags{
+					model.TagGrouping: {"Soundtrack", "Live"},
+				},
 			}
 			ctx = context.Background()
 		})
@@ -357,6 +360,7 @@ var _ = Describe("helpers", func() {
 				osChild := osChildFromMediaFile(ctx, mf)
 				Expect(osChild).ToNot(BeNil())
 				Expect(osChild.Comment).To(Equal("Test Comment"))
+				Expect(osChild.Groupings).To(Equal(responses.Array[string]{"Soundtrack", "Live"}))
 			})
 		})
 

--- a/server/subsonic/responses/.snapshots/Responses AlbumList with OS data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumList with OS data should match .JSON
@@ -32,6 +32,7 @@
           "mood1",
           "mood2"
         ],
+        "groupings": [],
         "artists": [
           {
             "id": "artist-1",

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
@@ -125,6 +125,10 @@
           "happy",
           "sad"
         ],
+        "groupings": [
+          "Soundtrack",
+          "Live"
+        ],
         "artists": [
           {
             "id": "1",
@@ -204,6 +208,7 @@
         "samplingRate": 0,
         "bitDepth": 0,
         "moods": [],
+        "groupings": [],
         "artists": [],
         "displayArtist": "",
         "albumArtists": [],

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .XML
@@ -22,6 +22,8 @@
       <replayGain trackGain="1" albumGain="2" trackPeak="3" albumPeak="4" baseGain="5" fallbackGain="6"></replayGain>
       <moods>happy</moods>
       <moods>sad</moods>
+      <groupings>Soundtrack</groupings>
+      <groupings>Live</groupings>
       <artists id="1" name="artist1"></artists>
       <artists id="2" name="artist2"></artists>
       <albumArtists id="1" name="album artist1"></albumArtists>

--- a/server/subsonic/responses/.snapshots/Responses Child with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses Child with data should match .JSON
@@ -56,6 +56,10 @@
           "happy",
           "sad"
         ],
+        "groupings": [
+          "Soundtrack",
+          "Live"
+        ],
         "artists": [
           {
             "id": "1",
@@ -135,6 +139,7 @@
         "samplingRate": 0,
         "bitDepth": 0,
         "moods": [],
+        "groupings": [],
         "artists": [],
         "displayArtist": "",
         "albumArtists": [],

--- a/server/subsonic/responses/.snapshots/Responses Child with data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses Child with data should match .XML
@@ -8,6 +8,8 @@
       <replayGain trackGain="1" albumGain="2" trackPeak="3" albumPeak="4" baseGain="5" fallbackGain="6"></replayGain>
       <moods>happy</moods>
       <moods>sad</moods>
+      <groupings>Soundtrack</groupings>
+      <groupings>Live</groupings>
       <artists id="1" name="artist1"></artists>
       <artists id="2" name="artist2"></artists>
       <albumArtists id="1" name="album artist1"></albumArtists>

--- a/server/subsonic/responses/.snapshots/Responses Child without data should match OpenSubsonic .JSON
+++ b/server/subsonic/responses/.snapshots/Responses Child without data should match OpenSubsonic .JSON
@@ -22,6 +22,7 @@
         "samplingRate": 0,
         "bitDepth": 0,
         "moods": [],
+        "groupings": [],
         "artists": [],
         "displayArtist": "",
         "albumArtists": [],

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -182,6 +182,7 @@ type OpenSubsonicChild struct {
 	SamplingRate       int32               `xml:"samplingRate,attr,omitempty"       json:"samplingRate"`
 	BitDepth           int32               `xml:"bitDepth,attr,omitempty"           json:"bitDepth"`
 	Moods              Array[string]       `xml:"moods,omitempty"                   json:"moods"`
+	Groupings          Array[string]       `xml:"groupings,omitempty"               json:"groupings"`
 	Artists            Array[ArtistID3Ref] `xml:"artists,omitempty"                 json:"artists"`
 	DisplayArtist      string              `xml:"displayArtist,attr,omitempty"      json:"displayArtist"`
 	AlbumArtists       Array[ArtistID3Ref] `xml:"albumArtists,omitempty"            json:"albumArtists"`

--- a/server/subsonic/responses/responses_test.go
+++ b/server/subsonic/responses/responses_test.go
@@ -206,6 +206,12 @@ var _ = Describe("Responses", func() {
 				response.Directory.Child[0].OpenSubsonicChild = &OpenSubsonicChild{}
 				Expect(json.MarshalIndent(response, "", "  ")).To(MatchSnapshot())
 			})
+			It("should include empty groupings in OpenSubsonic .JSON", func() {
+				response.Directory.Child[0].OpenSubsonicChild = &OpenSubsonicChild{}
+				encoded, err := json.Marshal(response)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(encoded)).To(ContainSubstring(`"groupings":[]`))
+			})
 		})
 		Context("with data", func() {
 			BeforeEach(func() {
@@ -224,6 +230,7 @@ var _ = Describe("Responses", func() {
 					Isrc: []string{"ISRC-1", "ISRC-2"},
 					BPM:  127, ChannelCount: 2, SamplingRate: 44100, BitDepth: 16,
 					Moods:         []string{"happy", "sad"},
+					Groupings:     []string{"Soundtrack", "Live"},
 					ReplayGain:    ReplayGain{TrackGain: gg.P(1.0), AlbumGain: gg.P(2.0), TrackPeak: gg.P(3.0), AlbumPeak: gg.P(4.0), BaseGain: gg.P(5.0), FallbackGain: gg.P(6.0)},
 					DisplayArtist: "artist 1 & artist 2",
 					Artists: []ArtistID3Ref{
@@ -320,6 +327,7 @@ var _ = Describe("Responses", func() {
 					Comment: "a comment", MediaType: MediaTypeSong, MusicBrainzId: "4321", SortName: "sorted song",
 					Isrc:       []string{"ISRC-1"},
 					Moods:      []string{"happy", "sad"},
+					Groupings:  []string{"Soundtrack", "Live"},
 					ReplayGain: ReplayGain{TrackGain: gg.P(1.0), AlbumGain: gg.P(2.0), TrackPeak: gg.P(3.0), AlbumPeak: gg.P(4.0), BaseGain: gg.P(5.0), FallbackGain: gg.P(6.0)},
 					BPM:        127, ChannelCount: 2, SamplingRate: 44100, BitDepth: 16,
 					DisplayArtist: "artist1 & artist2",


### PR DESCRIPTION
### Description
Exposes the ID3 `Grouping` tag in OpenSubsonic child responses so clients that consume OpenSubsonic output can access grouping metadata.

- Adds a `Groupings Array[string]` field to `OpenSubsonicChild` in `server/subsonic/responses/responses.go` with appropriate `xml`/`json` tags.
- Populates `child.Groupings` from `mf.Tags.Values(model.TagGrouping)` in `server/subsonic/helpers.go` when building OpenSubsonic child responses.

### Related Issues
Implements the spec change proposed in opensubsonic/open-subsonic-api#232.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Run the unit tests:
   ```
   go test ./server/subsonic/...
   ```
2. Verify that the OpenSubsonic responses (e.g. `getSong`, `getAlbum`, `getAlbumList`) include a `groupings` array in both JSON and XML output.
3. For a media file tagged with one or more `GROUPING` values, confirm the values appear in the response; for files without the tag, confirm an empty `groupings: []` array is emitted in JSON.

### Additional Notes
- Updated snapshot files under `server/subsonic/responses/.snapshots/` to include the new `groupings` field in JSON and XML outputs.
- Added an explicit test asserting that an empty `groupings` array is emitted in OpenSubsonic JSON output.
- No breaking changes: the new field is additive and backwards-compatible with existing OpenSubsonic clients.