### PR TITLE
fix(subsonic): make search3 empty-query pagination fast at large offsets

### DIFF
--- a/db/migrations/20260612171826_add_media_file_missing_library_id_index.sql
+++ b/db/migrations/20260612171826_add_media_file_missing_library_id_index.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+-- Covering index for the rowid-only pagination query used by search3 with an empty query
+-- (full library sync). It must cover both `missing` and `library_id` so SQLite never touches
+-- the (wide) media_file rows while skipping over large offsets.
+-- Replaces media_file_missing: the composite serves all `missing = ?` lookups via its prefix.
+create index if not exists media_file_missing_library_id
+    on media_file(missing, library_id);
+drop index if exists media_file_missing;
+
+-- +goose Down
+create index if not exists media_file_missing
+    on media_file(missing);
+drop index if exists media_file_missing_library_id;

--- a/persistence/artist_repository.go
+++ b/persistence/artist_repository.go
@@ -540,13 +540,28 @@ func (r *artistRepository) RefreshStats(allArtists bool) (int64, error) {
 	return totalRowsAffected, nil
 }
 
+// applyLibraryFilterToSearchQuery is applyLibraryFilterToArtistQuery with the join order
+// pinned via CROSS JOIN (SQLite's explicit join-order override): the search Phase 1 paginates
+// rowids by artist.id, and when the planner drives from library_artist it must sort every
+// junction row on every page (temp b-tree over the whole table). Keeping artist as the outer
+// table streams rows in artist.id order from its primary key index, so LIMIT/OFFSET
+// short-circuits. Search-only: other artist queries keep the planner's freedom.
+func (r *artistRepository) applyLibraryFilterToSearchQuery(query SelectBuilder) SelectBuilder {
+	user := loggedUser(r.ctx)
+	query = query.CrossJoin("library_artist on library_artist.artist_id = artist.id")
+	if user.ID != invalidUserId && !user.IsAdmin {
+		query = query.Join("user_library on user_library.library_id = library_artist.library_id AND user_library.user_id = ?", user.ID)
+	}
+	return query
+}
+
 func (r *artistRepository) searchCfg() searchConfig {
 	return searchConfig{
 		// Natural order for artists is more performant by ID, due to GROUP BY clause in selectArtist
 		NaturalOrder:  "artist.id",
 		OrderBy:       []string{"sum(json_extract(stats, '$.total.m')) desc", "name"},
 		MBIDFields:    []string{"mbz_artist_id"},
-		LibraryFilter: r.applyLibraryFilterToArtistQuery,
+		LibraryFilter: r.applyLibraryFilterToSearchQuery,
 	}
 }
 

--- a/persistence/artist_repository_test.go
+++ b/persistence/artist_repository_test.go
@@ -594,6 +594,44 @@ var _ = Describe("ArtistRepository", func() {
 				})
 			})
 
