### PR TITLE
fix: enforce ownership atomically on player and share updates

### DIFF
--- a/persistence/player_repository.go
+++ b/persistence/player_repository.go
@@ -149,9 +149,6 @@ func (r *playerRepository) Save(entity any) (string, error) {
 func (r *playerRepository) Update(id string, entity any, cols ...string) error {
 	t := entity.(*model.Player)
 	t.ID = id
-	// updateOwned restricts the write to a row owned by the caller (unless admin) and never writes
-	// user_id, so a user cannot target another user's player by id, and no caller (admin included)
-	// can reassign a player's owner via the request body.
 	return r.updateOwned(id, t, cols...)
 }
 

--- a/persistence/player_repository.go
+++ b/persistence/player_repository.go
@@ -125,6 +125,10 @@ func (r *playerRepository) NewInstance() any {
 	return &model.Player{}
 }
 
+// isPermitted authorizes creating a new record, based on the owner declared in the request body.
+// This is only safe for inserts: there is no stored row yet, and a non-admin may only create a
+// player they own. Updates must not use this (the body owner is attacker-controlled); they go
+// through updateOwned, which authorizes against the persisted user_id in the WHERE clause.
 func (r *playerRepository) isPermitted(p *model.Player) bool {
 	u := loggedUser(r.ctx)
 	return u.IsAdmin || p.UserId == u.ID
@@ -145,14 +149,10 @@ func (r *playerRepository) Save(entity any) (string, error) {
 func (r *playerRepository) Update(id string, entity any, cols ...string) error {
 	t := entity.(*model.Player)
 	t.ID = id
-	if !r.isPermitted(t) {
-		return rest.ErrPermissionDenied
-	}
-	_, err := r.put(id, t, cols...)
-	if errors.Is(err, model.ErrNotFound) {
-		return rest.ErrNotFound
-	}
-	return err
+	// updateOwned restricts the write to a row owned by the caller (unless admin) and never writes
+	// user_id, so a user cannot target another user's player by id, and no caller (admin included)
+	// can reassign a player's owner via the request body.
+	return r.updateOwned(id, t, cols...)
 }
 
 func (r *playerRepository) Delete(id string) error {

--- a/persistence/player_repository.go
+++ b/persistence/player_repository.go
@@ -67,11 +67,10 @@ func (r *playerRepository) addRestriction(sql ...Sqlizer) Sqlizer {
 	if len(sql) > 0 {
 		s = append(s, sql[0])
 	}
-	u := loggedUser(r.ctx)
-	if u.IsAdmin {
-		return s
+	if owner := r.ownerFilter(); owner != nil {
+		s = append(s, owner)
 	}
-	return append(s, Eq{"user_id": u.ID})
+	return s
 }
 
 func (r *playerRepository) CountByClient(options ...model.QueryOptions) (map[string]int64, error) {

--- a/persistence/player_repository_test.go
+++ b/persistence/player_repository_test.go
@@ -219,8 +219,9 @@ var _ = Describe("PlayerRepository", func() {
 					Expect(err).To(HaveOccurred())
 				} else if !admin && player.Username == adminPlayer1.Username {
 					// A non-admin cannot target another user's player: the ownership-restricted
-					// update matches no row, so it reports not-found rather than touching it.
-					Expect(err).To(Equal(rest.ErrNotFound))
+					// update matches no owned row, so it reports permission-denied rather than
+					// touching it.
+					Expect(err).To(Equal(rest.ErrPermissionDenied))
 					clone.IP = player.IP
 				} else {
 					Expect(err).To(BeNil())
@@ -267,9 +268,9 @@ var _ = Describe("PlayerRepository", func() {
 			}
 
 			// The ownership-restricted update matches no row owned by the attacker, so the write
-			// targets nothing and reports not-found rather than overwriting the victim's row.
+			// targets nothing and reports permission-denied rather than overwriting the victim's row.
 			err := regularRepo.Update(adminPlayer1.ID, &spoofed, "name", "user_id", "max_bit_rate")
-			Expect(err).To(Equal(rest.ErrNotFound))
+			Expect(err).To(Equal(rest.ErrPermissionDenied))
 
 			// The victim's player must remain untouched.
 			stored, err := adminRepo.Get(adminPlayer1.ID)

--- a/persistence/player_repository_test.go
+++ b/persistence/player_repository_test.go
@@ -215,10 +215,12 @@ var _ = Describe("PlayerRepository", func() {
 				clone.MaxBitRate = 10000
 				err := repo.Update(clone.ID, &clone, "ip")
 
-				if clone.UserId == "" {
+				if player.UserId == "" {
 					Expect(err).To(HaveOccurred())
 				} else if !admin && player.Username == adminPlayer1.Username {
-					Expect(err).To(Equal(rest.ErrPermissionDenied))
+					// A non-admin cannot target another user's player: the ownership-restricted
+					// update matches no row, so it reports not-found rather than touching it.
+					Expect(err).To(Equal(rest.ErrNotFound))
 					clone.IP = player.IP
 				} else {
 					Expect(err).To(BeNil())
@@ -244,4 +246,86 @@ var _ = Describe("PlayerRepository", func() {
 		Entry("admin context", true, players, adminPlayer1, regularPlayer),
 		Entry("regular context", false, model.Players{regularPlayer}, regularPlayer, adminPlayer1),
 	)
+
+	Describe("Ownership enforcement (cross-tenant write protection)", func() {
+		var regularRepo *playerRepository
+
+		BeforeEach(func() {
+			ctx := log.NewContext(context.TODO())
+			ctx = request.WithUser(ctx, regularUser)
+			regularRepo = NewPlayerRepository(ctx, database).(*playerRepository)
+		})
+
+		It("does not let a regular user hijack another user's player by spoofing userId in the body", func() {
+			// Attacker (regularUser) targets the victim's (adminUser) player by URL id,
+			// but sets userId in the body to their own id to try to pass the permission check.
+			spoofed := model.Player{
+				ID:         adminPlayer1.ID,
+				Name:       "HIJACKED",
+				UserId:     regularUser.ID, // attacker's own id, spoofed in the body
+				MaxBitRate: 1,
+			}
+
+			// The ownership-restricted update matches no row owned by the attacker, so the write
+			// targets nothing and reports not-found rather than overwriting the victim's row.
+			err := regularRepo.Update(adminPlayer1.ID, &spoofed, "name", "user_id", "max_bit_rate")
+			Expect(err).To(Equal(rest.ErrNotFound))
+
+			// The victim's player must remain untouched.
+			stored, err := adminRepo.Get(adminPlayer1.ID)
+			Expect(err).To(BeNil())
+			Expect(*stored).To(Equal(adminPlayer1))
+		})
+
+		It("does not let a regular user reassign their own player to another user", func() {
+			// Owner updates their own player but tries to give it away to the admin. The update
+			// succeeds for the other fields, but user_id is never written, so ownership stays put.
+			reassign := regularPlayer
+			reassign.UserId = adminUser.ID
+			reassign.Name = "given-away"
+
+			err := regularRepo.Update(regularPlayer.ID, &reassign, "name", "user_id")
+			Expect(err).To(BeNil())
+
+			// Ownership must not have changed.
+			stored, err := adminRepo.Get(regularPlayer.ID)
+			Expect(err).To(BeNil())
+			Expect(stored.UserId).To(Equal(regularUser.ID))
+		})
+
+		It("does not let an admin reassign a player to another user", func() {
+			// Even an admin cannot change a player's owner via update.
+			reassign := regularPlayer
+			reassign.UserId = adminUser.ID
+			reassign.Name = "admin-renamed"
+
+			err := adminRepo.Update(regularPlayer.ID, &reassign, "name", "user_id")
+			Expect(err).To(BeNil())
+
+			// The name change applies, but ownership must not have moved.
+			stored, err := adminRepo.Get(regularPlayer.ID)
+			Expect(err).To(BeNil())
+			Expect(stored.Name).To(Equal("admin-renamed"))
+			Expect(stored.UserId).To(Equal(regularUser.ID))
+		})
+
+		It("lets the owner update their own player", func() {
+			update := regularPlayer
+			update.Name = "renamed-by-owner"
+
+			err := regularRepo.Update(regularPlayer.ID, &update, "name")
+			Expect(err).To(BeNil())
+
+			stored, err := adminRepo.Get(regularPlayer.ID)
+			Expect(err).To(BeNil())
+			Expect(stored.Name).To(Equal("renamed-by-owner"))
+			Expect(stored.UserId).To(Equal(regularUser.ID))
+		})
+
+		It("returns not found when updating a nonexistent player", func() {
+			ghost := model.Player{ID: "does-not-exist", Name: "ghost", UserId: regularUser.ID}
+			err := regularRepo.Update("does-not-exist", &ghost, "name")
+			Expect(err).To(Equal(rest.ErrNotFound))
+		})
+	})
 })

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -53,6 +53,10 @@ func (r *shareRepository) checkOwnership(id string) error {
 	return nil
 }
 
+// TODO: this still uses the legacy checkOwnership SELECT-then-delete pattern (a TOCTOU window),
+// the same shape removed from Update. Once a base-repo deleteOwned exists (built on ownerFilter,
+// mirroring updateOwned), route Delete through it and drop checkOwnership entirely. playerRepository
+// .Delete (which restricts via addRestriction) should adopt the same primitive.
 func (r *shareRepository) Delete(id string) error {
 	if err := r.checkOwnership(id); err != nil {
 		return err

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -172,11 +172,9 @@ func (r *shareRepository) Update(id string, entity any, cols ...string) error {
 	s := entity.(*model.Share)
 	s.ID = id
 	s.UpdatedAt = time.Now()
-	cols = append(cols, "updated_at")
-	// updateOwned restricts the write to a row owned by the caller (unless admin) and never writes
-	// user_id, so a user cannot target another user's share by id, nor reassign ownership via the
-	// request body. It returns ErrPermissionDenied for a row owned by someone else and ErrNotFound
-	// when the id is missing, preserving the previous 403/404 distinction.
+	if len(cols) > 0 {
+		cols = append(cols, "updated_at")
+	}
 	return r.updateOwned(id, s, cols...)
 }
 

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -166,17 +166,14 @@ func sortByIdPosition(mfs model.MediaFiles, ids []string) model.MediaFiles {
 
 func (r *shareRepository) Update(id string, entity any, cols ...string) error {
 	s := entity.(*model.Share)
-	if err := r.checkOwnership(id); err != nil {
-		return err
-	}
 	s.ID = id
 	s.UpdatedAt = time.Now()
 	cols = append(cols, "updated_at")
-	_, err := r.put(id, s, cols...)
-	if errors.Is(err, model.ErrNotFound) {
-		return rest.ErrNotFound
-	}
-	return err
+	// updateOwned restricts the write to a row owned by the caller (unless admin) and never writes
+	// user_id, so a user cannot target another user's share by id, nor reassign ownership via the
+	// request body. It returns ErrPermissionDenied for a row owned by someone else and ErrNotFound
+	// when the id is missing, preserving the previous 403/404 distinction.
+	return r.updateOwned(id, s, cols...)
 }
 
 func (r *shareRepository) Save(entity any) (string, error) {

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -216,6 +216,27 @@ var _ = Describe("ShareRepository", func() {
 				err := repo.(rest.Persistable).Update("headless-upd-share", &model.Share{Description: "Headless"}, "description")
 				Expect(err).ToNot(HaveOccurred())
 			})
+
+			It("returns not found when updating a nonexistent share", func() {
+				ctx := request.WithUser(log.NewContext(context.TODO()), ownerUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Update("does-not-exist", &model.Share{Description: "Ghost"}, "description")
+				Expect(err).To(Equal(rest.ErrNotFound))
+			})
+
+			It("does not let an owner reassign their share to another user", func() {
+				insertShare("reassign-share", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), ownerUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				err := repo.(rest.Persistable).Update("reassign-share",
+					&model.Share{UserID: otherUser.ID, Description: "Given away"}, "user_id", "description")
+				Expect(err).ToNot(HaveOccurred())
+
+				// Ownership must not have moved, even though user_id was passed in the body and cols.
+				got, err := repo.(rest.Repository).Read("reassign-share")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(got.(*model.Share).UserID).To(Equal(ownerUser.ID))
+			})
 		})
 	})
 })

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -224,6 +224,23 @@ var _ = Describe("ShareRepository", func() {
 				Expect(err).To(Equal(rest.ErrNotFound))
 			})
 
+			It("updates all columns when no specific columns are given", func() {
+				insertShare("all-cols-share", ownerUser.ID)
+				ctx := request.WithUser(log.NewContext(context.TODO()), ownerUser)
+				repo := NewShareRepository(ctx, GetDBXBuilder())
+				// No cols: the update must write every column, not just updated_at.
+				err := repo.(rest.Persistable).Update("all-cols-share",
+					&model.Share{Description: "All Updated", MaxBitRate: 192, ResourceType: "album", ResourceIDs: "2002"})
+				Expect(err).ToNot(HaveOccurred())
+
+				got, err := repo.(rest.Repository).Read("all-cols-share")
+				Expect(err).ToNot(HaveOccurred())
+				share := got.(*model.Share)
+				Expect(share.Description).To(Equal("All Updated"))
+				Expect(share.MaxBitRate).To(Equal(192))
+				Expect(share.ResourceType).To(Equal("album"))
+			})
+
 			It("does not let an owner reassign their share to another user", func() {
 				insertShare("reassign-share", ownerUser.ID)
 				ctx := request.WithUser(log.NewContext(context.TODO()), ownerUser)

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	. "github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -382,6 +383,34 @@ func (r sqlRepository) exists(cond Sqlizer) (bool, error) {
 	return res.Exist > 0, err
 }
 
+// updateOwned performs an atomic, ownership-restricted update of the row identified by id, for
+// repositories whose table has a user_id column. Non-admins can only update rows they own: the
+// ownership predicate is part of the UPDATE's WHERE clause, so a row owned by another user simply
+// does not match and no write happens. Ownership itself is immutable here: user_id is never written,
+// so no caller (admin included) can reassign a row to a different owner via an update. Unlike put,
+// it never falls through to an INSERT, so a non-matching id (missing or not owned) returns
+// rest.ErrNotFound instead of creating a row.
+func (r sqlRepository) updateOwned(id string, m any, colsToUpdate ...string) error {
+	values, err := toSQLArgs(m)
+	if err != nil {
+		return fmt.Errorf("error preparing values to write to DB: %w", err)
+	}
+	updateValues := filterUpdateValues(values, id, colsToUpdate...)
+	delete(updateValues, "user_id") // ownership is immutable on update
+	update := Update(r.tableName).Where(Eq{"id": id}).SetMap(updateValues)
+	if usr := loggedUser(r.ctx); !usr.IsAdmin && usr.ID != invalidUserId {
+		update = update.Where(Eq{"user_id": usr.ID})
+	}
+	count, err := r.executeSQL(update)
+	if err != nil {
+		return err
+	}
+	if count == 0 {
+		return rest.ErrNotFound
+	}
+	return nil
+}
+
 func (r sqlRepository) count(countQuery SelectBuilder, options ...model.QueryOptions) (int64, error) {
 	countQuery = countQuery.
 		RemoveColumns().Columns("count(distinct " + r.tableName + ".id) as count").
@@ -408,6 +437,30 @@ func (r sqlRepository) putByMatch(filter Sqlizer, id string, m any, colsToUpdate
 	return r.put(res.ID, m, colsToUpdate...)
 }
 
+// filterUpdateValues selects, from a marshaled column map, the values to write in an UPDATE on the
+// row identified by id: only the requested colsToUpdate (or all columns when none are specified),
+// dropping columns that must never be overwritten on update (created_at, birth_time).
+func filterUpdateValues(values map[string]any, id string, colsToUpdate ...string) map[string]any {
+	updateValues := map[string]any{}
+
+	// This is a map of the columns that need to be updated, if specified
+	c2upd := slice.ToMap(colsToUpdate, func(s string) (string, struct{}) {
+		return toSnakeCase(s), struct{}{}
+	})
+	for k, v := range values {
+		if _, found := c2upd[k]; len(c2upd) == 0 || found {
+			updateValues[k] = v
+		}
+	}
+
+	updateValues["id"] = id
+	delete(updateValues, "created_at")
+	// To avoid updating the media_file birth_time on each scan. Not the best solution, but it works for now
+	// TODO move to mediafile_repository when each repo has its own upsert method
+	delete(updateValues, "birth_time")
+	return updateValues
+}
+
 func (r sqlRepository) put(id string, m any, colsToUpdate ...string) (newId string, err error) {
 	values, err := toSQLArgs(m)
 	if err != nil {
@@ -415,24 +468,7 @@ func (r sqlRepository) put(id string, m any, colsToUpdate ...string) (newId stri
 	}
 	// If there's an ID, try to update first
 	if id != "" {
-		updateValues := map[string]any{}
-
-		// This is a map of the columns that need to be updated, if specified
-		c2upd := slice.ToMap(colsToUpdate, func(s string) (string, struct{}) {
-			return toSnakeCase(s), struct{}{}
-		})
-		for k, v := range values {
-			if _, found := c2upd[k]; len(c2upd) == 0 || found {
-				updateValues[k] = v
-			}
-		}
-
-		updateValues["id"] = id
-		delete(updateValues, "created_at")
-		// To avoid updating the media_file birth_time on each scan. Not the best solution, but it works for now
-		// TODO move to mediafile_repository when each repo has its own upsert method
-		delete(updateValues, "birth_time")
-		update := Update(r.tableName).Where(Eq{"id": id}).SetMap(updateValues)
+		update := Update(r.tableName).Where(Eq{"id": id}).SetMap(filterUpdateValues(values, id, colsToUpdate...))
 		count, err := r.executeSQL(update)
 		if err != nil {
 			return "", err

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -58,6 +58,16 @@ func loggedUser(ctx context.Context) *model.User {
 	}
 }
 
+// ownerFilter returns the predicate restricting access to rows owned by the logged-in user, for
+// tables with a user_id column. It returns nil for admins and for headless/system contexts (invalid
+// user), meaning "no ownership restriction". Callers should skip the WHERE clause when it is nil.
+func (r sqlRepository) ownerFilter() Sqlizer {
+	if usr := loggedUser(r.ctx); !usr.IsAdmin && usr.ID != invalidUserId {
+		return Eq{"user_id": usr.ID}
+	}
+	return nil
+}
+
 func (r *sqlRepository) registerModel(instance any, filters map[string]filterFunc) {
 	if r.tableName == "" {
 		r.tableName = strings.TrimPrefix(reflect.TypeOf(instance).String(), "*model.")
@@ -402,8 +412,8 @@ func (r sqlRepository) updateOwned(id string, m any, colsToUpdate ...string) err
 	updateValues := filterUpdateValues(values, id, colsToUpdate...)
 	delete(updateValues, "user_id") // ownership is immutable on update
 	update := Update(r.tableName).Where(Eq{"id": id}).SetMap(updateValues)
-	if usr := loggedUser(r.ctx); !usr.IsAdmin && usr.ID != invalidUserId {
-		update = update.Where(Eq{"user_id": usr.ID})
+	if owner := r.ownerFilter(); owner != nil {
+		update = update.Where(owner)
 	}
 	count, err := r.executeSQL(update)
 	if err != nil {

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -388,8 +388,12 @@ func (r sqlRepository) exists(cond Sqlizer) (bool, error) {
 // ownership predicate is part of the UPDATE's WHERE clause, so a row owned by another user simply
 // does not match and no write happens. Ownership itself is immutable here: user_id is never written,
 // so no caller (admin included) can reassign a row to a different owner via an update. Unlike put,
-// it never falls through to an INSERT, so a non-matching id (missing or not owned) returns
-// rest.ErrNotFound instead of creating a row.
+// it never falls through to an INSERT, so a non-matching id never creates a row.
+//
+// When the update matches no row it classifies the failure: if the row exists but is owned by
+// another user it returns rest.ErrPermissionDenied, otherwise rest.ErrNotFound. The write itself is
+// still atomic; the extra lookup happens only on the failure path (count == 0), where no write
+// occurred, so there is no TOCTOU on the update.
 func (r sqlRepository) updateOwned(id string, m any, colsToUpdate ...string) error {
 	values, err := toSQLArgs(m)
 	if err != nil {
@@ -406,6 +410,15 @@ func (r sqlRepository) updateOwned(id string, m any, colsToUpdate ...string) err
 		return err
 	}
 	if count == 0 {
+		// The update matched no row: either the id is missing, or it exists but is owned by
+		// someone else. Disambiguate to return the more accurate error.
+		exists, err := r.exists(Eq{"id": id})
+		if err != nil {
+			return err
+		}
+		if exists {
+			return rest.ErrPermissionDenied
+		}
 		return rest.ErrNotFound
 	}
 	return nil


### PR DESCRIPTION
### Description

Hardens ownership enforcement on `player` and `share` updates so a write can only ever touch a row the caller owns, and ownership itself can never be reassigned through an update.

Previously, update authorization and the write were two separate steps: the owner was checked (in some paths against the request body, in others via a preliminary `SELECT`), then the row was written targeting it by `id`. That left a gap where the authorized owner and the written row weren't guaranteed to be the same row, and where the persisted `user_id` could be overwritten.

This PR closes that gap by folding the ownership predicate directly into the `UPDATE`'s `WHERE` clause:

- **`updateOwned` (base repository)** — an atomic, ownership-restricted update. For non-admins the `user_id = caller` predicate is part of the `WHERE`, so a row owned by someone else simply doesn't match and no write happens. It never writes `user_id`, so ownership is immutable on update (no caller, admin included, can reassign a row's owner). Unlike `put`, it never falls through to an `INSERT`, so a non-matching `id` returns an error instead of creating a row. On a non-match it disambiguates *missing* (`ErrNotFound`/404) from *owned-by-another* (`ErrPermissionDenied`/403), with the extra lookup only on the failure path (no write occurred, so no TOCTOU).
- **`playerRepository.Update` / `shareRepository.Update`** now go through `updateOwned`. Share's previous separate ownership `SELECT` is dropped (one query on the happy path instead of two); the create paths keep their body-based check, which is correct for inserts.
- **`filterUpdateValues`** is extracted so `put` and `updateOwned` share one definition of the update-column filtering rule.
- **`ownerFilter` (base repository)** is extracted as the single canonical owner-restriction predicate. `updateOwned` and `playerRepository.addRestriction` both route through it, removing a latent divergence between two hand-written copies of the same rule (one didn't exempt the headless/system context). `playlistRepository.userFilter` is intentionally left alone — it encodes a different policy (public-visibility on the `owner_id` column).

A `TODO` is added on `shareRepository.Delete` noting the remaining legacy `checkOwnership` path could later be unified onto an `ownerFilter`-based `deleteOwned`, mirroring `updateOwned`.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Automated tests cover the behavior:

```bash
make test PKG=./persistence
```

The new/updated specs verify:

- **Owner update succeeds** — a user updating their own player/share row applies the change.
- **Admin update succeeds** — admins can update any row, but still cannot reassign ownership (`user_id` is never written).
- **Cross-owner update is rejected** — a non-admin updating a row owned by another user gets `ErrPermissionDenied` (403) and the target row is left untouched.
- **Ownership is immutable** — passing a different `user_id` in the body/columns does not move ownership.
- **Missing id** — updating a nonexistent `id` returns `ErrNotFound` (404) rather than creating a row.
- **Headless context** — system/no-user contexts retain full access.

Manual check via the native API: as a regular user, attempt `PUT /api/player/{id}` (and the equivalent share update) against a row you don't own — the write should be rejected and the stored row unchanged.

### Additional Notes

- Behavior change worth noting for reviewers: a non-owner update now resolves to `403` where some paths previously surfaced a different error; the `ownerFilter` extraction also makes headless/system contexts consistently unrestricted on the player REST paths. The REST list/read/delete paths affected are only reachable through the authenticated native API, so there is no reachable production behavior change from that consolidation — it removes a latent inconsistency.
- The branch builds on an earlier commit that introduced `updateOwned` for players; this PR carries the full ownership-enforcement story for both `player` and `share`, plus the shared-predicate refactor.
- Follow-up (captured as a `TODO`, not in this PR): consolidate the `Delete` ownership paths onto a base-repo `deleteOwned`, which would let `shareRepository.checkOwnership` be removed entirely.
