### PR TITLE
feat(ui): rate the current track from the player toolbar - #5569

### DIFF
--- a/ui/src/audioplayer/PlayerToolbar.jsx
+++ b/ui/src/audioplayer/PlayerToolbar.jsx
@@ -5,10 +5,11 @@ import { GlobalHotKeys } from 'react-hotkeys'
 import IconButton from '@material-ui/core/IconButton'
 import { useMediaQuery } from '@material-ui/core'
 import { RiSaveLine } from 'react-icons/ri'
-import { LoveButton, useToggleLove } from '../common'
+import { LoveButton, RatingField, useToggleLove } from '../common'
 import { openSaveQueueDialog } from '../actions'
 import { keyMap } from '../hotkeys'
 import { makeStyles } from '@material-ui/core/styles'
+import config from '../config'
 
 const useStyles = makeStyles((theme) => ({
   toolbar: {
@@ -50,6 +51,10 @@ const useStyles = makeStyles((theme) => ({
   },
   mobileIcon: {
     fontSize: '18px',
+    display: 'flex',
+    alignItems: 'center',
+  },
+  rating: {
     display: 'flex',
     alignItems: 'center',
   },
@@ -99,16 +104,34 @@ const PlayerToolbar = ({ id, isRadio }) => {
     />
   )
 
+  // Inline star rating for the currently-playing track. Only shown when star
+  // rating is enabled and we have a real (non-radio) song loaded. `alwaysVisible`
+  // keeps the empty stars on screen so an unrated track can be rated in place.
+  const ratingControl =
+    config.enableStarRating && !isRadio && !!id && data ? (
+      <RatingField
+        record={data}
+        resource={'song'}
+        size={'small'}
+        alwaysVisible
+        className={classes.rating}
+      />
+    ) : null
+
   return (
     <>
       <GlobalHotKeys keyMap={keyMap} handlers={handlers} allowChanges />
       {isDesktop ? (
         <li className={`${listItemClass} item`}>
+          {ratingControl}
           {saveQueueButton}
           {loveButton}
         </li>
       ) : (
         <>
+          {ratingControl && (
+            <li className={`${listItemClass} item`}>{ratingControl}</li>
+          )}
           <li className={`${listItemClass} item`}>{saveQueueButton}</li>
           <li className={`${listItemClass} item`}>{loveButton}</li>
         </>

--- a/ui/src/audioplayer/PlayerToolbar.test.jsx
+++ b/ui/src/audioplayer/PlayerToolbar.test.jsx
@@ -30,6 +30,11 @@ vi.mock('../common', () => ({
       Love
     </button>
   ),
+  RatingField: ({ className }) => (
+    <span data-testid="rating-field" className={className}>
+      Rating
+    </span>
+  ),
   useToggleLove: vi.fn(),
 }))
 
@@ -61,19 +66,27 @@ describe('<PlayerToolbar />', () => {
       useMediaQuery.mockReturnValue(true) // isDesktop = true
     })
 
-    it('renders desktop toolbar with both buttons', () => {
+    it('renders desktop toolbar with rating and buttons', () => {
       render(<PlayerToolbar id="song-1" />)
 
-      // Both buttons should be in a single list item
+      // Rating + both buttons should be in a single list item
       const listItems = screen.getAllByRole('listitem')
       expect(listItems).toHaveLength(1)
 
-      // Verify both buttons are rendered
+      // Verify rating and both buttons are rendered
+      expect(screen.getByTestId('rating-field')).toBeInTheDocument()
       expect(screen.getByTestId('save-queue-button')).toBeInTheDocument()
       expect(screen.getByTestId('love-button')).toBeInTheDocument()
 
       // Verify desktop classes are applied
       expect(listItems[0].className).toContain('toolbar')
+    })
+
+    it('hides the rating for radio streams', () => {
+      render(<PlayerToolbar id="song-1" isRadio={true} />)
+
+      expect(screen.queryByTestId('rating-field')).not.toBeInTheDocument()
+      expect(screen.getByTestId('love-button')).toBeInTheDocument()
     })
 
     it('disables save queue button when isRadio is true', () => {
@@ -109,20 +122,22 @@ describe('<PlayerToolbar />', () => {
       useMediaQuery.mockReturnValue(false) // isDesktop = false
     })
 
-    it('renders mobile toolbar with buttons in separate list items', () => {
+    it('renders mobile toolbar with rating and buttons in separate list items', () => {
       render(<PlayerToolbar id="song-1" />)
 
-      // Each button should be in its own list item
+      // Rating + each button should be in its own list item
       const listItems = screen.getAllByRole('listitem')
-      expect(listItems).toHaveLength(2)
+      expect(listItems).toHaveLength(3)
 
-      // Verify both buttons are rendered
+      // Verify rating and both buttons are rendered
+      expect(screen.getByTestId('rating-field')).toBeInTheDocument()
       expect(screen.getByTestId('save-queue-button')).toBeInTheDocument()
       expect(screen.getByTestId('love-button')).toBeInTheDocument()
 
       // Verify mobile classes are applied
       expect(listItems[0].className).toContain('mobileListItem')
       expect(listItems[1].className).toContain('mobileListItem')
+      expect(listItems[2].className).toContain('mobileListItem')
     })
 
     it('disables save queue button when isRadio is true', () => {

--- a/ui/src/common/RatingField.jsx
+++ b/ui/src/common/RatingField.jsx
@@ -27,6 +27,7 @@ export const RatingField = ({
   className,
   size,
   color,
+  alwaysVisible,
   ...rest
 }) => {
   const record = useRecordContext(rest) || {}
@@ -59,7 +60,7 @@ export const RatingField = ({
         className={clsx(
           className,
           classes.rating,
-          rating > 0 ? classes.show : classes.hide,
+          rating > 0 || alwaysVisible ? classes.show : classes.hide,
         )}
         value={rating}
         size={size}
@@ -75,10 +76,15 @@ RatingField.propTypes = {
   record: PropTypes.object,
   visible: PropTypes.bool,
   size: PropTypes.string,
+  // When true, the empty stars are always shown (not just on hover / when
+  // already rated). Used by the player toolbar so the current track can be
+  // rated directly.
+  alwaysVisible: PropTypes.bool,
 }
 
 RatingField.defaultProps = {
   visible: true,
   size: 'small',
   color: 'inherit',
+  alwaysVisible: false,
 }


### PR DESCRIPTION
### Description

Adds an inline star-rating control to the player (now-playing) toolbar, right next to the Love button, so you can rate the track you're currently listening to without leaving what you're doing. Today the toolbar only exposes Love; to set a 1–5 star rating you have to find the track in a song/album/playlist list and hover the row.

It reuses the existing `RatingField` / `useRating`, and adds a small `alwaysVisible` prop to `RatingField` so the empty stars render for unrated tracks (the list views only reveal them on row hover, which isn't meaningful in the toolbar).

### Related Issues

Closes #5569

### Type of Change

- [x] New feature

### Checklist

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added tests that prove my feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run with star rating enabled (`ND_ENABLESTARRATING=true`, the default).
2. Play any track.
3. In the player bar at the bottom, a 5-star control appears next to the Love button. Click a star to rate; click an already-set star to clear it.
4. Confirm the control is **not** shown for radio streams.

Automated: `cd ui && npm test -- PlayerToolbar` (also passes `npm run lint` and `prettier -c`).

### Additional Notes

- UI-only change; no Go/server changes.
- Gated entirely by the existing `EnableStarRating` setting, and hidden for radio streams, so default behaviour is unchanged for anyone with star rating disabled.
- Happy to add a screenshot/GIF if useful.