### PR TITLE
Refactor: Gruvbox Dark theme

### DIFF
--- a/ui/src/themes/gruvboxDark.css.js
+++ b/ui/src/themes/gruvboxDark.css.js
@@ -5,7 +5,7 @@ const stylesheet = `
 }
 
 .react-jinke-music-player-main .music-player-panel .panel-content .rc-slider-handle, .react-jinke-music-player-main .music-player-panel .panel-content .rc-slider-track {
-    background-color: #458588
+    background-color: #ebdbb2
 }
 
 .react-jinke-music-player-main ::-webkit-scrollbar-thumb {
@@ -49,6 +49,13 @@ const stylesheet = `
 
 .MuiCheckbox-colorSecondary.Mui-checked {
     color: #458588 !important
+}
+.react-jinke-music-player-main .music-player-panel svg {
+    color: #ebdbb2;
+    fill: #ebdbb2;
+}
+.react-jinke-music-player-main .music-player-panel button {
+    color: #ebdbb2;
 }
 `
 

--- a/ui/src/themes/gruvboxDark.js
+++ b/ui/src/themes/gruvboxDark.js
@@ -14,22 +14,34 @@ export default {
     background: {
       default: '#282828',
     },
+    text: {
+      primary: '#ebdbb2',
+      secondary: '#a89984',
+    },
   },
   overrides: {
     MuiPaper: {
       root: {
         color: '#ebdbb2',
         backgroundColor: '#3c3836',
-        MuiSnackbarContent: {
-          root: {
-            color: '#ebdbb2',
-            backgroundColor: '#cc241d',
-          },
-          message: {
-            color: '#ebdbb2',
-            backgroundColor: '#cc241d',
-          },
-        },
+      },
+    },
+    MuiSnackbarContent: {
+      root: {
+        color: '#3c3836',
+        backgroundColor: '#a89984',
+      },
+      message: {
+        color: '#3c3836',
+        backgroundColor: '#a89984',
+      },
+    },
+    MuiTypography: {
+      root: {
+        color: '#ebdbb2',
+      },
+      colorTextSecondary: {
+        color: '#a89984',
       },
     },
     MuiButton: {
@@ -45,6 +57,19 @@ export default {
         color: '#ebdbb2',
       },
     },
+    MuiListItemIcon: {
+      root: {
+        color: '#ebdbb2',
+      },
+    },
+    MuiListItemText: {
+      primary: {
+        color: '#ebdbb2',
+      },
+      secondary: {
+        color: '#a89984',
+      },
+    },
     MuiChip: {
       clickable: {
         background: '#49483e',
@@ -57,11 +82,12 @@ export default {
     },
     MuiFormHelperText: {
       root: {
-        Mui: {
-          error: {
-            color: '#cc241d',
-          },
-        },
+        color: '#ebdbb2',
+      },
+    },
+    Mui: {
+      error: {
+        color: '#cc241d',
       },
     },
     MuiTableHead: {
@@ -111,6 +137,17 @@ export default {
       bgContainer: {
         background:
           'linear-gradient(to bottom, rgba(52 52 52 / 72%), rgb(48 48 48))!important',
+      },
+    },
+    NDAlbumGridView: {
+      albumName: {
+        marginTop: '0.5rem',
+        fontWeight: 700,
+        textTransform: 'none',
+        color: '#ebdbb2',
+      },
+      albumSubtitle: {
+        color: '#a89984',
       },
     },
   },

--- a/ui/src/themes/gruvboxDark.js
+++ b/ui/src/themes/gruvboxDark.js
@@ -84,8 +84,6 @@ export default {
       root: {
         color: '#ebdbb2',
       },
-    },
-    Mui: {
       error: {
         color: '#cc241d',
       },


### PR DESCRIPTION
### Description
Refactored the existing Gruvbox Dark theme to follow the project's standard structure, adding full palette and component overrides.

### Related Issues
N/A

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [ ] All existing and new tests pass

### How to Test
1. Select "Gruvbox Dark" in the theme settings
2. Verify colors match the Gruvbox Dark palette across album grid, player, login and tables

### Screenshots
<img width="749" height="996" alt="Captura_de_tela_20260601_163425" src="https://github.com/user-attachments/assets/675d5bcd-5c13-4e79-9826-5c5baee38aa6" />

<img width="908" height="1010" alt="Captura_de_tela_20260601_162329" src="https://github.com/user-attachments/assets/d760bcee-550d-44b4-81a7-b6f109137465" />

### Additional Notes
This is my first contribution to Navidrome.