### PR TITLE
fix(artwork): never serve artist folder images as album art

### DIFF
--- a/core/artwork/e2e/album_test.go
+++ b/core/artwork/e2e/album_test.go
@@ -357,6 +357,98 @@ var _ = Describe("Album artwork resolution", func() {
 		})
 	})
 
+	// Regression introduced in v0.62.0 (#5451 + #5457): the parent-folder
+	// fallback can pick up images from the ARTIST folder, serving the artist
+	// thumbnail as album art for any album without its own image files.
+	When("an album has no images and the artist folder has folder.jpg", func() {
+		// Artist/
+		// ├── folder.jpg               ← artist thumbnail, must NOT become album art
+		// ├── Album A/
+		// │   └── 01 - Track.mp3       (no images)
+		// └── Album B/
+		//     ├── 01 - Track.mp3
+		//     └── cover.jpg
+		It("does not use the artist image as album art", func() {
+			conf.Server.CoverArtPriority = defaultCoverPriority
+			setLayout(fstest.MapFS{
+				"Artist/folder.jpg":             imageFile("artist-thumbnail"),
+				"Artist/Album A/01 - Track.mp3": trackFile(1, "Track A", map[string]any{"album": "Album A", "albumartist": "Artist"}),
+				"Artist/Album B/01 - Track.mp3": trackFile(1, "Track B", map[string]any{"album": "Album B", "albumartist": "Artist"}),
+				"Artist/Album B/cover.jpg":      imageFile("album-b"),
+			})
+			scan()
+
+			alA := albumByName("Album A")
+			_, err := readArtworkOrErr(alA.CoverArtID())
+			Expect(err).To(HaveOccurred(),
+				"Album A has no images of its own, so it must fall through to the placeholder "+
+					"instead of inheriting the artist folder's folder.jpg")
+
+			alB := albumByName("Album B")
+			Expect(readArtwork(alB.CoverArtID())).To(Equal(imageBytes("album-b")))
+		})
+	})
+
+	When("a single-disc album is spread across sibling folders under the artist folder", func() {
+		// Artist/
+		// ├── folder.jpg               ← artist thumbnail, must NOT become album art
+		// ├── Album A/
+		// │   └── 01 - Track.mp3       (album: "Album A")
+		// ├── Album A bonus/
+		// │   └── 02 - Track.mp3       (album: "Album A" — same album, second folder)
+		// └── Album B/
+		//     ├── 01 - Track.mp3
+		//     └── cover.jpg
+		It("does not use the artist image as album art for the spread album", func() {
+			conf.Server.CoverArtPriority = defaultCoverPriority
+			setLayout(fstest.MapFS{
+				"Artist/folder.jpg":                   imageFile("artist-thumbnail"),
+				"Artist/Album A/01 - Track.mp3":       trackFile(1, "Track A1", map[string]any{"album": "Album A", "albumartist": "Artist"}),
+				"Artist/Album A bonus/02 - Track.mp3": trackFile(2, "Track A2", map[string]any{"album": "Album A", "albumartist": "Artist"}),
+				"Artist/Album B/01 - Track.mp3":       trackFile(1, "Track B", map[string]any{"album": "Album B", "albumartist": "Artist"}),
+				"Artist/Album B/cover.jpg":            imageFile("album-b"),
+			})
+			scan()
+
+			alA := albumByName("Album A")
+			Expect(alA.FolderIDs).To(HaveLen(2),
+				"sanity check: scanner should treat the two sibling folders as one spread album")
+			_, err := readArtworkOrErr(alA.CoverArtID())
+			Expect(err).To(HaveOccurred(),
+				"the spread album has no images of its own, so it must fall through to the "+
+					"placeholder instead of inheriting the artist folder's folder.jpg")
+		})
+	})
+
+	When("a spread album has its own front.jpg but the artist folder has cover.jpg", func() {
+		// Artist/
+		// ├── cover.jpg                ← artist image; matches cover.* (first pattern),
+		// │                              must NOT shadow the album's own front.jpg
+		// ├── Album A/
+		// │   ├── 01 - Track.mp3       (album: "Album A")
+		// │   └── front.jpg            ← should win
+		// ├── Album A bonus/
+		// │   └── 02 - Track.mp3       (album: "Album A")
+		// └── Album B/
+		//     └── 01 - Track.mp3
+		It("prefers the album's own art over the artist image", func() {
+			conf.Server.CoverArtPriority = defaultCoverPriority
+			setLayout(fstest.MapFS{
+				"Artist/cover.jpg":                    imageFile("artist-image"),
+				"Artist/Album A/01 - Track.mp3":       trackFile(1, "Track A1", map[string]any{"album": "Album A", "albumartist": "Artist"}),
+				"Artist/Album A/front.jpg":            imageFile("album-a-front"),
+				"Artist/Album A bonus/02 - Track.mp3": trackFile(2, "Track A2", map[string]any{"album": "Album A", "albumartist": "Artist"}),
+				"Artist/Album B/01 - Track.mp3":       trackFile(1, "Track B", map[string]any{"album": "Album B", "albumartist": "Artist"}),
+			})
+			scan()
+
+			alA := albumByName("Album A")
+			Expect(alA.FolderIDs).To(HaveLen(2),
+				"sanity check: scanner should treat the two sibling folders as one spread album")
+			Expect(readArtwork(alA.CoverArtID())).To(Equal(imageBytes("album-a-front")))
+		})
+	})
+
 	When("embedded is first in CoverArtPriority but the track has no embedded art", func() {
 		// Artist/
 		// └── Album/

--- a/core/artwork/e2e/suite_test.go
+++ b/core/artwork/e2e/suite_test.go
@@ -2,6 +2,7 @@ package artworke2e_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
@@ -103,4 +104,17 @@ func firstAlbum() model.Album {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(albums).To(HaveLen(1), "expected exactly one album, got %d", len(albums))
 	return albums[0]
+}
+
+func albumByName(name string) model.Album {
+	GinkgoHelper()
+	albums, err := ds.Album(ctx).GetAll(model.QueryOptions{})
+	Expect(err).ToNot(HaveOccurred())
+	for _, al := range albums {
+		if al.Name == name {
+			return al
+		}
+	}
+	Fail(fmt.Sprintf("album %q not found among %d albums", name, len(albums)))
+	return model.Album{}
 }

--- a/core/artwork/reader_album.go
+++ b/core/artwork/reader_album.go
@@ -113,36 +113,12 @@ func loadAlbumFoldersPaths(ctx context.Context, ds model.DataStore, albums ...mo
 		return nil, nil, nil, err
 	}
 
-	folderIDSet := make(map[string]bool, len(folderIDs))
-	for _, id := range folderIDs {
-		folderIDSet[id] = true
+	parent, err := albumRootParent(ctx, ds, folders, folderIDs)
+	if err != nil {
+		return nil, nil, nil, err
 	}
-
-	// Check if all folders share a common parent that is not already included.
-	// This finds cover art in the album root folder (e.g., "Artist/Album/cover.jpg"
-	// when tracks are in disc subfolders like "Artist/Album/CD1/" and "Artist/Album/CD2/").
-	// For single-folder albums, the parent is only included when the folder has no
-	// images of its own (indicating a disc subfolder needing parent artwork).
-	// In both cases the parent must look like an album root, not an artist-level
-	// folder, so artist images are never served as album art.
-	if commonParentID := commonParentFolder(folders, folderIDSet); commonParentID != "" {
-		if len(folders) >= 2 || !anyFolderHasImages(folders) {
-			parentFolder, err := ds.Folder(ctx).Get(commonParentID)
-			if errors.Is(err, model.ErrNotFound) {
-				log.Warn(ctx, "Parent folder not found for album cover art lookup", "parentID", commonParentID)
-			} else if err != nil {
-				return nil, nil, nil, err
-			}
-			if parentFolder != nil && parentFolder.ParentID != "" {
-				isAlbumRoot, err := isAlbumRootFolder(ctx, ds, *parentFolder, folderIDs)
-				if err != nil {
-					return nil, nil, nil, err
-				}
-				if isAlbumRoot {
-					folders = append(folders, *parentFolder)
-				}
-			}
-		}
+	if parent != nil {
+		folders = append(folders, *parent)
 	}
 
 	var paths []string
@@ -167,37 +143,48 @@ func loadAlbumFoldersPaths(ctx context.Context, ds model.DataStore, albums ...mo
 	return paths, imgFiles, &updatedAt, nil
 }
 
-// isAlbumRootFolder reports whether parent is the album's own root folder, as
-// opposed to an artist-level folder. A parent qualifies only when no audio
-// belonging to other albums lives in it or anywhere beneath it: an artist
-// folder contains other albums' tracks, while an album root above disc
-// subfolders contains only this album's.
-func isAlbumRootFolder(ctx context.Context, ds model.DataStore, parent model.Folder, albumFolderIDs []string) (bool, error) {
-	if parent.NumAudioFiles > 0 {
-		return false, nil
+// albumRootParent returns the common parent of the album's folders when it
+// qualifies as the album's root folder (e.g. "Artist/Album" above disc
+// subfolders), or nil when there is no such parent. This finds cover art in
+// the album root folder when tracks live in disc subfolders, like
+// "Artist/Album/cover.jpg" with tracks in "Artist/Album/CD1/" and
+// "Artist/Album/CD2/". The parent must look like an album root, not an
+// artist-level folder — it qualifies only when it holds no audio belonging to
+// other albums — so artist images are never served as album art.
+func albumRootParent(ctx context.Context, ds model.DataStore, folders []model.Folder, folderIDs []string) (*model.Folder, error) {
+	folderIDSet := make(map[string]bool, len(folderIDs))
+	for _, id := range folderIDs {
+		folderIDSet[id] = true
 	}
-	parentRel := strings.TrimPrefix(path.Join(parent.Path, parent.Name), "/")
-	otherAudio, err := ds.Folder(ctx).GetAll(model.QueryOptions{
-		Max: 1,
-		Filters: squirrel.And{
-			squirrel.Eq{"folder.library_id": parent.LibraryID, "missing": false},
-			squirrel.Gt{"folder.num_audio_files": 0},
-			squirrel.NotEq{"folder.id": albumFolderIDs},
-			squirrel.Or{
-				squirrel.Eq{"folder.path": parentRel},
-				squirrel.Expr(`folder.path LIKE ? ESCAPE '\'`, escapeLike(parentRel)+"/%"),
-			},
-		},
-	})
+	commonParentID := commonParentFolder(folders, folderIDSet)
+	if commonParentID == "" {
+		return nil, nil
+	}
+	// Single-folder albums only use the parent when the folder has no images
+	// of its own (indicating a disc subfolder needing parent artwork).
+	if len(folders) < 2 && anyFolderHasImages(folders) {
+		return nil, nil
+	}
+	parent, err := ds.Folder(ctx).Get(commonParentID)
+	if errors.Is(err, model.ErrNotFound) {
+		log.Warn(ctx, "Parent folder not found for album cover art lookup", "parentID", commonParentID)
+		return nil, nil
+	}
 	if err != nil {
-		return false, err
+		return nil, err
 	}
-	return len(otherAudio) == 0, nil
-}
-
-// escapeLike escapes SQL LIKE wildcards so a path can be used as a literal prefix.
-func escapeLike(s string) string {
-	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
+	if parent.ParentID == "" {
+		// The library root can never be an album root
+		return nil, nil
+	}
+	hasOtherAudio, err := ds.Folder(ctx).HasAudioOutsideFolders(*parent, folderIDs)
+	if err != nil {
+		return nil, err
+	}
+	if hasOtherAudio {
+		return nil, nil
+	}
+	return parent, nil
 }
 
 func anyFolderHasImages(folders []model.Folder) bool {

--- a/core/artwork/reader_album.go
+++ b/core/artwork/reader_album.go
@@ -123,6 +123,8 @@ func loadAlbumFoldersPaths(ctx context.Context, ds model.DataStore, albums ...mo
 	// when tracks are in disc subfolders like "Artist/Album/CD1/" and "Artist/Album/CD2/").
 	// For single-folder albums, the parent is only included when the folder has no
 	// images of its own (indicating a disc subfolder needing parent artwork).
+	// In both cases the parent must look like an album root, not an artist-level
+	// folder, so artist images are never served as album art.
 	if commonParentID := commonParentFolder(folders, folderIDSet); commonParentID != "" {
 		if len(folders) >= 2 || !anyFolderHasImages(folders) {
 			parentFolder, err := ds.Folder(ctx).Get(commonParentID)
@@ -132,7 +134,13 @@ func loadAlbumFoldersPaths(ctx context.Context, ds model.DataStore, albums ...mo
 				return nil, nil, nil, err
 			}
 			if parentFolder != nil && parentFolder.ParentID != "" {
-				folders = append(folders, *parentFolder)
+				isAlbumRoot, err := isAlbumRootFolder(ctx, ds, *parentFolder, folderIDs)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+				if isAlbumRoot {
+					folders = append(folders, *parentFolder)
+				}
 			}
 		}
 	}
@@ -157,6 +165,39 @@ func loadAlbumFoldersPaths(ctx context.Context, ds model.DataStore, albums ...mo
 	slices.SortFunc(imgFiles, compareImageFiles)
 
 	return paths, imgFiles, &updatedAt, nil
+}
+
+// isAlbumRootFolder reports whether parent is the album's own root folder, as
+// opposed to an artist-level folder. A parent qualifies only when no audio
+// belonging to other albums lives in it or anywhere beneath it: an artist
+// folder contains other albums' tracks, while an album root above disc
+// subfolders contains only this album's.
+func isAlbumRootFolder(ctx context.Context, ds model.DataStore, parent model.Folder, albumFolderIDs []string) (bool, error) {
+	if parent.NumAudioFiles > 0 {
+		return false, nil
+	}
+	parentRel := strings.TrimPrefix(path.Join(parent.Path, parent.Name), "/")
+	otherAudio, err := ds.Folder(ctx).GetAll(model.QueryOptions{
+		Max: 1,
+		Filters: squirrel.And{
+			squirrel.Eq{"folder.library_id": parent.LibraryID, "missing": false},
+			squirrel.Gt{"folder.num_audio_files": 0},
+			squirrel.NotEq{"folder.id": albumFolderIDs},
+			squirrel.Or{
+				squirrel.Eq{"folder.path": parentRel},
+				squirrel.Expr(`folder.path LIKE ? ESCAPE '\'`, escapeLike(parentRel)+"/%"),
+			},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+	return len(otherAudio) == 0, nil
+}
+
+// escapeLike escapes SQL LIKE wildcards so a path can be used as a literal prefix.
+func escapeLike(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
 }
 
 func anyFolderHasImages(folders []model.Folder) bool {

--- a/core/artwork/reader_album_test.go
+++ b/core/artwork/reader_album_test.go
@@ -360,36 +360,7 @@ var _ = Describe("Album Artwork Reader", func() {
 				ImagesUpdatedAt: expectedAt,
 				ImageFiles:      []string{"folder.jpg"},
 			}
-			repo.otherAudioResult = []model.Folder{{ID: "otherAlbumFolder"}}
-
-			_, imgFiles, _, err := loadAlbumFoldersPaths(ctx, ds, album)
-
-			Expect(err).ToNot(HaveOccurred())
-			Expect(imgFiles).To(BeEmpty())
-		})
-
-		It("does not include parent images when the parent itself contains audio files", func() {
-			// Audio directly in the parent cannot belong to this album (the
-			// parent is not one of the album's folders), so it is artist-like
-			repo.result = []model.Folder{
-				{
-					ID:              "folder1",
-					Path:            "Artist",
-					Name:            "Album",
-					ParentID:        "artistFolder",
-					ImagesUpdatedAt: now,
-					ImageFiles:      []string{},
-				},
-			}
-			repo.parentResult = &model.Folder{
-				ID:              "artistFolder",
-				Path:            ".",
-				Name:            "Artist",
-				ParentID:        "libraryRoot",
-				NumAudioFiles:   3,
-				ImagesUpdatedAt: expectedAt,
-				ImageFiles:      []string{"folder.jpg"},
-			}
+			repo.hasOtherAudio = true
 
 			_, imgFiles, _, err := loadAlbumFoldersPaths(ctx, ds, album)
 

--- a/core/artwork/reader_album_test.go
+++ b/core/artwork/reader_album_test.go
@@ -339,6 +339,90 @@ var _ = Describe("Album Artwork Reader", func() {
 			Expect(repo.getCallCount).To(Equal(1))
 		})
 
+		It("does not include parent images when other albums' audio lives under the parent", func() {
+			// Simulates: Artist/folder.jpg with Artist/Album (no images) and
+			// another album's tracks elsewhere under the artist folder
+			repo.result = []model.Folder{
+				{
+					ID:              "folder1",
+					Path:            "Artist",
+					Name:            "Album",
+					ParentID:        "artistFolder",
+					ImagesUpdatedAt: now,
+					ImageFiles:      []string{},
+				},
+			}
+			repo.parentResult = &model.Folder{
+				ID:              "artistFolder",
+				Path:            ".",
+				Name:            "Artist",
+				ParentID:        "libraryRoot",
+				ImagesUpdatedAt: expectedAt,
+				ImageFiles:      []string{"folder.jpg"},
+			}
+			repo.otherAudioResult = []model.Folder{{ID: "otherAlbumFolder"}}
+
+			_, imgFiles, _, err := loadAlbumFoldersPaths(ctx, ds, album)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(imgFiles).To(BeEmpty())
+		})
+
+		It("does not include parent images when the parent itself contains audio files", func() {
+			// Audio directly in the parent cannot belong to this album (the
+			// parent is not one of the album's folders), so it is artist-like
+			repo.result = []model.Folder{
+				{
+					ID:              "folder1",
+					Path:            "Artist",
+					Name:            "Album",
+					ParentID:        "artistFolder",
+					ImagesUpdatedAt: now,
+					ImageFiles:      []string{},
+				},
+			}
+			repo.parentResult = &model.Folder{
+				ID:              "artistFolder",
+				Path:            ".",
+				Name:            "Artist",
+				ParentID:        "libraryRoot",
+				NumAudioFiles:   3,
+				ImagesUpdatedAt: expectedAt,
+				ImageFiles:      []string{"folder.jpg"},
+			}
+
+			_, imgFiles, _, err := loadAlbumFoldersPaths(ctx, ds, album)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(imgFiles).To(BeEmpty())
+		})
+
+		It("propagates errors from the album-root check", func() {
+			repo.result = []model.Folder{
+				{
+					ID:              "folder1",
+					Path:            "Artist/Album",
+					Name:            "disc1",
+					ParentID:        "albumFolder",
+					ImagesUpdatedAt: now,
+					ImageFiles:      []string{},
+				},
+			}
+			repo.parentResult = &model.Folder{
+				ID:              "albumFolder",
+				Path:            "Artist",
+				Name:            "Album",
+				ParentID:        "artistFolder",
+				ImagesUpdatedAt: expectedAt,
+				ImageFiles:      []string{"cover.jpg"},
+			}
+			repo.otherAudioErr = errors.New("db connection failed")
+
+			_, _, _, err := loadAlbumFoldersPaths(ctx, ds, album)
+
+			Expect(err).To(MatchError("db connection failed"))
+		})
+
 		It("propagates non-ErrNotFound errors from parent folder lookup", func() {
 			repo.result = []model.Folder{
 				{

--- a/core/artwork/reader_artist_test.go
+++ b/core/artwork/reader_artist_test.go
@@ -7,7 +7,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -703,20 +702,18 @@ type fakeFolderRepo struct {
 	getErr       error
 	getCallCount int
 	err          error
-	// otherAudioResult is returned for the isAlbumRootFolder subtree query
-	// (recognized by its num_audio_files filter). Empty means the parent
-	// qualifies as an album root.
-	otherAudioResult []model.Folder
-	otherAudioErr    error
+	// hasOtherAudio is returned by HasAudioOutsideFolders (the album-root
+	// check). False means the parent qualifies as an album root.
+	hasOtherAudio bool
+	otherAudioErr error
 }
 
-func (f *fakeFolderRepo) GetAll(opts ...model.QueryOptions) ([]model.Folder, error) {
-	if len(opts) > 0 && opts[0].Filters != nil {
-		if sql, _, err := opts[0].Filters.ToSql(); err == nil && strings.Contains(sql, "num_audio_files") {
-			return f.otherAudioResult, f.otherAudioErr
-		}
-	}
+func (f *fakeFolderRepo) GetAll(...model.QueryOptions) ([]model.Folder, error) {
 	return f.result, f.err
+}
+
+func (f *fakeFolderRepo) HasAudioOutsideFolders(model.Folder, []string) (bool, error) {
+	return f.hasOtherAudio, f.otherAudioErr
 }
 
 func (f *fakeFolderRepo) Get(id string) (*model.Folder, error) {

--- a/core/artwork/reader_artist_test.go
+++ b/core/artwork/reader_artist_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -702,9 +703,19 @@ type fakeFolderRepo struct {
 	getErr       error
 	getCallCount int
 	err          error
+	// otherAudioResult is returned for the isAlbumRootFolder subtree query
+	// (recognized by its num_audio_files filter). Empty means the parent
+	// qualifies as an album root.
+	otherAudioResult []model.Folder
+	otherAudioErr    error
 }
 
-func (f *fakeFolderRepo) GetAll(...model.QueryOptions) ([]model.Folder, error) {
+func (f *fakeFolderRepo) GetAll(opts ...model.QueryOptions) ([]model.Folder, error) {
+	if len(opts) > 0 && opts[0].Filters != nil {
+		if sql, _, err := opts[0].Filters.ToSql(); err == nil && strings.Contains(sql, "num_audio_files") {
+			return f.otherAudioResult, f.otherAudioErr
+		}
+	}
 	return f.result, f.err
 }
 

--- a/model/folder.go
+++ b/model/folder.go
@@ -86,6 +86,10 @@ type FolderRepository interface {
 	GetAll(...QueryOptions) ([]Folder, error)
 	CountAll(...QueryOptions) (int64, error)
 	GetFolderUpdateInfo(lib Library, targetPaths ...string) (map[string]FolderUpdateInfo, error)
+	// HasAudioOutsideFolders reports whether any folder in parent's subtree
+	// (including parent itself) contains audio files and is not one of the
+	// given folder IDs.
+	HasAudioOutsideFolders(parent Folder, excludeFolderIDs []string) (bool, error)
 	Put(*Folder) error
 	MarkMissing(missing bool, ids ...string) error
 	GetTouchedWithPlaylists() (FolderCursor, error)

--- a/persistence/folder_repository.go
+++ b/persistence/folder_repository.go
@@ -7,6 +7,7 @@ import (
 	"iter"
 	"maps"
 	"os"
+	"path"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -186,6 +187,35 @@ func (r folderRepository) queryFolderUpdateInfo(where And) (map[string]model.Fol
 		m[f.ID] = model.FolderUpdateInfo{UpdatedAt: f.UpdatedAt, Hash: f.Hash}
 	}
 	return m, nil
+}
+
+// HasAudioOutsideFolders reports whether any folder in parent's subtree
+// (including parent itself) contains audio files and is not one of the given
+// folder IDs. LIKE wildcards in the parent path are escaped, so it is always
+// matched as a literal prefix.
+func (r folderRepository) HasAudioOutsideFolders(parent model.Folder, excludeFolderIDs []string) (bool, error) {
+	if parent.NumAudioFiles > 0 {
+		return true, nil
+	}
+	parentPath := strings.TrimPrefix(path.Join(parent.Path, parent.Name), "/")
+	query := r.newSelect().Columns("count(*)").Where(And{
+		Eq{"library_id": parent.LibraryID, "missing": false},
+		Gt{"num_audio_files": 0},
+		NotEq{"id": excludeFolderIDs},
+		Or{
+			// Direct children have path = parentPath; deeper descendants match the prefix
+			Eq{"path": parentPath},
+			Expr(`path LIKE ? ESCAPE '\'`, escapeLikePrefix(parentPath)+"/%"),
+		},
+	})
+	count, err := r.count(query)
+	return count > 0, err
+}
+
+// escapeLikePrefix escapes SQL LIKE wildcards so a string can be used as a
+// literal prefix in a LIKE pattern (with ESCAPE '\').
+func escapeLikePrefix(s string) string {
+	return strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`).Replace(s)
 }
 
 func (r folderRepository) Put(f *model.Folder) error {

--- a/persistence/folder_repository.go
+++ b/persistence/folder_repository.go
@@ -198,7 +198,7 @@ func (r folderRepository) HasAudioOutsideFolders(parent model.Folder, excludeFol
 		return true, nil
 	}
 	parentPath := strings.TrimPrefix(path.Join(parent.Path, parent.Name), "/")
-	query := r.newSelect().Columns("count(*)").Where(And{
+	return r.exists(And{
 		Eq{"library_id": parent.LibraryID, "missing": false},
 		Gt{"num_audio_files": 0},
 		NotEq{"id": excludeFolderIDs},
@@ -208,8 +208,6 @@ func (r folderRepository) HasAudioOutsideFolders(parent model.Folder, excludeFol
 			Expr(`path LIKE ? ESCAPE '\'`, escapeLikePrefix(parentPath)+"/%"),
 		},
 	})
-	count, err := r.count(query)
-	return count > 0, err
 }
 
 // escapeLikePrefix escapes SQL LIKE wildcards so a string can be used as a

--- a/persistence/folder_repository_test.go
+++ b/persistence/folder_repository_test.go
@@ -217,6 +217,67 @@ var _ = Describe("FolderRepository", func() {
 		})
 	})
 
+	Describe("HasAudioOutsideFolders", func() {
+		var albumRoot, disc1, disc2 *model.Folder
+
+		// TestHasAudio/Album/
+		// ├── CD1/   (audio, belongs to the album)
+		// └── CD2/   (audio, belongs to the album)
+		BeforeEach(func() {
+			albumRoot = model.NewFolder(testLib, "TestHasAudio/Album")
+			disc1 = model.NewFolder(testLib, "TestHasAudio/Album/CD1")
+			disc1.NumAudioFiles = 5
+			disc2 = model.NewFolder(testLib, "TestHasAudio/Album/CD2")
+			disc2.NumAudioFiles = 5
+			for _, f := range []*model.Folder{albumRoot, disc1, disc2} {
+				Expect(repo.Put(f)).To(Succeed())
+			}
+		})
+
+		It("returns false when all audio under the parent belongs to the given folders", func() {
+			Expect(repo.HasAudioOutsideFolders(*albumRoot, []string{disc1.ID, disc2.ID})).To(BeFalse())
+		})
+
+		It("returns true when another folder under the parent has audio", func() {
+			bonus := model.NewFolder(testLib, "TestHasAudio/Album/Bonus")
+			bonus.NumAudioFiles = 1
+			Expect(repo.Put(bonus)).To(Succeed())
+
+			Expect(repo.HasAudioOutsideFolders(*albumRoot, []string{disc1.ID, disc2.ID})).To(BeTrue())
+		})
+
+		It("returns true when the parent itself contains audio files", func() {
+			albumRoot.NumAudioFiles = 2
+
+			Expect(repo.HasAudioOutsideFolders(*albumRoot, []string{disc1.ID, disc2.ID})).To(BeTrue())
+		})
+
+		It("ignores audio outside the parent's subtree", func() {
+			other := model.NewFolder(testLib, "TestHasAudio/Other Album")
+			other.NumAudioFiles = 10
+			Expect(repo.Put(other)).To(Succeed())
+
+			Expect(repo.HasAudioOutsideFolders(*albumRoot, []string{disc1.ID, disc2.ID})).To(BeFalse())
+		})
+
+		It("ignores missing folders", func() {
+			gone := model.NewFolder(testLib, "TestHasAudio/Album/Gone")
+			gone.NumAudioFiles = 3
+			gone.Missing = true
+			Expect(repo.Put(gone)).To(Succeed())
+
+			Expect(repo.HasAudioOutsideFolders(*albumRoot, []string{disc1.ID, disc2.ID})).To(BeFalse())
+		})
+
+		It("does not treat LIKE wildcards in the parent path as patterns", func() {
+			// "TestHas_udio" would LIKE-match "TestHasAudio" if "_" were not escaped
+			wildcardRoot := model.NewFolder(testLib, "TestHas_udio/Album")
+			Expect(repo.Put(wildcardRoot)).To(Succeed())
+
+			Expect(repo.HasAudioOutsideFolders(*wildcardRoot, []string{"none"})).To(BeFalse())
+		})
+	})
+
 	Describe("wrapFolderCursor", func() {
 		It("does not panic when the cursor yields a dbFolder with nil Folder", func() {
 			// Simulate what queryWithStableResults does on the rows.Err() path:


### PR DESCRIPTION
### Description
Since v0.62.0, the album cover-art parent-folder fallback (#5451/#5457) could pick up images from the **artist** folder: any album without image files in its own folder(s) inherited the artist thumbnail (e.g. `Artist/folder.jpg`) as its cover art. Single-disc albums spread across sibling folders were also affected — there the artist image could even shadow the album's own art, due to `CoverArtPriority` pattern order.

The fix gates the parent-folder inclusion with a structural check instead of folder-name matching: the common parent only qualifies as an album root when no audio belonging to other albums lives anywhere under it. An artist folder contains other albums' tracks, while an album root above disc subfolders contains only the album's own, so this works for any disc-subfolder naming scheme and keeps the multi-disc behavior from #5376/#5456 intact. The check is exposed as a new `FolderRepository.HasAudioOutsideFolders` method, and the parent resolution was extracted into a dedicated helper.

Known residual: an artist whose *only* album has no images anywhere is structurally indistinguishable from an album root, so that one layout still inherits the artist image.

### Related Issues
Fixes #5599 

Regression introduced by #5451/#5457 (related to #5376 and #5456). Reported [on Reddit](https://www.reddit.com/r/navidrome/comments/1u06x0g/comment/oqlz5ep/).

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Create a library like:
   ```
   Artist/folder.jpg            ← artist thumbnail
   Artist/Album A/01.mp3        (no images)
   Artist/Album B/01.mp3
   Artist/Album B/cover.jpg
   ```
2. Scan and open Album A. Before this PR it shows the artist thumbnail; with it, the placeholder.
3. Album B, multi-disc layouts (`Album/CD1`, `CD2` + root `cover.jpg`), and single-disc-subfolder layouts keep their current artwork.

The new e2e specs cover these scenarios: `make test PKG=./core/artwork/e2e`.

### Additional Notes
The artwork resolution code is accumulating real complexity by trying to handle ever more layout edge cases — multi-disc roots, disc subfolders with arbitrary names, spread albums, parent fallbacks, and now structural artist-folder detection. This may be a sign we should rethink the artwork implementation (e.g. classify folders at scan time instead of guessing at read time), and possibly drop support for some of these edge cases in the future.
