### PR TITLE
chore(subsonic): only log response body on send error when at trace level or higher

### DIFF
--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -375,6 +375,10 @@ func sendResponse(w http.ResponseWriter, r *http.Request, payload *responses.Sub
 	}
 
 	if _, err := w.Write(response); err != nil { //nolint:gosec
-		log.Error(r, "Error sending response to client", "endpoint", r.URL.Path, "payload", string(response), err)
+		if log.IsGreaterOrEqualTo(log.LevelTrace) {
+			log.Error(r, "Error sending response to client", "endpoint", r.URL.Path, "payload", string(response), err)
+		} else {
+			log.Error(r, "Error sending response to client", "endpoint", r.URL.Path, err)
+		}
 	}
 }


### PR DESCRIPTION
### Description
If the request is failed to be sent (most likely, the client cancels the request before completely received), the full request body is logged.
For larger requests (`/rest/getStarred2`, `/rest/getPlayQueue`) this can result in very large logs.
Change the flow to only log when using trace logging.

### Related Issues


### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactor
- [ ] Other (please describe): 

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
Send a request with a large response body, cancel it. Confirm that logging does not include the payload unless at trace.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->