### PR TITLE
fix(transcoding): preserve source metadata when transcoding downloads

### DIFF
--- a/consts/consts.go
+++ b/consts/consts.go
@@ -156,25 +156,25 @@ var (
 			Name:           "mp3 audio",
 			TargetFormat:   "mp3",
 			DefaultBitRate: 192,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -f mp3 -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -f mp3 -",
 		},
 		{
 			Name:           "opus audio",
 			TargetFormat:   "opus",
 			DefaultBitRate: 128,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a libopus -f opus -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -c:a libopus -f opus -",
 		},
 		{
 			Name:           "aac audio",
 			TargetFormat:   "aac",
 			DefaultBitRate: 256,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a aac -f adts -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -c:a aac -f adts -",
 		},
 		{
 			Name:           "flac audio",
 			TargetFormat:   "flac",
 			DefaultBitRate: 0,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -v 0 -c:a flac -f flac -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -v 0 -c:a flac -f flac -",
 		},
 	}
 )

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -156,25 +156,25 @@ var (
 			Name:           "mp3 audio",
 			TargetFormat:   "mp3",
 			DefaultBitRate: 192,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -f mp3 -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -f mp3 -",
 		},
 		{
 			Name:           "opus audio",
 			TargetFormat:   "opus",
 			DefaultBitRate: 128,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a libopus -f opus -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a libopus -f opus -",
 		},
 		{
 			Name:           "aac audio",
 			TargetFormat:   "aac",
 			DefaultBitRate: 256,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a aac -f adts -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a aac -f adts -",
 		},
 		{
 			Name:           "flac audio",
 			TargetFormat:   "flac",
 			DefaultBitRate: 0,
-			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -v 0 -c:a flac -f flac -",
+			Command:        "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -v 0 -c:a flac -f flac -",
 		},
 	}
 )

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -404,10 +404,12 @@ func buildDynamicArgs(opts TranscodeOptions) []string {
 	args = append(args, "-map", "0:a:0")
 
 	// Preserve source tags. -map_metadata 0 copies format-level tags (MP3/FLAC);
-	// -map_metadata 0:s:0 copies stream-level tags (OPUS/OGG). Both are needed
-	// because the two source families store tags at different levels. Note: adts
-	// (AAC) output cannot hold tags, so these are a no-op there.
-	args = append(args, "-map_metadata", "0", "-map_metadata", "0:s:0")
+	// -map_metadata 0:s:a:0 copies tags from the first audio stream (OPUS/OGG).
+	// Both are needed because the two source families store tags at different
+	// levels. Targeting the audio stream explicitly (s:a:0 rather than s:0) avoids
+	// pulling metadata from an embedded cover-art/video stream at index 0. Note:
+	// adts (AAC) output cannot hold tags, so these are a no-op there.
+	args = append(args, "-map_metadata", "0", "-map_metadata", "0:s:a:0")
 
 	if codec, ok := formatCodecMap[opts.Format]; ok {
 		args = append(args, "-c:a", codec)

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -403,6 +403,12 @@ func buildDynamicArgs(opts TranscodeOptions) []string {
 	args = append(args, "-i", opts.FilePath)
 	args = append(args, "-map", "0:a:0")
 
+	// Preserve source tags. -map_metadata 0 copies format-level tags (MP3/FLAC);
+	// -map_metadata 0:s:0 copies stream-level tags (OPUS/OGG). Both are needed
+	// because the two source families store tags at different levels. Note: adts
+	// (AAC) output cannot hold tags, so these are a no-op there.
+	args = append(args, "-map_metadata", "0", "-map_metadata", "0:s:0")
+
 	if codec, ok := formatCodecMap[opts.Format]; ok {
 		args = append(args, "-c:a", codec)
 	}

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -82,16 +82,16 @@ var _ = Describe("ffmpeg", func() {
 
 	Describe("isDefaultCommand", func() {
 		It("returns true for known default mp3 command", func() {
-			Expect(isDefaultCommand("mp3", "ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -f mp3 -")).To(BeTrue())
+			Expect(isDefaultCommand("mp3", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -f mp3 -")).To(BeTrue())
 		})
 		It("returns true for known default opus command", func() {
-			Expect(isDefaultCommand("opus", "ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a libopus -f opus -")).To(BeTrue())
+			Expect(isDefaultCommand("opus", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a libopus -f opus -")).To(BeTrue())
 		})
 		It("returns true for known default aac command", func() {
-			Expect(isDefaultCommand("aac", "ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a aac -f adts -")).To(BeTrue())
+			Expect(isDefaultCommand("aac", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a aac -f adts -")).To(BeTrue())
 		})
 		It("returns true for known default flac command", func() {
-			Expect(isDefaultCommand("flac", "ffmpeg -ss %t -i %s -map 0:a:0 -v 0 -c:a flac -f flac -")).To(BeTrue())
+			Expect(isDefaultCommand("flac", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -v 0 -c:a flac -f flac -")).To(BeTrue())
 		})
 		It("returns false for a custom command", func() {
 			Expect(isDefaultCommand("mp3", "ffmpeg -i %s -b:a %bk -custom-flag -f mp3 -")).To(BeFalse())
@@ -113,6 +113,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.flac",
 				"-map", "0:a:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:0",
 				"-c:a", "libmp3lame",
 				"-b:a", "256k",
 				"-ar", "48000",
@@ -132,6 +133,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.dsf",
 				"-map", "0:a:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:0",
 				"-c:a", "flac",
 				"-ar", "48000",
 				"-v", "0",
@@ -149,6 +151,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.flac",
 				"-map", "0:a:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:0",
 				"-c:a", "libopus",
 				"-b:a", "128k",
 				"-v", "0",
@@ -169,6 +172,7 @@ var _ = Describe("ffmpeg", func() {
 				"-ss", "30",
 				"-i", "/music/file.mp3",
 				"-map", "0:a:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:0",
 				"-c:a", "libmp3lame",
 				"-b:a", "192k",
 				"-v", "0",
@@ -186,6 +190,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.flac",
 				"-map", "0:a:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:0",
 				"-c:a", "aac",
 				"-b:a", "256k",
 				"-v", "0",
@@ -203,6 +208,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.dsf",
 				"-map", "0:a:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:0",
 				"-c:a", "flac",
 				"-sample_fmt", "s32",
 				"-v", "0",

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -82,16 +82,16 @@ var _ = Describe("ffmpeg", func() {
 
 	Describe("isDefaultCommand", func() {
 		It("returns true for known default mp3 command", func() {
-			Expect(isDefaultCommand("mp3", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -f mp3 -")).To(BeTrue())
+			Expect(isDefaultCommand("mp3", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -f mp3 -")).To(BeTrue())
 		})
 		It("returns true for known default opus command", func() {
-			Expect(isDefaultCommand("opus", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a libopus -f opus -")).To(BeTrue())
+			Expect(isDefaultCommand("opus", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -c:a libopus -f opus -")).To(BeTrue())
 		})
 		It("returns true for known default aac command", func() {
-			Expect(isDefaultCommand("aac", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a aac -f adts -")).To(BeTrue())
+			Expect(isDefaultCommand("aac", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -c:a aac -f adts -")).To(BeTrue())
 		})
 		It("returns true for known default flac command", func() {
-			Expect(isDefaultCommand("flac", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -v 0 -c:a flac -f flac -")).To(BeTrue())
+			Expect(isDefaultCommand("flac", "ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -v 0 -c:a flac -f flac -")).To(BeTrue())
 		})
 		It("returns false for a custom command", func() {
 			Expect(isDefaultCommand("mp3", "ffmpeg -i %s -b:a %bk -custom-flag -f mp3 -")).To(BeFalse())
@@ -113,7 +113,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.flac",
 				"-map", "0:a:0",
-				"-map_metadata", "0", "-map_metadata", "0:s:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:a:0",
 				"-c:a", "libmp3lame",
 				"-b:a", "256k",
 				"-ar", "48000",
@@ -133,7 +133,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.dsf",
 				"-map", "0:a:0",
-				"-map_metadata", "0", "-map_metadata", "0:s:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:a:0",
 				"-c:a", "flac",
 				"-ar", "48000",
 				"-v", "0",
@@ -151,7 +151,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.flac",
 				"-map", "0:a:0",
-				"-map_metadata", "0", "-map_metadata", "0:s:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:a:0",
 				"-c:a", "libopus",
 				"-b:a", "128k",
 				"-v", "0",
@@ -172,7 +172,7 @@ var _ = Describe("ffmpeg", func() {
 				"-ss", "30",
 				"-i", "/music/file.mp3",
 				"-map", "0:a:0",
-				"-map_metadata", "0", "-map_metadata", "0:s:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:a:0",
 				"-c:a", "libmp3lame",
 				"-b:a", "192k",
 				"-v", "0",
@@ -190,7 +190,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.flac",
 				"-map", "0:a:0",
-				"-map_metadata", "0", "-map_metadata", "0:s:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:a:0",
 				"-c:a", "aac",
 				"-b:a", "256k",
 				"-v", "0",
@@ -208,7 +208,7 @@ var _ = Describe("ffmpeg", func() {
 			Expect(args).To(Equal([]string{
 				"ffmpeg", "-i", "/music/file.dsf",
 				"-map", "0:a:0",
-				"-map_metadata", "0", "-map_metadata", "0:s:0",
+				"-map_metadata", "0", "-map_metadata", "0:s:a:0",
 				"-c:a", "flac",
 				"-sample_fmt", "s32",
 				"-v", "0",

--- a/db/migrations/20260618120509_add_metadata_to_default_transcodings.go
+++ b/db/migrations/20260618120509_add_metadata_to_default_transcodings.go
@@ -14,10 +14,12 @@ func init() {
 // metadataPairs maps the current default commands (no metadata mapping) to the
 // new defaults that preserve source tags. Index 0 = old, index 1 = new.
 //
-// The new commands add `-map_metadata 0 -map_metadata 0:s:0` after `-map 0:a:0`:
+// The new commands add `-map_metadata 0 -map_metadata 0:s:a:0` after `-map 0:a:0`:
 // `-map_metadata 0` copies format-level tags (MP3/FLAC sources) and
-// `-map_metadata 0:s:0` copies stream-level tags (OPUS/OGG sources); both are
-// needed because the two source families store tags at different levels.
+// `-map_metadata 0:s:a:0` copies tags from the first audio stream (OPUS/OGG
+// sources); both are needed because the two source families store tags at
+// different levels. Targeting the audio stream explicitly avoids pulling
+// metadata from an embedded cover-art/video stream at index 0.
 //
 // AAC is included for consistency, but its `-f adts` container cannot hold tags,
 // so the flags are a no-op there.
@@ -27,34 +29,34 @@ func init() {
 var metadataPairs = [][2]string{
 	{
 		"ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -f mp3 -",
-		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -f mp3 -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -f mp3 -",
 	},
 	{
 		"ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a libopus -f opus -",
-		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a libopus -f opus -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -c:a libopus -f opus -",
 	},
 	{
 		"ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a aac -f adts -",
-		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a aac -f adts -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -b:a %bk -v 0 -c:a aac -f adts -",
 	},
 	{
 		"ffmpeg -ss %t -i %s -map 0:a:0 -v 0 -c:a flac -f flac -",
-		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -v 0 -c:a flac -f flac -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:a:0 -v 0 -c:a flac -f flac -",
 	},
 }
 
-func upAddMetadataToDefaultTranscodings(_ context.Context, tx *sql.Tx) error {
+func upAddMetadataToDefaultTranscodings(ctx context.Context, tx *sql.Tx) error {
 	for _, p := range metadataPairs {
-		if _, err := tx.Exec(`UPDATE transcoding SET command = ? WHERE command = ?`, p[1], p[0]); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE transcoding SET command = ? WHERE command = ?`, p[1], p[0]); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func downAddMetadataToDefaultTranscodings(_ context.Context, tx *sql.Tx) error {
+func downAddMetadataToDefaultTranscodings(ctx context.Context, tx *sql.Tx) error {
 	for _, p := range metadataPairs {
-		if _, err := tx.Exec(`UPDATE transcoding SET command = ? WHERE command = ?`, p[0], p[1]); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE transcoding SET command = ? WHERE command = ?`, p[0], p[1]); err != nil {
 			return err
 		}
 	}

--- a/db/migrations/20260618120509_add_metadata_to_default_transcodings.go
+++ b/db/migrations/20260618120509_add_metadata_to_default_transcodings.go
@@ -1,0 +1,62 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddMetadataToDefaultTranscodings, downAddMetadataToDefaultTranscodings)
+}
+
+// metadataPairs maps the current default commands (no metadata mapping) to the
+// new defaults that preserve source tags. Index 0 = old, index 1 = new.
+//
+// The new commands add `-map_metadata 0 -map_metadata 0:s:0` after `-map 0:a:0`:
+// `-map_metadata 0` copies format-level tags (MP3/FLAC sources) and
+// `-map_metadata 0:s:0` copies stream-level tags (OPUS/OGG sources); both are
+// needed because the two source families store tags at different levels.
+//
+// AAC is included for consistency, but its `-f adts` container cannot hold tags,
+// so the flags are a no-op there.
+//
+// Only rows still holding the exact unmodified default are updated, so any
+// user-customized command is left untouched.
+var metadataPairs = [][2]string{
+	{
+		"ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -f mp3 -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -f mp3 -",
+	},
+	{
+		"ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a libopus -f opus -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a libopus -f opus -",
+	},
+	{
+		"ffmpeg -ss %t -i %s -map 0:a:0 -b:a %bk -v 0 -c:a aac -f adts -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -b:a %bk -v 0 -c:a aac -f adts -",
+	},
+	{
+		"ffmpeg -ss %t -i %s -map 0:a:0 -v 0 -c:a flac -f flac -",
+		"ffmpeg -ss %t -i %s -map 0:a:0 -map_metadata 0 -map_metadata 0:s:0 -v 0 -c:a flac -f flac -",
+	},
+}
+
+func upAddMetadataToDefaultTranscodings(_ context.Context, tx *sql.Tx) error {
+	for _, p := range metadataPairs {
+		if _, err := tx.Exec(`UPDATE transcoding SET command = ? WHERE command = ?`, p[1], p[0]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func downAddMetadataToDefaultTranscodings(_ context.Context, tx *sql.Tx) error {
+	for _, p := range metadataPairs {
+		if _, err := tx.Exec(`UPDATE transcoding SET command = ? WHERE command = ?`, p[0], p[1]); err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
### Description

When downloading a track transcoded to a different format, all source tags (title, artist, album, date, track, genre, etc.) were lost. Downloading in the original format was unaffected, because that path copies the file byte-for-byte.

The cause is that the default transcoding commands use `-map 0:a:0` (audio stream only) without any metadata mapping, so ffmpeg drops all tags.

This PR adds `-map_metadata 0 -map_metadata 0:s:0` to the default commands. **Both** flags are required, because the two source families store tags at different levels:

- `-map_metadata 0` copies **format-level** tags (MP3, FLAC sources)
- `-map_metadata 0:s:0` copies **stream-level** tags (OPUS, OGG sources — the case in the issue)

The flags are added in three coordinated places, because for a user on the default command the ffmpeg args are built **programmatically** in Go (`buildDynamicArgs`) and the stored command string is not executed:

1. `consts.go` default commands — applies to **new installations** (seeded into the DB).
2. `buildDynamicArgs` — the path that actually runs for default-command users.
3. A migration that updates only `transcoding` rows still holding the **exact** old default command, so any user-customized command is left untouched.

These three must stay in lockstep, since `isDefaultCommand` compares the stored command against the consts default to decide which path to take.

### Related Issues

Fixes #5623

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Have a source file with embedded tags — ideally **OPUS** (the issue's case), to exercise the stream-level path. MP3/FLAC sources work too.
2. In the web UI, open the album/track and use **Download** → choose a format other than original (e.g. MP3).
3. Inspect the downloaded file's tags, e.g. `ffprobe -hide_banner downloaded.mp3` or any tag editor.
4. **Expected:** title, artist, album, date, track, genre survive the transcode (previously only an auto-generated `encoder` tag remained).
5. Edge cases:
   - Source MP3 → MP3/OPUS/FLAC: format-level tags preserved.
   - Source OPUS → MP3/FLAC: stream-level tags preserved.
   - Existing installation upgrade: a user still on the default command gets the fix automatically (via the migration); a user with a customized command is **not** modified.

### Additional Notes

- **AAC is intentionally a no-op.** The default AAC command uses `-f adts`, a raw bitstream container that cannot hold any metadata. The flags are added to the AAC default for consistency, but AAC downloads will still have no tags. The MP4 alternative (`-f ipod`) was previously reverted because it produces corrupt/silent audio when ffmpeg pipes to stdout (see migration `20260310113858`), so it isn't a viable fix here. The reporter mentions AAC specifically — this PR fixes MP3/OPUS/FLAC; AAC metadata would need its own investigation into the pipe-vs-container conflict.
- The migration matches the exact current default strings (the `-ss %t -i %s` form established by `move_ss_before_input`), following the same pattern as the existing `fix_aac_transcode_command` migration. A non-matching string results in zero updated rows, so customized commands are never touched.
