### PR TITLE
fix(scrobbler): proxy NowPlaying even when ignoreScrobble is set

### DIFF
--- a/core/scrobbler/play_tracker.go
+++ b/core/scrobbler/play_tracker.go
@@ -371,9 +371,13 @@ func (p *playTracker) ReportPlayback(ctx context.Context, params ReportPlaybackP
 		p.broker.SendBroadcastMessage(ctx, &events.NowPlayingCount{Count: p.playMap.Len()})
 	}
 
-	// NowPlaying is proxied to external agents even when ignoreScrobble is set:
-	// "ignore the scrobble submission" still means "tell external services what's
-	// currently playing" (mirrors the legacy scrobble endpoint's submission=false).
+	// NowPlaying gating, by design distinct from scrobble submission:
+	//   - IgnoreScrobble=true   -> still send NowPlaying (suppresses only the
+	//     scrobble submission/play-count above), mirroring the legacy scrobble
+	//     endpoint's submission=false behavior.
+	//   - player.ScrobbleEnabled=false -> never send NowPlaying.
+	// External agents here are the active scrobblers (Last.fm, ListenBrainz, and
+	// scrobbler plugins) returned by getActiveScrobblers; see dispatchNowPlaying.
 	if player.ScrobbleEnabled &&
 		(params.State == StateStarting || params.State == StatePlaying) {
 		if info, err := p.playMap.Get(clientId); err == nil {

--- a/core/scrobbler/play_tracker.go
+++ b/core/scrobbler/play_tracker.go
@@ -371,7 +371,10 @@ func (p *playTracker) ReportPlayback(ctx context.Context, params ReportPlaybackP
 		p.broker.SendBroadcastMessage(ctx, &events.NowPlayingCount{Count: p.playMap.Len()})
 	}
 
-	if !params.IgnoreScrobble && player.ScrobbleEnabled &&
+	// NowPlaying is proxied to external agents even when ignoreScrobble is set:
+	// "ignore the scrobble submission" still means "tell external services what's
+	// currently playing" (mirrors the legacy scrobble endpoint's submission=false).
+	if player.ScrobbleEnabled &&
 		(params.State == StateStarting || params.State == StatePlaying) {
 		if info, err := p.playMap.Get(clientId); err == nil {
 			p.enqueueNowPlaying(ctx, clientId, user.ID, &info.MediaFile, int(params.PositionMs/1000))

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -521,6 +521,7 @@ var _ = Describe("PlayTracker", func() {
 			})
 
 			It("does NOT scrobble when ignoreScrobble=true even if threshold met", func() {
+				fake.ScrobbleCalled.Store(false)
 				err := tracker.ReportPlayback(ctx, ReportPlaybackParams{
 					MediaId: "123", PositionMs: 0, State: "starting", PlaybackRate: 1.0, ClientId: defaultClientId,
 				})
@@ -531,6 +532,7 @@ var _ = Describe("PlayTracker", func() {
 				})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(track.PlayCount).To(Equal(int64(0)))
+				Consistently(func() bool { return fake.ScrobbleCalled.Load() }).Should(BeFalse())
 			})
 
 			It("does NOT scrobble when player ScrobbleEnabled=false even if threshold met", func() {

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -715,14 +715,14 @@ var _ = Describe("PlayTracker", func() {
 				Consistently(func() bool { return fake.GetNowPlayingCalled() }).Should(BeFalse())
 			})
 
-			It("does NOT dispatch when ignoreScrobble=true", func() {
+			It("still dispatches NowPlaying when ignoreScrobble=true", func() {
 				fake.nowPlayingCalled.Store(false)
 				err := tracker.ReportPlayback(ctx, ReportPlaybackParams{
 					MediaId: "123", PositionMs: 0, State: "starting", PlaybackRate: 1.0, ClientId: defaultClientId,
 					IgnoreScrobble: true,
 				})
 				Expect(err).ToNot(HaveOccurred())
-				Consistently(func() bool { return fake.GetNowPlayingCalled() }).Should(BeFalse())
+				Eventually(func() bool { return fake.GetNowPlayingCalled() }).Should(BeTrue())
 			})
 
 			It("does NOT dispatch when ScrobbleEnabled=false", func() {


### PR DESCRIPTION
### Description

When a client reports playback via the `reportPlayback` (OpenSubsonic `playbackReport`) endpoint with `ignoreScrobble=true`, Navidrome suppressed **both** the scrobble submission **and** the NowPlaying update proxied to external agents (Last.fm, ListenBrainz, plugins).

These are independent concerns: `ignoreScrobble=true` means "don't record this play as a scrobble", but Navidrome should still tell external services what the user is currently listening to. The `!params.IgnoreScrobble` check belonged only on the scrobble-submission / play-count path, not on the NowPlaying dispatch.

This PR removes the `!params.IgnoreScrobble` guard from the NowPlaying enqueue, leaving it gated solely by the player's `ScrobbleEnabled` flag. This mirrors the long-standing behavior of the legacy `scrobble` endpoint, where `submission=false` has always still set NowPlaying.

### Related Issues
<!-- None -->

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Configure an external scrobbler (e.g. Last.fm or ListenBrainz) and authorize it for a user, on a player with scrobbling enabled.
2. Send a `reportPlayback` request with `state=starting` (or `playing`) and `ignoreScrobble=true`.
3. **Expected:** the NowPlaying update is still dispatched to the external agent(s), while the scrobble submission / play-count increment is skipped.

Automated coverage: `core/scrobbler/play_tracker_test.go` — the `external scrobbler dispatch` describe block now asserts NowPlaying is still dispatched when `ignoreScrobble=true`, while the existing `ScrobbleEnabled=false` case continues to suppress it.

```
make test PKG=./core/scrobbler
```

### Additional Notes

This is a deliberate behavior change to an explicit prior test contract: the previous test (`does NOT dispatch when ignoreScrobble=true`) codified the buggy behavior and has been inverted (`still dispatches NowPlaying when ignoreScrobble=true`). The scrobble-submission and play-count behavior for `ignoreScrobble=true` is unchanged — only the NowPlaying proxy is now decoupled from the `ignoreScrobble` flag.
