### PR TITLE
fix(conf): make Dir safe to copy to prevent sync.Once corruption

### DIFF
--- a/conf/dir.go
+++ b/conf/dir.go
@@ -1,20 +1,20 @@
 package conf
 
 import (
+	"cmp"
 	"fmt"
 	"os"
-	"sync"
 )
 
-// Dir wraps a directory path and lazily creates the directory on first use.
-// The directory is created at most once; if creation fails, the error is
-// permanently cached (sync.Once semantics). Dir is not safe for mutation
-// after Path() has been called.
+// Dir wraps a directory path and creates the directory on demand. Dir is a
+// plain value type — safe to copy, compare, and print via reflection-based
+// formatters (pretty.Sprintf("%# v", ...)) without any concurrency hazards.
+// Directory creation is delegated to os.MkdirAll on every Path() call;
+// MkdirAll is idempotent, so repeated calls cost one stat syscall when the
+// directory already exists.
 type Dir struct {
 	path string
 	perm os.FileMode
-	once sync.Once
-	err  error
 }
 
 // NewDir creates a new Dir with the given path and default permissions (os.ModePerm).
@@ -23,31 +23,32 @@ func NewDir(path string) Dir {
 }
 
 // NewDirWithPerm creates a new Dir with the given path and permissions.
+// A perm of 0 is treated as "default" and resolves to os.ModePerm at
+// directory-creation time; pass an explicit non-zero mode to constrain the
+// permissions.
 func NewDirWithPerm(path string, perm os.FileMode) Dir {
 	return Dir{path: path, perm: perm}
 }
 
 // String returns the raw path without creating the directory. Satisfies fmt.Stringer.
