### PR TITLE
feat(share): Improve Share Download UX

### DIFF
--- a/resources/i18n/ar.json
+++ b/resources/i18n/ar.json
@@ -196,6 +196,13 @@
                 "updatedAt": "آخر تحديث",
                 "createdAt": "تاريخ الإنشاء",
                 "downloadable": "هل يسمح بالتنزيل؟"
+            },
+            "actions": {
+                "download": {
+                    "title": "تحميل",
+                    "currentTrack": "المقطع الحالي",
+                    "allTracks": "جميع المقاطع"
+                }
             }
         }
     },

--- a/resources/i18n/bg.json
+++ b/resources/i18n/bg.json
@@ -256,6 +256,13 @@
         "updatedAt": "Актуализирана на",
         "createdAt": "Създадена на",
         "downloadable": "Разреши изтегляния?"
+      },
+      "actions": {
+        "download": {
+          "title": "Изтегляне",
+          "currentTrack": "Текуща песен",
+          "allTracks": "Всички песни"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/bs.json
+++ b/resources/i18n/bs.json
@@ -253,6 +253,13 @@
         "updatedAt": "Ažurirano",
         "createdAt": "Kreirano",
         "downloadable": "Dozvoli preuzimanje?"
+      },
+      "actions": {
+        "download": {
+          "title": "Preuzmi",
+          "currentTrack": "Trenutna pjesma",
+          "allTracks": "Sve pjesme"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/ca.json
+++ b/resources/i18n/ca.json
@@ -256,6 +256,13 @@
         "updatedAt": "Actualitzat",
         "createdAt": "Creat",
         "downloadable": "Permet descarregar?"
+      },
+      "actions": {
+        "download": {
+          "title": "Descarrega",
+          "currentTrack": "Pista actual",
+          "allTracks": "Totes les pistes"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/cs.json
+++ b/resources/i18n/cs.json
@@ -196,6 +196,13 @@
                 "updatedAt": "Nahráno",
                 "createdAt": "Vytvořeno",
                 "downloadable": "Povolit stahování?"
+            },
+            "actions": {
+                "download": {
+                    "title": "Stáhnout",
+                    "currentTrack": "Aktuální skladba",
+                    "allTracks": "Všechny skladby"
+                }
             }
         }
     },

--- a/resources/i18n/da.json
+++ b/resources/i18n/da.json
@@ -256,6 +256,13 @@
         "updatedAt": "Opdateret d.",
         "createdAt": "Oprettet d.",
         "downloadable": "Tillad downloads?"
+      },
+      "actions": {
+        "download": {
+          "title": "Download",
+          "currentTrack": "Nuværende nummer",
+          "allTracks": "Alle numre"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/de.json
+++ b/resources/i18n/de.json
@@ -258,6 +258,13 @@
         "updatedAt": "Geändert am",
         "createdAt": "Erstellt am",
         "downloadable": "Downloads erlauben?"
+      },
+      "actions": {
+        "download": {
+          "title": "Herunterladen",
+          "currentTrack": "Aktueller Titel",
+          "allTracks": "Alle Titel"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/el.json
+++ b/resources/i18n/el.json
@@ -256,6 +256,13 @@
         "updatedAt": "Ενημερώθηκε στις",
         "createdAt": "Δημιουργήθηκε στις",
         "downloadable": "Επιτρέπονται οι λήψεις?"
+      },
+      "actions": {
+        "download": {
+          "title": "Λήψη",
+          "currentTrack": "Τρέχον κομμάτι",
+          "allTracks": "Όλα τα κομμάτια"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/eo.json
+++ b/resources/i18n/eo.json
@@ -256,6 +256,13 @@
         "updatedAt": "Ĝisdatiĝis je",
         "createdAt": "Fariĝis je",
         "downloadable": "Ĉu Ebligi Elŝutojn?"
+      },
+      "actions": {
+        "download": {
+          "title": "Elŝuti",
+          "currentTrack": "Nuna trako",
+          "allTracks": "Ĉiuj trakoj"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/es.json
+++ b/resources/i18n/es.json
@@ -258,6 +258,13 @@
         "updatedAt": "Actualizado el",
         "createdAt": "Creado el",
         "downloadable": "¿Permitir descargas?"
+      },
+      "actions": {
+        "download": {
+          "title": "Descargar",
+          "currentTrack": "Pista actual",
+          "allTracks": "Todas las pistas"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/eu.json
+++ b/resources/i18n/eu.json
@@ -260,7 +260,13 @@
         "createdAt": "Sortze-data:"
       },
       "notifications": {},
-      "actions": {}
+      "actions": {
+        "download": {
+          "title": "Deskargatu",
+          "currentTrack": "Uneko pista",
+          "allTracks": "Pista guztiak"
+        }
+      }
     },
     "missing": {
       "name": "Aurkitu ez den fitxategia |||| Aurkitu ez diren fitxategiak",
@@ -601,7 +607,7 @@
     "shareSuccess": "URLa arbelera kopiatu da: %{url}",
     "shareFailure": "Errorea %{url} URLa arbelera kopiatzean",
     "downloadDialogTitle": "Deskargatu '%{name}' %{resource}, (%{size})",
-    "downloadOriginalFormat": "Deskargatu jatorrizko formatua"    
+    "downloadOriginalFormat": "Deskargatu jatorrizko formatua"
   },
   "menu": {
     "library": "Liburutegia",

--- a/resources/i18n/fa.json
+++ b/resources/i18n/fa.json
@@ -196,6 +196,13 @@
                 "updatedAt": "",
                 "createdAt": "",
                 "downloadable": ""
+            },
+            "actions": {
+                "download": {
+                    "title": "دانلود",
+                    "currentTrack": "آهنگ فعلی",
+                    "allTracks": "همه آهنگ‌ها"
+                }
             }
         }
     },

--- a/resources/i18n/fi.json
+++ b/resources/i18n/fi.json
@@ -258,6 +258,13 @@
         "updatedAt": "Päivitetty",
         "createdAt": "Luotu",
         "downloadable": "Salli lataus?"
+      },
+      "actions": {
+        "download": {
+          "title": "Lataa",
+          "currentTrack": "Nykyinen kappale",
+          "allTracks": "Kaikki kappaleet"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/fr.json
+++ b/resources/i18n/fr.json
@@ -256,6 +256,13 @@
         "updatedAt": "Mis à jour le",
         "createdAt": "Créé le",
         "downloadable": "Autoriser les téléchargements ?"
+      },
+      "actions": {
+        "download": {
+          "title": "Télécharger",
+          "currentTrack": "Piste en cours",
+          "allTracks": "Toutes les pistes"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/gl.json
+++ b/resources/i18n/gl.json
@@ -258,6 +258,13 @@
         "updatedAt": "Actualizada o",
         "createdAt": "Creada o",
         "downloadable": "Permitir descargas?"
+      },
+      "actions": {
+        "download": {
+          "title": "Descargar",
+          "currentTrack": "Pista actual",
+          "allTracks": "Todas as pistas"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/hi.json
+++ b/resources/i18n/hi.json
@@ -255,7 +255,13 @@
         "createdAt": "बनाया गया"
       },
       "notifications": {},
-      "actions": {}
+      "actions": {
+        "download": {
+          "title": "डाउनलोड",
+          "currentTrack": "वर्तमान ट्रैक",
+          "allTracks": "सभी ट्रैक"
+        }
+      }
     },
     "missing": {
       "name": "गुम फ़ाइल |||| गुम फ़ाइलें",

--- a/resources/i18n/hu.json
+++ b/resources/i18n/hu.json
@@ -256,6 +256,13 @@
         "updatedAt": "Frissítve",
         "createdAt": "Létrehozva",
         "downloadable": "Engedélyezed a letöltéseket?"
+      },
+      "actions": {
+        "download": {
+          "title": "Letöltés",
+          "currentTrack": "Jelenlegi szám",
+          "allTracks": "Összes szám"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/id.json
+++ b/resources/i18n/id.json
@@ -258,6 +258,13 @@
         "updatedAt": "Diperbarui pada",
         "createdAt": "Dibuat pada",
         "downloadable": "Izinkan Pengunduhan?"
+      },
+      "actions": {
+        "download": {
+          "title": "Unduh",
+          "currentTrack": "Trek saat ini",
+          "allTracks": "Semua trek"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/it.json
+++ b/resources/i18n/it.json
@@ -260,7 +260,13 @@
                 "createdAt": "Data di creazione"
             },
             "notifications": {},
-            "actions": {}
+            "actions": {
+                "download": {
+                    "title": "Scarica",
+                    "currentTrack": "Traccia corrente",
+                    "allTracks": "Tutte le tracce"
+                }
+            }
         },
         "missing": {
             "name": "File mancante |||| File mancanti",

--- a/resources/i18n/ja.json
+++ b/resources/i18n/ja.json
@@ -253,6 +253,13 @@
         "updatedAt": "更新日",
         "createdAt": "作成日",
         "downloadable": "ダウンロードを許可しますか？"
+      },
+      "actions": {
+        "download": {
+          "title": "ダウンロード",
+          "currentTrack": "現在のトラック",
+          "allTracks": "すべてのトラック"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/ko.json
+++ b/resources/i18n/ko.json
@@ -12,7 +12,7 @@
         "artist": "아티스트",
         "album": "앨범",
         "path": "파일 경로",
-		"libraryName": "라이브러리",
+        "libraryName": "라이브러리",
         "genre": "장르",
         "compilation": "컴필레이션",
         "year": "년",
@@ -183,7 +183,7 @@
         "scrobbleEnabled": "외부 서비스에 스크로블 보내기"
       }
     },
-"transcoding": {
+    "transcoding": {
       "name": "트랜스코딩 |||| 트랜스코딩",
       "fields": {
         "name": "이름",
@@ -254,7 +254,13 @@
         "createdAt": "생성됨"
       },
       "notifications": {},
-      "actions": {}
+      "actions": {
+        "download": {
+          "title": "다운로드",
+          "currentTrack": "현재 트랙",
+          "allTracks": "모든 트랙"
+        }
+      }
     },
     "missing": {
       "name": "누락 파일 |||| 누락 파일들",

--- a/resources/i18n/nl.json
+++ b/resources/i18n/nl.json
@@ -258,6 +258,13 @@
         "updatedAt": "Bijgewerkt op",
         "createdAt": "Aangemaakt op",
         "downloadable": "Downloads toestaan?"
+      },
+      "actions": {
+        "download": {
+          "title": "Downloaden",
+          "currentTrack": "Huidig nummer",
+          "allTracks": "Alle nummers"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/no.json
+++ b/resources/i18n/no.json
@@ -253,6 +253,13 @@
         "updatedAt": "Oppdatert",
         "createdAt": "Opprettet",
         "downloadable": "Tillat Nedlastinger?"
+      },
+      "actions": {
+        "download": {
+          "title": "Last ned",
+          "currentTrack": "Gjeldende spor",
+          "allTracks": "Alle spor"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/pl.json
+++ b/resources/i18n/pl.json
@@ -255,6 +255,13 @@
         "updatedAt": "Zaktualizowano",
         "createdAt": "Stworzono",
         "downloadable": "Zezwolić Na Pobieranie?"
+      },
+      "actions": {
+        "download": {
+          "title": "Pobierz",
+          "currentTrack": "Bieżący utwór",
+          "allTracks": "Wszystkie utwory"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/pt-br.json
+++ b/resources/i18n/pt-br.json
@@ -258,6 +258,13 @@
         "updatedAt": "Últ. Atualização",
         "createdAt": "Data de Criação",
         "downloadable": "Permitir Baixar?"
+      },
+      "actions": {
+        "download": {
+          "title": "Baixar",
+          "currentTrack": "Faixa atual",
+          "allTracks": "Todas as faixas"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/ru.json
+++ b/resources/i18n/ru.json
@@ -258,6 +258,13 @@
         "updatedAt": "Обновлено",
         "createdAt": "Создано",
         "downloadable": "Разрешить загрузку?"
+      },
+      "actions": {
+        "download": {
+          "title": "Скачать",
+          "currentTrack": "Текущий трек",
+          "allTracks": "Все треки"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/sl.json
+++ b/resources/i18n/sl.json
@@ -256,6 +256,13 @@
         "updatedAt": "Posodobljeno ob",
         "createdAt": "Ustvarjeno ob",
         "downloadable": "Dovoli prenose?"
+      },
+      "actions": {
+        "download": {
+          "title": "Prenesi",
+          "currentTrack": "Trenutna skladba",
+          "allTracks": "Vse skladbe"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/sr.json
+++ b/resources/i18n/sr.json
@@ -260,7 +260,13 @@
         "createdAt": "Креирано"
       },
       "notifications": {},
-      "actions": {}
+      "actions": {
+        "download": {
+          "title": "Преузми",
+          "currentTrack": "Тренутна песма",
+          "allTracks": "Све песме"
+        }
+      }
     },
     "missing": {
       "name": "Фајл који недостаје|||| Фајлови који недостају",

--- a/resources/i18n/sv.json
+++ b/resources/i18n/sv.json
@@ -256,6 +256,13 @@
         "updatedAt": "Uppdaterad",
         "createdAt": "Skapad",
         "downloadable": "Tillåt nedladdning?"
+      },
+      "actions": {
+        "download": {
+          "title": "Ladda ner",
+          "currentTrack": "Nuvarande spår",
+          "allTracks": "Alla spår"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/th.json
+++ b/resources/i18n/th.json
@@ -258,6 +258,13 @@
         "updatedAt": "อัปเดตเมื่อ",
         "createdAt": "สร้างเมื่อ",
         "downloadable": "อนุญาตให้ดาวโหลด?"
+      },
+      "actions": {
+        "download": {
+          "title": "ดาวน์โหลด",
+          "currentTrack": "แทร็กปัจจุบัน",
+          "allTracks": "แทร็กทั้งหมด"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/tr.json
+++ b/resources/i18n/tr.json
@@ -253,6 +253,13 @@
         "updatedAt": "Güncelleme Tarihi",
         "createdAt": "Oluşturma Tarihi",
         "downloadable": "İndirmelere İzin Ver"
+      },
+      "actions": {
+        "download": {
+          "title": "İndir",
+          "currentTrack": "Mevcut parça",
+          "allTracks": "Tüm parçalar"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/uk.json
+++ b/resources/i18n/uk.json
@@ -256,6 +256,13 @@
         "updatedAt": "Оновлено",
         "createdAt": "Створено",
         "downloadable": "Дозволити завантаження?"
+      },
+      "actions": {
+        "download": {
+          "title": "Завантажити",
+          "currentTrack": "Поточний трек",
+          "allTracks": "Усі треки"
+        }
       }
     },
     "missing": {

--- a/resources/i18n/zh-Hans.json
+++ b/resources/i18n/zh-Hans.json
@@ -258,7 +258,13 @@
         "createdAt": "创建于"
       },
       "notifications": {},
-      "actions": {}
+      "actions": {
+        "download": {
+          "title": "下载",
+          "currentTrack": "当前曲目",
+          "allTracks": "所有曲目"
+        }
+      }
     },
     "missing": {
       "name": "丢失文件",

--- a/resources/i18n/zh-Hant.json
+++ b/resources/i18n/zh-Hant.json
@@ -258,6 +258,13 @@
         "updatedAt": "更新於",
         "createdAt": "建立於",
         "downloadable": "允許下載？"
+      },
+      "actions": {
+        "download": {
+          "title": "下載",
+          "currentTrack": "目前曲目",
+          "allTracks": "所有曲目"
+        }
       }
     },
     "missing": {

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -2,10 +2,13 @@ package public
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/core/auth"
 	streampkg "github.com/navidrome/navidrome/core/stream"
 	"github.com/navidrome/navidrome/log"
@@ -72,6 +75,10 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.Header().Set("X-Content-Duration", strconv.FormatFloat(float64(stream.Duration()), 'G', -1, 32))
 
+	if conf.Server.EnableDownloads && p.BoolOr("download", false) {
+		w.Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename(mf, info.format)+"\"")
+	}
+
 	n, err := stream.Serve(ctx, w, r)
 	if err != nil || n == 0 {
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -99,4 +106,16 @@ func decodeStreamInfo(tokenString string) (shareTrackInfo, error) {
 		bitrate: c.BitRate,
 		shareID: c.ShareID,
 	}, nil
+}
+
+func sanitizeName(target string) string {
+	return strings.ReplaceAll(target, "/", "_")
+}
+
+func downloadFilename(mf *model.MediaFile, format string) string {
+	ext := mf.Suffix
+	if format != "" && format != "raw" {
+		ext = format
+	}
+	return fmt.Sprintf("%s - %s.%s", sanitizeName(mf.Artist), sanitizeName(mf.Title), ext)
 }

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -3,6 +3,7 @@ package public
 import (
 	"errors"
 	"fmt"
+	"mime"
 	"net/http"
 	"strconv"
 	"strings"
@@ -76,7 +77,9 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Content-Duration", strconv.FormatFloat(float64(stream.Duration()), 'G', -1, 32))
 
 	if conf.Server.EnableDownloads && p.BoolOr("download", false) {
-		w.Header().Set("Content-Disposition", "attachment; filename=\""+downloadFilename(mf, info.format)+"\"")
+		w.Header().Set("Content-Disposition", mime.FormatMediaType(
+			"attachment", map[string]string{"filename": downloadFilename(mf, info.format)},
+		))
 	}
 
 	n, err := stream.Serve(ctx, w, r)

--- a/server/public/handle_streams_test.go
+++ b/server/public/handle_streams_test.go
@@ -192,3 +192,52 @@ var _ = Describe("handleStream", func() {
 		Expect(w.Code).To(Equal(http.StatusBadRequest))
 	})
 })
+
+var _ = Describe("sanitizeName", func() {
+	It("leaves a plain string unchanged", func() {
+		Expect(sanitizeName("Artist Name")).To(Equal("Artist Name"))
+	})
+
+	It("replaces a single slash with an underscore", func() {
+		Expect(sanitizeName("AC/DC")).To(Equal("AC_DC"))
+	})
+
+	It("replaces multiple slashes with underscores", func() {
+		Expect(sanitizeName("a/b/c")).To(Equal("a_b_c"))
+	})
+})
+
+var _ = Describe("downloadFilename", func() {
+	var mf *model.MediaFile
+
+	BeforeEach(func() {
+		mf = &model.MediaFile{
+			Artist:    "The Beatles",
+			Title:     "Hey Jude",
+			Suffix:    "flac",
+			UpdatedAt: time.Now(),
+		}
+	})
+
+	It("uses the media file suffix when format is empty", func() {
+		Expect(downloadFilename(mf, "")).To(Equal("The Beatles - Hey Jude.flac"))
+	})
+
+	It("uses the media file suffix when format is 'raw'", func() {
+		Expect(downloadFilename(mf, "raw")).To(Equal("The Beatles - Hey Jude.flac"))
+	})
+
+	It("uses the format as the extension when a real format is given", func() {
+		Expect(downloadFilename(mf, "mp3")).To(Equal("The Beatles - Hey Jude.mp3"))
+	})
+
+	It("sanitizes slashes in the artist name", func() {
+		mf.Artist = "AC/DC"
+		Expect(downloadFilename(mf, "")).To(Equal("AC_DC - Hey Jude.flac"))
+	})
+
+	It("sanitizes slashes in the title", func() {
+		mf.Title = "Love/Hate"
+		Expect(downloadFilename(mf, "")).To(Equal("The Beatles - Love_Hate.flac"))
+	})
+})

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -160,6 +160,9 @@ func addShareData(r *http.Request, data map[string]any, shareInfo *model.Share) 
 		Description:  shareInfo.Description,
 		Downloadable: shareInfo.Downloadable,
 	}
+	if sd.Description == "" {
+		sd.Description = shareInfo.Contents
+	}
 	sd.Tracks = slice.Map(shareInfo.Tracks, func(mf model.MediaFile) shareTrack {
 		return shareTrack{
 			ID:        mf.ID,

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -312,6 +312,13 @@ var _ = Describe("addShareData", func() {
 				addShareData(r, data, shareInfo)
 				Expect(data["ShareDescription"]).To(Equal(shareInfo.Contents))
 			})
+			It("should use shareInfo.Contents as ShareInfo.Description", func() {
+				addShareData(r, data, shareInfo)
+				var sd shareData
+				err := json.Unmarshal([]byte(data["ShareInfo"].(string)), &sd)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sd.Description).To(Equal(shareInfo.Contents))
+			})
 		})
 	})
 })

--- a/ui/index.html
+++ b/ui/index.html
@@ -26,7 +26,7 @@
     <meta property="og:image" content="{{ .ShareImageURL }}">
     <meta property="og:image:width" content="300">
     <meta property="og:image:height" content="300">
-    <title>Navidrome</title>
+    <title>{{ if .ShareDescription }}{{ .ShareDescription }} | Navidrome{{ else }}Navidrome{{ end }}</title>
     <script>
       // Shim for libraries that check for Node.js process object
       window.process = { env: {} };

--- a/ui/src/App.jsx
+++ b/ui/src/App.jsx
@@ -6,6 +6,7 @@ import {
   Resource,
   useSetLocale,
   useRefresh,
+  TranslationProvider,
 } from 'react-admin'
 import { HotKeys } from 'react-hotkeys'
 import dataProvider from './dataProvider'
@@ -192,7 +193,13 @@ const AppWithHotkeys = () => {
   let language = localStorage.getItem('locale') || 'en'
   document.documentElement.lang = language
   if (config.enableSharing && shareInfo) {
-    return <SharePlayer />
+    return (
+      <Provider store={adminStore}>
+        <TranslationProvider i18nProvider={i18nProvider}>
+          <SharePlayer />
+        </TranslationProvider>
+      </Provider>
+    )
   }
   return (
     <HotKeys keyMap={keyMap}>

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -260,7 +260,13 @@
         "createdAt": "Created at"
       },
       "notifications": {},
-      "actions": {}
+      "actions": {
+        "download": {
+          "title": "Download",
+          "currentTrack": "Current Track",
+          "allTracks": "All Tracks"
+        }
+      }
     },
     "missing": {
       "name": "Missing File |||| Missing Files",

--- a/ui/src/layout/Login.jsx
+++ b/ui/src/layout/Login.jsx
@@ -8,21 +8,15 @@ import CardActions from '@material-ui/core/CardActions'
 import CircularProgress from '@material-ui/core/CircularProgress'
 import Link from '@material-ui/core/Link'
 import TextField from '@material-ui/core/TextField'
-import { ThemeProvider, makeStyles } from '@material-ui/core/styles'
-import {
-  createMuiTheme,
-  useLogin,
-  useNotify,
-  useTranslate,
-  useVersion,
-} from 'react-admin'
+import { makeStyles } from '@material-ui/core/styles'
+import { useLogin, useNotify, useTranslate } from 'react-admin'
 import Logo from '../icons/android-icon-192x192.png'
 
 import Notification from './Notification'
-import useCurrentTheme from '../themes/useCurrentTheme'
 import config from '../config'
 import { clearQueue } from '../actions'
 import { INSIGHTS_DOC_URL } from '../consts.js'
+import withTheme from '../utils/withTheme'
 
 const useStyles = makeStyles(
   (theme) => ({
@@ -399,18 +393,6 @@ Login.propTypes = {
   previousRoute: PropTypes.string,
 }
 
-// We need to put the ThemeProvider decoration in another component
-// Because otherwise the useStyles() hook used in Login won't get
-// the right theme
-const LoginWithTheme = (props) => {
-  const theme = useCurrentTheme()
-  const version = useVersion()
-
-  return (
-    <ThemeProvider theme={createMuiTheme(theme)}>
-      <Login key={version} {...props} />
-    </ThemeProvider>
-  )
-}
+const LoginWithTheme = withTheme(Login)
 
 export default LoginWithTheme

--- a/ui/src/share/SharePlayer.jsx
+++ b/ui/src/share/SharePlayer.jsx
@@ -1,10 +1,25 @@
+import { useState } from 'react'
+import { useTranslate } from 'react-admin'
 import ReactJkMusicPlayer from 'navidrome-music-player'
+
 import config, { shareInfo } from '../config'
-import { shareCoverUrl, shareDownloadUrl, shareStreamUrl } from '../utils'
+import {
+  shareCoverUrl,
+  shareDownloadUrl,
+  shareStreamUrl,
+  toDownloadUrl,
+} from '../utils'
+import withTheme from '../utils/withTheme'
+import { DialogTitle } from '../dialogs/DialogTitle'
 
 import { makeStyles } from '@material-ui/core/styles'
+import { Button, Dialog, DialogContent } from '@material-ui/core'
+import {
+  QueueMusic as QueueMusicIcon,
+  MusicNote as MusicNoteIcon,
+} from '@material-ui/icons'
 
-const useStyle = makeStyles({
+const useStyle = makeStyles((theme) => ({
   player: {
     '& .group .next-audio': {
       pointerEvents: (props) => props.single && 'none',
@@ -20,10 +35,38 @@ const useStyle = makeStyles({
       },
     },
   },
-})
+  columnLayout: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+  },
+}))
+
+const downloadFile = (src, filename) => {
+  const link = document.createElement('a')
+  link.href = src
+  link.download = filename ?? '' // when blank, will use the Content-Disposition header
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+}
 
 const SharePlayer = () => {
+  const translate = useTranslate()
   const classes = useStyle({ single: shareInfo?.tracks.length === 1 })
+  const [downloadInfo, setDownloadInfo] = useState(null)
+
+  const handleCustomDownload = (downloadInfo) => {
+    if (shareInfo?.tracks) {
+      if (shareInfo.tracks.length === 1) {
+        downloadFile(toDownloadUrl(downloadInfo.src))
+      } else {
+        setDownloadInfo(downloadInfo)
+      }
+    }
+  }
+
+  const handleClose = () => setDownloadInfo(null)
 
   const list = shareInfo?.tracks.map((s) => {
     return {
@@ -34,11 +77,7 @@ const SharePlayer = () => {
       duration: s.duration,
     }
   })
-  const onBeforeAudioDownload = () => {
-    return Promise.resolve({
-      src: shareDownloadUrl(shareInfo?.id),
-    })
-  }
+
   const options = {
     audioLists: list,
     mode: 'full',
@@ -56,12 +95,52 @@ const SharePlayer = () => {
     sortableOptions: { delay: 200, delayOnTouchOnly: true },
   }
   return (
-    <ReactJkMusicPlayer
-      {...options}
-      className={classes.player}
-      onBeforeAudioDownload={onBeforeAudioDownload}
-    />
+    <>
+      <ReactJkMusicPlayer
+        {...options}
+        className={classes.player}
+        customDownloader={handleCustomDownload}
+      />
+      <Dialog
+        id="share-download-menu"
+        open={downloadInfo}
+        onClose={handleClose}
+        aria-labelledby="share-download-title"
+      >
+        <DialogTitle id="share-download-title" onClose={handleClose}>
+          {translate('resources.share.actions.download.title')}
+        </DialogTitle>
+        <DialogContent className={classes.columnLayout} dividers>
+          <Button
+            variant="contained"
+            startIcon={<MusicNoteIcon />}
+            onClick={() => {
+              downloadFile(toDownloadUrl(downloadInfo.src))
+              setDownloadInfo(null)
+            }}
+          >
+            {translate('resources.share.actions.download.currentTrack')}
+          </Button>
+          <Button
+            variant="contained"
+            startIcon={<QueueMusicIcon />}
+            disabled={!shareInfo}
+            onClick={() => {
+              downloadFile(
+                shareDownloadUrl(shareInfo?.id),
+                shareInfo?.description + '.zip',
+              )
+              setDownloadInfo(null)
+            }}
+          >
+            {translate('resources.share.actions.download.allTracks')}
+          </Button>
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }
 
-export default SharePlayer
+const SharePlayerWithTheme = withTheme(SharePlayer)
+
+export default SharePlayerWithTheme

--- a/ui/src/share/SharePlayer.jsx
+++ b/ui/src/share/SharePlayer.jsx
@@ -103,7 +103,7 @@ const SharePlayer = () => {
       />
       <Dialog
         id="share-download-menu"
-        open={downloadInfo}
+        open={!!downloadInfo}
         onClose={handleClose}
         aria-labelledby="share-download-title"
       >
@@ -126,9 +126,12 @@ const SharePlayer = () => {
             startIcon={<QueueMusicIcon />}
             disabled={!shareInfo}
             onClick={() => {
+              let url = shareDownloadUrl(shareInfo?.id)
               downloadFile(
                 shareDownloadUrl(shareInfo?.id),
-                shareInfo?.description + '.zip',
+                shareInfo?.description && shareInfo.description.trim() !== ''
+                  ? shareInfo.description + '.zip'
+                  : shareInfo?.id + '.zip',
               )
               setDownloadInfo(null)
             }}

--- a/ui/src/share/SharePlayer.test.jsx
+++ b/ui/src/share/SharePlayer.test.jsx
@@ -1,0 +1,293 @@
+/* eslint-disable no-import-assign */
+import React from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Mock ReactJkMusicPlayer - capture the customDownloader prop so tests can invoke it
+let capturedCustomDownloader = null
+vi.mock('navidrome-music-player', () => ({
+  default: vi.fn(({ customDownloader, className }) => {
+    capturedCustomDownloader = customDownloader
+    return <div data-testid="music-player" className={className} />
+  }),
+}))
+
+vi.mock('../config', () => ({
+  default: {
+    defaultLanguage: '',
+    enableDownloads: true,
+    publicBaseUrl: '/share',
+    baseUrl: 'https://example.com',
+  },
+}))
+
+vi.mock('../utils', async (importOriginal) => {
+  const orig = await importOriginal()
+  return {
+    baseUrl: orig.baseUrl,
+    shareStreamUrl: (id) => `/share/s/${id}`,
+    shareCoverUrl: (id) => `/share/img/${id}`,
+    shareDownloadUrl: (id) => `/share/d/${id}`,
+    toDownloadUrl: (src) => `${src}?download=true`,
+  }
+})
+
+vi.mock('react-admin', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useTranslate: () => (key) => key,
+  }
+})
+
+vi.mock('../dialogs/DialogTitle', () => ({
+  DialogTitle: ({ children, onClose }) => (
+    <div data-testid="dialog-title">
+      {children}
+      <button aria-label="close" onClick={onClose}>
+        ×
+      </button>
+    </div>
+  ),
+}))
+
+vi.mock('../dataProvider', async (importOriginal) => ({
+  ...(await importOriginal()),
+  httpClient: vi.fn(),
+}))
+
+// Spy on document.createElement to intercept anchor clicks
+let createdLinks = []
+const originalCreateElement = document.createElement.bind(document)
+
+import { TestContext } from 'ra-test'
+import SharePlayer from './SharePlayer'
+import * as configModule from '../config'
+
+describe('SharePlayer', () => {
+  beforeEach(async () => {
+    capturedCustomDownloader = null
+    createdLinks = []
+    configModule.shareInfo = {
+      id: 'share-1',
+      description: 'My Playlist',
+      downloadable: true,
+      tracks: [
+        {
+          id: 'track-1',
+          title: 'Song One',
+          artist: 'Artist One',
+          duration: 180,
+        },
+        {
+          id: 'track-2',
+          title: 'Song Two',
+          artist: 'Artist Two',
+          duration: 240,
+        },
+      ],
+    }
+
+    vi.spyOn(document, 'createElement').mockImplementation((tag) => {
+      const el = originalCreateElement(tag)
+      if (tag === 'a') {
+        vi.spyOn(el, 'click').mockImplementation(() => {})
+        createdLinks.push(el)
+      }
+      return el
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    configModule.shareInfo = null
+  })
+
+  it('renders the music player', () => {
+    render(
+      <TestContext>
+        <SharePlayer />
+      </TestContext>,
+    )
+    expect(screen.getByTestId('music-player')).toBeInTheDocument()
+  })
+
+  it('does not show the download dialog initially', () => {
+    render(
+      <TestContext>
+        <SharePlayer />
+      </TestContext>,
+    )
+    // Dialog is closed: the MUI Dialog root should not be present or should be hidden
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  describe('customDownloader with multiple tracks', () => {
+    it('opens the download dialog when customDownloader is called', () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+
+      expect(
+        screen.getByText('resources.share.actions.download.title'),
+      ).toBeInTheDocument()
+    })
+
+    it('shows "Current Track" and "All Tracks" buttons in the dialog', () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+
+      expect(
+        screen.getByText('resources.share.actions.download.currentTrack'),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText('resources.share.actions.download.allTracks'),
+      ).toBeInTheDocument()
+    })
+
+    it('downloads the current track when "Current Track" is clicked', () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+
+      fireEvent.click(
+        screen.getByText('resources.share.actions.download.currentTrack'),
+      )
+
+      expect(createdLinks).toHaveLength(1)
+      expect(createdLinks[0].href).toContain('download=true')
+      expect(createdLinks[0].click).toHaveBeenCalled()
+      expect(createdLinks[0]).not.toBeInTheDocument() // Link should be removed after click
+    })
+
+    it('closes the dialog after clicking "Current Track"', async () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+      fireEvent.click(
+        screen.getByText('resources.share.actions.download.currentTrack'),
+      )
+
+      await waitFor(() =>
+        expect(
+          screen.queryByText('resources.share.actions.download.title'),
+        ).not.toBeInTheDocument(),
+      )
+    })
+
+    it('downloads all tracks as zip when "All Tracks" is clicked', () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+
+      fireEvent.click(
+        screen.getByText('resources.share.actions.download.allTracks'),
+      )
+
+      expect(createdLinks).toHaveLength(1)
+      expect(createdLinks[0].href).toContain('/share/d/share-1')
+      expect(createdLinks[0].download).toBe('My Playlist.zip')
+      expect(createdLinks[0].click).toHaveBeenCalled()
+      expect(createdLinks[0]).not.toBeInTheDocument() 
+    })
+
+    it('closes the dialog after clicking "All Tracks"', async () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+      fireEvent.click(
+        screen.getByText('resources.share.actions.download.allTracks'),
+      )
+
+      await waitFor(() =>
+        expect(
+          screen.queryByText('resources.share.actions.download.title'),
+        ).not.toBeInTheDocument(),
+      )
+    })
+
+    it('closes the dialog when the close button is clicked', async () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+      expect(
+        screen.getByText('resources.share.actions.download.title'),
+      ).toBeInTheDocument()
+
+      fireEvent.click(screen.getByLabelText('close'))
+
+      await waitFor(() =>
+        expect(
+          screen.queryByText('resources.share.actions.download.title'),
+        ).not.toBeInTheDocument(),
+      )
+    })
+  })
+
+  describe('customDownloader with a single track', () => {
+    beforeEach(() => {
+      configModule.shareInfo = {
+        id: 'share-2',
+        description: 'Single Track',
+        downloadable: true,
+        tracks: [
+          {
+            id: 'track-1',
+            title: 'Only Song',
+            artist: 'Solo Artist',
+            duration: 200,
+          },
+        ],
+      }
+    })
+
+    it('downloads the track directly without opening a dialog', () => {
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+
+      // Dialog title should NOT appear — direct download, no dialog
+      expect(
+        screen.queryByText('resources.share.actions.download.title'),
+      ).not.toBeInTheDocument()
+      // A link should have been clicked directly
+      expect(createdLinks).toHaveLength(1)
+      expect(createdLinks[0].href).toContain('download=true')
+      expect(createdLinks[0].click).toHaveBeenCalled()
+      expect(createdLinks[0]).not.toBeInTheDocument() 
+    })
+  })
+})

--- a/ui/src/share/SharePlayer.test.jsx
+++ b/ui/src/share/SharePlayer.test.jsx
@@ -209,7 +209,7 @@ describe('SharePlayer', () => {
       expect(createdLinks[0].href).toContain('/share/d/share-1')
       expect(createdLinks[0].download).toBe('My Playlist.zip')
       expect(createdLinks[0].click).toHaveBeenCalled()
-      expect(createdLinks[0]).not.toBeInTheDocument() 
+      expect(createdLinks[0]).not.toBeInTheDocument()
     })
 
     it('closes the dialog after clicking "All Tracks"', async () => {
@@ -287,7 +287,7 @@ describe('SharePlayer', () => {
       expect(createdLinks).toHaveLength(1)
       expect(createdLinks[0].href).toContain('download=true')
       expect(createdLinks[0].click).toHaveBeenCalled()
-      expect(createdLinks[0]).not.toBeInTheDocument() 
+      expect(createdLinks[0]).not.toBeInTheDocument()
     })
   })
 })

--- a/ui/src/share/SharePlayer.test.jsx
+++ b/ui/src/share/SharePlayer.test.jsx
@@ -212,6 +212,28 @@ describe('SharePlayer', () => {
       expect(createdLinks[0]).not.toBeInTheDocument()
     })
 
+    it('fallback to share id if description is empty', () => {
+      configModule.shareInfo.description = ''
+
+      render(
+        <TestContext>
+          <SharePlayer />
+        </TestContext>,
+      )
+
+      capturedCustomDownloader({ src: '/share/s/track-1' })
+
+      fireEvent.click(
+        screen.getByText('resources.share.actions.download.allTracks'),
+      )
+
+      expect(createdLinks).toHaveLength(1)
+      expect(createdLinks[0].href).toContain('/share/d/share-1')
+      expect(createdLinks[0].download).toBe('share-1.zip')
+      expect(createdLinks[0].click).toHaveBeenCalled()
+      expect(createdLinks[0]).not.toBeInTheDocument()
+    })
+
     it('closes the dialog after clicking "All Tracks"', async () => {
       render(
         <TestContext>

--- a/ui/src/utils/urls.js
+++ b/ui/src/utils/urls.js
@@ -29,6 +29,12 @@ export const shareStreamUrl = (id) => {
   return shareUrl(config.publicBaseUrl + '/s/' + id)
 }
 
+export const toDownloadUrl = (src) => {
+  const url = new URL(src, window.origin)
+  url.searchParams.set('download', 'true')
+  return url.toString()
+}
+
 export const shareDownloadUrl = (id) => {
   return shareUrl(config.publicBaseUrl + '/d/' + id)
 }

--- a/ui/src/utils/urls.test.js
+++ b/ui/src/utils/urls.test.js
@@ -1,4 +1,4 @@
-import { isLastFmURL } from './urls'
+import { isLastFmURL, toDownloadUrl } from './urls'
 
 describe('isLastFmURL', () => {
   it('returns true for valid Last.fm music URLs', () => {
@@ -21,5 +21,25 @@ describe('isLastFmURL', () => {
     expect(isLastFmURL('https://last.fm/user/someone')).toBe(false)
     expect(isLastFmURL(null)).toBe(false)
     expect(isLastFmURL('not-a-url')).toBe(false)
+  })
+})
+
+describe('toDownloadUrl', () => {
+  it('appends download=true to an absolute URL', () => {
+    const result = toDownloadUrl('https://example.com/share/s/abc123')
+    expect(new URL(result).searchParams.get('download')).toBe('true')
+  })
+
+  it('appends download=true to a relative URL resolved against window.origin', () => {
+    const result = toDownloadUrl('/share/s/abc123')
+    expect(new URL(result).searchParams.get('download')).toBe('true')
+    expect(new URL(result).pathname).toBe('/share/s/abc123')
+  })
+
+  it('preserves existing query parameters', () => {
+    const result = toDownloadUrl('https://example.com/share/s/abc123?format=mp3')
+    const url = new URL(result)
+    expect(url.searchParams.get('format')).toBe('mp3')
+    expect(url.searchParams.get('download')).toBe('true')
   })
 })

--- a/ui/src/utils/urls.test.js
+++ b/ui/src/utils/urls.test.js
@@ -37,7 +37,9 @@ describe('toDownloadUrl', () => {
   })
 
   it('preserves existing query parameters', () => {
-    const result = toDownloadUrl('https://example.com/share/s/abc123?format=mp3')
+    const result = toDownloadUrl(
+      'https://example.com/share/s/abc123?format=mp3',
+    )
     const url = new URL(result)
     expect(url.searchParams.get('format')).toBe('mp3')
     expect(url.searchParams.get('download')).toBe('true')

--- a/ui/src/utils/withTheme.jsx
+++ b/ui/src/utils/withTheme.jsx
@@ -1,0 +1,31 @@
+import { useEffect } from 'react'
+import { ThemeProvider, makeStyles } from '@material-ui/core/styles'
+import {
+  createMuiTheme,
+  useRefresh,
+  useSetLocale,
+  useVersion,
+} from 'react-admin'
+
+import useCurrentTheme from '../themes/useCurrentTheme'
+import config from '../config'
+import { retrieveTranslation } from '../i18n'
+
+const withTheme = (Component) => {
+  const WithTheme = (props) => {
+    const theme = useCurrentTheme()
+    const version = useVersion()
+
+    return (
+      <ThemeProvider theme={createMuiTheme(theme)}>
+        <Component key={version} {...props} />
+      </ThemeProvider>
+    )
+  }
+
+  WithTheme.displayName = `WithTheme(${Component.displayName ?? Component.name ?? 'Component'})`
+
+  return WithTheme
+}
+
+export default withTheme

--- a/ui/src/utils/withTheme.jsx
+++ b/ui/src/utils/withTheme.jsx
@@ -1,15 +1,7 @@
-import { useEffect } from 'react'
-import { ThemeProvider, makeStyles } from '@material-ui/core/styles'
-import {
-  createMuiTheme,
-  useRefresh,
-  useSetLocale,
-  useVersion,
-} from 'react-admin'
+import { ThemeProvider } from '@material-ui/core/styles'
+import { createMuiTheme, useVersion } from 'react-admin'
 
 import useCurrentTheme from '../themes/useCurrentTheme'
-import config from '../config'
-import { retrieveTranslation } from '../i18n'
 
 const withTheme = (Component) => {
   const WithTheme = (props) => {


### PR DESCRIPTION
### Description
Improves the UX of the share download feature (See #5630).

Adds a dialog to the download button on the share page, allowing the user to select whether to download the currently-playing track, or the full playlist. If the playlist only contains a single track, the dialog is bypassed and the single track is downloaded without being zipped.

Adds a download flag to the stream endpoint. When set to true, a `Content-Disposition: attachment; filename="..."` header is added to mark the response as a download, and to allow it to be saved with a useful name. Either the name of the playlist, or the track details (Artist - Title). If downloading a single track, this will add the appropriate extension (including if transcoding). Will sanitize the name to remove slashes (/), any other special characters are handled by the user's browser.

Download is now initiated by firing a click on a hidden <a> element, which allows the download to be natively tracked by the browser. The browser will give visual feedback to the user, so they are aware that the download has begun, and can track its progress.

Sets ShareInfo.Description to ShareInfo.Contents when Description is unset, so that the share has a useful name even if the user did not set a description.

#### Minor changes:

Adds the share name to the page title, so that it shows in the tab.

Makes the default app styles apply to the share page, for a more unified look.

#### AI Use

Complete translations for non-english languages were included, these were generated with Claude Opus.

### Related Issues
Implements #5630

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Make sure EnableSharing is set to true
2. Create a share, then navigate to it (if running in dev mode, you will need to make sure to open the share using the server port instead of the UI port)

### Screenshots / Demos (if applicable)

<img width="295" height="245" alt="Screenshot from 2026-06-19 13-05-14" src="https://github.com/user-attachments/assets/5d95d58d-d010-4f11-ab32-6505002596ac" />

https://github.com/user-attachments/assets/2919360c-1435-476d-b2ee-bf1f29f0914b