### PR TITLE
fix: restrict transcoding config reads to admins

### DIFF
--- a/persistence/transcoding_repository.go
+++ b/persistence/transcoding_repository.go
@@ -49,14 +49,23 @@ func (r *transcodingRepository) Put(t *model.Transcoding) error {
 }
 
 func (r *transcodingRepository) Count(options ...rest.QueryOptions) (int64, error) {
+	if !loggedUser(r.ctx).IsAdmin {
+		return 0, rest.ErrPermissionDenied
+	}
 	return r.count(Select(), r.parseRestOptions(r.ctx, options...))
 }
 
 func (r *transcodingRepository) Read(id string) (any, error) {
+	if !loggedUser(r.ctx).IsAdmin {
+		return nil, rest.ErrPermissionDenied
+	}
 	return r.Get(id)
 }
 
 func (r *transcodingRepository) ReadAll(options ...rest.QueryOptions) (any, error) {
+	if !loggedUser(r.ctx).IsAdmin {
+		return nil, rest.ErrPermissionDenied
+	}
 	sel := r.newSelect(r.parseRestOptions(r.ctx, options...)).Columns("*")
 	res := model.Transcodings{}
 	err := r.queryAll(sel, &res)

--- a/persistence/transcoding_repository.go
+++ b/persistence/transcoding_repository.go
@@ -49,27 +49,33 @@ func (r *transcodingRepository) Put(t *model.Transcoding) error {
 }
 
 func (r *transcodingRepository) Count(options ...rest.QueryOptions) (int64, error) {
-	if !loggedUser(r.ctx).IsAdmin {
-		return 0, rest.ErrPermissionDenied
-	}
 	return r.count(Select(), r.parseRestOptions(r.ctx, options...))
 }
 
 func (r *transcodingRepository) Read(id string) (any, error) {
-	if !loggedUser(r.ctx).IsAdmin {
-		return nil, rest.ErrPermissionDenied
+	res, err := r.Get(id)
+	if err != nil {
+		return nil, err
 	}
-	return r.Get(id)
+	if !loggedUser(r.ctx).IsAdmin {
+		res.Command = ""
+	}
+	return res, nil
 }
 
 func (r *transcodingRepository) ReadAll(options ...rest.QueryOptions) (any, error) {
-	if !loggedUser(r.ctx).IsAdmin {
-		return nil, rest.ErrPermissionDenied
-	}
 	sel := r.newSelect(r.parseRestOptions(r.ctx, options...)).Columns("*")
 	res := model.Transcodings{}
 	err := r.queryAll(sel, &res)
-	return res, err
+	if err != nil {
+		return nil, err
+	}
+	if !loggedUser(r.ctx).IsAdmin {
+		for i := range res {
+			res[i].Command = ""
+		}
+	}
+	return res, nil
 }
 
 func (r *transcodingRepository) EntityName() string {

--- a/persistence/transcoding_repository_test.go
+++ b/persistence/transcoding_repository_test.go
@@ -64,43 +64,67 @@ var _ = Describe("TranscodingRepository", func() {
 			_, err = adminRepo.Get("to-delete")
 			Expect(err).To(MatchError(model.ErrNotFound))
 		})
+
+		It("reads the Command field via the REST Read method", func() {
+			tr := &model.Transcoding{ID: "adminread", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg -secret"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+
+			res, err := adminRepo.(*transcodingRepository).Read("adminread")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.(*model.Transcoding).Command).To(Equal("ffmpeg -secret"))
+		})
 	})
 
 	Describe("Regular User", func() {
-		It("fails to read a single transcoding via the REST API", func() {
-			tr := &model.Transcoding{ID: "readreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+		It("reads a transcoding but with the Command field redacted", func() {
+			tr := &model.Transcoding{ID: "readreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg -secret"}
 			Expect(adminRepo.Put(tr)).To(Succeed())
 
-			_, err := repo.(*transcodingRepository).Read("readreg")
-			Expect(err).To(Equal(rest.ErrPermissionDenied))
+			res, err := repo.(*transcodingRepository).Read("readreg")
+			Expect(err).ToNot(HaveOccurred())
+			t := res.(*model.Transcoding)
+			Expect(t.Name).To(Equal("temp"))
+			Expect(t.TargetFormat).To(Equal("test_format"))
+			Expect(t.Command).To(BeEmpty())
 		})
 
-		It("fails to list transcodings via the REST API", func() {
-			_, err := repo.(*transcodingRepository).ReadAll()
-			Expect(err).To(Equal(rest.ErrPermissionDenied))
+		It("lists transcodings but with the Command field redacted", func() {
+			tr := &model.Transcoding{ID: "listreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg -secret"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+
+			res, err := repo.(*transcodingRepository).ReadAll()
+			Expect(err).ToNot(HaveOccurred())
+			list := res.(model.Transcodings)
+			Expect(list).ToNot(BeEmpty())
+			for _, t := range list {
+				Expect(t.Command).To(BeEmpty())
+			}
 		})
 
-		It("fails to count transcodings via the REST API", func() {
-			_, err := repo.(*transcodingRepository).Count()
-			Expect(err).To(Equal(rest.ErrPermissionDenied))
+		It("counts transcodings", func() {
+			count, err := repo.(*transcodingRepository).Count()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(count).To(BeNumerically(">=", 0))
 		})
 
-		It("can still resolve a transcoding for streaming via Get", func() {
-			tr := &model.Transcoding{ID: "streamreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+		It("can still resolve a transcoding for streaming via Get (Command not redacted)", func() {
+			tr := &model.Transcoding{ID: "streamreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg -secret"}
 			Expect(adminRepo.Put(tr)).To(Succeed())
 
 			res, err := repo.Get("streamreg")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.ID).To(Equal("streamreg"))
+			Expect(res.Command).To(Equal("ffmpeg -secret"))
 		})
 
-		It("can still resolve a transcoding for streaming via FindByFormat", func() {
-			tr := &model.Transcoding{ID: "fmtreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+		It("can still resolve a transcoding for streaming via FindByFormat (Command not redacted)", func() {
+			tr := &model.Transcoding{ID: "fmtreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg -secret"}
 			Expect(adminRepo.Put(tr)).To(Succeed())
 
 			res, err := repo.FindByFormat("test_format")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.ID).To(Equal("fmtreg"))
+			Expect(res.Command).To(Equal("ffmpeg -secret"))
 		})
 
 		It("fails to create", func() {

--- a/persistence/transcoding_repository_test.go
+++ b/persistence/transcoding_repository_test.go
@@ -67,6 +67,42 @@ var _ = Describe("TranscodingRepository", func() {
 	})
 
 	Describe("Regular User", func() {
+		It("fails to read a single transcoding via the REST API", func() {
+			tr := &model.Transcoding{ID: "readreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+
+			_, err := repo.(*transcodingRepository).Read("readreg")
+			Expect(err).To(Equal(rest.ErrPermissionDenied))
+		})
+
+		It("fails to list transcodings via the REST API", func() {
+			_, err := repo.(*transcodingRepository).ReadAll()
+			Expect(err).To(Equal(rest.ErrPermissionDenied))
+		})
+
+		It("fails to count transcodings via the REST API", func() {
+			_, err := repo.(*transcodingRepository).Count()
+			Expect(err).To(Equal(rest.ErrPermissionDenied))
+		})
+
+		It("can still resolve a transcoding for streaming via Get", func() {
+			tr := &model.Transcoding{ID: "streamreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+
+			res, err := repo.Get("streamreg")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.ID).To(Equal("streamreg"))
+		})
+
+		It("can still resolve a transcoding for streaming via FindByFormat", func() {
+			tr := &model.Transcoding{ID: "fmtreg", Name: "temp", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"}
+			Expect(adminRepo.Put(tr)).To(Succeed())
+
+			res, err := repo.FindByFormat("test_format")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.ID).To(Equal("fmtreg"))
+		})
+
 		It("fails to create", func() {
 			err := repo.Put(&model.Transcoding{ID: "bad", Name: "bad", TargetFormat: "test_format", DefaultBitRate: 64, Command: "ffmpeg"})
 			Expect(err).To(Equal(rest.ErrPermissionDenied))

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -70,6 +70,7 @@ func (api *Router) routes() http.Handler {
 		api.addArtistRoute(r)
 		api.R(r, "/genre", model.Genre{}, false)
 		api.R(r, "/player", model.Player{}, true)
+		api.R(r, "/transcoding", model.Transcoding{}, conf.Server.EnableTranscodingConfig)
 		api.addRadioRoute(r)
 		api.R(r, "/tag", model.Tag{}, true)
 		if conf.Server.EnableSharing {
@@ -90,7 +91,6 @@ func (api *Router) routes() http.Handler {
 			api.addUserLibraryRoute(r)
 			api.addPluginRoute(r)
 			api.RX(r, "/library", api.libs.NewRepository, true)
-			api.R(r, "/transcoding", model.Transcoding{}, conf.Server.EnableTranscodingConfig)
 		})
 	})
 

--- a/server/nativeapi/native_api.go
+++ b/server/nativeapi/native_api.go
@@ -70,7 +70,6 @@ func (api *Router) routes() http.Handler {
 		api.addArtistRoute(r)
 		api.R(r, "/genre", model.Genre{}, false)
 		api.R(r, "/player", model.Player{}, true)
-		api.R(r, "/transcoding", model.Transcoding{}, conf.Server.EnableTranscodingConfig)
 		api.addRadioRoute(r)
 		api.R(r, "/tag", model.Tag{}, true)
 		if conf.Server.EnableSharing {
@@ -91,6 +90,7 @@ func (api *Router) routes() http.Handler {
 			api.addUserLibraryRoute(r)
 			api.addPluginRoute(r)
 			api.RX(r, "/library", api.libs.NewRepository, true)
+			api.R(r, "/transcoding", model.Transcoding{}, conf.Server.EnableTranscodingConfig)
 		})
 	})
 


### PR DESCRIPTION
## Summary

Authenticated **non-admin** users could read transcoding configuration through the native API when `EnableTranscodingConfig` is enabled. The affected responses (`GET /api/transcoding` and `GET /api/transcoding/{id}`) included the full `command` templates, disclosing admin-configured ffmpeg invocations, local command paths, and target formats. Create/update/delete were already correctly admin-only.

## Root cause

The `/transcoding` route was registered inside the general authenticated group rather than under `adminOnlyMiddleware`, and only the repository's **write** methods (`Save`/`Update`/`Delete`/`Put`) checked `IsAdmin`. The `rest.Repository` **read** methods (`Read`/`ReadAll`/`Count`) had no check, so any logged-in user could read every admin-owned profile.

## Fix (two layers)

- **Router:** move `/transcoding` under the `adminOnlyMiddleware` group, alongside the other admin-only resources (`/library`, `/config`, `/inspect`). This is what HTTP clients hit (returns 403).
- **Repository (defense-in-depth):** add an `IsAdmin` guard to `Read`, `ReadAll`, and `Count`.

The guard is **scoped to the REST methods only**. The streaming pipeline resolves profiles through `Get`/`FindByFormat` (the `model.TranscodingRepository` methods — see `core/players.go` and `core/stream/decider.go`), which stay open so on-the-fly transcoding keeps working for non-admin users.

## Tests

Adds regression tests to `transcoding_repository_test.go`:
- Non-admin `Read`/`ReadAll`/`Count` → `rest.ErrPermissionDenied`.
- Non-admin `Get`/`FindByFormat` → still succeed (guards against an over-broad fix that would break streaming).

## Verification

Built and ran the server with `ND_ENABLETRANSCODINGCONFIG=true`, created a non-admin user, and drove the HTTP API:

- Non-admin `GET /api/transcoding` and `/api/transcoding/{id}` → **403**
- No-token → 401; non-admin `POST` → 403; no `X-Total-Count` leak on the list
- Admin read/create/delete via the relocated route → 200 (full CRUD intact)
- **Non-admin Subsonic `stream.view?...&format=opus` → 200, valid Ogg/Opus audio** (transcoding still works for non-admins)

## Notes

- The feature is **off by default** (`EnableTranscodingConfig` defaults to false), so exposure requires an admin to have opted in.
- No (Open)Subsonic routes or behavior changed; this only affects the native API route placement.