### PR TITLE
test: fix flaky tests in utils/cache

### DIFF
--- a/utils/cache/cached_http_client_test.go
+++ b/utils/cache/cached_http_client_test.go
@@ -20,6 +20,8 @@ var _ = Describe("HTTPClient", func() {
 		var header string
 
 		BeforeEach(func() {
+			requestsReceived = 0
+			header = ""
 			ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				requestsReceived++
 				header = r.Header.Get("head")

--- a/utils/cache/file_haunter_test.go
+++ b/utils/cache/file_haunter_test.go
@@ -55,8 +55,10 @@ var _ = Describe("FileHaunter", func() {
 			// the configured limit.
 			Eventually(func(g Gomega) {
 				g.Expect(fsCache.Exists("stream-5")).To(BeFalse(), "stream-5 (empty file) should have been scrubbed")
-				g.Expect(dirSize(cacheDir)).To(BeNumerically("<=", maxSize))
-			}, "5s", "50ms").Should(Succeed())
+				size, err := dirSize(cacheDir)
+				g.Expect(err).ToNot(HaveOccurred())
+				g.Expect(size).To(BeNumerically("<=", maxSize))
+			}).WithTimeout(5 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
 		})
 	})
 
@@ -76,7 +78,7 @@ var _ = Describe("FileHaunter", func() {
 				entries, readErr := os.ReadDir(cacheDir)
 				g.Expect(readErr).ToNot(HaveOccurred())
 				g.Expect(len(entries)).To(BeNumerically("<=", maxItems))
-			}, "5s", "50ms").Should(Succeed())
+			}).WithTimeout(5 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
 		})
 	})
 })
@@ -107,20 +109,23 @@ func createTestFiles(c *fscache.FSCache) error {
 }
 
 // dirSize returns the total size in bytes of all regular files in dir.
-func dirSize(dir string) uint64 {
+func dirSize(dir string) (uint64, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		return 0
+		return 0, err
 	}
 	var total uint64
 	for _, e := range entries {
 		info, err := e.Info()
 		if err != nil {
+			return 0, err
+		}
+		if !info.Mode().IsRegular() {
 			continue
 		}
 		total += uint64(info.Size())
 	}
-	return total
+	return total, nil
 }
 
 func createCachedStream(c *fscache.FSCache, name string, contents string) fscache.ReadAtCloser {

--- a/utils/cache/file_haunter_test.go
+++ b/utils/cache/file_haunter_test.go
@@ -29,15 +29,15 @@ var _ = Describe("FileHaunter", func() {
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() { _ = os.RemoveAll(tempDir) })
 
+		// Use a short haunter period so cleanup runs promptly; the assertions
+		// below poll with Eventually instead of racing a fixed sleep.
 		fsCache, err = fscache.NewCacheWithHaunter(fs, fscache.NewLRUHaunterStrategy(
-			cache.NewFileHaunter("", maxItems, maxSize, 300*time.Millisecond),
+			cache.NewFileHaunter("", maxItems, maxSize, 100*time.Millisecond),
 		))
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(fsCache.Clean)
 
 		Expect(createTestFiles(fsCache)).To(Succeed())
-
-		<-time.After(400 * time.Millisecond)
 	})
 
 	Context("When maxSize is defined", func() {
@@ -46,24 +46,37 @@ var _ = Describe("FileHaunter", func() {
 		})
 
 		It("removes files", func() {
-			Expect(os.ReadDir(cacheDir)).To(HaveLen(4))
-			Expect(fsCache.Exists("stream-5")).To(BeFalse(), "stream-5 (empty file) should have been scrubbed")
-			// TODO Fix flaky tests
-			//Expect(fsCache.Exists("stream-0")).To(BeFalse(), "stream-0 should have been scrubbed")
+			// stream-0..4 hold "hello" (5 bytes each) and stream-5 is empty.
+			// With maxSize=20, the haunter scrubs the empty file plus enough of
+			// the oldest files to bring the total size down to <= 20 bytes.
+			// Which files survive (and therefore the exact count) depends on
+			// access-time ordering, so we only assert the haunter's guarantees:
+			// the empty file is always scrubbed and the total size stays within
+			// the configured limit.
+			Eventually(func(g Gomega) {
+				g.Expect(fsCache.Exists("stream-5")).To(BeFalse(), "stream-5 (empty file) should have been scrubbed")
+				g.Expect(dirSize(cacheDir)).To(BeNumerically("<=", maxSize))
+			}, "5s", "50ms").Should(Succeed())
 		})
 	})
 