+			Context("Empty Query (sync pagination)", func() {
+				It("paginates all artists in natural order without overlaps or gaps", func() {
+					all, err := repo.Search("", model.QueryOptions{Max: 1000})
+					Expect(err).ToNot(HaveOccurred())
+					Expect(len(all)).To(BeNumerically(">", 1))
+
+					var paged model.Artists
+					pageSize := 2
+					for offset := 0; offset < len(all); offset += pageSize {
+						page, err := repo.Search("", model.QueryOptions{Max: pageSize, Offset: offset})
+						Expect(err).ToNot(HaveOccurred())
+						paged = append(paged, page...)
+					}
+					Expect(paged).To(HaveLen(len(all)))
+					for i := range all {
+						Expect(paged[i].ID).To(Equal(all[i].ID))
+					}
+				})
+
+				It("respects library filtering for restricted users", func() {
+					// Create an artist only in library 2 (not accessible to restricted user)
+					lib2Artist := model.Artist{ID: "empty-query-lib2-artist", Name: "Empty Query Lib2 Artist"}
+					Expect(repo.Put(&lib2Artist)).To(Succeed())
+					Expect(lr.AddArtist(lib2.ID, lib2Artist.ID)).To(Succeed())
+
+					results, err := restrictedRepo.Search("", model.QueryOptions{Max: 1000})
+					Expect(err).ToNot(HaveOccurred())
+					for _, a := range results {
+						Expect(a.ID).ToNot(Equal(lib2Artist.ID), "Empty query search should respect library filtering")
+					}
+
+					// Clean up
+					if raw, ok := repo.(*artistRepository); ok {
+						_, _ = raw.executeSQL(squirrel.Delete(raw.tableName).Where(squirrel.Eq{"id": lib2Artist.ID}))
+					}
+				})
+			})
+
 			Context("Headless Processes (No User Context)", func() {
 				It("should see all artists from all libraries when no user is in context", func() {
 					// Add artists to different libraries

--- a/persistence/artist_repository_test.go
+++ b/persistence/artist_repository_test.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -595,6 +596,28 @@ var _ = Describe("ArtistRepository", func() {
 			})
 
 			Context("Empty Query (sync pagination)", func() {
+				It("does not duplicate artists that belong to multiple libraries", func() {
+					// An artist in two libraries has two library_artist rows; pagination
+					// must still enumerate it exactly once, at a stable offset.
+					Expect(lr.AddArtist(lib2.ID, artistBeatles.ID)).To(Succeed())
+
+					all, err := repo.Search("", model.QueryOptions{Max: 1000})
+					Expect(err).ToNot(HaveOccurred())
+
+					seen := map[string]bool{}
+					var paged model.Artists
+					for offset := range len(all) {
+						page, err := repo.Search("", model.QueryOptions{Max: 1, Offset: offset})
+						Expect(err).ToNot(HaveOccurred())
+						for _, a := range page {
+							Expect(seen[a.ID]).To(BeFalse(), fmt.Sprintf("artist %s returned twice", a.ID))
+							seen[a.ID] = true
+						}
+						paged = append(paged, page...)
+					}
+					Expect(paged).To(HaveLen(len(all)))
+				})
+
 				It("paginates all artists in natural order without overlaps or gaps", func() {
 					all, err := repo.Search("", model.QueryOptions{Max: 1000})
 					Expect(err).ToNot(HaveOccurred())

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -652,6 +652,49 @@ var _ = Describe("MediaRepository", func() {
 				_, _ = raw.executeSQL(squirrel.Delete(raw.tableName).Where(squirrel.Eq{"id": missingMediaFile.ID}))
 			})
 		})
+
+		Context("empty query (natural order pagination)", func() {
+			It("returns all non-missing files in natural order", func() {
+				results, err := mr.Search("", model.QueryOptions{Max: 1000})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).ToNot(BeEmpty())
+				for _, result := range results {
+					Expect(result.Missing).To(BeFalse())
+				}
+			})
+
+			It(`treats quoted empty query ("") the same as empty`, func() {
+				all, err := mr.Search("", model.QueryOptions{Max: 1000})
+				Expect(err).ToNot(HaveOccurred())
+				quoted, err := mr.Search(`""`, model.QueryOptions{Max: 1000})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(quoted).To(HaveLen(len(all)))
+			})
+
+			It("paginates without overlaps or gaps", func() {
+				all, err := mr.Search("", model.QueryOptions{Max: 1000})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(all)).To(BeNumerically(">", 3))
+
+				var paged model.MediaFiles
+				pageSize := 3
+				for offset := 0; offset < len(all); offset += pageSize {
+					page, err := mr.Search("", model.QueryOptions{Max: pageSize, Offset: offset})
+					Expect(err).ToNot(HaveOccurred())
+					paged = append(paged, page...)
+				}
+				Expect(paged).To(HaveLen(len(all)))
+				for i := range all {
+					Expect(paged[i].ID).To(Equal(all[i].ID), fmt.Sprintf("row %d differs", i))
+				}
+			})
+
+			It("returns empty page when offset is beyond the total", func() {
+				results, err := mr.Search("", model.QueryOptions{Max: 10, Offset: 100000})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).To(BeEmpty())
+			})
+		})
 	})
 
 	Describe("FindByPaths", func() {

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -21,8 +21,10 @@ type searchConfig struct {
 	NaturalOrder string   // ORDER BY for empty-query results (e.g. "album.rowid")
 	OrderBy      []string // ORDER BY for text search results (e.g. ["name"])
 	MBIDFields   []string // columns to match when query is a UUID
-	// LibraryFilter overrides the default applyLibraryFilter for FTS Phase 1.
-	// Needed when library access requires a junction table (e.g. artist → library_artist).
+	// LibraryFilter overrides the default applyLibraryFilter for the rowid Phase 1 of
+	// two-phase searches (FTS and empty-query). Needed when library access goes through a
+	// junction table (e.g. artist → library_artist), whose JOIN can fan out rowids for
+	// entities in multiple libraries — Phase 1 dedups whenever this is set.
 	LibraryFilter func(sq SelectBuilder) SelectBuilder
 }
 
@@ -58,7 +60,8 @@ func (r sqlRepository) doSearch(sq SelectBuilder, q string, results any, cfg sea
 
 	// Empty query (OpenSubsonic `search3?query=""`) — return all in natural order.
 	if q == "" || q == `""` {
-		return r.executeNaturalSearch(sq, results, cfg, options)
+		rowidCore := Select(r.tableName + ".rowid").From(r.tableName).OrderBy(cfg.NaturalOrder)
+		return r.executeTwoPhase(sq, results, rowidCore, cfg, options)
 	}
 
 	// MBID search: if query is a valid UUID, search by MBID fields instead
@@ -82,18 +85,16 @@ func (r sqlRepository) doSearch(sq SelectBuilder, q string, results any, cfg sea
 	return strategy.execute(r, sq, results, cfg, options)
 }
 
-// executeNaturalSearch returns all non-missing rows in natural order, for the empty-query
-// case (`search3?query=""`), which clients like Symfonium use to paginate over the whole
-// library when syncing. It runs in two phases, like ftsSearch.execute:
-//   - Phase 1: rowid-only query on the main table (no JOINs), so SQLite can paginate via a
-//     covering index. With the JOINs of the full SELECT, large offsets degrade to O(offset)
-//     join probes — multi-second responses on 100k+ libraries (the whole table is walked).
+// executeTwoPhase runs a search in two phases:
+//   - Phase 1: rowidCore (strategy-specific FROM/JOINs and ORDER BY) plus the shared search
+//     contract applied here — non-missing rows only, library access, options.Filters, and
+//     pagination. Keeping Phase 1 free of the full SELECT's JOINs lets SQLite paginate via a
+//     covering index; with those JOINs, large offsets degrade to O(offset) join probes —
+//     multi-second responses on 100k+ libraries.
 //   - Phase 2: full SELECT with all JOINs, scoped to Phase 1's rowid page.
-func (r sqlRepository) executeNaturalSearch(sq SelectBuilder, results any, cfg searchConfig, options model.QueryOptions) error {
-	rowidQuery := Select(r.tableName + ".rowid").
-		From(r.tableName).
-		Where(Eq{r.tableName + ".missing": false}).
-		OrderBy(cfg.NaturalOrder)
+func (r sqlRepository) executeTwoPhase(sq SelectBuilder, results any, rowidCore SelectBuilder, cfg searchConfig, options model.QueryOptions) error {
+	rowidQuery := rowidCore.
+		Where(Eq{r.tableName + ".missing": false})
 	if options.Max > 0 {
 		rowidQuery = rowidQuery.Limit(uint64(options.Max))
 	}
@@ -101,7 +102,10 @@ func (r sqlRepository) executeNaturalSearch(sq SelectBuilder, results any, cfg s
 		rowidQuery = rowidQuery.Offset(uint64(options.Offset))
 	}
 	if cfg.LibraryFilter != nil {
-		rowidQuery = cfg.LibraryFilter(rowidQuery)
+		// Junction-table library filters can repeat rowids for entities in multiple
+		// libraries, which would corrupt offset-based pagination — dedup before paginating.
+		// (DISTINCT, not GROUP BY: bm25() can't be evaluated in a grouped query.)
+		rowidQuery = cfg.LibraryFilter(rowidQuery).Distinct()
 	} else {
 		rowidQuery = r.applyLibraryFilter(rowidQuery)
 	}

--- a/persistence/sql_search.go
+++ b/persistence/sql_search.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"fmt"
 	"strings"
 
 	. "github.com/Masterminds/squirrel"
@@ -57,8 +58,7 @@ func (r sqlRepository) doSearch(sq SelectBuilder, q string, results any, cfg sea
 
 	// Empty query (OpenSubsonic `search3?query=""`) — return all in natural order.
 	if q == "" || q == `""` {
-		sq = sq.OrderBy(cfg.NaturalOrder)
-		return r.queryAll(sq, results, options)
+		return r.executeNaturalSearch(sq, results, cfg, options)
 	}
 
 	// MBID search: if query is a valid UUID, search by MBID fields instead
@@ -80,6 +80,52 @@ func (r sqlRepository) doSearch(sq SelectBuilder, q string, results any, cfg sea
 	}
 
 	return strategy.execute(r, sq, results, cfg, options)
+}
+
+// executeNaturalSearch returns all non-missing rows in natural order, for the empty-query
+// case (`search3?query=""`), which clients like Symfonium use to paginate over the whole
+// library when syncing. It runs in two phases, like ftsSearch.execute:
+//   - Phase 1: rowid-only query on the main table (no JOINs), so SQLite can paginate via a
+//     covering index. With the JOINs of the full SELECT, large offsets degrade to O(offset)
+//     join probes — multi-second responses on 100k+ libraries (the whole table is walked).
+//   - Phase 2: full SELECT with all JOINs, scoped to Phase 1's rowid page.
+func (r sqlRepository) executeNaturalSearch(sq SelectBuilder, results any, cfg searchConfig, options model.QueryOptions) error {
+	rowidQuery := Select(r.tableName + ".rowid").
+		From(r.tableName).
+		Where(Eq{r.tableName + ".missing": false}).
+		OrderBy(cfg.NaturalOrder)
+	if options.Max > 0 {
+		rowidQuery = rowidQuery.Limit(uint64(options.Max))
+	}
+	if options.Offset > 0 {
+		rowidQuery = rowidQuery.Offset(uint64(options.Offset))
+	}
+	if cfg.LibraryFilter != nil {
+		rowidQuery = cfg.LibraryFilter(rowidQuery)
+	} else {
+		rowidQuery = r.applyLibraryFilter(rowidQuery)
+	}
+	if options.Filters != nil {
+		rowidQuery = rowidQuery.Where(options.Filters)
+	}
+	return r.hydrateRowidPage(sq, rowidQuery, results)
+}
+
+// hydrateRowidPage joins sq to the ordered rowid set produced by rowidQuery, preserving its
+// ordering. rowidQuery must handle pagination itself; sq's LIMIT/OFFSET are stripped.
+func (r sqlRepository) hydrateRowidPage(sq SelectBuilder, rowidQuery SelectBuilder, results any) error {
+	rowidSQL, rowidArgs, err := rowidQuery.ToSql()
+	if err != nil {
+		return fmt.Errorf("building rowid query: %w", err)
+	}
+	sq = sq.RemoveLimit().RemoveOffset()
+	rankedSubquery := fmt.Sprintf(
+		"(SELECT rowid as _rid, row_number() OVER () AS _rn FROM (%s)) AS _ranked",
+		rowidSQL,
+	)
+	sq = sq.Join(rankedSubquery+" ON "+r.tableName+".rowid = _ranked._rid", rowidArgs...)
+	sq = sq.OrderBy("_ranked._rn")
+	return r.queryAll(sq, results)
 }
 
 func mbidExpr(tableName, mbid string, mbidFields ...string) Sqlizer {

--- a/persistence/sql_search_fts.go
+++ b/persistence/sql_search_fts.go
@@ -284,11 +284,9 @@ func (s *ftsSearch) ToSql() (string, []any, error) {
 	return sql, []any{s.matchExpr}, nil
 }
 
-// execute runs a two-phase FTS5 search:
-//   - Phase 1: lightweight rowid query (main table + FTS + library filter) for ranking and pagination.
-//   - Phase 2: full SELECT with all JOINs, scoped to Phase 1's rowid set.
-//
-// Complex ORDER BY (function calls, aggregations) are dropped from Phase 1.
+// execute runs a two-phase FTS5 search (see executeTwoPhase): Phase 1 here contributes the
+// FTS MATCH join and BM25 rank ordering. Complex ORDER BY (function calls, aggregations) are
+// dropped from Phase 1.
 func (s *ftsSearch) execute(r sqlRepository, sq SelectBuilder, dest any, cfg searchConfig, options model.QueryOptions) error {
 	qualifiedOrderBys := []string{s.rankExpr}
 	for _, ob := range cfg.OrderBy {
@@ -297,32 +295,11 @@ func (s *ftsSearch) execute(r sqlRepository, sq SelectBuilder, dest any, cfg sea
 		}
 	}
 
-	// Phase 1: fresh query — must set LIMIT/OFFSET from options explicitly.
-	// Mirror applyOptions behavior: Max=0 means no limit, not LIMIT 0.
-	rowidQuery := Select(s.tableName+".rowid").
+	rowidCore := Select(s.tableName+".rowid").
 		From(s.tableName).
 		Join(s.ftsTable+" ON "+s.ftsTable+".rowid = "+s.tableName+".rowid AND "+s.ftsTable+" MATCH ?", s.matchExpr).
-		Where(Eq{s.tableName + ".missing": false}).
 		OrderBy(qualifiedOrderBys...)
-	if options.Max > 0 {
-		rowidQuery = rowidQuery.Limit(uint64(options.Max))
-	}
-	if options.Offset > 0 {
-		rowidQuery = rowidQuery.Offset(uint64(options.Offset))
-	}
-
-	// Library filter + musicFolderId must be applied here, before pagination.
-	if cfg.LibraryFilter != nil {
-		rowidQuery = cfg.LibraryFilter(rowidQuery)
-	} else {
-		rowidQuery = r.applyLibraryFilter(rowidQuery)
-	}
-	if options.Filters != nil {
-		rowidQuery = rowidQuery.Where(options.Filters)
-	}
-
-	// Phase 2: full SELECT joined on the ranked rowid set to hydrate with all columns.
-	return r.hydrateRowidPage(sq, rowidQuery, dest)
+	return r.executeTwoPhase(sq, dest, rowidCore, cfg, options)
 }
 
 // qualifyOrderBy prepends tableName to a simple column name. Returns empty string for

--- a/persistence/sql_search_fts.go
+++ b/persistence/sql_search_fts.go
@@ -321,21 +321,8 @@ func (s *ftsSearch) execute(r sqlRepository, sq SelectBuilder, dest any, cfg sea
 		rowidQuery = rowidQuery.Where(options.Filters)
 	}
 
-	rowidSQL, rowidArgs, err := rowidQuery.ToSql()
-	if err != nil {
-		return fmt.Errorf("building FTS rowid query: %w", err)
-	}
-
-	// Phase 2: strip LIMIT/OFFSET from sq (Phase 1 handled pagination),
-	// join on the ranked rowid set to hydrate with full columns.
-	sq = sq.RemoveLimit().RemoveOffset()
-	rankedSubquery := fmt.Sprintf(
-		"(SELECT rowid as _rid, row_number() OVER () AS _rn FROM (%s)) AS _ranked",
-		rowidSQL,
-	)
-	sq = sq.Join(rankedSubquery+" ON "+s.tableName+".rowid = _ranked._rid", rowidArgs...)
-	sq = sq.OrderBy("_ranked._rn")
-	return r.queryAll(sq, dest)
+	// Phase 2: full SELECT joined on the ranked rowid set to hydrate with all columns.
+	return r.hydrateRowidPage(sq, rowidQuery, dest)
 }
 
 // qualifyOrderBy prepends tableName to a simple column name. Returns empty string for


### PR DESCRIPTION
### Description

`search3` with an empty query — the way clients like Symfonium paginate over the whole library when syncing — degraded linearly with offset on large libraries. On a 920K-track test library, pages above offset ~600K took 3–5s each on fast hardware (much worse on a Pi), matching a recent report of a 2.5h sync that "massively slows down after the first ~100K tracks" ([reddit thread](https://www.reddit.com/r/Symfonium/comments/1u3qtmc/comment/or7hyrl/)).

Root cause: the large-offset optimization in `optimizePagination` (the "special case after 50K", `DevOffsetOptimize`) rewrites `OFFSET n` into `rowid NOT IN (SELECT rowid … LIMIT n)`, but the subquery inherits all the LEFT JOINs of the full SELECT (annotation, bookmark, library), so SQLite performs ~offset join probes per page — measured to be just as slow as plain OFFSET.

The fix reuses the two-phase pattern the FTS search already uses, now shared via `executeTwoPhase`/`hydrateRowidPage`:

- **Phase 1** paginates rowids on the bare main table, which SQLite satisfies with a covering index at any offset. A new migration replaces the `media_file_missing` index with a composite `media_file(missing, library_id)` so the query stays covering for non-admin users (whose queries filter by library).
- **Phase 2** hydrates only the page's rows with the full SELECT and all its JOINs.

Two issues found along the way are also fixed:

- Artists in multiple libraries produced duplicate rowids in Phase 1 (junction-table fan-out), corrupting offset pagination — short pages and repeated artists. Phase 1 now dedups (`DISTINCT`) whenever a junction-based library filter is used. This also fixes the same pre-existing flaw in the FTS search path. (`DISTINCT` rather than `GROUP BY` because `bm25()` cannot be evaluated in a grouped query.)
- With the library filter present, SQLite drove the artist Phase 1 from `library_artist` and sorted the entire junction table on every page (a flat ~200ms penalty at 405K artists, even at offset 0). The search-only artist library filter now pins the join order with `CROSS JOIN` so Phase 1 streams from the artist primary key index.

Benchmarks on a generated library (920K tracks / 85K albums / 405K artists), end-to-end `search3` responses, 500 items per page:

| Entity / offset | Before | After |
|---|---|---|
| Songs @ 919,500 | 3.0–5.3s | **0.10s** |
| Songs @ 400,000 | 0.5–1.7s | 0.10s |
| Songs, non-admin @ 919,500 | ~5s (SQL-level) | 0.21s |
| Artists @ 399,000 | 0.55–1.24s (SQL-level) | 0.25s |
| Artists @ 0 | ~0.07s | 0.07s |
| Albums @ 84,500 | 0.28s | 0.19s |

Songs response time is now flat at any offset; a full 920K-track sync drops from 1h+ of server time to ~3 minutes.

### Related Issues

Related to https://www.reddit.com/r/Symfonium/comments/1u3qtmc/comment/or7hyrl/ (no GitHub issue filed).

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Generate a large fake library, or use any library with 100K+ tracks. (I used a script that inserts 920K tracks / 85K albums / 405K artists directly into a fresh DB; happy to share it.)
2. Start the server and run empty-query paginated searches as a Subsonic client would during sync:
   ```bash
   curl 'http://localhost:4533/rest/search3.view?u=USER&p=PASS&c=test&v=1.16.1&f=json&query=&songCount=500&songOffset=900000&artistCount=0&albumCount=0'
   ```
3. Expected: response time stays roughly constant (~100ms-class) regardless of `songOffset`/`albumOffset`/`artistOffset`; previously it grew linearly into multiple seconds.
4. Verify page boundaries: an offset one short of the library size returns exactly 1 song; an offset equal to it returns an empty result; consecutive pages have no gaps or duplicates.
5. Verify with a non-admin user (library filter path) and with `musicFolderId` set.
6. Regression checks: regular text searches (`query=something`) return the same results as before; multi-library setups don't repeat artists across pages.

### Additional Notes

- The migration drops the single-column `media_file_missing` index in favor of the composite one (its prefix serves all `missing = ?` lookups), so there is a one-time index rebuild on upgrade — a few seconds on very large libraries.
- `CROSS JOIN` as a join-order override is SQLite-specific behavior (semantics are identical to `JOIN`); flagging it since it's one more SQLite-ism for the multi-DB effort to catalog.
- The generic `optimizePagination` in `sql_base_repository.go` still has the JOIN-inheritance problem for other offset-paged queries (e.g. album lists at large offsets) — it currently buys nothing over plain OFFSET whenever the SELECT has JOINs. Left out of scope; worth a follow-up.
