### PR TITLE
perf(matcher): index-space resolution + batched title lookups

### DIFF
--- a/core/external/provider_topsongs_test.go
+++ b/core/external/provider_topsongs_test.go
@@ -205,8 +205,8 @@ var _ = Describe("Provider - TopSongs", func() {
 
 		// Since there are no MBIDs, loadTracksByMBID should not make any database call
 		// loadTracksByTitle should make a database call for title matching
-		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song one"}
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
+		song1 := model.MediaFile{ID: "song-1", Title: "Song One", Artist: "Artist One", OrderArtistName: "artist one", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song one"}
+		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", OrderArtistName: "artist one", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)
@@ -237,7 +237,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
 
 		// Mock the title fallback query (finds song2 by title)
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
+		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", OrderArtistName: "artist one", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song2}, nil).Once()
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)

--- a/core/external/provider_topsongs_test.go
+++ b/core/external/provider_topsongs_test.go
@@ -205,8 +205,8 @@ var _ = Describe("Provider - TopSongs", func() {
 
 		// Since there are no MBIDs, loadTracksByMBID should not make any database call
 		// loadTracksByTitle should make a database call for title matching
-		song1 := model.MediaFile{ID: "song-1", Title: "Song One", Artist: "Artist One", OrderArtistName: "artist one", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song one"}
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", OrderArtistName: "artist one", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
+		song1 := model.MediaFile{ID: "song-1", Title: "Song One", Artist: "Artist One", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song one"}
+		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)
@@ -237,7 +237,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
 
 		// Mock the title fallback query (finds song2 by title)
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", OrderArtistName: "artist one", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
+		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song2}, nil).Once()
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)

--- a/core/matcher/doc.go
+++ b/core/matcher/doc.go
@@ -1,0 +1,92 @@
+// Package matcher matches song results from external agents (Last.fm, Deezer,
+// etc.) to tracks in the local music library, prioritizing accuracy over recall.
+//
+// It exposes a single [Matcher] type with two entry points that share the same
+// matching algorithm:
+//
+//   - [Matcher.MatchSongs] returns an ordered, deduplicated slice of library
+//     tracks, capped at a requested count. Use it when presenting "similar
+//     songs" results to a client.
+//   - [Matcher.MatchSongsIndexed] returns a map from input-song index to matched
+//     track, with no deduplication. Use it when the caller needs to correlate
+//     each result back to its input position (e.g. to attach a per-song
+//     similarity score).
+//
+// # Algorithm Overview
+//
+// Each input song is resolved to its best-matching library track using four
+// strategies, applied in priority order. A song matched by a higher-priority
+// strategy is never reconsidered by a lower-priority one:
+//
+//  1. Direct ID match: songs with an ID are matched to a MediaFile by ID.
+//  2. MusicBrainz Recording ID (MBID) match: songs with an MBID are matched to
+//     tracks with the same mbz_recording_id.
+//  3. ISRC match: songs with an ISRC are matched to tracks carrying that ISRC tag.
+//  4. Title+Artist fuzzy match: remaining songs are matched by fuzzy string
+//     comparison with metadata-specificity scoring (see below).
+//
+// Priority order is ID > MBID > ISRC > Title+Artist, so more reliable
+// identifiers always take precedence over fuzzy text matching. Missing tracks
+// (those no longer present on disk) are never matched.
+//
+// # Fuzzy Matching Details
+//
+// Title+artist matching uses Jaro-Winkler similarity, with a threshold
+// configurable via conf.Server.Matcher.FuzzyThreshold (default 85%). A library
+// track must clear the title threshold to be considered. Candidates that clear
+// it are ranked by, in order:
+//
+//  1. Title similarity (Jaro-Winkler score, 0.0–1.0)
+//  2. Duration proximity (closer duration scores higher; 1.0 when the agent
+//     reports no duration)
+//  3. Preferred-track flag (enabled by conf.Server.Matcher.PreferStarred;
+//     prioritizes tracks that are starred or rated >= 4)
+//  4. Specificity level (0–5, based on metadata precision; higher is better)
+//  5. Album similarity (Jaro-Winkler, as the final tiebreaker)
+//
+// The specificity levels, from most to least specific, are:
+//
+//	Level 5: Title + Artist MBID + Album MBID
+//	Level 4: Title + Artist MBID + Album name (fuzzy)
+//	Level 3: Title + Artist name + Album name (fuzzy)
+//	Level 2: Title + Artist MBID
+//	Level 1: Title + Artist name
+//	Level 0: Title only
+//
+// Each input song is scored independently, so two songs with the same title and
+// artist but different durations can resolve to different library tracks (each
+// matches the track closest to its own duration).
+//
+// # Examples
+//
+// MBID priority — an identifier match wins over a title+artist match:
+//
+//	Agent returns: {Name: "Paranoid Android", MBID: "abc-123", Artist: "Radiohead"}
+//	Library has:
+//	  {ID: "t1", Title: "Paranoid Android", MbzRecordingID: "abc-123"}
+//	  {ID: "t2", Title: "Paranoid Android", Artist: "Radiohead"}
+//	Result: t1 (MBID match takes priority over title+artist)
+//
+// ISRC priority — likewise, an ISRC match wins over title+artist:
+//
+//	Agent returns: {Name: "Paranoid Android", ISRC: "GBAYE0000351", Artist: "Radiohead"}
+//	Library has:
+//	  {ID: "t1", Title: "Paranoid Android", Tags: {isrc: ["GBAYE0000351"]}}
+//	  {ID: "t2", Title: "Paranoid Android", Artist: "Radiohead"}
+//	Result: t1 (ISRC match takes priority over title+artist)
+//
+// Specificity ranking — a better album match wins among title+artist candidates:
+//
+//	Agent returns: {Name: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}
+//	Library has:
+//	  {ID: "t1", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "101"}       // Level 1
+//	  {ID: "t2", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}  // Level 3
+//	Result: t2 (Level 3 beats Level 1 due to the album match)
+//
+// Fuzzy title matching — the threshold controls how close a title must be:
+//
+//	Agent returns: {Name: "Bohemian Rhapsody", Artist: "Queen"}
+//	Library has:   {ID: "t1", Title: "Bohemian Rhapsody - Remastered", Artist: "Queen"}
+//	With threshold 85%: match succeeds (similarity ~0.87)
+//	With threshold 100%: no match (not an exact title)
+package matcher

--- a/core/matcher/doc.go
+++ b/core/matcher/doc.go
@@ -53,6 +53,11 @@
 //	Level 1: Title + Artist name
 //	Level 0: Title only
 //
+// The title phase always requires an agent artist to scope the library query, so
+// Level 0 does not mean "no artist": it applies when a candidate matches on title
+// but its own artist differs from the query's (e.g. a cover or a featured-artist
+// credit), leaving the title as the only shared field.
+//
 // Each input song is scored independently, so two songs with the same title and
 // artist but different durations can resolve to different library tracks (each
 // matches the track closest to its own duration).

--- a/core/matcher/doc.go
+++ b/core/matcher/doc.go
@@ -59,34 +59,45 @@
 //
 // # Examples
 //
-// MBID priority — an identifier match wins over a title+artist match:
+// All examples below exercise the title+artist phase, where the interesting
+// behavior lives. (Identifier phases — ID, MBID, ISRC — are exact lookups that
+// always win over fuzzy matching; they need no illustration.)
 //
-//	Agent returns: {Name: "Paranoid Android", MBID: "abc-123", Artist: "Radiohead"}
-//	Library has:
-//	  {ID: "t1", Title: "Paranoid Android", MbzRecordingID: "abc-123"}
-//	  {ID: "t2", Title: "Paranoid Android", Artist: "Radiohead"}
-//	Result: t1 (MBID match takes priority over title+artist)
-//
-// ISRC priority — likewise, an ISRC match wins over title+artist:
-//
-//	Agent returns: {Name: "Paranoid Android", ISRC: "GBAYE0000351", Artist: "Radiohead"}
-//	Library has:
-//	  {ID: "t1", Title: "Paranoid Android", Tags: {isrc: ["GBAYE0000351"]}}
-//	  {ID: "t2", Title: "Paranoid Android", Artist: "Radiohead"}
-//	Result: t1 (ISRC match takes priority over title+artist)
-//
-// Specificity ranking — a better album match wins among title+artist candidates:
-//
-//	Agent returns: {Name: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}
-//	Library has:
-//	  {ID: "t1", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "101"}       // Level 1
-//	  {ID: "t2", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}  // Level 3
-//	Result: t2 (Level 3 beats Level 1 due to the album match)
-//
-// Fuzzy title matching — the threshold controls how close a title must be:
+// Title threshold — a near-miss title still matches; an exact-only threshold
+// rejects it:
 //
 //	Agent returns: {Name: "Bohemian Rhapsody", Artist: "Queen"}
 //	Library has:   {ID: "t1", Title: "Bohemian Rhapsody - Remastered", Artist: "Queen"}
 //	With threshold 85%: match succeeds (similarity ~0.87)
 //	With threshold 100%: no match (not an exact title)
+//
+// Specificity ranking — among candidates that clear the title threshold, a
+// better album match wins:
+//
+//	Agent returns: {Name: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}
+//	Library has:
+//	  {ID: "t1", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "101"}       // Level 1
+//	  {ID: "t2", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}  // Level 3
+//	Result: t2 (Level 3 beats Level 1 on the album match)
+//
+// Duration tiebreak — with title and artist equal, the closest duration wins,
+// so two near-identical input songs can resolve to different tracks:
+//
+//	Agent returns:
+//	  {Name: "Untitled", Artist: "Interpol", Duration: 245000}  // 4:05
+//	  {Name: "Untitled", Artist: "Interpol", Duration: 600000}  // 10:00 (a live take)
+//	Library has:
+//	  {ID: "studio", Title: "Untitled", Artist: "Interpol", Duration: 248}  // 4:08
+//	  {ID: "live",   Title: "Untitled", Artist: "Interpol", Duration: 602}  // 10:02
+//	Result: studio for the first song, live for the second
+//
+// Preferred track — when conf.Server.Matcher.PreferStarred is enabled, a
+// starred (or rating >= 4) track is preferred even over a more specific match,
+// because the preferred flag outranks specificity:
+//
+//	Agent returns: {Name: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}
+//	Library has:
+//	  {ID: "exact",   Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}            // Level 3
+//	  {ID: "starred", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles", Starred: true} // Level 1, starred
+//	Result: starred (the preferred flag outranks the better album match)
 package matcher

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -390,6 +390,8 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 	}
 
 	threshold := float64(conf.Server.Matcher.FuzzyThreshold) / 100.0
+	var failed int
+	var lastErr error
 	for artist, queries := range byArtist {
 		tracks, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 			Filters: squirrel.And{
@@ -401,6 +403,8 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		if err != nil {
 			// Best-effort: one artist's lookup failing must not sink matches for the others.
 			log.Warn(ctx, "matchByTitle: artist lookup failed, skipping", "artist", artist, err)
+			failed++
+			lastErr = err
 			continue
 		}
 		sanitized := make([]sanitizedTrack, len(tracks))
@@ -414,6 +418,12 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 				result[iq.index] = mf
 			}
 		}
+	}
+
+	// If every artist query failed, this is a systemic DB problem rather than a
+	// best-effort miss, so surface it instead of silently returning no matches.
+	if failed == len(byArtist) {
+		return fmt.Errorf("all %d artist lookups failed, last error: %w", failed, lastErr)
 	}
 	return nil
 }

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -46,11 +46,11 @@ func New(ds model.DataStore) *Matcher {
 // # Fuzzy Matching Details
 //
 // For title+artist matching, the algorithm uses Jaro-Winkler similarity (threshold configurable
-// via Matcher.FuzzyThreshold, default 85%). Matches are ranked by:
+// via conf.Server.Matcher.FuzzyThreshold, default 85%). Matches are ranked by:
 //
 //  1. Title similarity (Jaro-Winkler score, 0.0-1.0)
 //  2. Duration proximity (closer duration = higher score, 1.0 if unknown)
-//  3. Preferred track flag (enabled by Matcher.PreferStarred; prioritized when the track is
+//  3. Preferred track flag (enabled by conf.Server.Matcher.PreferStarred; prioritized when the track is
 //     starred or has rating >= 4)
 //  4. Specificity level (0-5, based on metadata precision):
 //     - Level 5: Title + Artist MBID + Album MBID (most specific)

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -111,12 +111,11 @@ func (m *Matcher) MatchSongs(ctx context.Context, songs []agents.Song, count int
 	if len(songs) == 0 {
 		return nil, nil
 	}
-
-	byID, byMBID, byISRC, byTitle, err := m.loadAllMatches(ctx, songs)
+	matches, err := m.resolveMatches(ctx, songs)
 	if err != nil {
 		return nil, err
 	}
-	return m.selectBestMatchingSongs(songs, byID, byMBID, byISRC, byTitle, count), nil
+	return orderAndDedup(songs, matches, count), nil
 }
 
 // MatchSongsIndexed matches agent song results to local library tracks and returns a map
@@ -126,73 +125,39 @@ func (m *Matcher) MatchSongsIndexed(ctx context.Context, songs []agents.Song) (m
 	if len(songs) == 0 {
 		return nil, nil
 	}
+	return m.resolveMatches(ctx, songs)
+}
 
-	byID, byMBID, byISRC, byTitle, err := m.loadAllMatches(ctx, songs)
-	if err != nil {
-		return nil, err
-	}
-
+// resolveMatches resolves each input song to its best-matching library track,
+// keyed by the song's index. Loaders run in priority order (ID > MBID > ISRC >
+// Title); each only fills indices not already matched by a higher-priority loader.
+func (m *Matcher) resolveMatches(ctx context.Context, songs []agents.Song) (map[int]model.MediaFile, error) {
 	result := make(map[int]model.MediaFile, len(songs))
-	for i, t := range songs {
-		if mf, found := findMatchingTrack(t, byID, byMBID, byISRC, byTitle); found {
-			result[i] = mf
-		}
+	if err := m.matchByID(ctx, songs, result); err != nil {
+		return nil, fmt.Errorf("failed to match tracks by ID: %w", err)
+	}
+	if err := m.matchByMBID(ctx, songs, result); err != nil {
+		return nil, fmt.Errorf("failed to match tracks by MBID: %w", err)
+	}
+	if err := m.matchByISRC(ctx, songs, result); err != nil {
+		return nil, fmt.Errorf("failed to match tracks by ISRC: %w", err)
+	}
+	if err := m.matchByTitle(ctx, songs, result); err != nil {
+		return nil, fmt.Errorf("failed to match tracks by title: %w", err)
 	}
 	return result, nil
 }
 
-func (m *Matcher) loadAllMatches(ctx context.Context, songs []agents.Song) (byID, byMBID, byISRC, byTitle map[string]model.MediaFile, err error) {
-	byID, err = m.loadTracksByID(ctx, songs)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to load tracks by ID: %w", err)
-	}
-	byMBID, err = m.loadTracksByMBID(ctx, songs, byID)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to load tracks by MBID: %w", err)
-	}
-	byISRC, err = m.loadTracksByISRC(ctx, songs, byID, byMBID)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to load tracks by ISRC: %w", err)
-	}
-	byTitle, err = m.loadTracksByTitleAndArtist(ctx, songs, byID, byMBID, byISRC)
-	if err != nil {
-		return nil, nil, nil, nil, fmt.Errorf("failed to load tracks by title: %w", err)
-	}
-	return byID, byMBID, byISRC, byTitle, nil
-}
-
-// songMatchedIn checks if a song has already been matched in any of the provided match maps.
-func songMatchedIn(s agents.Song, priorMatches ...map[string]model.MediaFile) bool {
-	_, found := lookupByIdentifiers(s, priorMatches...)
-	return found
-}
-
-// lookupByIdentifiers searches for a song's identifiers (ID, MBID, ISRC) in the provided maps.
-func lookupByIdentifiers(s agents.Song, maps ...map[string]model.MediaFile) (model.MediaFile, bool) {
-	keys := []string{s.ID, s.MBID, s.ISRC}
-	for _, m := range maps {
-		for _, key := range keys {
-			if key != "" {
-				if mf, ok := m[key]; ok && mf.ID != "" {
-					return mf, true
-				}
-			}
-		}
-	}
-	return model.MediaFile{}, false
-}
-
-// loadTracksByID fetches MediaFiles from the library using direct ID matching.
-func (m *Matcher) loadTracksByID(ctx context.Context, songs []agents.Song) (map[string]model.MediaFile, error) {
+// matchByID fills result with direct ID matches.
+func (m *Matcher) matchByID(ctx context.Context, songs []agents.Song, result map[int]model.MediaFile) error {
 	var ids []string
 	for _, s := range songs {
 		if s.ID != "" {
 			ids = append(ids, s.ID)
 		}
 	}
-	matches := map[string]model.MediaFile{}
 	if len(ids) == 0 {
-		return matches, nil
+		return nil
 	}
 	res, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 		Filters: squirrel.And{
@@ -201,27 +166,39 @@ func (m *Matcher) loadTracksByID(ctx context.Context, songs []agents.Song) (map[
 		},
 	})
 	if err != nil {
-		return matches, err
+		return err
 	}
+	byID := make(map[string]model.MediaFile, len(res))
 	for _, mf := range res {
-		if _, ok := matches[mf.ID]; !ok {
-			matches[mf.ID] = mf
+		if _, ok := byID[mf.ID]; !ok {
+			byID[mf.ID] = mf
 		}
 	}
-	return matches, nil
+	for i, s := range songs {
+		if s.ID == "" {
+			continue
+		}
+		if mf, ok := byID[s.ID]; ok {
+			result[i] = mf
+		}
+	}
+	return nil
 }
 
-// loadTracksByMBID fetches MediaFiles from the library using MusicBrainz Recording IDs.
-func (m *Matcher) loadTracksByMBID(ctx context.Context, songs []agents.Song, priorMatches ...map[string]model.MediaFile) (map[string]model.MediaFile, error) {
+// matchByMBID fills result with MusicBrainz Recording ID matches, skipping
+// songs already matched by a higher-priority loader.
+func (m *Matcher) matchByMBID(ctx context.Context, songs []agents.Song, result map[int]model.MediaFile) error {
 	var mbids []string
-	for _, s := range songs {
-		if s.MBID != "" && !songMatchedIn(s, priorMatches...) {
+	for i, s := range songs {
+		if _, done := result[i]; done {
+			continue
+		}
+		if s.MBID != "" {
 			mbids = append(mbids, s.MBID)
 		}
 	}
-	matches := map[string]model.MediaFile{}
 	if len(mbids) == 0 {
-		return matches, nil
+		return nil
 	}
 	res, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 		Filters: squirrel.And{
@@ -230,45 +207,72 @@ func (m *Matcher) loadTracksByMBID(ctx context.Context, songs []agents.Song, pri
 		},
 	})
 	if err != nil {
-		return matches, err
+		return err
 	}
+	byMBID := make(map[string]model.MediaFile, len(res))
 	for _, mf := range res {
 		if id := mf.MbzRecordingID; id != "" {
-			if _, ok := matches[id]; !ok {
-				matches[id] = mf
+			if _, ok := byMBID[id]; !ok {
+				byMBID[id] = mf
 			}
 		}
 	}
-	return matches, nil
+	for i, s := range songs {
+		if _, done := result[i]; done {
+			continue
+		}
+		if s.MBID == "" {
+			continue
+		}
+		if mf, ok := byMBID[s.MBID]; ok {
+			result[i] = mf
+		}
+	}
+	return nil
 }
 
-// loadTracksByISRC fetches MediaFiles from the library using ISRC matching.
-func (m *Matcher) loadTracksByISRC(ctx context.Context, songs []agents.Song, priorMatches ...map[string]model.MediaFile) (map[string]model.MediaFile, error) {
+// matchByISRC fills result with ISRC tag matches, skipping songs already
+// matched by a higher-priority loader.
+func (m *Matcher) matchByISRC(ctx context.Context, songs []agents.Song, result map[int]model.MediaFile) error {
 	var isrcs []string
-	for _, s := range songs {
-		if s.ISRC != "" && !songMatchedIn(s, priorMatches...) {
+	for i, s := range songs {
+		if _, done := result[i]; done {
+			continue
+		}
+		if s.ISRC != "" {
 			isrcs = append(isrcs, s.ISRC)
 		}
 	}
-	matches := map[string]model.MediaFile{}
 	if len(isrcs) == 0 {
-		return matches, nil
+		return nil
 	}
 	res, err := m.ds.MediaFile(ctx).GetAllByTags(model.TagISRC, isrcs, model.QueryOptions{
 		Filters: squirrel.Eq{"missing": false},
 		Sort:    "starred desc, rating desc, year asc, compilation asc",
 	})
 	if err != nil {
-		return matches, err
+		return err
 	}
+	byISRC := map[string]model.MediaFile{}
 	for _, mf := range res {
 		for _, isrc := range mf.Tags.Values(model.TagISRC) {
-			if _, ok := matches[isrc]; !ok {
-				matches[isrc] = mf
+			if _, ok := byISRC[isrc]; !ok {
+				byISRC[isrc] = mf
 			}
 		}
 	}
-	return matches, nil
+	for i, s := range songs {
+		if _, done := result[i]; done {
+			continue
+		}
+		if s.ISRC == "" {
+			continue
+		}
+		if mf, ok := byISRC[s.ISRC]; ok {
+			result[i] = mf
+		}
+	}
+	return nil
 }
 
 // songQuery represents a normalized query for matching a song to library tracks.
@@ -354,24 +358,41 @@ func computeSpecificityLevel(q songQuery, t sanitizedTrack, albumThreshold float
 	return -1
 }
 
-// loadTracksByTitleAndArtist loads tracks matching by title with optional artist/album filtering.
-func (m *Matcher) loadTracksByTitleAndArtist(ctx context.Context, songs []agents.Song, priorMatches ...map[string]model.MediaFile) (map[string]model.MediaFile, error) {
-	queries := m.buildTitleQueries(songs, priorMatches...)
-	if len(queries) == 0 {
-		return map[string]model.MediaFile{}, nil
+// indexedQuery pairs a normalized songQuery with the index of the input song
+// it came from, so title matches can be written back to result by index.
+type indexedQuery struct {
+	index int
+	query songQuery
+}
+
+// matchByTitle fills result with fuzzy title+artist matches, skipping songs
+// already matched by a higher-priority loader.
+func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result map[int]model.MediaFile) error {
+	byArtist := map[string][]indexedQuery{}
+	for i, s := range songs {
+		if _, done := result[i]; done {
+			continue
+		}
+		artist := str.SanitizeFieldForSortingNoArticle(s.Artist)
+		if artist == "" {
+			continue
+		}
+		q := songQuery{
+			title:      str.SanitizeFieldForSorting(s.Name),
+			artist:     artist,
+			artistMBID: s.ArtistMBID,
+			album:      str.SanitizeFieldForSorting(s.Album),
+			albumMBID:  s.AlbumMBID,
+			durationMs: s.Duration,
+		}
+		byArtist[artist] = append(byArtist[artist], indexedQuery{index: i, query: q})
+	}
+	if len(byArtist) == 0 {
+		return nil
 	}
 
 	threshold := float64(conf.Server.Matcher.FuzzyThreshold) / 100.0
-
-	byArtist := map[string][]songQuery{}
-	for _, q := range queries {
-		if q.artist != "" {
-			byArtist[q.artist] = append(byArtist[q.artist], q)
-		}
-	}
-
-	matches := map[string]model.MediaFile{}
-	for artist, artistQueries := range byArtist {
+	for artist, queries := range byArtist {
 		tracks, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 			Filters: squirrel.And{
 				squirrel.Eq{"order_artist_name": artist},
@@ -382,22 +403,17 @@ func (m *Matcher) loadTracksByTitleAndArtist(ctx context.Context, songs []agents
 		if err != nil {
 			continue
 		}
-
 		sanitized := make([]sanitizedTrack, len(tracks))
 		for i := range tracks {
 			sanitized[i] = newSanitizedTrack(&tracks[i])
 		}
-
-		for _, q := range artistQueries {
-			if mf, found := m.findBestMatch(q, sanitized, threshold); found {
-				key := q.title + "|" + q.artist
-				if _, exists := matches[key]; !exists {
-					matches[key] = mf
-				}
+		for _, iq := range queries {
+			if mf, found := m.findBestMatch(iq.query, sanitized, threshold); found {
+				result[iq.index] = mf
 			}
 		}
 	}
-	return matches, nil
+	return nil
 }
 
 // durationProximity returns a score from 0.0 to 1.0 indicating how close the track's duration
@@ -450,64 +466,32 @@ func isPreferredTrack(mf *model.MediaFile) bool {
 	return mf.Starred || mf.Rating >= 4
 }
 
-// buildTitleQueries converts agent songs into normalized songQuery structs for title+artist matching.
-func (m *Matcher) buildTitleQueries(songs []agents.Song, priorMatches ...map[string]model.MediaFile) []songQuery {
-	var queries []songQuery
-	for _, s := range songs {
-		if songMatchedIn(s, priorMatches...) {
-			continue
-		}
-		queries = append(queries, songQuery{
-			title:      str.SanitizeFieldForSorting(s.Name),
-			artist:     str.SanitizeFieldForSortingNoArticle(s.Artist),
-			artistMBID: s.ArtistMBID,
-			album:      str.SanitizeFieldForSorting(s.Album),
-			albumMBID:  s.AlbumMBID,
-			durationMs: s.Duration,
-		})
-	}
-	return queries
-}
-
-// selectBestMatchingSongs assembles the final result by mapping input songs to their best matching
-// library tracks using priority order: ID > MBID > ISRC > title+artist.
-func (m *Matcher) selectBestMatchingSongs(songs []agents.Song, byID, byMBID, byISRC, byTitleArtist map[string]model.MediaFile, count int) model.MediaFiles {
+// orderAndDedup builds the final ordered result from the per-index matches,
+// applying the count limit and deduplication. A library track is added at most
+// once unless the same input song appears more than once (callers rely on that
+// 1:1 positional behavior for identical duplicate inputs).
+func orderAndDedup(songs []agents.Song, matches map[int]model.MediaFile, count int) model.MediaFiles {
 	mfs := make(model.MediaFiles, 0, len(songs))
 	addedBy := make(map[string]agents.Song, len(songs))
 
-	for _, t := range songs {
+	for i, s := range songs {
 		if len(mfs) == count {
 			break
 		}
-
-		mf, found := findMatchingTrack(t, byID, byMBID, byISRC, byTitleArtist)
+		mf, found := matches[i]
 		if !found {
 			continue
 		}
-
 		if prevSong, alreadyAdded := addedBy[mf.ID]; alreadyAdded {
-			if t != prevSong {
+			if s != prevSong {
 				continue
 			}
 		} else {
-			addedBy[mf.ID] = t
+			addedBy[mf.ID] = s
 		}
-
 		mfs = append(mfs, mf)
 	}
 	return mfs
-}
-
-// findMatchingTrack looks up a song in the match maps using priority order.
-func findMatchingTrack(t agents.Song, byID, byMBID, byISRC, byTitleArtist map[string]model.MediaFile) (model.MediaFile, bool) {
-	if mf, found := lookupByIdentifiers(t, byID, byMBID, byISRC); found {
-		return mf, true
-	}
-	key := str.SanitizeFieldForSorting(t.Name) + "|" + str.SanitizeFieldForSortingNoArticle(t.Artist)
-	if mf, ok := byTitleArtist[key]; ok {
-		return mf, true
-	}
-	return model.MediaFile{}, false
 }
 
 // similarityRatio calculates the similarity between two strings using Jaro-Winkler algorithm.

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -24,90 +24,14 @@ func New(ds model.DataStore) *Matcher {
 	return &Matcher{ds: ds}
 }
 
-// MatchSongs matches agent song results to local library tracks using a multi-phase
-// matching algorithm that prioritizes accuracy over recall.
+// MatchSongs matches agent songs to library tracks and returns up to count
+// tracks in the input's order. See the package documentation for the matching
+// algorithm.
 //
-// # Algorithm Overview
-//
-// The algorithm matches songs from external agents (Last.fm, Deezer, etc.) to tracks in the
-// local music library using four matching strategies in priority order:
-//
-//  1. Direct ID match: Songs with an ID field are matched directly to MediaFiles by ID
-//  2. MusicBrainz Recording ID (MBID) match: Songs with MBID are matched to tracks with
-//     matching mbz_recording_id
-//  3. ISRC match: Songs with ISRC are matched to tracks with matching ISRC tag
-//  4. Title+Artist fuzzy match: Remaining songs are matched using fuzzy string comparison
-//     with metadata specificity scoring
-//
-// # Matching Priority
-//
-// When selecting the final result, matches are prioritized in order: ID > MBID > ISRC > Title+Artist.
-// This ensures that more reliable identifiers take precedence over fuzzy text matching.
-//
-// # Fuzzy Matching Details
-//
-// For title+artist matching, the algorithm uses Jaro-Winkler similarity (threshold configurable
-// via conf.Server.Matcher.FuzzyThreshold, default 85%). Matches are ranked by:
-//
-//  1. Title similarity (Jaro-Winkler score, 0.0-1.0)
-//  2. Duration proximity (closer duration = higher score, 1.0 if unknown)
-//  3. Preferred track flag (enabled by conf.Server.Matcher.PreferStarred; prioritized when the track is
-//     starred or has rating >= 4)
-//  4. Specificity level (0-5, based on metadata precision):
-//     - Level 5: Title + Artist MBID + Album MBID (most specific)
-//     - Level 4: Title + Artist MBID + Album name (fuzzy)
-//     - Level 3: Title + Artist name + Album name (fuzzy)
-//     - Level 2: Title + Artist MBID
-//     - Level 1: Title + Artist name
-//     - Level 0: Title only
-//  5. Album similarity (Jaro-Winkler, as final tiebreaker)
-//
-// # Examples
-//
-// Example 1 - MBID Priority:
-//
-//	Agent returns: {Name: "Paranoid Android", MBID: "abc-123", Artist: "Radiohead"}
-//	Library has: [
-//	  {ID: "t1", Title: "Paranoid Android", MbzRecordingID: "abc-123"},
-//	  {ID: "t2", Title: "Paranoid Android", Artist: "Radiohead"},
-//	]
-//	Result: t1 (MBID match takes priority over title+artist)
-//
-// Example 2 - ISRC Priority:
-//
-//	Agent returns: {Name: "Paranoid Android", ISRC: "GBAYE0000351", Artist: "Radiohead"}
-//	Library has: [
-//	  {ID: "t1", Title: "Paranoid Android", Tags: {isrc: ["GBAYE0000351"]}},
-//	  {ID: "t2", Title: "Paranoid Android", Artist: "Radiohead"},
-//	]
-//	Result: t1 (ISRC match takes priority over title+artist)
-//
-// Example 3 - Specificity Ranking:
-//
-//	Agent returns: {Name: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"}
-//	Library has: [
-//	  {ID: "t1", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "101"},           // Level 1
-//	  {ID: "t2", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator"},      // Level 3
-//	]
-//	Result: t2 (Level 3 beats Level 1 due to album match)
-//
-// Example 4 - Fuzzy Title Matching:
-//
-//	Agent returns: {Name: "Bohemian Rhapsody", Artist: "Queen"}
-//	Library has: {ID: "t1", Title: "Bohemian Rhapsody - Remastered", Artist: "Queen"}
-//	With threshold=85%: Match succeeds (similarity ~0.87)
-//	With threshold=100%: No match (not exact)
-//
-// # Parameters
-//
-//   - ctx: Context for database operations
-//   - songs: Slice of agent.Song results from external providers
-//   - count: Maximum number of matches to return
-//
-// # Returns
-//
-// Returns up to 'count' MediaFiles from the library that best match the input songs,
-// preserving the original order from the agent. Songs that cannot be matched are skipped.
+// Each library track appears at most once, unless the same input song is
+// repeated: identical input songs intentionally yield repeated output tracks,
+// while distinct songs that resolve to the same track are deduplicated. Songs
+// that cannot be matched are skipped.
 func (m *Matcher) MatchSongs(ctx context.Context, songs []agents.Song, count int) (model.MediaFiles, error) {
 	if len(songs) == 0 {
 		return nil, nil
@@ -119,9 +43,11 @@ func (m *Matcher) MatchSongs(ctx context.Context, songs []agents.Song, count int
 	return orderAndDedup(songs, matches, count), nil
 }
 
-// MatchSongsIndexed matches agent song results to local library tracks and returns a map
-// from input song index to matched MediaFile. Songs that cannot be matched are omitted from the map.
-// This preserves original indices, allowing callers to correlate results back to the input slice.
+// MatchSongsIndexed matches agent songs to library tracks and returns a map from
+// input-song index to matched track, letting callers correlate results back to
+// the input slice. Unmatched songs are omitted from the map. Unlike MatchSongs,
+// results are not deduplicated. See the package documentation for the matching
+// algorithm.
 func (m *Matcher) MatchSongsIndexed(ctx context.Context, songs []agents.Song) (map[int]model.MediaFile, error) {
 	if len(songs) == 0 {
 		return nil, nil

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/core/agents"
+	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/str"
 	"github.com/xrash/smetrics"
@@ -398,6 +399,8 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 			Sort: "starred desc, rating desc, year asc, compilation asc",
 		})
 		if err != nil {
+			// Best-effort: one artist's lookup failing must not sink matches for the others.
+			log.Warn(ctx, "matchByTitle: artist lookup failed, skipping", "artist", artist, err)
 			continue
 		}
 		sanitized := make([]sanitizedTrack, len(tracks))

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -407,6 +407,8 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		for i := range tracks {
 			sanitized[i] = newSanitizedTrack(&tracks[i])
 		}
+		// Each song is matched independently by index, so two songs with the same
+		// (title, artist) but different durations can resolve to different tracks.
 		for _, iq := range queries {
 			if mf, found := m.findBestMatch(iq.query, sanitized, threshold); found {
 				result[iq.index] = mf

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -352,10 +352,7 @@ func computeSpecificityLevel(q songQuery, t sanitizedTrack, albumThreshold float
 	if q.artist != "" && t.artist == q.artist {
 		return 1
 	}
-	if t.title == q.title {
-		return 0
-	}
-	return -1
+	return 0
 }
 
 // indexedQuery pairs a normalized songQuery with the index of the input song

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -243,9 +243,8 @@ func (s matchScore) betterThan(other matchScore) bool {
 }
 
 // sanitizedTrack holds pre-sanitized fields for a media file, avoiding redundant sanitization
-// when the same track is scored against multiple queries in the inner loop. The `mf` field
-// is a pointer to avoid copying the large MediaFile struct into each entry of the per-artist
-// sanitized slice.
+// when the same track is scored against multiple queries. The `mf` field is a pointer to avoid
+// copying the large MediaFile struct into each entry of the sanitized slice.
 type sanitizedTrack struct {
 	mf     *model.MediaFile
 	title  string
@@ -264,6 +263,12 @@ func newSanitizedTrack(mf *model.MediaFile) sanitizedTrack {
 
 // computeSpecificityLevel determines how well query metadata matches a track (0-5).
 // The track's title, artist, and album fields must be pre-sanitized.
+//
+// TODO: the artist-MBID levels (5, 4, 2) read the deprecated MediaFile.MbzArtistID
+// column, which is not populated — the artist MBID lives in the artist table and is
+// only hydrated by GetWithParticipants, not the bulk GetAll path used here. As a
+// result those levels never fire. To make them work, hydrate the artist participant
+// (or denormalize mbz_artist_id onto media_file) so t.mf carries the artist MBID.
 func computeSpecificityLevel(q songQuery, t sanitizedTrack, albumThreshold float64) int {
 	if q.artistMBID != "" && q.albumMBID != "" &&
 		t.mf.MbzArtistID == q.artistMBID && t.mf.MbzAlbumID == q.albumMBID {
@@ -319,10 +324,8 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		return nil
 	}
 
-	// Fetch all candidate tracks for every artist in the batch with a single query
-	// (order_artist_name IN (...)) instead of one query per artist. On a large
-	// library a batch of songs spans dozens of artists, and the per-query overhead
-	// dominates, so collapsing the round-trips is the main cost saver here.
+	// One batched query (order_artist_name IN ...) instead of one per artist: on a
+	// large library the per-query overhead dominates, so this is the main cost saver.
 	artists := make([]string, 0, len(byArtist))
 	for artist := range byArtist {
 		artists = append(artists, artist)
@@ -338,11 +341,12 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		return err
 	}
 
-	// Group by order_artist_name — the exact field the query filtered on, which
-	// matches how byArtist is keyed (a track's display Artist may differ from its
-	// sort/album artist, so re-deriving from tracks[i].Artist would misbucket).
-	// Fall back to sanitizing Artist when order_artist_name is unset (the same
-	// normalization the query artist uses).
+	// Key on order_artist_name — the exact field the query filtered on, which matches
+	// how byArtist is keyed. A track's display Artist can differ (collaborations,
+	// "feat." credits), so re-deriving from Artist would misbucket. This reads the
+	// deprecated MediaFile.OrderArtistName column because the bulk GetAll path does
+	// not hydrate participant detail (only {id, name}), so the participant's order
+	// name is empty here; the column is the only populated source.
 	tracksByArtist := make(map[string][]sanitizedTrack, len(byArtist))
 	for i := range tracks {
 		key := tracks[i].OrderArtistName

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -69,8 +69,14 @@ func (m *Matcher) resolveMatches(ctx context.Context, songs []agents.Song) (map[
 	if err := m.matchByISRC(ctx, songs, result); err != nil {
 		return nil, fmt.Errorf("failed to match tracks by ISRC: %w", err)
 	}
+	// The title phase is best-effort: a DB failure there must not discard the exact
+	// matches already found by the higher-priority phases. Only surface it as fatal
+	// when nothing matched at all.
 	if err := m.matchByTitle(ctx, songs, result); err != nil {
-		return nil, fmt.Errorf("failed to match tracks by title: %w", err)
+		if len(result) == 0 {
+			return nil, fmt.Errorf("failed to match tracks by title: %w", err)
+		}
+		log.Warn(ctx, "Title matching failed; returning matches from exact phases only", err)
 	}
 	return result, nil
 }

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -319,28 +319,42 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		return nil
 	}
 
+	// Fetch all candidate tracks for every artist in the batch with a single query
+	// (order_artist_name IN (...)) instead of one query per artist. On a large
+	// library a batch of songs spans dozens of artists, and the per-query overhead
+	// dominates, so collapsing the round-trips is the main cost saver here.
+	artists := make([]string, 0, len(byArtist))
+	for artist := range byArtist {
+		artists = append(artists, artist)
+	}
+	tracks, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
+		Filters: squirrel.And{
+			squirrel.Eq{"order_artist_name": artists},
+			squirrel.Eq{"missing": false},
+		},
+		Sort: "starred desc, rating desc, year asc, compilation asc",
+	})
+	if err != nil {
+		return err
+	}
+
+	// Group by order_artist_name — the exact field the query filtered on, which
+	// matches how byArtist is keyed (a track's display Artist may differ from its
+	// sort/album artist, so re-deriving from tracks[i].Artist would misbucket).
+	// Fall back to sanitizing Artist when order_artist_name is unset (the same
+	// normalization the query artist uses).
+	tracksByArtist := make(map[string][]sanitizedTrack, len(byArtist))
+	for i := range tracks {
+		key := tracks[i].OrderArtistName
+		if key == "" {
+			key = str.SanitizeFieldForSortingNoArticle(tracks[i].Artist)
+		}
+		tracksByArtist[key] = append(tracksByArtist[key], newSanitizedTrack(&tracks[i]))
+	}
+
 	threshold := float64(conf.Server.Matcher.FuzzyThreshold) / 100.0
-	var failed int
-	var lastErr error
 	for artist, queries := range byArtist {
-		tracks, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
-			Filters: squirrel.And{
-				squirrel.Eq{"order_artist_name": artist},
-				squirrel.Eq{"missing": false},
-			},
-			Sort: "starred desc, rating desc, year asc, compilation asc",
-		})
-		if err != nil {
-			// Best-effort: one artist's lookup failing must not sink matches for the others.
-			log.Warn(ctx, "matchByTitle: artist lookup failed, skipping", "artist", artist, err)
-			failed++
-			lastErr = err
-			continue
-		}
-		sanitized := make([]sanitizedTrack, len(tracks))
-		for i := range tracks {
-			sanitized[i] = newSanitizedTrack(&tracks[i])
-		}
+		sanitized := tracksByArtist[artist]
 		// Each song is matched independently by index, so two songs with the same
 		// (title, artist) but different durations can resolve to different tracks.
 		for _, iq := range queries {
@@ -348,12 +362,6 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 				result[iq.index] = mf
 			}
 		}
-	}
-
-	// If every artist query failed, this is a systemic DB problem rather than a
-	// best-effort miss, so surface it instead of silently returning no matches.
-	if failed == len(byArtist) {
-		return fmt.Errorf("all %d artist lookups failed, last error: %w", failed, lastErr)
 	}
 	return nil
 }

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -432,6 +432,7 @@ func (m *Matcher) findBestMatch(q songQuery, sanitizedTracks []sanitizedTrack, t
 	bestScore := matchScore{titleSimilarity: -1}
 	found := false
 
+	preferStarred := conf.Server.Matcher.PreferStarred
 	for _, t := range sanitizedTracks {
 		titleSim := similarityRatio(q.title, t.title)
 
@@ -447,7 +448,7 @@ func (m *Matcher) findBestMatch(q songQuery, sanitizedTracks []sanitizedTrack, t
 		score := matchScore{
 			titleSimilarity:   titleSim,
 			durationProximity: durationProximity(q.durationMs, t.mf.Duration),
-			preferredMatch:    conf.Server.Matcher.PreferStarred && isPreferredTrack(t.mf),
+			preferredMatch:    preferStarred && isPreferredTrack(t.mf),
 			albumSimilarity:   albumSim,
 			specificityLevel:  computeSpecificityLevel(q, t, threshold),
 		}

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -171,9 +171,7 @@ func (m *Matcher) matchByID(ctx context.Context, songs []agents.Song, result map
 	}
 	byID := make(map[string]model.MediaFile, len(res))
 	for _, mf := range res {
-		if _, ok := byID[mf.ID]; !ok {
-			byID[mf.ID] = mf
-		}
+		byID[mf.ID] = mf // media_file.id is unique, so no dedup needed
 	}
 	for i, s := range songs {
 		if s.ID == "" {
@@ -254,7 +252,7 @@ func (m *Matcher) matchByISRC(ctx context.Context, songs []agents.Song, result m
 	if err != nil {
 		return err
 	}
-	byISRC := map[string]model.MediaFile{}
+	byISRC := make(map[string]model.MediaFile, len(res))
 	for _, mf := range res {
 		for _, isrc := range mf.Tags.Values(model.TagISRC) {
 			if _, ok := byISRC[isrc]; !ok {
@@ -373,7 +371,7 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		}
 		artist := str.SanitizeFieldForSortingNoArticle(s.Artist)
 		if artist == "" {
-			continue
+			continue // title matching needs an artist to scope the library query
 		}
 		q := songQuery{
 			title:      str.SanitizeFieldForSorting(s.Name),

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -409,7 +409,7 @@ func isPreferredTrack(mf *model.MediaFile) bool {
 // 1:1 positional behavior for identical duplicate inputs).
 func orderAndDedup(songs []agents.Song, matches map[int]model.MediaFile, count int) model.MediaFiles {
 	mfs := make(model.MediaFiles, 0, len(songs))
-	addedBy := make(map[string]agents.Song, len(songs))
+	addedBy := make(map[string]int, len(songs))
 
 	for i, s := range songs {
 		if len(mfs) == count {
@@ -419,12 +419,12 @@ func orderAndDedup(songs []agents.Song, matches map[int]model.MediaFile, count i
 		if !found {
 			continue
 		}
-		if prevSong, alreadyAdded := addedBy[mf.ID]; alreadyAdded {
-			if s != prevSong {
+		if prevIdx, alreadyAdded := addedBy[mf.ID]; alreadyAdded {
+			if s != songs[prevIdx] {
 				continue
 			}
 		} else {
-			addedBy[mf.ID] = s
+			addedBy[mf.ID] = i
 		}
 		mfs = append(mfs, mf)
 	}

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -53,24 +53,30 @@ var _ = Describe("Matcher", func() {
 			Return(matches, nil).Once()
 	}
 
-	// allowOtherPhases installs .Maybe() catch-alls so phases that short-circuit (return
-	// early without hitting the DB) don't cause test failures for unexpected calls. Call
-	// this after expect*Phase for the phases the test actually wants to verify.
-	allowOtherPhases := func() {
+	// allowIdentifierPhases installs .Maybe() catch-alls for the ID/MBID/ISRC phases so
+	// tests that only care about the title phase don't fail on those unexpected calls.
+	allowIdentifierPhases := func() {
 		mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("media_file.id"))).
 			Return(model.MediaFiles{}, nil).Maybe()
 		mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("mbz_recording_id"))).
 			Return(model.MediaFiles{}, nil).Maybe()
 		mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInEq("missing"))).
 			Return(model.MediaFiles{}, nil).Maybe()
+	}
+
+	// allowOtherPhases installs .Maybe() catch-alls so phases that short-circuit (return
+	// early without hitting the DB) don't cause test failures for unexpected calls. Call
+	// this after expect*Phase for the phases the test actually wants to verify.
+	allowOtherPhases := func() {
+		allowIdentifierPhases()
 		mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
 			Return(model.MediaFiles{}, nil).Maybe()
 	}
 
-	// setupTitleOnlyExpectations is a convenience for fuzzy-match tests that only exercise
-	// the title+artist phase. The title phase uses .Maybe() because it may short-circuit
-	// when no songs have an artist.
-	setupTitleOnlyExpectations := func(artistTracks model.MediaFiles) {
+	// allowTitlePhase is a convenience for fuzzy-match tests that only exercise the
+	// title+artist phase. It uses .Maybe() because the phase may short-circuit when no
+	// songs have an artist.
+	allowTitlePhase := func(artistTracks model.MediaFiles) {
 		mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
 			Return(artistTracks, nil).Maybe()
 	}
@@ -141,7 +147,7 @@ var _ = Describe("Matcher", func() {
 				titleMatch := model.MediaFile{
 					ID: "track-title", Title: "Enjoy the Silence", Artist: "Depeche Mode",
 				}
-				setupTitleOnlyExpectations(model.MediaFiles{titleMatch})
+				allowTitlePhase(model.MediaFiles{titleMatch})
 				result, err := m.MatchSongs(ctx, songs, 5)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(HaveLen(1))
@@ -156,7 +162,7 @@ var _ = Describe("Matcher", func() {
 				fuzzyMatch := model.MediaFile{
 					ID: "track-fuzzy", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
 				}
-				setupTitleOnlyExpectations(model.MediaFiles{fuzzyMatch})
+				allowTitlePhase(model.MediaFiles{fuzzyMatch})
 				result, err := m.MatchSongs(ctx, songs, 5)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(HaveLen(1))
@@ -171,7 +177,7 @@ var _ = Describe("Matcher", func() {
 				differentTracks := model.MediaFiles{
 					{ID: "different", Title: "Tomorrow Never Knows", Artist: "The Beatles"},
 				}
-				setupTitleOnlyExpectations(differentTracks)
+				allowTitlePhase(differentTracks)
 				result, err := m.MatchSongs(ctx, songs, 5)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(BeEmpty())
@@ -188,7 +194,7 @@ var _ = Describe("Matcher", func() {
 				libraryTrack := model.MediaFile{
 					ID: "br-live", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
 				}
-				setupTitleOnlyExpectations(model.MediaFiles{libraryTrack})
+				allowTitlePhase(model.MediaFiles{libraryTrack})
 				result, err := m.MatchSongs(ctx, songs, 5)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(HaveLen(1))
@@ -204,7 +210,7 @@ var _ = Describe("Matcher", func() {
 				libraryTrack := model.MediaFile{
 					ID: "br", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "A Night at the Opera",
 				}
-				setupTitleOnlyExpectations(model.MediaFiles{libraryTrack})
+				allowTitlePhase(model.MediaFiles{libraryTrack})
 				result, err := m.MatchSongs(ctx, songs, 5)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(HaveLen(2))
@@ -247,7 +253,7 @@ var _ = Describe("Matcher", func() {
 					{ID: "b", Title: "Song B", Artist: "Artist"},
 					{ID: "c", Title: "Song C", Artist: "Artist"},
 				}
-				setupTitleOnlyExpectations(tracks)
+				allowTitlePhase(tracks)
 				result, err := m.MatchSongs(ctx, songs, 2)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result).To(HaveLen(2))
@@ -262,19 +268,10 @@ var _ = Describe("Matcher", func() {
 			})
 		})
 
+		// These tests register their own order_artist_name expectations per-test (to inject
+		// errors deterministically), so they use allowIdentifierPhases — NOT allowOtherPhases,
+		// which would add a .Maybe() title-phase catch-all that masks the injected errors.
 		Context("title phase DB errors", func() {
-			// allowIdentifierPhases installs .Maybe() catch-alls for the ID/MBID/ISRC
-			// phases only, leaving the order_artist_name expectations to each test so
-			// the title-phase error behavior can be exercised deterministically.
-			allowIdentifierPhases := func() {
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("media_file.id"))).
-					Return(model.MediaFiles{}, nil).Maybe()
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("mbz_recording_id"))).
-					Return(model.MediaFiles{}, nil).Maybe()
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInEq("missing"))).
-					Return(model.MediaFiles{}, nil).Maybe()
-			}
-
 			It("returns an error when every artist lookup fails", func() {
 				songs := []agents.Song{
 					{Name: "Song A", Artist: "Artist One"},
@@ -374,7 +371,7 @@ var _ = Describe("Matcher", func() {
 				{Name: "Similar Song", Artist: "Depeche Mode", ArtistMBID: "artist-mbid-123", Album: "Violator", AlbumMBID: "album-mbid-456"},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{wrongMatch, correctMatch})
+			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -394,7 +391,7 @@ var _ = Describe("Matcher", func() {
 				{Name: "Similar Song", Artist: "Depeche Mode", Album: "Violator"},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{wrongMatch, correctMatch})
+			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -414,7 +411,7 @@ var _ = Describe("Matcher", func() {
 				{Name: "Similar Song", Artist: "Depeche Mode"},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{wrongMatch, correctMatch})
+			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -428,7 +425,7 @@ var _ = Describe("Matcher", func() {
 				{Name: "Similar Song"},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{})
+			allowTitlePhase(model.MediaFiles{})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -447,7 +444,7 @@ var _ = Describe("Matcher", func() {
 				{Name: "Yesterday", Artist: "Frank Sinatra", Album: "My Way"},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{cover1, cover2, cover3})
+			allowTitlePhase(model.MediaFiles{cover1, cover2, cover3})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -475,7 +472,7 @@ var _ = Describe("Matcher", func() {
 				{Name: "Song B", Artist: "Artist Two"},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{lessAccurateMatch, preciseMatch, artistTwoMatch})
+			allowTitlePhase(model.MediaFiles{lessAccurateMatch, preciseMatch, artistTwoMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -498,7 +495,7 @@ var _ = Describe("Matcher", func() {
 					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead"},
 				}
 
-				setupTitleOnlyExpectations(artistTracks)
+				allowTitlePhase(artistTracks)
 
 				result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -517,7 +514,7 @@ var _ = Describe("Matcher", func() {
 					{ID: "live", Title: "Bohemian Rhapsody (Live)", Artist: "Queen"},
 				}
 
-				setupTitleOnlyExpectations(artistTracks)
+				allowTitlePhase(artistTracks)
 
 				result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -538,7 +535,7 @@ var _ = Describe("Matcher", func() {
 					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead"},
 				}
 
-				setupTitleOnlyExpectations(artistTracks)
+				allowTitlePhase(artistTracks)
 
 				result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -558,7 +555,7 @@ var _ = Describe("Matcher", func() {
 					{ID: "extended", Title: "Song (Extended Mix)", Artist: "Artist"},
 				}
 
-				setupTitleOnlyExpectations(artistTracks)
+				allowTitlePhase(artistTracks)
 
 				result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -586,7 +583,7 @@ var _ = Describe("Matcher", func() {
 				ID: "wrong", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "Greatest Hits",
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{wrongMatch, correctMatch})
+			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -606,7 +603,7 @@ var _ = Describe("Matcher", func() {
 				ID: "wrong", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "101",
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{wrongMatch, correctMatch})
+			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -626,7 +623,7 @@ var _ = Describe("Matcher", func() {
 				ID: "fuzzy", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator (Deluxe Edition)",
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{fuzzyMatch, exactMatch})
+			allowTitlePhase(model.MediaFiles{fuzzyMatch, exactMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -647,7 +644,7 @@ var _ = Describe("Matcher", func() {
 				ID: "starred", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles", Annotations: model.Annotations{Starred: true},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{albumMatch, starredTrack})
+			allowTitlePhase(model.MediaFiles{albumMatch, starredTrack})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -668,7 +665,7 @@ var _ = Describe("Matcher", func() {
 				ID: "rated", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles", Annotations: model.Annotations{Rating: 4},
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{albumMatch, ratedTrack})
+			allowTitlePhase(model.MediaFiles{albumMatch, ratedTrack})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -694,7 +691,7 @@ var _ = Describe("Matcher", func() {
 				ID: "wrong", Title: "Similar Song", Artist: "Test Artist", Duration: 240.0,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{wrongDuration, correctMatch})
+			allowTitlePhase(model.MediaFiles{wrongDuration, correctMatch})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -711,7 +708,7 @@ var _ = Describe("Matcher", func() {
 				ID: "close-duration", Title: "Similar Song", Artist: "Test Artist", Duration: 182.5,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{closeDuration})
+			allowTitlePhase(model.MediaFiles{closeDuration})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -731,7 +728,7 @@ var _ = Describe("Matcher", func() {
 				ID: "far", Title: "Similar Song", Artist: "Test Artist", Duration: 190.0,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{farDuration, closeDuration})
+			allowTitlePhase(model.MediaFiles{farDuration, closeDuration})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -748,7 +745,7 @@ var _ = Describe("Matcher", func() {
 				ID: "different", Title: "Similar Song", Artist: "Test Artist", Duration: 300.0,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{differentDuration})
+			allowTitlePhase(model.MediaFiles{differentDuration})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -768,7 +765,7 @@ var _ = Describe("Matcher", func() {
 				ID: "correct-title", Title: "Similar Song", Artist: "Test Artist", Duration: 300.0,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{differentTitle, correctTitle})
+			allowTitlePhase(model.MediaFiles{differentTitle, correctTitle})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -785,7 +782,7 @@ var _ = Describe("Matcher", func() {
 				ID: "any", Title: "Similar Song", Artist: "Test Artist", Duration: 999.0,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{anyTrack})
+			allowTitlePhase(model.MediaFiles{anyTrack})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -802,7 +799,7 @@ var _ = Describe("Matcher", func() {
 				ID: "short", Title: "Short Song", Artist: "Test Artist", Duration: 31.0,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{shortTrack})
+			allowTitlePhase(model.MediaFiles{shortTrack})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -823,7 +820,7 @@ var _ = Describe("Matcher", func() {
 				ID: "long", Title: "Same Song", Artist: "Same Artist", Duration: 240.0,
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{shortTrack, longTrack})
+			allowTitlePhase(model.MediaFiles{shortTrack, longTrack})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -850,7 +847,7 @@ var _ = Describe("Matcher", func() {
 				ID: "yesterday", Title: "Yesterday", Artist: "The Beatles", Album: "Help!",
 			}
 
-			setupTitleOnlyExpectations(model.MediaFiles{libraryTrack})
+			allowTitlePhase(model.MediaFiles{libraryTrack})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -870,7 +867,7 @@ var _ = Describe("Matcher", func() {
 			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist"}
 			trackC := model.MediaFile{ID: "track-c", Title: "Song C", Artist: "Artist"}
 
-			setupTitleOnlyExpectations(model.MediaFiles{trackA, trackB, trackC})
+			allowTitlePhase(model.MediaFiles{trackA, trackB, trackC})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
 
@@ -891,7 +888,7 @@ var _ = Describe("Matcher", func() {
 			trackA := model.MediaFile{ID: "track-a", Title: "Song A", Artist: "Artist"}
 			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist"}
 
-			setupTitleOnlyExpectations(model.MediaFiles{trackA, trackB})
+			allowTitlePhase(model.MediaFiles{trackA, trackB})
 
 			result, err := m.MatchSongs(ctx, songs, 2)
 

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -764,6 +764,28 @@ var _ = Describe("Matcher", func() {
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].ID).To(Equal("short"))
 		})
+
+		It("matches same title+artist songs to their own closest-duration track", func() {
+			songs := []agents.Song{
+				{Name: "Same Song", Artist: "Same Artist", Duration: 180000},
+				{Name: "Same Song", Artist: "Same Artist", Duration: 240000},
+			}
+			shortTrack := model.MediaFile{
+				ID: "short", Title: "Same Song", Artist: "Same Artist", Duration: 180.0,
+			}
+			longTrack := model.MediaFile{
+				ID: "long", Title: "Same Song", Artist: "Same Artist", Duration: 240.0,
+			}
+
+			setupTitleOnlyExpectations(model.MediaFiles{shortTrack, longTrack})
+
+			result, err := m.MatchSongs(ctx, songs, 5)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(2))
+			Expect(result[0].ID).To(Equal("short"))
+			Expect(result[1].ID).To(Equal("long"))
+		})
 	})
 
 	Describe("deduplication edge cases", func() {

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -303,6 +303,26 @@ var _ = Describe("Matcher", func() {
 				Expect(result).To(HaveLen(1))
 				Expect(result[0].ID).To(Equal("good"))
 			})
+
+			It("keeps exact-phase matches when every artist lookup fails", func() {
+				songs := []agents.Song{
+					{ID: "track-1", Name: "Exact Song", Artist: "Exact Artist"},
+					{Name: "Fuzzy Song", Artist: "Fuzzy Artist"},
+				}
+				idMatch := model.MediaFile{ID: "track-1", Title: "Exact Song", Artist: "Exact Artist"}
+				expectIDPhase(model.MediaFiles{idMatch})
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("mbz_recording_id"))).
+					Return(model.MediaFiles{}, nil).Maybe()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInEq("missing"))).
+					Return(model.MediaFiles{}, nil).Maybe()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
+					Return(nil, errors.New("db down"))
+
+				result, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(result[0].ID).To(Equal("track-1"))
+			})
 		})
 	})
 

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -261,6 +261,52 @@ var _ = Describe("Matcher", func() {
 				Expect(result).To(BeEmpty())
 			})
 		})
+
+		Context("title phase DB errors", func() {
+			// allowIdentifierPhases installs .Maybe() catch-alls for the ID/MBID/ISRC
+			// phases only, leaving the order_artist_name expectations to each test so
+			// the title-phase error behavior can be exercised deterministically.
+			allowIdentifierPhases := func() {
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("media_file.id"))).
+					Return(model.MediaFiles{}, nil).Maybe()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("mbz_recording_id"))).
+					Return(model.MediaFiles{}, nil).Maybe()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInEq("missing"))).
+					Return(model.MediaFiles{}, nil).Maybe()
+			}
+
+			It("returns an error when every artist lookup fails", func() {
+				songs := []agents.Song{
+					{Name: "Song A", Artist: "Artist One"},
+					{Name: "Song B", Artist: "Artist Two"},
+				}
+				allowIdentifierPhases()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
+					Return(nil, errors.New("db down"))
+
+				_, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("db down"))
+			})
+
+			It("returns partial results when only some artist lookups fail", func() {
+				songs := []agents.Song{
+					{Name: "Song A", Artist: "Good Artist"},
+					{Name: "Song B", Artist: "Bad Artist"},
+				}
+				goodTrack := model.MediaFile{ID: "good", Title: "Song A", Artist: "Good Artist"}
+				allowIdentifierPhases()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchArtistName("good artist"))).
+					Return(model.MediaFiles{goodTrack}, nil)
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchArtistName("bad artist"))).
+					Return(nil, errors.New("db hiccup"))
+
+				result, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(result[0].ID).To(Equal("good"))
+			})
+		})
 	})
 
 	Describe("MatchSongsIndexed", func() {
@@ -902,6 +948,23 @@ func matchFieldInAnd(fieldName string) func(opt model.QueryOptions) bool {
 		}
 		_, hasField := eq[fieldName]
 		return hasField
+	}
+}
+
+// matchArtistName returns a matcher that checks whether the title-phase query
+// filters on a specific sanitized order_artist_name value, so a test can return
+// different results for different artists in the same matchByTitle run.
+func matchArtistName(artist string) func(opt model.QueryOptions) bool {
+	return func(opt model.QueryOptions) bool {
+		and, ok := opt.Filters.(squirrel.And)
+		if !ok || len(and) < 2 {
+			return false
+		}
+		eq, hasEq := and[0].(squirrel.Eq)
+		if !hasEq {
+			return false
+		}
+		return eq["order_artist_name"] == artist
 	}
 }
 

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -268,6 +268,26 @@ var _ = Describe("Matcher", func() {
 			})
 		})
 
+		Context("artist grouping", func() {
+			It("groups title-phase tracks by order_artist_name, not display Artist", func() {
+				songs := []agents.Song{
+					{Name: "Song A", Artist: "Daft Punk"},
+				}
+				// Display Artist differs from the query artist; only OrderArtistName
+				// matches, so grouping must key on it (a "feat." credit, collaboration, etc.).
+				track := model.MediaFile{
+					ID: "oan-track", Title: "Song A",
+					Artist: "Daft Punk feat. Pharrell", OrderArtistName: "daft punk",
+				}
+				allowTitlePhase(model.MediaFiles{track})
+
+				result, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(result[0].ID).To(Equal("oan-track"))
+			})
+		})
+
 		// These tests register their own order_artist_name expectation per-test (to inject
 		// an error), so they use allowIdentifierPhases — NOT allowOtherPhases, which would
 		// add a .Maybe() title-phase catch-all that masks the injected error.

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -954,14 +954,17 @@ func matchFieldInAnd(fieldName string) func(opt model.QueryOptions) bool {
 func matchArtistName(artist string) func(opt model.QueryOptions) bool {
 	return func(opt model.QueryOptions) bool {
 		and, ok := opt.Filters.(squirrel.And)
-		if !ok || len(and) < 2 {
+		if !ok {
 			return false
 		}
-		eq, hasEq := and[0].(squirrel.Eq)
-		if !hasEq {
-			return false
+		for _, filter := range and {
+			if eq, ok := filter.(squirrel.Eq); ok {
+				if val, has := eq["order_artist_name"]; has {
+					return val == artist
+				}
+			}
 		}
-		return eq["order_artist_name"] == artist
+		return false
 	}
 }
 

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -268,11 +268,11 @@ var _ = Describe("Matcher", func() {
 			})
 		})
 
-		// These tests register their own order_artist_name expectations per-test (to inject
-		// errors deterministically), so they use allowIdentifierPhases — NOT allowOtherPhases,
-		// which would add a .Maybe() title-phase catch-all that masks the injected errors.
+		// These tests register their own order_artist_name expectation per-test (to inject
+		// an error), so they use allowIdentifierPhases — NOT allowOtherPhases, which would
+		// add a .Maybe() title-phase catch-all that masks the injected error.
 		Context("title phase DB errors", func() {
-			It("returns an error when every artist lookup fails", func() {
+			It("returns an error when the title query fails and nothing else matched", func() {
 				songs := []agents.Song{
 					{Name: "Song A", Artist: "Artist One"},
 					{Name: "Song B", Artist: "Artist Two"},
@@ -286,25 +286,7 @@ var _ = Describe("Matcher", func() {
 				Expect(err.Error()).To(ContainSubstring("db down"))
 			})
 
-			It("returns partial results when only some artist lookups fail", func() {
-				songs := []agents.Song{
-					{Name: "Song A", Artist: "Good Artist"},
-					{Name: "Song B", Artist: "Bad Artist"},
-				}
-				goodTrack := model.MediaFile{ID: "good", Title: "Song A", Artist: "Good Artist"}
-				allowIdentifierPhases()
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchArtistName("good artist"))).
-					Return(model.MediaFiles{goodTrack}, nil)
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchArtistName("bad artist"))).
-					Return(nil, errors.New("db hiccup"))
-
-				result, err := m.MatchSongs(ctx, songs, 5)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(HaveLen(1))
-				Expect(result[0].ID).To(Equal("good"))
-			})
-
-			It("keeps exact-phase matches when every artist lookup fails", func() {
+			It("keeps exact-phase matches when the title query fails", func() {
 				songs := []agents.Song{
 					{ID: "track-1", Name: "Exact Song", Artist: "Exact Artist"},
 					{Name: "Fuzzy Song", Artist: "Fuzzy Artist"},
@@ -965,26 +947,6 @@ func matchFieldInAnd(fieldName string) func(opt model.QueryOptions) bool {
 		}
 		_, hasField := eq[fieldName]
 		return hasField
-	}
-}
-
-// matchArtistName returns a matcher that checks whether the title-phase query
-// filters on a specific sanitized order_artist_name value, so a test can return
-// different results for different artists in the same matchByTitle run.
-func matchArtistName(artist string) func(opt model.QueryOptions) bool {
-	return func(opt model.QueryOptions) bool {
-		and, ok := opt.Filters.(squirrel.And)
-		if !ok {
-			return false
-		}
-		for _, filter := range and {
-			if eq, ok := filter.(squirrel.Eq); ok {
-				if val, has := eq["order_artist_name"]; has {
-					return val == artist
-				}
-			}
-		}
-		return false
 	}
 }
 


### PR DESCRIPTION
### Description

This PR restructures `core/matcher` (the service that maps external-agent song results — Last.fm/Deezer/etc. — to local library tracks for the "similar songs" and sonic-similarity features) for clarity, and along the way fixes a significant performance problem the new structure made obvious.

**1. Index-space refactor (structure).** Matching was done in *identifier-space*: four parallel `map[string]MediaFile` lookups (keyed by ID, MBID, ISRC, and a `title|artist` string), with the ID > MBID > ISRC > Title priority order re-encoded in three different places, and the title key derived twice (once when storing, again — re-sanitized from scratch — when looking up). Matching now happens in *song-index space*: a single `resolveMatches` builds one `map[int]MediaFile` (input-song index → best match), with four loaders that run in priority order and only fill indices not yet matched. Priority now lives in exactly one place: the loader call order. This deletes the per-song lookup helper, the identifier-lookup helper, the "already matched?" helper, three variadic params, and the duplicated key derivation.

**2. Batched title lookups (performance).** Profiling the refactored matcher against a real ~95k-track library showed it was ~90% bound in `matchByTitle`, which issued **one `GetAll` query per distinct artist, serially** — roughly 89 separate multi-join queries for a 100-song batch (~6s). This is now a **single `order_artist_name IN (...)` query** plus in-memory grouping by artist. Measured on the 95k-track DB:

| Batch size | Before | After | Speedup |
| --- | --- | --- | --- |
| 20 songs | ~1.4 s | ~0.25 s | ~5–6× |
| 100 songs | ~6.0 s | ~0.4 s | ~14× |

(Memory also drops ~20–35%.) Returned tracks are grouped by `order_artist_name` — the exact field the query filters on — so collaboration/"feat." tracks (whose display `Artist` differs from the sort artist) bucket correctly.

**3. Package documentation.** The long algorithm doc that lived on `MatchSongs` moved to a package-level `doc.go`, with examples reworked to focus on the non-obvious fuzzy-matching behavior (title threshold, specificity ranking, duration tiebreak, preferred-track bias).

Both public methods keep their contracts: `MatchSongs` returns an ordered, deduplicated, count-limited slice; `MatchSongsIndexed` returns every matched index with no dedup. Behavior is pinned by the existing comprehensive test suite.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [x] Refactor
- [x] Other (please describe): performance improvement (title-phase query batching)

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

This is internal to `core/matcher` with no API or config surface change, so it's covered by the package test suites:

1. Run the matcher tests and its consumers:
   ```bash
   make test PKG="./core/matcher ./core/external ./core/sonic"
   ```
   All should pass. The consumers confirm the public method contracts are unchanged.

2. (Optional, end-to-end) With a large populated library, exercise the "similar songs" / sonic-similarity paths via a Subsonic client. The title-matching path (agent songs without library identifiers) is where the speedup shows: a batch that previously took several seconds should now return in well under a second.

### Additional Notes

Two intentional, narrow behavior changes a reviewer should be aware of:

1. **Per-index title matching.** Each input song is scored independently, so two songs with the same title and artist but different durations resolve to the track closest to each one's duration, instead of both collapsing to a single shared match (the old code's first-write-wins key discarded per-song duration hints for all but the first). Pinned by a test.

2. **Title-phase error model.** Because the title phase is now a single query (rather than a per-artist loop), it is all-or-nothing like the ID/MBID/ISRC loaders: a DB failure there is surfaced only when no song matched in any phase, so a title-query failure never discards exact-identifier matches already found.

Implementation notes worth a reviewer's eye:

- The title-phase grouping reads `MediaFile.OrderArtistName`, which is deprecated in favor of `Participants`. It is intentionally kept here because the bulk `GetAll` path does not hydrate participant detail (rich fields come only from the per-record `GetWithParticipants` JOIN), so the participant's order name is empty on this path — the column is the only populated source, and it is exactly the field the query filters on.
- A `TODO` is added in `computeSpecificityLevel`: its artist-MBID specificity levels read the deprecated, unpopulated `MediaFile.MbzArtistID` column (the artist MBID lives in the `artist` table and is not denormalized onto `media_file`), so those levels never fire today. Fixing that is out of scope for this PR.

No config, no migration, no API change.
