### PR TITLE
fix(playlists): preserve unchanged fields on partial REST updates

### DIFF
--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -106,11 +106,7 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 
 	usr, _ := request.UserFrom(ctx)
 	ownerChanged := sent("ownerId") && entity.OwnerID != "" && entity.OwnerID != current.OwnerID
-	// Permission check uses the deserialized entity directly (not gated by `sent`)
-	// so a non-admin can't smuggle in an owner change via a case-variant JSON key
-	// like {"OwnerId":"x"} — Go's json decoder is case-insensitive on field match
-	// but rest.Put's field-name extraction is case-sensitive.
-	if !usr.IsAdmin && entity.OwnerID != "" && entity.OwnerID != current.OwnerID {
+	if !usr.IsAdmin && ownerChanged {
 		return rest.ErrPermissionDenied
 	}
 

--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 
 	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/model"
@@ -126,8 +127,10 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 
 // applyContentUpdate handles updates that change at least one of name/comment/
 // owner/rules. It goes through updateMetadata, which always bumps updatedAt
-// (invalidating cached cover-art URLs). Pointer args are nil for fields not
-// present in the request.
+// (invalidating cached cover-art URLs). namePtr/commentPtr are nil when the
+// field is absent from the request OR present-but-unchanged (so updateMetadata
+// skips them); publicPtr is nil only when public is absent from the request
+// (an idempotent public value is still forwarded).
 func (s *playlists) applyContentUpdate(ctx context.Context, current, entity *model.Playlist,
 	sent func(string) bool, nameChanged, commentChanged, ownerChanged, rulesChanged bool,
 ) error {
@@ -175,15 +178,17 @@ func (s *playlists) applyFlagsOnly(ctx context.Context, current, entity *model.P
 }
 
 // sentFields returns a predicate that reports whether a JSON field was present
-// in the request body. An empty cols list means "treat the entity as a full
-// record" — every field is considered sent.
+// in the request body. Matching is case-insensitive to mirror Go's json
+// decoder, which populates struct fields from case-variant keys like
+// {"Name":"x"} or {"OWNERID":"y"}. An empty cols list means "treat the entity
+// as a full record" — every field is considered sent.
 func sentFields(cols []string) func(string) bool {
 	if len(cols) == 0 {
 		return func(string) bool { return true }
 	}
-	set := slice.ToMap(cols, func(c string) (string, struct{}) { return c, struct{}{} })
+	set := slice.ToMap(cols, func(c string) (string, struct{}) { return strings.ToLower(c), struct{}{} })
 	return func(field string) bool {
-		_, ok := set[field]
+		_, ok := set[strings.ToLower(field)]
 		return ok
 	}
 }

--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -105,7 +105,11 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 
 	usr, _ := request.UserFrom(ctx)
 	ownerChanged := sent("ownerId") && entity.OwnerID != "" && entity.OwnerID != current.OwnerID
-	if !usr.IsAdmin && ownerChanged {
+	// Permission check uses the deserialized entity directly (not gated by `sent`)
+	// so a non-admin can't smuggle in an owner change via a case-variant JSON key
+	// like {"OwnerId":"x"} — Go's json decoder is case-insensitive on field match
+	// but rest.Put's field-name extraction is case-sensitive.
+	if !usr.IsAdmin && entity.OwnerID != "" && entity.OwnerID != current.OwnerID {
 		return rest.ErrPermissionDenied
 	}
 
@@ -121,8 +125,9 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 }
 
 // applyContentUpdate handles updates that change at least one of name/comment/
-// owner/rules — the path that goes through updateMetadata and may rewrite the
-// backing M3U file. Pointer args are nil for fields not present in the request.
+// owner/rules. It goes through updateMetadata, which always bumps updatedAt
+// (invalidating cached cover-art URLs). Pointer args are nil for fields not
+// present in the request.
 func (s *playlists) applyContentUpdate(ctx context.Context, current, entity *model.Playlist,
 	sent func(string) bool, nameChanged, commentChanged, ownerChanged, rulesChanged bool,
 ) error {

--- a/core/playlists/rest_adapter.go
+++ b/core/playlists/rest_adapter.go
@@ -9,6 +9,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
 	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/utils/slice"
 )
 
 // --- REST adapter (follows Share/Library pattern) ---
@@ -34,8 +35,8 @@ func (r *playlistRepositoryWrapper) Save(entity any) (string, error) {
 	return r.service.savePlaylist(r.ctx, entity.(*model.Playlist))
 }
 
-func (r *playlistRepositoryWrapper) Update(id string, entity any, _ ...string) error {
-	return r.service.updatePlaylistEntity(r.ctx, id, entity.(*model.Playlist))
+func (r *playlistRepositoryWrapper) Update(id string, entity any, cols ...string) error {
+	return r.service.updatePlaylistEntity(r.ctx, id, entity.(*model.Playlist), cols...)
 }
 
 func (r *playlistRepositoryWrapper) Delete(id string) error {
@@ -79,7 +80,15 @@ func (s *playlists) savePlaylist(ctx context.Context, pls *model.Playlist) (stri
 
 // updatePlaylistEntity updates playlist metadata with permission checks.
 // Used by the REST API wrapper.
-func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity *model.Playlist) error {
+//
+// cols names the fields the client actually sent in the JSON body (extracted by
+// rest.Put). When non-empty, fields outside cols are not considered changed and
+// are left untouched — this prevents partial requests like bulk "Make Public"
+// (body: {"public": true}) from wiping fields that just happen to be zero in
+// the deserialized entity (see issue #5541). An empty cols means "treat the
+// entity as a complete record" — preserved for callers that don't use the REST
+// wrapper.
+func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity *model.Playlist, cols ...string) error {
 	current, err := s.checkWritable(ctx, id)
 	if err != nil {
 		switch {
@@ -91,41 +100,87 @@ func (s *playlists) updatePlaylistEntity(ctx context.Context, id string, entity 
 			return err
 		}
 	}
+
+	sent := sentFields(cols)
+
 	usr, _ := request.UserFrom(ctx)
-	if !usr.IsAdmin && entity.OwnerID != "" && entity.OwnerID != current.OwnerID {
+	ownerChanged := sent("ownerId") && entity.OwnerID != "" && entity.OwnerID != current.OwnerID
+	if !usr.IsAdmin && ownerChanged {
 		return rest.ErrPermissionDenied
 	}
 
-	contentChanged := entity.Name != current.Name ||
-		entity.Comment != current.Comment ||
-		(entity.OwnerID != "" && entity.OwnerID != current.OwnerID) ||
-		!rulesEqual(current.Rules, entity.Rules)
+	nameChanged := sent("name") && entity.Name != current.Name
+	commentChanged := sent("comment") && entity.Comment != current.Comment
+	rulesChanged := sent("rules") && !rulesEqual(current.Rules, entity.Rules)
 
-	if contentChanged {
-		if entity.OwnerID != "" {
-			current.OwnerID = entity.OwnerID
-		}
+	if nameChanged || commentChanged || ownerChanged || rulesChanged {
+		return s.applyContentUpdate(ctx, current, entity, sent,
+			nameChanged, commentChanged, ownerChanged, rulesChanged)
+	}
+	return s.applyFlagsOnly(ctx, current, entity, sent)
+}
+
+// applyContentUpdate handles updates that change at least one of name/comment/
+// owner/rules — the path that goes through updateMetadata and may rewrite the
+// backing M3U file. Pointer args are nil for fields not present in the request.
+func (s *playlists) applyContentUpdate(ctx context.Context, current, entity *model.Playlist,
+	sent func(string) bool, nameChanged, commentChanged, ownerChanged, rulesChanged bool,
+) error {
+	if ownerChanged {
+		current.OwnerID = entity.OwnerID
+	}
+	if rulesChanged {
 		current.Rules = entity.Rules
-		if current.Path != "" && current.Sync != entity.Sync {
-			current.Sync = entity.Sync
-		}
-		return s.updateMetadata(ctx, s.ds, current, &entity.Name, &entity.Comment, &entity.Public)
 	}
-
-	// Only sync/public changed — skip updatedAt so cover art URLs stay stable
-	var cols []string
-	if current.Path != "" && current.Sync != entity.Sync {
+	if sent("sync") && current.Path != "" && current.Sync != entity.Sync {
 		current.Sync = entity.Sync
-		cols = append(cols, "sync")
 	}
-	if current.Public != entity.Public {
+	var namePtr, commentPtr *string
+	var publicPtr *bool
+	if nameChanged {
+		namePtr = &entity.Name
+	}
+	if commentChanged {
+		commentPtr = &entity.Comment
+	}
+	if sent("public") {
+		publicPtr = &entity.Public
+	}
+	return s.updateMetadata(ctx, s.ds, current, namePtr, commentPtr, publicPtr)
+}
+
+// applyFlagsOnly handles updates that only toggle sync/public — skips
+// updatedAt so cover art URLs stay stable.
+func (s *playlists) applyFlagsOnly(ctx context.Context, current, entity *model.Playlist,
+	sent func(string) bool,
+) error {
+	var updateCols []string
+	if sent("sync") && current.Path != "" && current.Sync != entity.Sync {
+		current.Sync = entity.Sync
+		updateCols = append(updateCols, "sync")
+	}
+	if sent("public") && current.Public != entity.Public {
 		current.Public = entity.Public
-		cols = append(cols, "public")
+		updateCols = append(updateCols, "public")
 	}
-	if len(cols) == 0 {
+	if len(updateCols) == 0 {
 		return nil
 	}
-	return s.ds.Playlist(ctx).Put(current, cols...)
+	return s.ds.Playlist(ctx).Put(current, updateCols...)
+}
+
+// sentFields returns a predicate that reports whether a JSON field was present
+// in the request body. An empty cols list means "treat the entity as a full
+// record" — every field is considered sent.
+func sentFields(cols []string) func(string) bool {
+	if len(cols) == 0 {
+		return func(string) bool { return true }
+	}
+	set := slice.ToMap(cols, func(c string) (string, struct{}) { return c, struct{}{} })
+	return func(field string) bool {
+		_, ok := set[field]
+		return ok
+	}
 }
 
 func rulesEqual(a, b *criteria.Criteria) bool {

--- a/core/playlists/rest_adapter_test.go
+++ b/core/playlists/rest_adapter_test.go
@@ -367,6 +367,18 @@ var _ = Describe("REST Adapter", func() {
 					err := repo.Update("partial", &model.Playlist{Public: true}, "public")
 					Expect(err).ToNot(HaveOccurred())
 				})
+
+				It("matches cols case-insensitively (mirrors json decoder behavior)", func() {
+					// Go's json decoder populates struct fields from case-variant keys
+					// like {"Name":"x"}, but rest.Put's field-name extraction is
+					// case-sensitive. sentFields normalizes both sides so a request
+					// with {"Name":"Renamed"} is honored, not silently ignored.
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					err := repo.Update("partial", &model.Playlist{Name: "Renamed"}, "Name")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Name).To(Equal("Renamed"))
+					Expect(mockPlsRepo.Last.Comment).To(Equal("Original comment"))
+				})
 			})
 		})
 

--- a/core/playlists/rest_adapter_test.go
+++ b/core/playlists/rest_adapter_test.go
@@ -218,6 +218,72 @@ var _ = Describe("REST Adapter", func() {
 				err := repo.Update("nonexistent", pls)
 				Expect(err).To(Equal(rest.ErrNotFound))
 			})
+
+			// Regression tests for #5541: partial REST updates (e.g. bulk "Make Public")
+			// must only touch the fields the client actually sent. The cols list from
+			// rest.Put names those fields; fields outside it must be left alone, even
+			// when the deserialized entity has zero values for them.
+			Context("with partial updates (cols)", func() {
+				BeforeEach(func() {
+					ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+					mockPlsRepo.Data["partial"] = &model.Playlist{
+						ID:      "partial",
+						Name:    "Original Name",
+						Comment: "Original comment",
+						OwnerID: "user-1",
+						Public:  false,
+					}
+				})
+
+				It("preserves name and comment when only public is sent (bulk Make Public)", func() {
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					err := repo.Update("partial", &model.Playlist{Public: true}, "public")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Name).To(Equal("Original Name"))
+					Expect(mockPlsRepo.Last.Comment).To(Equal("Original comment"))
+					Expect(mockPlsRepo.Last.Public).To(BeTrue())
+				})
+
+				It("preserves name when only sync is sent for a file-backed playlist", func() {
+					mockPlsRepo.Data["file-partial"] = &model.Playlist{
+						ID:      "file-partial",
+						Name:    "Keep Me",
+						OwnerID: "user-1",
+						Path:    "/music/p.m3u",
+						Sync:    true,
+					}
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					err := repo.Update("file-partial", &model.Playlist{Sync: false}, "sync")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Name).To(Equal("Keep Me"))
+					Expect(mockPlsRepo.Last.Sync).To(BeFalse())
+				})
+
+				It("renames the playlist when only name is sent", func() {
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					err := repo.Update("partial", &model.Playlist{Name: "Renamed"}, "name")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Name).To(Equal("Renamed"))
+					Expect(mockPlsRepo.Last.Comment).To(Equal("Original comment"))
+					Expect(mockPlsRepo.Last.Public).To(BeFalse())
+				})
+
+				It("clears the comment when an empty comment is sent explicitly", func() {
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					err := repo.Update("partial", &model.Playlist{Comment: ""}, "comment")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Comment).To(BeEmpty())
+					Expect(mockPlsRepo.Last.Name).To(Equal("Original Name"))
+				})
+
+				It("does not treat a missing ownerId as an ownership transfer attempt", func() {
+					// A non-admin user sending only {public:true} should not be blocked
+					// just because OwnerID is the zero value in the deserialized entity.
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					err := repo.Update("partial", &model.Playlist{Public: true}, "public")
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
 		})
 
 		Describe("Delete", func() {

--- a/core/playlists/rest_adapter_test.go
+++ b/core/playlists/rest_adapter_test.go
@@ -125,17 +125,24 @@ var _ = Describe("REST Adapter", func() {
 				Expect(err).To(Equal(rest.ErrPermissionDenied))
 			})
 
-			It("denies regular user even when ownerId arrives under a case-variant JSON key", func() {
-				// rest.Put's field-name extraction is case-sensitive, but Go's json
-				// decoder is case-insensitive on struct fields, so {"OwnerId":"x"}
-				// populates entity.OwnerID while cols carries "OwnerId" instead of
-				// "ownerId". The permission gate must still fire.
-				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
-				repo = ps.NewRepository(ctx).(rest.Persistable)
-				pls := &model.Playlist{OwnerID: "other-user"}
-				err := repo.Update("pls-1", pls, "OwnerId")
-				Expect(err).To(Equal(rest.ErrPermissionDenied))
-			})
+			DescribeTable("denies regular user from changing ownership under any case-variant JSON key",
+				func(colName string) {
+					// rest.Put's field-name extraction is case-sensitive, but Go's
+					// json decoder is case-insensitive on struct fields, so any
+					// {"OwnerId":"x"} / {"OWNERID":"x"} / {"ownerid":"x"} populates
+					// entity.OwnerID. sentFields normalizes both sides so the
+					// permission gate fires regardless of casing.
+					ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					pls := &model.Playlist{OwnerID: "other-user"}
+					err := repo.Update("pls-1", pls, colName)
+					Expect(err).To(Equal(rest.ErrPermissionDenied))
+				},
+				Entry("canonical camelCase", "ownerId"),
+				Entry("PascalCase", "OwnerId"),
+				Entry("all upper", "OWNERID"),
+				Entry("all lower", "ownerid"),
+			)
 
 			It("updates smart playlist rules", func() {
 				mockPlsRepo.Data["smart-1"] = &model.Playlist{

--- a/core/playlists/rest_adapter_test.go
+++ b/core/playlists/rest_adapter_test.go
@@ -125,6 +125,18 @@ var _ = Describe("REST Adapter", func() {
 				Expect(err).To(Equal(rest.ErrPermissionDenied))
 			})
 
+			It("denies regular user even when ownerId arrives under a case-variant JSON key", func() {
+				// rest.Put's field-name extraction is case-sensitive, but Go's json
+				// decoder is case-insensitive on struct fields, so {"OwnerId":"x"}
+				// populates entity.OwnerID while cols carries "OwnerId" instead of
+				// "ownerId". The permission gate must still fire.
+				ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+				repo = ps.NewRepository(ctx).(rest.Persistable)
+				pls := &model.Playlist{OwnerID: "other-user"}
+				err := repo.Update("pls-1", pls, "OwnerId")
+				Expect(err).To(Equal(rest.ErrPermissionDenied))
+			})
+
 			It("updates smart playlist rules", func() {
 				mockPlsRepo.Data["smart-1"] = &model.Playlist{
 					ID:      "smart-1",
@@ -274,6 +286,78 @@ var _ = Describe("REST Adapter", func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(mockPlsRepo.Last.Comment).To(BeEmpty())
 					Expect(mockPlsRepo.Last.Name).To(Equal("Original Name"))
+				})
+
+				It("updates rules-only on a smart playlist (Feishin-style edit)", func() {
+					mockPlsRepo.Data["smart-partial"] = &model.Playlist{
+						ID:      "smart-partial",
+						Name:    "Smart Original",
+						Comment: "smart comment",
+						OwnerID: "user-1",
+						Public:  true,
+						Rules:   &criteria.Criteria{Expression: criteria.Is{"genre": "Rock"}},
+					}
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					newRules := &criteria.Criteria{Expression: criteria.Is{"genre": "Jazz"}, Sort: "year DESC"}
+					err := repo.Update("smart-partial", &model.Playlist{Rules: newRules}, "rules")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Rules).To(Equal(newRules))
+					Expect(mockPlsRepo.Last.Name).To(Equal("Smart Original"))
+					Expect(mockPlsRepo.Last.Comment).To(Equal("smart comment"))
+					Expect(mockPlsRepo.Last.Public).To(BeTrue())
+				})
+
+				It("updates name and rules together (smart-playlist Edit form)", func() {
+					mockPlsRepo.Data["smart-edit"] = &model.Playlist{
+						ID:      "smart-edit",
+						Name:    "Smart Original",
+						Comment: "smart comment",
+						OwnerID: "user-1",
+						Rules:   &criteria.Criteria{Expression: criteria.Is{"genre": "Rock"}},
+					}
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					newRules := &criteria.Criteria{Expression: criteria.Is{"artist": "Miles Davis"}, Sort: "album"}
+					err := repo.Update("smart-edit",
+						&model.Playlist{Name: "Smart Renamed", Rules: newRules},
+						"name", "rules")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Name).To(Equal("Smart Renamed"))
+					Expect(mockPlsRepo.Last.Rules).To(Equal(newRules))
+					Expect(mockPlsRepo.Last.Comment).To(Equal("smart comment"))
+				})
+
+				It("does not bump the saved rules on an idempotent rules-only PUT", func() {
+					rules := &criteria.Criteria{Expression: criteria.Is{"genre": "Rock"}}
+					mockPlsRepo.Data["smart-idempotent"] = &model.Playlist{
+						ID:      "smart-idempotent",
+						Name:    "Smart Idempotent",
+						OwnerID: "user-1",
+						Rules:   rules,
+					}
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					// Same rules sent back — rulesEqual should report no change and
+					// the request should no-op (no Put call).
+					sameRules := &criteria.Criteria{Expression: criteria.Is{"genre": "Rock"}}
+					err := repo.Update("smart-idempotent", &model.Playlist{Rules: sameRules}, "rules")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last).To(BeNil()) // no Put happened
+				})
+
+				It("preserves rules when only public is sent (smart playlist + bulk Make Public)", func() {
+					rules := &criteria.Criteria{Expression: criteria.Is{"genre": "Rock"}}
+					mockPlsRepo.Data["smart-public"] = &model.Playlist{
+						ID:      "smart-public",
+						Name:    "Smart Public",
+						OwnerID: "user-1",
+						Public:  false,
+						Rules:   rules,
+					}
+					repo = ps.NewRepository(ctx).(rest.Persistable)
+					err := repo.Update("smart-public", &model.Playlist{Public: true}, "public")
+					Expect(err).ToNot(HaveOccurred())
+					Expect(mockPlsRepo.Last.Public).To(BeTrue())
+					Expect(mockPlsRepo.Last.Rules).To(Equal(rules))
+					Expect(mockPlsRepo.Last.Name).To(Equal("Smart Public"))
 				})
 
 				It("does not treat a missing ownerId as an ownership transfer attempt", func() {


### PR DESCRIPTION
### Description

Fixes a bug where bulk actions on the Playlists list view (most visibly **MAKE PUBLIC** / **MAKE PRIVATE**) silently wiped the playlist's `name` (and `comment`) to empty strings, causing the UI to show `"Loading..."` indefinitely for affected playlists.

**Root cause.** The REST adapter at `core/playlists/rest_adapter.go` was discarding the `cols ...string` argument that `rest.Put` provides — the list of fields actually present in the JSON request body. `updatePlaylistEntity` then compared the deserialized entity's zero-valued `Name`/`Comment` to the DB row, decided "content changed", and called `updateMetadata` with `&entity.Name` — overwriting the name with `""`. The single-record `useUpdate` toggle in the same UI was unaffected because it spreads the full record into its payload; only the multi-select bulk path (which sends just `{"public": true}`) was hitting the bug.

**Fix.** Honor `cols`. A small `sentFields` predicate gates every field-change check and every pointer passed to `updateMetadata` by whether the field was actually present in the request body. Empty `cols` falls back to the existing "treat as a full record" behavior so non-REST callers are unaffected. The non-admin owner-change permission check is left keyed on the deserialized entity (`entity.OwnerID != ""`) rather than `sent("ownerId")`, since `rest.Put`'s field-name extraction is case-sensitive while Go's json decoder is case-insensitive — keeping the check entity-based prevents a case-variant key like `{"OwnerId":"x"}` from downgrading the 403 to a silent 200.

The cyclomatic complexity of `updatePlaylistEntity` grew enough to trip the linter, so the function is split into `applyContentUpdate` / `applyFlagsOnly` / `sentFields` helpers.

### Related Issues

Fixes #5541

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start the dev server: `make dev`
2. In the web UI, create three private playlists with distinct names (e.g. "Alpha", "Bravo", "Charlie").
3. Open the Playlists list view, select all three using the row checkboxes, and click **MAKE PUBLIC**.
4. **Expected:** all three rows still show their original names and the Public column flips to true. (Before this fix: rows showed "Loading..." indefinitely.)
5. Repeat with **MAKE PRIVATE** — names should still be intact.
6. Sanity: edit one playlist via the normal edit form, rename it, save — verify the rename still works.
7. Sanity (smart playlists / Feishin): use a client that updates a smart playlist's rules via a partial `PUT /api/playlist/{id}` with body `{"rules": {...}}` — name/comment/public/owner stay untouched while rules are updated.

Backend unit coverage is in `core/playlists/rest_adapter_test.go` under `Context("with partial updates (cols)")`:
- Bulk Make-Public preserves name/comment.
- Sync-only PUT preserves name on file-backed playlists.
- Partial rename touches only name.
- Explicit empty comment is honored (not treated as "absent").
- Bulk Make-Public on a smart playlist preserves rules.
- Rules-only PUT updates rules and preserves all other fields.
- Name + rules combined update both, preserves comment.
- Idempotent rules-only PUT is a no-op.
- Case-variant ownership-change attempts still return 403.

### Screenshots / Demos (if applicable)

N/A — no UI changes, only the bug-fix behavior is visible (names no longer disappear after bulk public toggle).

### Additional Notes

- **No API contract change.** The wire format for `PUT /api/playlist/{id}` is unchanged; the fix is entirely server-side in the REST adapter.
- **No DB migration.** No schema change.
- **No frontend change.** Considered fixing it at `ui/src/playlist/ChangePublicStatusButton.jsx` (spread the full record into each bulk update), but rejected: (a) any future partial-update endpoint would inherit the same class of bug, (b) per-record fetch round-trips would add latency to bulk actions.
- **Latent same-class bug in other resource wrappers.** `core/library.go` and `persistence/user_repository.go` discard `cols` the same way and are reachable via `rest.Put`. They aren't currently exercised by any bulk UI action, so the bug is latent there — but worth a separate, narrower follow-up PR rather than bundling them into this playlist-specific fix.
