### PR TITLE
Updated the AMusic theme to use the correct text colour for primary confirmation buttons

### DIFF
--- a/ui/src/themes/amusic.js
+++ b/ui/src/themes/amusic.js
@@ -192,6 +192,11 @@ export default {
         paddingBottom: '1rem',
       },
     },
+    RaConfirm: {
+      confirmPrimary: {
+        color: '#fff',
+      },
+    },
     RaDeleteWithConfirmButton: {
       deleteButton: {
         color: '#fff !important',


### PR DESCRIPTION
### Description
The AMusic theme has incorrect text colour on the confirmation buttons for actions like deleting a user or removing missing files which makes it very hard to read.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [ ] All existing and new tests pass

### Screenshots
This is what the buttons look like at the moment:

<img width="611" height="206" alt="before-delete-user" src="https://github.com/user-attachments/assets/c99034bd-a8ce-4ec5-8ed4-908fcf90b91c" />

<img width="611" height="230" alt="before-remove-missing" src="https://github.com/user-attachments/assets/3afedc06-7cc6-4e73-8b39-25cf3e299bf0" />

And this is what it looks like after the fix:

<img width="608" height="205" alt="after-delete-user" src="https://github.com/user-attachments/assets/6af667d6-3c75-4c16-97da-b30d625481ec" />

<img width="608" height="228" alt="after-remove-missing" src="https://github.com/user-attachments/assets/5b7f798f-55f5-4f2b-bf1b-5885b9c01322" />

It retains the existing dark grey colour when hovering over the buttons.