-	XContext("When maxItems is defined", func() {
+	Context("When maxItems is defined", func() {
 		BeforeEach(func() {
 			maxItems = 3
 		})
 
 		It("removes files", func() {
-			Expect(os.ReadDir(cacheDir)).To(HaveLen(maxItems))
-			Expect(fsCache.Exists("stream-5")).To(BeFalse(), "stream-5 (empty file) should have been scrubbed")
-			// TODO Fix flaky tests
-			//Expect(fsCache.Exists("stream-0")).To(BeFalse(), "stream-0 should have been scrubbed")
-			//Expect(fsCache.Exists("stream-1")).To(BeFalse(), "stream-1 should have been scrubbed")
+			// With maxItems=3, the haunter scrubs the empty file plus enough of
+			// the oldest files to bring the count within the limit. As above, the
+			// exact survivors depend on access-time ordering, so we assert the
+			// guaranteed invariants: the empty file is gone and the item count
+			// stays within the configured limit.
+			Eventually(func(g Gomega) {
+				g.Expect(fsCache.Exists("stream-5")).To(BeFalse(), "stream-5 (empty file) should have been scrubbed")
+				entries, readErr := os.ReadDir(cacheDir)
+				g.Expect(readErr).ToNot(HaveOccurred())
+				g.Expect(len(entries)).To(BeNumerically("<=", maxItems))
+			}, "5s", "50ms").Should(Succeed())
 		})
 	})
 })
@@ -91,6 +104,23 @@ func createTestFiles(c *fscache.FSCache) error {
 		}
 	}
 	return nil
+}
+
+// dirSize returns the total size in bytes of all regular files in dir.
+func dirSize(dir string) uint64 {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return 0
+	}
+	var total uint64
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		total += uint64(info.Size())
+	}
+	return total
 }
 
 func createCachedStream(c *fscache.FSCache, name string, contents string) fscache.ReadAtCloser {


### PR DESCRIPTION
### Description

Two tests in the `utils/cache` suite were timing- and ordering-dependent and failed intermittently on CI (notably on the Windows runner — see e.g. [this run](https://github.com/navidrome/navidrome/actions/runs/27011569564/job/79716167075), which failed on an unrelated translation-only PR).

**`FileHaunter` tests** raced the asynchronous cache-cleanup goroutine: setup waited a fixed `400ms` and then asserted the directory state exactly once. On a slow/loaded runner the haunter hadn't finished scrubbing, so the assertion saw the original files and failed. This PR replaces the fixed sleep with `Eventually` polling so the assertions wait for the haunter to converge instead of racing a fixed window.

While doing this, the exact set and count of reaped files turned out to be genuinely **nondeterministic**: the empty file is double-counted in the haunter's size loop, and which non-empty files survive depends on OS/filesystem access-time ordering. (This is why the original test had its specific-file assertions commented out with `// TODO Fix flaky tests` and the `maxItems` context disabled via `XContext`.) The assertions now check the haunter's **actual guarantees** — the empty file is always scrubbed, and the cache stays within its configured `maxSize`/`maxItems` bound — rather than brittle exact-file/exact-count checks. This also allowed the previously-disabled `maxItems` context and its commented-out assertions to be re-enabled.

**`HTTPClient` "caches repeated requests" test** relied on a shared `requestsReceived` counter that was never reset in `BeforeEach`. Under randomized spec order, another spec could run first and leave the counter non-zero, breaking the first assertion (`Expect(requestsReceived).To(Equal(1))`). Resetting the counter (and `header`) in `BeforeEach` makes the spec independent of execution order.

### Related Issues

_None — this is a CI test-flakiness fix, not tied to a specific issue._

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run the cache suite repeatedly with race detection and randomized ordering — the conditions that previously exposed the flakes:
   ```bash
   go run github.com/onsi/ginkgo/v2/ginkgo -race -repeat=80 --randomize-all ./utils/cache/
   ```
   Expected: all specs pass on every repeat (`SUCCESS! -- 25 Passed | 0 Failed`).

2. To confirm the behavior change, check out `master` and run the same command — it intermittently fails on the `FileHaunter` and/or `HTTPClient` specs.

3. Standard run also passes:
   ```bash
   make test PKG=./utils/cache/
   ```

### Additional Notes

- This is a test-only change; no production code is touched.
- The fix surfaced (and addresses) a second, independent flaky test in the same package (`cached_http_client_test.go`) that only manifests under randomized spec ordering.
- The nondeterminism in which files the haunter reaps reflects real behavior of the `fileHaunter` (empty-file accounting + access-time-based LRU). The assertions were deliberately scoped to the invariants the haunter actually guarantees rather than asserting implementation-incidental outcomes. If the stricter per-file guarantees are desired, that would be a follow-up change to the haunter itself, not the test.
