### PR TITLE
perf(search): speed up CJK search with NOCASE covering indexes

### DIFF
--- a/db/migrations/20260615010718_add_like_search_covering_indexes.sql
+++ b/db/migrations/20260615010718_add_like_search_covering_indexes.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+-- COLLATE NOCASE covering indexes for the LIKE-based search fallback (CJK and
+-- punctuation-only queries route to it; see persistence/sql_search_like.go
+-- likeSearchColumns). Without these, a CJK search3 is a full scan of the wide
+-- media_file table across 4 columns (~4s on 1M songs); with them SQLite scans the
+-- narrow per-column indexes instead (~0.3s). Columns MUST match likeSearchColumns.
+-- A plain LIKE uses these because Navidrome runs with case_sensitive_like = OFF.
+CREATE INDEX IF NOT EXISTS idx_media_file_title_nocase ON media_file (title COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_media_file_album_nocase ON media_file (album COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_media_file_artist_nocase ON media_file (artist COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_media_file_album_artist_nocase ON media_file (album_artist COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_album_name_nocase ON album (name COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_album_album_artist_nocase ON album (album_artist COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_artist_name_nocase ON artist (name COLLATE NOCASE);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_media_file_title_nocase;
+DROP INDEX IF EXISTS idx_media_file_album_nocase;
+DROP INDEX IF EXISTS idx_media_file_artist_nocase;
+DROP INDEX IF EXISTS idx_media_file_album_artist_nocase;
+DROP INDEX IF EXISTS idx_album_name_nocase;
+DROP INDEX IF EXISTS idx_album_album_artist_nocase;
+DROP INDEX IF EXISTS idx_artist_name_nocase;

--- a/persistence/sql_search_like.go
+++ b/persistence/sql_search_like.go
@@ -71,6 +71,10 @@ func legacySearchExpr(tableName string, s string) Sqlizer {
 // likeSearchColumns defines the core columns to search with LIKE queries.
 // These are the primary user-visible fields for each entity type.
 // Used as a fallback when FTS5 cannot handle the query (e.g., CJK text, punctuation-only input).
+//
+// Each column needs a matching COLLATE NOCASE index (migration
+// add_like_search_covering_indexes) so these LIKE scans hit a narrow covering index
+// instead of the full table. The "likeSearchColumns covering indexes" test enforces this.
 var likeSearchColumns = map[string][]string{
 	"media_file": {"title", "album", "artist", "album_artist"},
 	"album":      {"name", "album_artist"},

--- a/persistence/sql_search_like_test.go
+++ b/persistence/sql_search_like_test.go
@@ -2,6 +2,8 @@ package persistence
 
 import (
 	"context"
+	"fmt"
+	"regexp"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -130,5 +132,39 @@ var _ = Describe("Legacy Integration Search", func() {
 		results, err := mr.Search("Beatles", model.QueryOptions{Max: 0})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(results).ToNot(BeEmpty(), "Max=0 should mean no limit, not LIMIT 0")
+	})
+})
+
+// Guards the invariant that every column searched by the LIKE fallback has a COLLATE NOCASE
+// covering index (migration add_like_search_covering_indexes). Without it a CJK/punctuation
+// search does a full table scan. If you add a column to likeSearchColumns without an index,
+// this test fails — keep the two in sync.
+var _ = Describe("likeSearchColumns covering indexes", func() {
+	It("has a COLLATE NOCASE index for every searched column", func() {
+		var indexSQLs []string
+		err := GetDBXBuilder().
+			NewQuery("SELECT sql FROM sqlite_master WHERE type='index' AND sql IS NOT NULL").
+			Column(&indexSQLs)
+		Expect(err).ToNot(HaveOccurred())
+
+		for table, columns := range likeSearchColumns {
+			// Match the index's target table precisely: "ON <table> (" (case-insensitive).
+			tableRe := regexp.MustCompile(`(?i)\bon\s+` + regexp.QuoteMeta(table) + `\s*\(`)
+			for _, col := range columns {
+				// Match e.g. "(title COLLATE NOCASE)" — column immediately followed by the
+				// NOCASE collation, case-insensitive (SQLite emits both "COLLATE" and "collate").
+				colRe := regexp.MustCompile(`(?i)\b` + regexp.QuoteMeta(col) + `\s+collate\s+nocase\b`)
+				found := false
+				for _, sql := range indexSQLs {
+					if tableRe.MatchString(sql) && colRe.MatchString(sql) {
+						found = true
+						break
+					}
+				}
+				Expect(found).To(BeTrue(),
+					fmt.Sprintf("missing COLLATE NOCASE index for %s.%s — add it to the "+
+						"add_like_search_covering_indexes migration to keep LIKE search fast", table, col))
+			}
+		}
 	})
 })


### PR DESCRIPTION
### Description

Search queries containing CJK (Chinese/Japanese/Korean) characters can be very slow on large libraries. Such queries — along with punctuation-only input — intentionally bypass FTS5 and fall back to `LIKE`-based search, because the `unicode61` tokenizer indexes whole space-free CJK runs as single tokens and can't substring-match them.

The problem: that `LIKE` fallback had no usable index, so each query did a full scan of the wide `media_file` table across four columns. On a ~1M-track library this measured around **4 seconds per CJK query**.

This PR adds `COLLATE NOCASE` covering indexes on exactly the columns the `LIKE` fallback searches (`likeSearchColumns`): `media_file(title, album, artist, album_artist)`, `album(name, album_artist)`, and `artist(name)`. SQLite then scans the narrow per-column indexes instead of the full table. A plain `LIKE` uses these because the server runs with `case_sensitive_like = OFF`.

**Results are unchanged — only latency improves.** End-to-end, CJK `search3` queries drop from ~4s to ~0.3s (~10–12x) on a 1M-track test library. The FTS path for Latin/numeric queries is untouched. The added indexes cost roughly +140 MiB on a 1M-track database, and also speed up the punctuation-only fallback.

A new test asserts that every column in `likeSearchColumns` has a matching `COLLATE NOCASE` index in the migrated schema, so the searched-column set and the migration can't silently drift out of sync (verified to fail when a column is added without its index).

### Related Issues

_None._

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Use a library with some CJK-titled tracks/albums/artists (or any library — the fallback also covers punctuation-only queries).
2. Call `search3` with a CJK query, e.g. `/rest/search3.view?...&query=<cjk-term>`, and confirm the expected artists/albums/songs are returned.
3. On a large library, compare response time before/after the migration — CJK queries should go from multi-second to sub-second, with identical results.
4. Confirm a regular (Latin/numeric) query still returns the same results and remains fast (it uses the unchanged FTS path).

### Additional Notes

- The migration is purely additive (creates indexes; `down` drops them); it adds some write cost on insert/update/delete and ~140 MiB on a 1M-track database.
- This delivers most of the achievable speedup with a minimal change. A future option for true ~1ms CJK substring search (including mid-string matches) would be a `trigram` FTS index, at a larger code and disk cost — intentionally out of scope here.
