### PR TITLE
refactor(transcoding): rename EnableTranscodingCancellation to Transcoding.EnableCancellation

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -47,7 +47,6 @@ type configOptions struct {
 	UIWelcomeMessage                string
 	MaxSidebarPlaylists             int
 	EnableTranscodingConfig         bool
-	EnableTranscodingCancellation   bool
 	EnableDownloads                 bool
 	EnableExternalServices          bool
 	EnableM3UExternalAlbumArt       bool
@@ -169,6 +168,7 @@ type scannerOptions struct {
 type transcodingOptions struct {
 	MaxConcurrent        int
 	MaxConcurrentPerUser int
+	EnableCancellation   bool
 }
 
 type subsonicOptions struct {
@@ -330,6 +330,7 @@ func Load(noConfigDump bool) {
 	mapDeprecatedOption("HTTPSecurityHeaders.CustomFrameOptionsValue", "HTTPHeaders.FrameOptions")
 	mapDeprecatedOption("CoverJpegQuality", "CoverArtQuality")
 	mapDeprecatedOption("SimilarSongsMatchThreshold", "Matcher.FuzzyThreshold")
+	mapDeprecatedOption("EnableTranscodingCancellation", "Transcoding.EnableCancellation")
 
 	err := viper.Unmarshal(&Server, viper.DecodeHook(
 		mapstructure.ComposeDecodeHookFunc(
@@ -455,6 +456,7 @@ func Load(noConfigDump bool) {
 	logDeprecatedOptions("HTTPSecurityHeaders.CustomFrameOptionsValue", "HTTPHeaders.FrameOptions")
 	logDeprecatedOptions("CoverJpegQuality", "CoverArtQuality")
 	logDeprecatedOptions("SimilarSongsMatchThreshold", "Matcher.FuzzyThreshold")
+	logDeprecatedOptions("EnableTranscodingCancellation", "Transcoding.EnableCancellation")
 
 	// Removed options
 	logRemovedOptions("Spotify.ID", "Spotify.Secret")
@@ -743,7 +745,6 @@ func setViperDefaults() {
 	viper.SetDefault("uiwelcomemessage", "")
 	viper.SetDefault("maxsidebarplaylists", consts.DefaultMaxSidebarPlaylists)
 	viper.SetDefault("enabletranscodingconfig", false)
-	viper.SetDefault("enabletranscodingcancellation", false)
 	viper.SetDefault("transcodingcachesize", "100MB")
 	viper.SetDefault("imagecachesize", "100MB")
 	viper.SetDefault("albumplaycountmode", consts.AlbumPlayCountModeAbsolute)
@@ -830,6 +831,7 @@ func setViperDefaults() {
 	viper.SetDefault("subsonic.minimalclients", "SubMusic")
 	viper.SetDefault("transcoding.maxconcurrent", 0)
 	viper.SetDefault("transcoding.maxconcurrentperuser", 0)
+	viper.SetDefault("transcoding.enablecancellation", false)
 	viper.SetDefault("agents", "deezer,lastfm,listenbrainz")
 	viper.SetDefault("lastfm.enabled", true)
 	viper.SetDefault("lastfm.language", consts.DefaultInfoLanguage)

--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -248,10 +248,10 @@ func NewTranscodingCache() TranscodingCache {
 			// the DoS the limiter is meant to prevent.
 			//
 			// When the limiter is disabled, preserve the legacy behavior
-			// governed by EnableTranscodingCancellation so this PR does not
-			// change observable behavior for operators who have not opted in.
+			// governed by Transcoding.EnableCancellation so unchanged configs
+			// keep their previous observable behavior.
 			var transcodingCtx context.Context
-			if job.ms.limiter.Enabled() || conf.Server.EnableTranscodingCancellation {
+			if job.ms.limiter.Enabled() || conf.Server.Transcoding.EnableCancellation {
 				transcodingCtx = ctx
 			} else {
 				transcodingCtx = request.AddValues(context.Background(), ctx)


### PR DESCRIPTION
### Description

Follow-up to #5522 (the transcoding concurrency limiter): move `EnableTranscodingCancellation` into the nested `Transcoding` config group so all transcoding-related knobs live together.

**Migration:**

- New canonical name: `Transcoding.EnableCancellation` (env var `ND_TRANSCODING_ENABLECANCELLATION`).
- The old top-level `EnableTranscodingCancellation` (env var `ND_ENABLETRANSCODINGCANCELLATION`) still works — it's mapped onto the new key at config load time via the existing `mapDeprecatedOption` plumbing, and `logDeprecatedOptions` emits a warning so operators know to update their config.
- No behavior change: the value is read at the same single site in `core/stream/media_streamer.go`.

**Note on the field removal:**

I removed the old `EnableTranscodingCancellation bool` struct field rather than leaving it as a deprecated alias. With both a struct field and a `SetDefault` for the legacy key, `viper.IsSet("EnableTranscodingCancellation")` returned `true` even when the user hadn't set it, which caused the deprecation mapper to clobber the new value. Removing the field and the legacy default makes `IsSet` honest — `true` only when the user actually set the legacy option.

### Related Issues

Follow-up to #5522.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

(Docs not updated — the rename should be reflected in the navidrome.org config reference once this lands. No new tests added — the existing deprecation plumbing is already covered, and the rename only changes where the value lives, not what it does.)

### How to Test

**Manual:**

1. Start the dev server with the **old** option set, e.g.
   ```bash
   ND_ENABLETRANSCODINGCANCELLATION=true make server
   ```
   Expected: server starts, logs `Option 'EnableTranscodingCancellation' is deprecated and will be ignored in a future release. Please use the new 'Transcoding.EnableCancellation'`, and a transcoded stream is still cancellable on client disconnect.

2. Start with the **new** option set:
   ```bash
   ND_TRANSCODING_ENABLECANCELLATION=true make server
   ```
   Expected: no deprecation warning, same observable behavior.

3. Start with **neither** set (default): no warning, cancellation off (unchanged from master).

### Screenshots / Demos (if applicable)

N/A — no UI changes.

### Additional Notes

The legacy field is gone for good in this PR (i.e. anyone reading `conf.Server.EnableTranscodingCancellation` in Go would break). There were no in-tree readers besides the single line this PR updated; external forks should switch to `conf.Server.Transcoding.EnableCancellation`.

The deprecation warning will eventually want a removal (a release or two from now) — but no rush on that, since the mapping is a single line and costs nothing.
