### PR TITLE
refactor(stream): remove dead type branches from getIntClaim

### DIFF
--- a/core/stream/token.go
+++ b/core/stream/token.go
@@ -92,17 +92,10 @@ func paramsFromToken(token jwt.Token) (*params, error) {
 	return &p, nil
 }
 
-// getIntClaim extracts an int claim from a JWT token, handling the case where
-// the value may be stored as int64 or float64 (common in JSON-based JWT libraries).
+// getIntClaim extracts a numeric claim from a JWT token. Numeric claims in a
+// parsed token are always deserialized as float64, regardless of the type used
+// when encoding.
 func getIntClaim(token jwt.Token, key string) int {
-	var v int
-	if err := token.Get(key, &v); err == nil {
-		return v
-	}
-	var v64 int64
-	if err := token.Get(key, &v64); err == nil {
-		return int(v64)
-	}
 	var f float64
 	if err := token.Get(key, &f); err == nil {
 		return int(f)


### PR DESCRIPTION
### Description

`getIntClaim` in `core/stream/token.go` tried to read numeric claims as `int`, then `int64`, then `float64`. However, the jwx library always deserializes numeric claims from a parsed token as `float64`, so the first two `Get` calls can never succeed — they are dead code. This PR removes the unreachable branches, keeping only the `float64` path, and updates the doc comment to explain the library behavior.

No behavior change: the existing token round-trip tests (which encode `int` claims like bitrate, channels, sample rate, and bit depth, then parse them back) confirm the `float64` branch is the one actually exercised.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (covered by existing token round-trip tests; no behavior change)
- [x] All existing and new tests pass

### How to Test

1. Run `make test PKG=./core/stream/...`
2. All tests pass, including the token round-trip specs that encode integer claims (`b`, `ch`, `sr`, `bd`, `ua`) and verify they parse back to the original values.

### Additional Notes

This was identified while reviewing how `jwx`'s `token.Get` handles type conversion: private claims parsed from a serialized JWT are always stored as `float64`, so the `int`/`int64` lookups unconditionally fail. If the int branch had been the live one, removing it would break the round-trip tests — they still pass, confirming the analysis.
