### PR TITLE
fix(nativeapi): make /api/song path filter work and use startsWith

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -104,6 +104,7 @@ var mediaFileFilter = sync.OnceValue(func() map[string]filterFunc {
 		"missing":    booleanFilter,
 		"artists_id": artistFilter,
 		"library_id": libraryIdFilter,
+		"path":       startsWithFilter("media_file.path"),
 	}
 	// Add all album tags as filters
 	for tag := range model.TagMappings() {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -524,6 +524,34 @@ var _ = Describe("MediaRepository", func() {
 				}
 			})
 		})
+
+		Describe("path", func() {
+			It("matches files whose path starts with the given prefix", func() {
+				res, err := mr.(model.ResourceRepository).ReadAll(rest.QueryOptions{
+					Filters: map[string]any{"path": "test/"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				files := res.(model.MediaFiles)
+
+				var found bool
+				for _, f := range files {
+					Expect(f.Path).To(HavePrefix("test/"))
+					if f.ID == mfWithoutAnnotation.ID {
+						found = true
+					}
+				}
+				Expect(found).To(BeTrue(), "MediaFile with matching path prefix should be included")
+			})
+
+			It("excludes files whose path does not start with the given prefix", func() {
+				res, err := mr.(model.ResourceRepository).ReadAll(rest.QueryOptions{
+					Filters: map[string]any{"path": "no-such-prefix/"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				files := res.(model.MediaFiles)
+				Expect(files).To(BeEmpty())
+			})
+		})
 	})
 
 	Describe("Search", func() {

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -197,15 +197,6 @@ func (r sqlRepository) applyFilters(sq SelectBuilder, options ...model.QueryOpti
 	return sq
 }
 
-func (r *sqlRepository) withTableName(filter filterFunc) filterFunc {
-	return func(field string, value any) Sqlizer {
-		if r.tableName != "" {
-			field = r.tableName + "." + field
-		}
-		return filter(field, value)
-	}
-}
-
 // libraryIdFilter is a filter function to be added to resources that have a library_id column.
 func libraryIdFilter(_ string, value any) Sqlizer {
 	return Eq{"library_id": value}

--- a/persistence/sql_restful.go
+++ b/persistence/sql_restful.go
@@ -46,7 +46,7 @@ func (r *sqlRepository) parseRestFilters(ctx context.Context, options rest.Query
 			continue
 		}
 		// Default to a "starts with" filter
-		filters = append(filters, startsWithFilter(f, v))
+		filters = append(filters, startsWithFilter(f)("", v))
 	}
 	return filters
 }
@@ -91,8 +91,10 @@ func eqFilter(field string, value any) Sqlizer {
 	return Eq{field: value}
 }
 
-func startsWithFilter(field string, value any) Sqlizer {
-	return Like{field: fmt.Sprintf("%s%%", value)}
+func startsWithFilter(field string) func(string, any) Sqlizer {
+	return func(_ string, value any) Sqlizer {
+		return Like{field: fmt.Sprintf("%s%%", value)}
+	}
 }
 
 func containsFilter(field string) func(string, any) Sqlizer {

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -59,7 +59,7 @@ func NewUserRepository(ctx context.Context, db dbx.Builder) model.UserRepository
 	r.registerModel(&model.User{}, map[string]filterFunc{
 		"id":       idFilter(r.tableName),
 		"password": invalidFilter(ctx),
-		"name":     r.withTableName(startsWithFilter),
+		"name":     startsWithFilter(r.tableName + ".name"),
 	})
 	once.Do(func() {
 		_ = r.initPasswordEncryptionKey()

--- a/persistence/user_repository_test.go
+++ b/persistence/user_repository_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
+	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -204,6 +205,52 @@ var _ = Describe("UserRepository", func() {
 				err := validatePasswordChange(&user, loggedUser)
 				Expect(err).ToNot(HaveOccurred())
 			})
+		})
+	})
+
+	Describe("ReadAll name filter", func() {
+		var adminRepo model.ResourceRepository
+
+		BeforeEach(func() {
+			adminCtx := request.WithUser(GinkgoT().Context(), model.User{ID: "admin-id", UserName: "admin", IsAdmin: true})
+			adminRepo = NewUserRepository(adminCtx, GetDBXBuilder()).(model.ResourceRepository)
+
+			for _, u := range []model.User{
+				{ID: "filter-alice", UserName: "alice_filter", Name: "Alice Filter", NewPassword: "x"},
+				{ID: "filter-bob", UserName: "bob_filter", Name: "Bob Filter", NewPassword: "x"},
+			} {
+				Expect(adminRepo.(model.UserRepository).Put(&u)).To(Succeed())
+			}
+		})
+
+		AfterEach(func() {
+			ur := adminRepo.(model.UserRepository)
+			_ = ur.Delete("filter-alice")
+			_ = ur.Delete("filter-bob")
+		})
+
+		It("matches users whose name starts with the given prefix", func() {
+			res, err := adminRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"name": "Alice"}})
+			Expect(err).ToNot(HaveOccurred())
+			users := res.(model.Users)
+
+			var names []string
+			for _, u := range users {
+				names = append(names, u.Name)
+			}
+			Expect(names).To(ContainElement("Alice Filter"))
+			Expect(names).ToNot(ContainElement("Bob Filter"))
+		})
+
+		It("does not match names by mid-string substring (startsWith, not contains)", func() {
+			res, err := adminRepo.ReadAll(rest.QueryOptions{Filters: map[string]any{"name": "Filter"}})
+			Expect(err).ToNot(HaveOccurred())
+			users := res.(model.Users)
+
+			for _, u := range users {
+				Expect(u.ID).ToNot(Or(Equal("filter-alice"), Equal("filter-bob")),
+					"a mid-string substring should not match a startsWith filter")
+			}
 		})
 	})
 


### PR DESCRIPTION
### Description

`GET /api/song?path=...` returned **HTTP 500** with `ambiguous column name: path`. The `path` param was never registered as a filter, so it fell through to a default unqualified `path LIKE ?` — ambiguous because the song query joins the `library` table, which also has a `path` column.

This PR registers a `path` filter qualified to `media_file.path`, using **startsWith** semantics (`LIKE arg || '%'`) against the library-relative path. Along the way, `startsWithFilter` was refactored to take a bound field and return a `filterFunc` (mirroring `containsFilter`), which let the filter be registered inline and removed the now-unused `withTableName` helper. The user `name` filter, which relied on that helper, is now qualified directly as `user.name`.

### Related Issues

<!-- No tracked issue. -->

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. `GET /api/song?path=1%25` (the original repro) → previously HTTP 500, now HTTP 200.
2. `GET /api/song?path=<library-relative-prefix>/` → returns only songs whose path starts with that prefix.
3. A mid-path substring (not a leading prefix) → empty list, confirming startsWith (not contains).
4. `GET /api/user?name=<prefix>` (admin) → users whose name starts with the prefix.

### Additional Notes

- Behavior is intentionally **startsWith** on the **library-relative** path stored in `media_file.path`, not the absolute filesystem path.
- Native-API-only — no (Open)Subsonic routes or behavior are affected.
