### PR TITLE
feat(ui): add a Favourite Songs view to the sidebar - #5571

### DIFF
--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -634,6 +634,7 @@
       }
     },
     "albumList": "Albums",
+    "favouriteSongs": "Favourite Songs",
     "playlists": "Playlists",
     "sharedPlaylists": "Shared Playlists",
     "about": "About"

--- a/ui/src/layout/Menu.jsx
+++ b/ui/src/layout/Menu.jsx
@@ -5,7 +5,10 @@ import clsx from 'clsx'
 import { useTranslate, MenuItemLink, getResources } from 'react-admin'
 import ViewListIcon from '@material-ui/icons/ViewList'
 import AlbumIcon from '@material-ui/icons/Album'
+import FavoriteIcon from '@material-ui/icons/Favorite'
+import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
 import SubMenu from './SubMenu'
+import DynamicMenuIcon from './DynamicMenuIcon'
 import { humanize, pluralize } from 'inflection'
 import albumLists from '../album/albumLists'
 import PlaylistsSubMenu from './PlaylistsSubMenu'
@@ -125,6 +128,25 @@ const Menu = ({ dense = false }) => {
           renderAlbumMenuItemLink(type, albumLists[type]),
         )}
       </SubMenu>
+      {config.enableFavourites && (
+        <MenuItemLink
+          key={'/favourites'}
+          to={'/favourites'}
+          activeClassName={classes.active}
+          primaryText={translate('menu.favouriteSongs', {
+            _: 'Favourite Songs',
+          })}
+          leftIcon={
+            <DynamicMenuIcon
+              path={'favourites'}
+              icon={FavoriteBorderIcon}
+              activeIcon={FavoriteIcon}
+            />
+          }
+          sidebarIsOpen={open}
+          dense={dense}
+        />
+      )}
       {resources.filter(subItems(undefined)).map(renderResourceMenuItemLink)}
       {config.devSidebarPlaylists && open ? (
         <>

--- a/ui/src/routes.jsx
+++ b/ui/src/routes.jsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { Route } from 'react-router-dom'
 import Personal from './personal/Personal'
+import StarredSongList from './song/StarredSongList'
 
 const routes = [
   <Route exact path="/personal" render={() => <Personal />} key={'personal'} />,
+  <Route
+    exact
+    path="/favourites"
+    render={(props) => <StarredSongList {...props} />}
+    key={'favourites'}
+  />,
 ]
 
 export default routes

--- a/ui/src/song/SongList.jsx
+++ b/ui/src/song/SongList.jsx
@@ -208,7 +208,7 @@ const SongList = (props) => {
     <>
       <List
         {...props}
-        sort={{ field: 'title', order: 'ASC' }}
+        sort={props.sort || { field: 'title', order: 'ASC' }}
         exporter={false}
         bulkActionButtons={<SongBulkActions />}
         actions={<SongListActions />}

--- a/ui/src/song/StarredSongList.jsx
+++ b/ui/src/song/StarredSongList.jsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { ResourceContextProvider } from 'react-admin'
+import SongList from './SongList'
+
+// Favourite Songs view: reuses the regular SongList with a PERMANENT
+// { starred: true } filter. react-admin keeps permanent filters separate from
+// the user-editable (stored) filters, so opening this view never leaks the
+// starred filter into the normal Songs list. Sorted by most-recently-favourited.
+const StarredSongList = (props) => (
+  <ResourceContextProvider value="song">
+    <SongList
+      {...props}
+      resource="song"
+      basePath="/song"
+      hasCreate={false}
+      hasEdit={false}
+      hasShow={false}
+      hasList={true}
+      filter={{ starred: true }}
+      sort={{ field: 'starred_at', order: 'DESC' }}
+    />
+  </ResourceContextProvider>
+)
+
+export default StarredSongList

--- a/ui/src/song/StarredSongList.test.jsx
+++ b/ui/src/song/StarredSongList.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import StarredSongList from './StarredSongList'
+
+vi.mock('react-admin', () => ({
+  ResourceContextProvider: ({ children }) => <div>{children}</div>,
+}))
+
+vi.mock('./SongList', () => ({
+  default: (props) => (
+    <div
+      data-testid="song-list"
+      data-resource={props.resource}
+      data-filter={JSON.stringify(props.filter)}
+      data-sort={JSON.stringify(props.sort)}
+    />
+  ),
+}))
+
+describe('<StarredSongList />', () => {
+  it('renders the song list scoped to starred songs', () => {
+    render(<StarredSongList />)
+
+    const list = screen.getByTestId('song-list')
+    expect(list.getAttribute('data-resource')).toBe('song')
+    expect(JSON.parse(list.getAttribute('data-filter'))).toEqual({
+      starred: true,
+    })
+    expect(JSON.parse(list.getAttribute('data-sort'))).toEqual({
+      field: 'starred_at',
+      order: 'DESC',
+    })
+  })
+})


### PR DESCRIPTION
### Description

Adds a **Favourite Songs** entry to the sidebar that opens the song list filtered to your starred tracks, sorted by most-recently-favourited. Today the UI can show favourite albums and artists, but there's no way to browse your favourite *songs* without hand-crafting a smart playlist.

It reuses the existing `SongList` with a **permanent** `{ starred: true }` filter, wrapped in a small `StarredSongList` view at the `/favourites` route. Because the filter is permanent (not a stored/user-editable filter), it never leaks into the normal Songs list. Gated by the existing `EnableFavourites` setting.

This is purely **additive** — the existing album/artist favourites are untouched.

### Related Issues

Closes #5571

### Type of Change

- [x] New feature

### Checklist

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed (added the `menu.favouriteSongs` string to `en.json`)
- [x] I have added tests that prove my feature works
- [x] All existing and new tests pass

### How to Test

1. Run with favourites enabled (`ND_ENABLEFAVOURITES=true`, the default).
2. Star a few songs (heart them from the player, a list, or a Subsonic client).
3. Click **Favourite Songs** in the sidebar — it shows only your starred tracks, newest-favourited first.
4. Confirm the regular **Songs** view is unaffected after visiting it (no leftover filter).

Automated: `cd ui && npm test -- StarredSongList` (also passes `npm run lint`, `prettier -c`, and the translation structure check).

### Additional Notes

- UI-only change; no Go/server changes (the `starred` filter and `starred_at` sort already exist on the media_file repository).
- Only the English string was added; other locales fall back until translated.