### PR TITLE
feat: add pagination to album songs view

### DIFF
--- a/ui/src/actions/dialogs.js
+++ b/ui/src/actions/dialogs.js
@@ -29,9 +29,10 @@ export const closeShareMenu = () => ({
   type: SHARE_MENU_CLOSE,
 })
 
-export const openAddToPlaylist = ({ selectedIds, onSuccess }) => ({
+export const openAddToPlaylist = ({ selectedIds, albumIds, onSuccess }) => ({
   type: ADD_TO_PLAYLIST_OPEN,
   selectedIds,
+  albumIds,
   onSuccess,
 })
 

--- a/ui/src/album/AlbumActions.jsx
+++ b/ui/src/album/AlbumActions.jsx
@@ -21,7 +21,6 @@ import {
   playNext,
   addTracks,
   playTracks,
-  shuffleTracks,
   openAddToPlaylist,
   openDownloadMenu,
   DOWNLOAD_MENU_ALBUM,
@@ -99,29 +98,30 @@ const AlbumActions = ({
   }, [getAllSongsAndDispatch])
 
   const handleShuffle = React.useCallback(() => {
-    getAllSongsAndDispatch(shuffleTracks)
-  }, [getAllSongsAndDispatch])
-
-  const handleAddToPlaylist = React.useCallback(() => {
-    if (ids && ids.length === record.songCount) {
-      const selectedIds = ids.filter((id) => !data[id].missing)
-      return dispatch(openAddToPlaylist({ selectedIds }))
+    const filter = { album_id: record.id }
+    if (config.skipLowRatingInShuffle) {
+      filter.not_disliked = true
     }
     dataProvider
       .getList('song', {
-        pagination: { page: 1, perPage: 0 },
-        sort: { field: 'album', order: 'ASC' },
-        filter: { album_id: record.id },
+        pagination: { page: 1, perPage: 500 },
+        sort: { field: 'random', order: 'ASC' },
+        filter,
       })
       .then((res) => {
-        const selectedIds = res.data
-          .filter((s) => !s.missing)
-          .map((s) => s.id)
-        dispatch(openAddToPlaylist({ selectedIds }))
+        const allData = res.data.reduce(
+          (acc, curr) => ({ ...acc, [curr.id]: curr }),
+          {},
+        )
+        dispatch(playTracks(allData))
       })
       .catch(() => {
         notify('ra.page.error', 'warning')
       })
+  }, [dataProvider, dispatch, record, notify])
+
+  const handleAddToPlaylist = React.useCallback(() => {
+    dispatch(openAddToPlaylist({ albumIds: [record.id] }))
   }, [dataProvider, dispatch, record, data, ids, notify])
 
   const handleShare = React.useCallback(() => {

--- a/ui/src/album/AlbumActions.jsx
+++ b/ui/src/album/AlbumActions.jsx
@@ -62,7 +62,7 @@ const AlbumActions = ({
 
   const getAllSongsAndDispatch = React.useCallback(
     (action) => {
-      if (ids?.length === record.songCount) {
+      if (ids && ids.length === record.songCount) {
         return dispatch(action(data, ids))
       }
       dataProvider
@@ -76,7 +76,8 @@ const AlbumActions = ({
             (acc, curr) => ({ ...acc, [curr.id]: curr }),
             {},
           )
-          dispatch(action(allData))
+          const allIds = res.data.map((s) => s.id)
+          dispatch(action(allData, allIds))
         })
         .catch(() => {
           notify('ra.page.error', 'warning')
@@ -102,7 +103,7 @@ const AlbumActions = ({
   }, [getAllSongsAndDispatch])
 
   const handleAddToPlaylist = React.useCallback(() => {
-    if (ids?.length === record.songCount) {
+    if (ids && ids.length === record.songCount) {
       const selectedIds = ids.filter((id) => !data[id].missing)
       return dispatch(openAddToPlaylist({ selectedIds }))
     }

--- a/ui/src/album/AlbumActions.jsx
+++ b/ui/src/album/AlbumActions.jsx
@@ -5,6 +5,8 @@ import {
   Button,
   sanitizeListRestProps,
   TopToolbar,
+  useDataProvider,
+  useNotify,
   useRecordContext,
   useTranslate,
 } from 'react-admin'
@@ -52,30 +54,74 @@ const AlbumActions = ({
 }) => {
   const dispatch = useDispatch()
   const translate = useTranslate()
+  const dataProvider = useDataProvider()
+  const notify = useNotify()
   const classes = useStyles()
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const isNotSmall = useMediaQuery((theme) => theme.breakpoints.up('sm'))
 
+  const getAllSongsAndDispatch = React.useCallback(
+    (action) => {
+      if (ids?.length === record.songCount) {
+        return dispatch(action(data, ids))
+      }
+      dataProvider
+        .getList('song', {
+          pagination: { page: 1, perPage: 0 },
+          sort: { field: 'album', order: 'ASC' },
+          filter: { album_id: record.id },
+        })
+        .then((res) => {
+          const allData = res.data.reduce(
+            (acc, curr) => ({ ...acc, [curr.id]: curr }),
+            {},
+          )
+          dispatch(action(allData))
+        })
+        .catch(() => {
+          notify('ra.page.error', 'warning')
+        })
+    },
+    [dataProvider, dispatch, record, data, ids, notify],
+  )
+
   const handlePlay = React.useCallback(() => {
-    dispatch(playTracks(data, ids))
-  }, [dispatch, data, ids])
+    getAllSongsAndDispatch(playTracks)
+  }, [getAllSongsAndDispatch])
 
   const handlePlayNext = React.useCallback(() => {
-    dispatch(playNext(data, ids))
-  }, [dispatch, data, ids])
+    getAllSongsAndDispatch(playNext)
+  }, [getAllSongsAndDispatch])
 
   const handlePlayLater = React.useCallback(() => {
-    dispatch(addTracks(data, ids))
-  }, [dispatch, data, ids])
+    getAllSongsAndDispatch(addTracks)
+  }, [getAllSongsAndDispatch])
 
   const handleShuffle = React.useCallback(() => {
-    dispatch(shuffleTracks(data, ids))
-  }, [dispatch, data, ids])
+    getAllSongsAndDispatch(shuffleTracks)
+  }, [getAllSongsAndDispatch])
 
   const handleAddToPlaylist = React.useCallback(() => {
-    const selectedIds = ids.filter((id) => !data[id].missing)
-    dispatch(openAddToPlaylist({ selectedIds }))
-  }, [dispatch, data, ids])
+    if (ids?.length === record.songCount) {
+      const selectedIds = ids.filter((id) => !data[id].missing)
+      return dispatch(openAddToPlaylist({ selectedIds }))
+    }
+    dataProvider
+      .getList('song', {
+        pagination: { page: 1, perPage: 0 },
+        sort: { field: 'album', order: 'ASC' },
+        filter: { album_id: record.id },
+      })
+      .then((res) => {
+        const selectedIds = res.data
+          .filter((s) => !s.missing)
+          .map((s) => s.id)
+        dispatch(openAddToPlaylist({ selectedIds }))
+      })
+      .catch(() => {
+        notify('ra.page.error', 'warning')
+      })
+  }, [dataProvider, dispatch, record, data, ids, notify])
 
   const handleShare = React.useCallback(() => {
     dispatch(openShareMenu([record.id], 'album', record.name))

--- a/ui/src/album/AlbumShow.jsx
+++ b/ui/src/album/AlbumShow.jsx
@@ -4,6 +4,7 @@ import {
   ShowContextProvider,
   useShowContext,
   useShowController,
+  Pagination,
   Title as RaTitle,
 } from 'react-admin'
 import { makeStyles } from '@material-ui/core/styles'
@@ -40,8 +41,7 @@ const AlbumShowLayout = (props) => {
           reference="song"
           target="album_id"
           sort={{ field: 'album', order: 'ASC' }}
-          perPage={0}
-          pagination={null}
+          perPage={50}
         >
           <AlbumSongs
             resource={'song'}
@@ -50,6 +50,7 @@ const AlbumShowLayout = (props) => {
             actions={
               <AlbumActions className={classes.albumActions} record={record} />
             }
+            pagination={<Pagination rowsPerPageOptions={[25, 50, 100]} />}
           />
         </ReferenceManyField>
       )}

--- a/ui/src/album/AlbumSongs.jsx
+++ b/ui/src/album/AlbumSongs.jsx
@@ -89,6 +89,7 @@ const useStyles = makeStyles(
 
 const AlbumSongs = (props) => {
   const { data, ids } = props
+  const listContext = useListContext(props)
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
   const classes = useStyles({ isDesktop })
   const dispatch = useDispatch()
@@ -210,6 +211,8 @@ const AlbumSongs = (props) => {
         </Card>
       </div>
       <ExpandInfoDialog content={<SongInfo />} />
+      {props.pagination &&
+        React.cloneElement(props.pagination, listContext)}
     </>
   )
 }
@@ -217,7 +220,17 @@ const AlbumSongs = (props) => {
 const SanitizedAlbumSongs = (props) => {
   removeAlbumCommentsFromSongs(props)
   const { loaded, loading, total, ...rest } = useListContext(props)
-  return <>{loaded && <AlbumSongs {...rest} actions={props.actions} />}</>
+  return (
+    <>
+      {loaded && (
+        <AlbumSongs
+          {...rest}
+          actions={props.actions}
+          pagination={props.pagination}
+        />
+      )}
+    </>
+  )
 }
 
 export default SanitizedAlbumSongs

--- a/ui/src/dialogs/AddToPlaylistDialog.jsx
+++ b/ui/src/dialogs/AddToPlaylistDialog.jsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles({
 
 export const AddToPlaylistDialog = () => {
   const classes = useStyles()
-  const { open, selectedIds, onSuccess, duplicateSong, duplicateIds } =
+  const { open, selectedIds, albumIds, onSuccess, duplicateSong, duplicateIds } =
     useSelector((state) => state.addToPlaylistDialog)
   const dispatch = useDispatch()
   const translate = useTranslate()
@@ -61,10 +61,11 @@ export const AddToPlaylistDialog = () => {
 
   const addToPlaylist = (playlistId, distinctIds) => {
     const trackIds = Array.isArray(distinctIds) ? distinctIds : selectedIds
-    if (trackIds.length) {
+    const data = albumIds?.length ? { albumIds } : { ids: trackIds }
+    if (albumIds?.length || trackIds.length) {
       dataProvider
         .create('playlistTrack', {
-          data: { ids: trackIds },
+          data,
           filter: { playlist_id: playlistId },
         })
         .then(() => {

--- a/ui/src/reducers/dialogReducer.js
+++ b/ui/src/reducers/dialogReducer.js
@@ -63,6 +63,7 @@ export const addToPlaylistDialogReducer = (
         ...previousState,
         open: true,
         selectedIds: payload.selectedIds,
+        albumIds: payload.albumIds,
         onSuccess: payload.onSuccess,
       }
     case ADD_TO_PLAYLIST_CLOSE:


### PR DESCRIPTION
## Summary

Large albums freeze the browser because all songs are loaded at once (`perPage={0}`). This adds pagination and server-side optimizations to the album songs view.

Fixes long-standing issues:

- [#2539 — Browser freezes with large number of tracks in album](https://github.com/navidrome/navidrome/issues/2539)
- [#1186 — Large album (~300 songs) completely freezes the app](https://github.com/navidrome/navidrome/issues/1186)
- [#4397 — Web interface stops responding with huge album (1096 tracks)](https://github.com/navidrome/navidrome/issues/4397)

## Changes

- **AlbumShow.jsx**: `perPage={0}` → `perPage={50}`, add `<Pagination rowsPerPageOptions={[25, 50, 100]} />`
- **AlbumSongs.jsx**: Pass through and render pagination prop
- **AlbumActions.jsx**: Play/Play Next/Add to Queue fetch all songs via API when paginated, preserving track order
- **Album Shuffle**: Fetches max 500 random songs **server-side** (`sort=random`) instead of loading all songs client-side. Respects `SkipLowRatingInShuffle` setting.
- **Add to Playlist**: Sends `albumIds` to server API instead of fetching all song IDs client-side. Server resolves album to tracks — no client-side loading needed.
- **AddToPlaylistDialog + dialogs action + reducer**: Support `albumIds` pass-through

## Test plan

- [ ] Open an album with 1000+ tracks — verify it loads quickly without freezing
- [ ] Verify pagination controls appear and page navigation works
- [ ] Click Play on a paginated album — verify all songs are played in order
- [ ] Click Shuffle on a large album — verify max 500 songs in queue, loaded quickly
- [ ] Add paginated album to playlist — verify all songs are added without loading delay
- [ ] Open a small album (<50 tracks) — verify no pagination appears
- [ ] With SkipLowRatingInShuffle enabled: verify 1-star songs excluded from album shuffle

🤖 Generated with [Claude Code](https://claude.com/claude-code)