### PR TITLE
fix(lastfm): require signed state token on link callback

### DIFF
--- a/adapters/lastfm/auth_router.go
+++ b/adapters/lastfm/auth_router.go
@@ -77,6 +77,13 @@ func (s *Router) getLinkStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp["status"] = key != ""
+	linkToken, err := createLinkToken(u.ID)
+	if err != nil {
+		log.Error(r.Context(), "Could not create LastFM link token", "userId", u.ID, err)
+		_ = rest.RespondWithError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	resp["linkToken"] = linkToken
 	_ = rest.RespondWithJSON(w, http.StatusOK, resp)
 }
 
@@ -97,9 +104,18 @@ func (s *Router) callback(w http.ResponseWriter, r *http.Request) {
 		_ = rest.RespondWithError(w, http.StatusBadRequest, "token not received")
 		return
 	}
-	uid, err := p.String("uid")
+	linkToken, err := p.String("uid")
 	if err != nil {
 		_ = rest.RespondWithError(w, http.StatusBadRequest, "uid not received")
+		return
+	}
+	// The `uid` parameter is a signed link token issued by getLinkStatus to the
+	// authenticated user. Verifying it here is what stops a third party from
+	// pointing the callback at someone else's account.
+	uid, err := verifyLinkToken(linkToken)
+	if err != nil {
+		log.Warn(r.Context(), "Rejected LastFM callback with invalid link token", "requestId", middleware.GetReqID(r.Context()), err)
+		_ = rest.RespondWithError(w, http.StatusBadRequest, "invalid link token")
 		return
 	}
 

--- a/adapters/lastfm/auth_router.go
+++ b/adapters/lastfm/auth_router.go
@@ -109,9 +109,6 @@ func (s *Router) callback(w http.ResponseWriter, r *http.Request) {
 		_ = rest.RespondWithError(w, http.StatusBadRequest, "uid not received")
 		return
 	}
