### PR TITLE
dont skip files that taglib doesn't like

### DIFF
--- a/adapters/gotaglib/gotaglib.go
+++ b/adapters/gotaglib/gotaglib.go
@@ -23,6 +23,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/core/storage/local"
 	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/metadata"
 	"go.senan.xyz/taglib"
 )
@@ -37,6 +38,27 @@ func (e extractor) Parse(files ...string) (map[string]metadata.Info, error) {
 		props, err := e.extractMetadata(path)
 		if err != nil {
 			continue
+			log.Warn("gotaglib: Error reading metadata from file. Importing without metadata", "filePath", path, err)
++			f, openErr := e.fs.Open(path)
++			if openErr != nil {
++				continue
++			}
++			info, statErr := f.Stat()
++			_ = f.Close()
++			if statErr != nil {
++				continue
++			}
++			fileInfo, ok := info.(metadata.FileInfo)
++			if !ok {
++				continue
++			}
++			results[path] = metadata.Info{
++				FileInfo:        fileInfo,
++				Tags:            model.RawTags{},
++				AudioProperties: metadata.AudioProperties{},
++				HasPicture:      false,
++			}
++			continue
 		}
 		results[path] = *props
 	}


### PR DESCRIPTION
Instead of importing nothing, import a file with empty metadata and audioproperties.
This is useful to import music formats that taglib cannot handle. For example retro music files (.mod, .xm, .midi) or music videos.

### Description
Currently, file formats that taglib cannot handle are skipped (nothing is imported by scanner).
This PR introduces 

### Related Issues
#2894
#1929
#5196

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
TODO: provide test files