-func (d *Dir) String() string {
+func (d Dir) String() string {
 	return d.path
 }
 
-// Path creates the directory on first call (via sync.Once) and returns the path.
-func (d *Dir) Path() (string, error) {
-	d.once.Do(func() {
-		if d.path == "" {
-			return
-		}
-		d.err = os.MkdirAll(d.path, d.perm)
-		if d.err != nil {
-			d.err = fmt.Errorf("creating directory %q: %w", d.path, d.err)
-		}
-	})
-	return d.path, d.err
+// Path ensures the directory exists and returns its path. Safe to call
+// repeatedly; an empty path is returned as-is with no error.
+func (d Dir) Path() (string, error) {
+	if d.path == "" {
+		return "", nil
+	}
+	if err := os.MkdirAll(d.path, cmp.Or(d.perm, os.ModePerm)); err != nil {
+		return d.path, fmt.Errorf("creating directory %q: %w", d.path, err)
+	}
+	return d.path, nil
 }
 
 // MustPath calls Path() and calls logFatal on error.
-func (d *Dir) MustPath() string {
+func (d Dir) MustPath() string {
 	path, err := d.Path()
 	if err != nil {
 		logFatal("creating directory:", err)
@@ -57,12 +58,12 @@ func (d *Dir) MustPath() string {
 
 // GoString implements fmt.GoStringer so that %#v (used by pretty.Sprintf)
 // prints the path string instead of the internal struct fields.
-func (d Dir) GoString() string { //nolint:govet // uses a value receiver so Dir values satisfy GoStringer
+func (d Dir) GoString() string {
 	return fmt.Sprintf("%q", d.path)
 }
 
 // MarshalText returns the raw path bytes. No side effects.
-func (d *Dir) MarshalText() ([]byte, error) {
+func (d Dir) MarshalText() ([]byte, error) {
 	return []byte(d.path), nil
 }
 

--- a/conf/dir_test.go
+++ b/conf/dir_test.go
@@ -2,7 +2,9 @@ package conf_test
 
 import (
 	"os"
+	"sync"
 
+	"github.com/kr/pretty"
 	"github.com/navidrome/navidrome/conf"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,9 +37,9 @@ var _ = Describe("Dir", func() {
 			Expect(target).To(BeADirectory())
 		})
 
-		It("returns the same result on subsequent calls (sync.Once)", func() {
+		It("is idempotent on subsequent calls", func() {
 			dir := GinkgoT().TempDir()
-			target := dir + "/once"
+			target := dir + "/idempotent"
 			d := conf.NewDir(target)
 
 			path1, err1 := d.Path()
@@ -45,6 +47,7 @@ var _ = Describe("Dir", func() {
 			Expect(err1).ToNot(HaveOccurred())
 			Expect(err2).ToNot(HaveOccurred())
 			Expect(path1).To(Equal(path2))
+			Expect(target).To(BeADirectory())
 		})
 
 		It("returns an error when directory cannot be created", func() {
@@ -122,6 +125,40 @@ var _ = Describe("Dir", func() {
 			err = d2.UnmarshalText(b)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(d2.String()).To(Equal(d1.String()))
+		})
+	})
+
+	Describe("GoString", func() {
+		// Regression: pretty.Sprintf("%# v", ...) is used by the
+		// configuration dump. It must render Dir as a quoted path via
+		// GoString, not dump the internal struct fields.
+		It("renders Dir as a quoted path under pretty.Sprintf", func() {
+			type host struct {
+				DataFolder conf.Dir
+			}
+			h := host{DataFolder: conf.NewDir("./data")}
+			out := pretty.Sprintf("%# v", h)
+			Expect(out).To(ContainSubstring(`DataFolder: "./data"`))
+			Expect(out).ToNot(ContainSubstring("perm:"))
+			Expect(out).ToNot(ContainSubstring("path:"))
+		})
+
+		It("is safe to copy and use concurrently", func() {
+			// Regression for the Windows "sync: unlock of unlocked mutex"
+			// crash that was caused by copying a Dir embedding sync.Once.
+			// Dir is a plain value type now, but keep the concurrent stress
+			// test to lock in the property.
+			dir := GinkgoT().TempDir()
+			d := conf.NewDir(dir + "/race")
+			var wg sync.WaitGroup
+			for range 10 {
+				wg.Go(func() {
+					copy1 := d
+					_ = pretty.Sprintf("%# v", copy1)
+					_, _ = copy1.Path()
+				})
+			}
+			wg.Wait()
 		})
 	})
 })


### PR DESCRIPTION
### Description

Fixes a latent `sync.Once` corruption bug in `conf.Dir` that surfaces as a Windows-CI flake — `fatal error: sync: unlock of unlocked mutex` during cache initialization.

**Root cause.** `Dir` embedded a `sync.Once` directly and exposed a value-receiver `GoString()` so that `pretty.Sprintf("%# v", Server)` could render the path. That meant every pretty-print copied the entire `Dir` along with its `Once`. When a goroutine concurrently used the original (or any copy) for `Path()`, the `Once`'s internal `Mutex` could land in an inconsistent state. The exact crash path observed:

```
goroutine N [running]:
  internal/sync.(*Mutex).unlockSlow         mutex.go:204
  sync.(*Once).doSlow                       once.go:80
  conf.(*Dir).Path                          conf/dir.go:37
  conf.(*Dir).MustPath                      conf/dir.go:51
  utils/cache.newFSCache                    utils/cache/file_caches.go:265
  utils/cache.NewFileCache.func1            utils/cache/file_caches.go:88
```

The race was between `NewFileCache`'s background init goroutine calling `conf.Server.CacheFolder.MustPath()` and `conf.Load()`'s `pretty.Sprintf("Configuration: %# v", Server)` — both touching the same `Once`, the latter producing copies of it. A `//nolint:govet` comment had been suppressing the exact `passes lock by value` warning that would have caught this.

**Fix.** Drop the `sync.Once` entirely. `Dir` is now a plain `{path, perm}` value type, and `Path()` calls `os.MkdirAll` on every invocation. `os.MkdirAll` is idempotent, so repeated calls on an existing directory cost one `stat` syscall — negligible for the few config paths read at startup and during cache init.

This removes the entire class of bug:
- No `Mutex`, so copies (via reflection, pretty-print, etc.) are safe.
- No state pointer indirection, so no nil-defensive checks scattered across methods, and no risk of two copies seeing different lifecycle state.
- `go vet` is happy with the value receivers — the `//nolint:govet` suppression on `GoString` is gone.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. `make test PKG=./conf/...` — passes; two new specs were added in `conf/dir_test.go`:
   - `GoString renders Dir as a quoted path under pretty.Sprintf` — asserts the pretty-print still produces `DataFolder: "./data"` (not the struct dump).
   - `GoString is safe to copy and use concurrently` — races 10 goroutines copying `Dir` and calling `Path()` + `pretty.Sprintf`, locking in the copy-safety property in case `Dir` ever grows non-trivial state again.
2. `go test -race ./conf` — clean under the race detector.
3. Spot-check downstream packages that consume `conf.Dir` (the lazy-Once removal touches their semantics): `make test PKG="./core/stream/... ./utils/cache/... ./scanner/... ./core/artwork/..."` — all green.

### Screenshots / Demos (if applicable)

N/A — no user-visible change.

### Additional Notes

- **Behavior change vs the previous lazy-Once design.** `Path()` now calls `os.MkdirAll` every time instead of caching the result of the first call. `os.MkdirAll` is idempotent — it returns `nil` cheaply when the directory already exists (one `stat` syscall). For the call sites that matter (startup config dirs, cache initialization), the cost is irrelevant. The error semantics change subtly: a transient failure on the first call no longer gets permanently cached; a retry can now succeed.
- **API impact:** all `Dir` methods now have **value receivers** (previously some were `*Dir`). Existing callers that held `*Dir` continue to work because Go auto-derefs for method calls. Callers that took the address of a `Dir` field for any other reason are unaffected.
- **Zero-value behavior:** `var d Dir` (no `NewDir`) yields `{path: "", perm: 0}`. `String()` returns `""`. `Path()` returns `"", nil`. `UnmarshalText` populates the fields directly. No nil-state defensive checks needed.
- The original crash was timing-dependent, so this PR's CI may not directly demonstrate it on this run. The new concurrent stress test exercises the same pattern deterministically on every platform.