-	// The `uid` parameter is a signed link token issued by getLinkStatus to the
-	// authenticated user. Verifying it here is what stops a third party from
-	// pointing the callback at someone else's account.
 	uid, err := verifyLinkToken(linkToken)
 	if err != nil {
 		log.Warn(r.Context(), "Rejected LastFM callback with invalid link token", "requestId", middleware.GetReqID(r.Context()), err)

--- a/adapters/lastfm/auth_router_test.go
+++ b/adapters/lastfm/auth_router_test.go
@@ -192,12 +192,27 @@ var _ = Describe("auth_router", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("rejects a public token that lacks the link scope", func() {
-			otherToken, err := auth.CreatePublicToken(auth.Claims{UserID: victimID})
+		It("rejects a token whose scope claim is wrong", func() {
+			wrongScopeToken, err := auth.EncodeToken(map[string]any{
+				"uid":   victimID,
+				"scope": "some-other-scope",
+				"exp":   time.Now().Add(linkTokenTTL).UTC().Unix(),
+			})
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = verifyLinkToken(otherToken)
+			_, err = verifyLinkToken(wrongScopeToken)
 			Expect(err).To(MatchError("invalid link token scope"))
+		})
+
+		It("rejects a scoped token that has no expiration", func() {
+			nonExpiringToken, err := auth.EncodeToken(map[string]any{
+				"uid":   victimID,
+				"scope": linkTokenScope,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = verifyLinkToken(nonExpiringToken)
+			Expect(err).To(MatchError("link token missing expiration"))
 		})
 	})
 })

--- a/adapters/lastfm/auth_router_test.go
+++ b/adapters/lastfm/auth_router_test.go
@@ -1,0 +1,203 @@
+package lastfm
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/navidrome/navidrome/core/agents"
+	"github.com/navidrome/navidrome/core/auth"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("auth_router", func() {
+	var (
+		ds         *tests.MockDataStore
+		userProps  *tests.MockedUserPropsRepo
+		httpClient *tests.FakeHttpClient
+		router     *Router
+	)
+
+	const (
+		victimID   = "victim-user-id"
+		attackerID = "attacker-user-id"
+	)
+
+	BeforeEach(func() {
+		userProps = &tests.MockedUserPropsRepo{}
+		ds = &tests.MockDataStore{
+			MockedProperty:  &tests.MockedPropertyRepo{},
+			MockedUserProps: userProps,
+		}
+		auth.Init(ds)
+
+		httpClient = &tests.FakeHttpClient{}
+		router = &Router{
+			ds:          ds,
+			apiKey:      "API_KEY",
+			secret:      "SECRET",
+			sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
+		}
+		router.client = newClient(router.apiKey, router.secret, httpClient)
+		router.Handler = router.routes()
+	})
+
+	storedSessionKey := func(userID string) string {
+		key, _ := userProps.Get(userID, sessionKeyProperty)
+		return key
+	}
+
+	stubGetSessionOK := func(sessionKey string) {
+		httpClient.Res = http.Response{
+			Body:       io.NopCloser(bytes.NewBufferString(`{"session":{"name":"Navidrome","key":"` + sessionKey + `","subscriber":0}}`)),
+			StatusCode: 200,
+		}
+	}
+
+	Describe("getLinkStatus", func() {
+		It("includes a signed linkToken for the authenticated user", func() {
+			req := httptest.NewRequest(http.MethodGet, "/link", nil)
+			ctx := request.WithUser(req.Context(), model.User{ID: victimID})
+			req = req.WithContext(ctx)
+			rec := httptest.NewRecorder()
+
+			router.getLinkStatus(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			var body map[string]any
+			Expect(json.Unmarshal(rec.Body.Bytes(), &body)).To(Succeed())
+			Expect(body["apiKey"]).To(Equal("API_KEY"))
+			Expect(body["status"]).To(Equal(false))
+			token, ok := body["linkToken"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(token).ToNot(BeEmpty())
+
+			verified, err := verifyLinkToken(token)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(verified).To(Equal(victimID))
+		})
+	})
+
+	Describe("callback", func() {
+		It("stores the session key under the user encoded in the signed token", func() {
+			stubGetSessionOK("LEGIT_SESSION")
+			linkToken, err := createLinkToken(victimID)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/link/callback?uid="+linkToken+"&token=LASTFM_TOKEN", nil)
+			rec := httptest.NewRecorder()
+			router.callback(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(storedSessionKey(victimID)).To(Equal("LEGIT_SESSION"))
+		})
+
+		It("rejects a raw (unsigned) uid value", func() {
+			req := httptest.NewRequest(http.MethodGet, "/link/callback?uid="+victimID+"&token=LASTFM_TOKEN", nil)
+			rec := httptest.NewRecorder()
+			router.callback(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			Expect(storedSessionKey(victimID)).To(BeEmpty())
+			Expect(httpClient.SavedRequest).To(BeNil())
+		})
+
+		It("rejects an expired link token", func() {
+			expiredToken, err := auth.EncodeToken(map[string]any{
+				"uid":   victimID,
+				"scope": linkTokenScope,
+				"exp":   time.Now().Add(-1 * time.Minute).UTC().Unix(),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/link/callback?uid="+expiredToken+"&token=LASTFM_TOKEN", nil)
+			rec := httptest.NewRecorder()
+			router.callback(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			Expect(storedSessionKey(victimID)).To(BeEmpty())
+			Expect(httpClient.SavedRequest).To(BeNil())
+		})
+
+		It("rejects a token with the wrong scope (e.g. a regular session JWT)", func() {
+			sessionJWT, err := auth.CreateToken(&model.User{ID: attackerID, UserName: "attacker"})
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/link/callback?uid="+sessionJWT+"&token=LASTFM_TOKEN", nil)
+			rec := httptest.NewRecorder()
+			router.callback(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+			Expect(storedSessionKey(attackerID)).To(BeEmpty())
+			Expect(httpClient.SavedRequest).To(BeNil())
+		})
+
+		It("writes only under the user encoded in the token, regardless of query manipulation", func() {
+			// An attacker holds a legitimate link token for their own account.
+			// They attempt to call the callback hoping to overwrite the victim's
+			// session key — but the handler must derive the user ID from the
+			// signed token, not from any other input.
+			stubGetSessionOK("ATTACKER_SESSION")
+			attackerToken, err := createLinkToken(attackerID)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/link/callback?uid="+attackerToken+"&token=LASTFM_TOKEN&user="+victimID, nil)
+			rec := httptest.NewRecorder()
+			router.callback(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			Expect(storedSessionKey(attackerID)).To(Equal("ATTACKER_SESSION"))
+			Expect(storedSessionKey(victimID)).To(BeEmpty())
+		})
+
+		It("returns 400 when uid is missing", func() {
+			req := httptest.NewRequest(http.MethodGet, "/link/callback?token=LASTFM_TOKEN", nil)
+			rec := httptest.NewRecorder()
+			router.callback(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("returns 400 when token is missing", func() {
+			linkToken, err := createLinkToken(victimID)
+			Expect(err).ToNot(HaveOccurred())
+
+			req := httptest.NewRequest(http.MethodGet, "/link/callback?uid="+linkToken, nil)
+			rec := httptest.NewRecorder()
+			router.callback(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		})
+	})
+
+	Describe("link token helpers", func() {
+		It("round-trips a freshly issued token", func() {
+			token, err := createLinkToken(victimID)
+			Expect(err).ToNot(HaveOccurred())
+
+			uid, err := verifyLinkToken(token)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uid).To(Equal(victimID))
+		})
+
+		It("rejects garbage", func() {
+			_, err := verifyLinkToken("not-a-jwt")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("rejects a public token that lacks the link scope", func() {
+			otherToken, err := auth.CreatePublicToken(auth.Claims{UserID: victimID})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = verifyLinkToken(otherToken)
+			Expect(err).To(MatchError("invalid link token scope"))
+		})
+	})
+})

--- a/adapters/lastfm/link_token.go
+++ b/adapters/lastfm/link_token.go
@@ -12,11 +12,9 @@ const (
 	linkTokenTTL   = 5 * time.Minute
 )
 
-// createLinkToken issues a short-lived, signed token that binds the Last.fm
-// link-callback to the authenticated user who initiated the OAuth flow. The
-// resulting opaque value is passed back through Last.fm via the `cb` URL and
-// verified on the callback, replacing the previously-trusted raw `uid` query
-// parameter.
+// createLinkToken issues a signed token binding the Last.fm callback to the
+// user who initiated the OAuth flow. It travels back through Last.fm via the
+// `cb` URL in place of the previously-trusted raw `uid` query parameter.
 func createLinkToken(userID string) (string, error) {
 	claims := map[string]any{
 		"uid":   userID,
@@ -35,9 +33,8 @@ func verifyLinkToken(tokenStr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// jwtauth.VerifyToken treats a token without `exp` as non-expiring; require
-	// it explicitly so a future regression in createLinkToken cannot silently
-	// turn link tokens into permanent bearer credentials.
+	// jwtauth treats a token without `exp` as non-expiring; require it
+	// explicitly so an accidental regression cannot mint permanent tokens.
 	if exp, ok := token.Expiration(); !ok || exp.IsZero() {
 		return "", errors.New("link token missing expiration")
 	}

--- a/adapters/lastfm/link_token.go
+++ b/adapters/lastfm/link_token.go
@@ -44,7 +44,7 @@ func verifyLinkToken(tokenStr string) (string, error) {
 	}
 	var uid string
 	if err := token.Get("uid", &uid); err != nil || uid == "" {
-		return "", errors.New("invalid link token subject")
+		return "", errors.New("invalid link token user ID")
 	}
 	return uid, nil
 }

--- a/adapters/lastfm/link_token.go
+++ b/adapters/lastfm/link_token.go
@@ -1,0 +1,47 @@
+package lastfm
+
+import (
+	"errors"
+	"time"
+
+	"github.com/navidrome/navidrome/core/auth"
+)
+
+const (
+	linkTokenScope = "lastfm-link"
+	linkTokenTTL   = 5 * time.Minute
+)
+
+// createLinkToken issues a short-lived, signed token that binds the Last.fm
+// link-callback to the authenticated user who initiated the OAuth flow. The
+// resulting opaque value is passed back through Last.fm via the `cb` URL and
+// verified on the callback, replacing the previously-trusted raw `uid` query
+// parameter.
+func createLinkToken(userID string) (string, error) {
+	claims := map[string]any{
+		"uid":   userID,
+		"scope": linkTokenScope,
+		"exp":   time.Now().Add(linkTokenTTL).UTC().Unix(),
+	}
+	return auth.EncodeToken(claims)
+}
+
+// verifyLinkToken validates a signed link token and returns the encoded user ID.
+// It enforces both the signature/expiry (via the underlying JWT verifier) and a
+// dedicated scope claim, preventing tokens minted for other purposes (e.g. a
+// regular session JWT) from being accepted here.
+func verifyLinkToken(tokenStr string) (string, error) {
+	token, err := auth.DecodeAndVerifyToken(tokenStr)
+	if err != nil {
+		return "", err
+	}
+	var scope string
+	if err := token.Get("scope", &scope); err != nil || scope != linkTokenScope {
+		return "", errors.New("invalid link token scope")
+	}
+	var uid string
+	if err := token.Get("uid", &uid); err != nil || uid == "" {
+		return "", errors.New("invalid link token subject")
+	}
+	return uid, nil
+}

--- a/adapters/lastfm/link_token.go
+++ b/adapters/lastfm/link_token.go
@@ -35,6 +35,12 @@ func verifyLinkToken(tokenStr string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	// jwtauth.VerifyToken treats a token without `exp` as non-expiring; require
+	// it explicitly so a future regression in createLinkToken cannot silently
+	// turn link tokens into permanent bearer credentials.
+	if exp, ok := token.Expiration(); !ok || exp.IsZero() {
+		return "", errors.New("link token missing expiration")
+	}
 	var scope string
 	if err := token.Get("scope", &scope); err != nil || scope != linkTokenScope {
 		return "", errors.New("invalid link token scope")

--- a/ui/src/personal/LastfmScrobbleToggle.jsx
+++ b/ui/src/personal/LastfmScrobbleToggle.jsx
@@ -79,10 +79,7 @@ export const LastfmScrobbleToggle = (props) => {
   }, [setLinked, setApiKey])
 
   const startLink = () => {
-    // Open the tab synchronously inside the click handler so popup blockers
-    // (Safari, Firefox-strict) keep it tied to the user gesture. The fetch
-    // for the signed link token runs in parallel; once it resolves we
-    // redirect the placeholder tab to Last.fm's auth URL.
+    // Open the tab synchronously so popup blockers attribute it to the click.
     const tab = openInNewTab('about:blank')
     openedTab.current = tab
     setCheckingLink(true)

--- a/ui/src/personal/LastfmScrobbleToggle.jsx
+++ b/ui/src/personal/LastfmScrobbleToggle.jsx
@@ -80,7 +80,13 @@ export const LastfmScrobbleToggle = (props) => {
 
   const startLink = () => {
     // Open the tab synchronously so popup blockers attribute it to the click.
-    const tab = openInNewTab('about:blank')
+    let tab
+    try {
+      tab = openInNewTab('about:blank')
+    } catch {
+      notify('message.lastfmLinkFailure', 'warning')
+      return
+    }
     openedTab.current = tab
     setCheckingLink(true)
     httpClient('/api/lastfm/link')

--- a/ui/src/personal/LastfmScrobbleToggle.jsx
+++ b/ui/src/personal/LastfmScrobbleToggle.jsx
@@ -13,38 +13,10 @@ import { baseUrl, openInNewTab } from '../utils'
 import { httpClient } from '../dataProvider'
 
 const Progress = (props) => {
-  const { setLinked, setCheckingLink, apiKey } = props
+  const { setLinked, setCheckingLink, openedTab } = props
   const notify = useNotify()
   let linkCheckDelay = 2000
   let linkChecks = 30
-  const openedTab = useRef()
-
-  useEffect(() => {
-    // Fetch a fresh, short-lived signed link token right before redirecting
-    // to Last.fm. The callback uses this token to authenticate the user,
-    // since the redirect back from Last.fm cannot carry an auth header.
-    httpClient('/api/lastfm/link')
-      .then((response) => {
-        const linkToken = response.json.linkToken
-        if (!linkToken) {
-          notify('message.lastfmLinkFailure', 'warning')
-          setCheckingLink(false)
-          return
-        }
-        const callbackEndpoint = baseUrl(
-          `/api/lastfm/link/callback?uid=${encodeURIComponent(linkToken)}`,
-        )
-        const callbackUrl = `${window.location.origin}${callbackEndpoint}`
-        openedTab.current = openInNewTab(
-          `https://www.last.fm/api/auth/?api_key=${apiKey}&cb=${callbackUrl}`,
-        )
-      })
-      .catch(() => {
-        notify('message.lastfmLinkFailure', 'warning')
-        setCheckingLink(false)
-      })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [apiKey])
 
   const endChecking = (success) => {
     linkCheckDelay = null
@@ -93,6 +65,7 @@ export const LastfmScrobbleToggle = (props) => {
   const [linked, setLinked] = useState(null)
   const [checkingLink, setCheckingLink] = useState(false)
   const [apiKey, setApiKey] = useState(false)
+  const openedTab = useRef()
 
   useEffect(() => {
     httpClient('/api/lastfm/link')
@@ -105,9 +78,39 @@ export const LastfmScrobbleToggle = (props) => {
       })
   }, [setLinked, setApiKey])
 
+  const startLink = () => {
+    // Open the tab synchronously inside the click handler so popup blockers
+    // (Safari, Firefox-strict) keep it tied to the user gesture. The fetch
+    // for the signed link token runs in parallel; once it resolves we
+    // redirect the placeholder tab to Last.fm's auth URL.
+    const tab = openInNewTab('about:blank')
+    openedTab.current = tab
+    setCheckingLink(true)
+    httpClient('/api/lastfm/link')
+      .then((response) => {
+        const linkToken = response.json.linkToken
+        if (!linkToken) {
+          tab?.close()
+          notify('message.lastfmLinkFailure', 'warning')
+          setCheckingLink(false)
+          return
+        }
+        const callbackEndpoint = baseUrl(
+          `/api/lastfm/link/callback?uid=${encodeURIComponent(linkToken)}`,
+        )
+        const callbackUrl = `${window.location.origin}${callbackEndpoint}`
+        tab.location.href = `https://www.last.fm/api/auth/?api_key=${apiKey}&cb=${callbackUrl}`
+      })
+      .catch(() => {
+        tab?.close()
+        notify('message.lastfmLinkFailure', 'warning')
+        setCheckingLink(false)
+      })
+  }
+
   const toggleScrobble = () => {
     if (!linked) {
-      setCheckingLink(true)
+      startLink()
     } else {
       httpClient('/api/lastfm/link', { method: 'DELETE' })
         .then(() => {
@@ -138,7 +141,7 @@ export const LastfmScrobbleToggle = (props) => {
         <Progress
           setLinked={setLinked}
           setCheckingLink={setCheckingLink}
-          apiKey={apiKey}
+          openedTab={openedTab}
         />
       )}
       {!apiKey && (

--- a/ui/src/personal/LastfmScrobbleToggle.jsx
+++ b/ui/src/personal/LastfmScrobbleToggle.jsx
@@ -20,13 +20,30 @@ const Progress = (props) => {
   const openedTab = useRef()
 
   useEffect(() => {
-    const callbackEndpoint = baseUrl(
-      `/api/lastfm/link/callback?uid=${localStorage.getItem('userId')}`,
-    )
-    const callbackUrl = `${window.location.origin}${callbackEndpoint}`
-    openedTab.current = openInNewTab(
-      `https://www.last.fm/api/auth/?api_key=${apiKey}&cb=${callbackUrl}`,
-    )
+    // Fetch a fresh, short-lived signed link token right before redirecting
+    // to Last.fm. The callback uses this token to authenticate the user,
+    // since the redirect back from Last.fm cannot carry an auth header.
+    httpClient('/api/lastfm/link')
+      .then((response) => {
+        const linkToken = response.json.linkToken
+        if (!linkToken) {
+          notify('message.lastfmLinkFailure', 'warning')
+          setCheckingLink(false)
+          return
+        }
+        const callbackEndpoint = baseUrl(
+          `/api/lastfm/link/callback?uid=${encodeURIComponent(linkToken)}`,
+        )
+        const callbackUrl = `${window.location.origin}${callbackEndpoint}`
+        openedTab.current = openInNewTab(
+          `https://www.last.fm/api/auth/?api_key=${apiKey}&cb=${callbackUrl}`,
+        )
+      })
+      .catch(() => {
+        notify('message.lastfmLinkFailure', 'warning')
+        setCheckingLink(false)
+      })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [apiKey])
 
   const endChecking = (success) => {


### PR DESCRIPTION
### Description

`/api/lastfm/link/callback` trusted a raw `uid` query parameter, letting any authenticated user redirect another user's scrobbles to their own Last.fm account by calling the callback directly with the victim's user ID and a Last.fm token from their own account.

The callback can't use the auth middleware, since it's a redirect from Last.fm and the browser can't attach a JWT header. Fixed using the standard OAuth `state` pattern: `GET /api/lastfm/link` now returns a 5-minute HMAC-signed token scoped to `"lastfm-link"`, bound to the authenticated user. The callback verifies signature, scope and expiry, then derives the user ID from the token; the `uid` query value is no longer trusted.

Reuses the existing HS256 secret, so no new key management.

### Related Issues

None (privately discovered).

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. `make server`, open **Personal → Last.fm scrobbling**, complete the OAuth flow; linking should succeed. Repeat on Safari to confirm the popup isn't blocked.
2. Exploit must be blocked: `GET /api/lastfm/link/callback?uid=<any-user-id>&token=<any-lastfm-token>` → **400** `{"error":"invalid link token"}`. Target user's `LastFMSessionKey` unchanged.
3. `make test PKG=./adapters/lastfm/...` passes.

### Screenshots / Demos (if applicable)

N/A. No visible UI changes.

### Additional Notes

- ListenBrainz is unaffected; its link flow is fully behind the auth middleware.
- No backward-compatibility shim: any link initiated under the old contract fails once and the user retries.
