### PR TITLE
fix(matcher): match by artist credit so artist-MBID specificity works and collaborators match

### DIFF
--- a/core/external/provider_similarsongs_test.go
+++ b/core/external/provider_similarsongs_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 			It("calls GetSimilarSongsByTrack and returns matched songs", func() {
 				track := model.MediaFile{ID: "track-1", Title: "Just Can't Get Enough", Artist: "Depeche Mode", MbzRecordingID: "track-mbid"}
 
-				// Depeche Mode artist row used by matcher phase-1 and phase-2 back-mapping.
+				// Depeche Mode artist row used by matcher artist resolution and track-fetch back-mapping.
 				dmArtist := model.Artist{ID: "dm-1", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid"}
 				dmParticipant := model.Participant{Artist: dmArtist}
 				matchedSong := model.MediaFile{
@@ -76,7 +76,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 						{Name: "Dreaming of Me", MBID: "", Artist: "Depeche Mode", ArtistMBID: "artist-mbid"},
 					}, nil).Once()
 
-				// Matcher phase-1: resolve Depeche Mode in the artist table.
+				// Matcher artist resolution: resolve Depeche Mode in the artist table.
 				artistRepo.On("GetAll", mock.Anything).Return(model.Artists{dmArtist}, nil).Maybe()
 
 				// ID phase: no IDs → squirrel.And with media_file.id; won't be called but guard it.
@@ -99,7 +99,7 @@ var _ = Describe("Provider - SimilarSongs", func() {
 					return hasMBID
 				})).Return(model.MediaFiles{}, nil).Maybe()
 
-				// Matcher phase-2: EXISTS query returns the matched song with participants.
+				// Matcher track-fetch: subquery returns the matched song with participants.
 				mediaFileRepo.On("GetAll", mock.MatchedBy(func(opt model.QueryOptions) bool {
 					and, ok := opt.Filters.(squirrel.And)
 					if !ok {

--- a/core/external/provider_similarsongs_test.go
+++ b/core/external/provider_similarsongs_test.go
@@ -3,6 +3,7 @@ package external_test
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/core/agents"
@@ -56,7 +57,14 @@ var _ = Describe("Provider - SimilarSongs", func() {
 		Context("when ID is a MediaFile (track)", func() {
 			It("calls GetSimilarSongsByTrack and returns matched songs", func() {
 				track := model.MediaFile{ID: "track-1", Title: "Just Can't Get Enough", Artist: "Depeche Mode", MbzRecordingID: "track-mbid"}
-				matchedSong := model.MediaFile{ID: "matched-1", Title: "Dreaming of Me", Artist: "Depeche Mode"}
+
+				// Depeche Mode artist row used by matcher phase-1 and phase-2 back-mapping.
+				dmArtist := model.Artist{ID: "dm-1", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid"}
+				dmParticipant := model.Participant{Artist: dmArtist}
+				matchedSong := model.MediaFile{
+					ID: "matched-1", Title: "Dreaming of Me", Artist: "Depeche Mode",
+					Participants: model.Participants{model.RoleArtist: model.ParticipantList{dmParticipant}},
+				}
 
 				// GetEntityByID tries Artist, Album, Playlist, then MediaFile
 				artistRepo.On("Get", "track-1").Return(nil, model.ErrNotFound).Once()
@@ -68,13 +76,16 @@ var _ = Describe("Provider - SimilarSongs", func() {
 						{Name: "Dreaming of Me", MBID: "", Artist: "Depeche Mode", ArtistMBID: "artist-mbid"},
 					}, nil).Once()
 
-				// Mock loadTracksByID - no ID matches
+				// Matcher phase-1: resolve Depeche Mode in the artist table.
+				artistRepo.On("GetAll", mock.Anything).Return(model.Artists{dmArtist}, nil).Maybe()
+
+				// ID phase: no IDs → squirrel.And with media_file.id; won't be called but guard it.
 				mediaFileRepo.On("GetAll", mock.MatchedBy(func(opt model.QueryOptions) bool {
 					_, ok := opt.Filters.(squirrel.Eq)
 					return ok
-				})).Return(model.MediaFiles{}, nil).Once()
+				})).Return(model.MediaFiles{}, nil).Maybe()
 
-				// Mock loadTracksByMBID - no MBID matches (empty MBID means this won't be called)
+				// MBID phase: won't fire (empty MBID).
 				mediaFileRepo.On("GetAll", mock.MatchedBy(func(opt model.QueryOptions) bool {
 					and, ok := opt.Filters.(squirrel.And)
 					if !ok || len(and) < 1 {
@@ -88,18 +99,19 @@ var _ = Describe("Provider - SimilarSongs", func() {
 					return hasMBID
 				})).Return(model.MediaFiles{}, nil).Maybe()
 
-				// Mock loadTracksByTitleAndArtist - queries by artist name
+				// Matcher phase-2: EXISTS query returns the matched song with participants.
 				mediaFileRepo.On("GetAll", mock.MatchedBy(func(opt model.QueryOptions) bool {
 					and, ok := opt.Filters.(squirrel.And)
-					if !ok || len(and) < 2 {
+					if !ok {
 						return false
 					}
-					eq, hasEq := and[0].(squirrel.Eq)
-					if !hasEq {
-						return false
+					for _, f := range and {
+						sql, _, err := f.ToSql()
+						if err == nil && strings.Contains(sql, "media_file_artists") {
+							return true
+						}
 					}
-					_, hasArtist := eq["order_artist_name"]
-					return hasArtist
+					return false
 				})).Return(model.MediaFiles{matchedSong}, nil).Maybe()
 
 				songs, err := provider.SimilarSongs(ctx, "track-1", 5)

--- a/core/external/provider_topsongs_test.go
+++ b/core/external/provider_topsongs_test.go
@@ -148,6 +148,8 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding the artist
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One", MbzArtistID: "mbid-artist-1"}
 		artistRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.Artists{artist1}, nil).Once()
+		// Matcher phase-1: artist resolution for the title-match path (song2 falls through).
+		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{artist1}, nil).Maybe()
 
 		// Mock agent response
 		agentSongs := []agents.Song{
@@ -159,7 +161,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding matching tracks (only find song 1 on bulk query)
 		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-song-1"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once() // bulk MBID query
-		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{}, nil).Once()      // title fallback for song2
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{}, nil).Once()      // title phase-2 for song2: no match
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)
 
@@ -195,6 +197,8 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding the artist
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One", MbzArtistID: "mbid-artist-1"}
 		artistRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.Artists{artist1}, nil).Once()
+		// Matcher phase-1: artist resolution for both title-fallback songs.
+		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{artist1}, nil).Maybe()
 
 		// Mock agent response with songs that have NO MBID (empty string)
 		agentSongs := []agents.Song{
@@ -203,10 +207,16 @@ var _ = Describe("Provider - TopSongs", func() {
 		}
 		ag.On("GetArtistTopSongs", ctx, "artist-1", "Artist One", "mbid-artist-1", 2).Return(agentSongs, nil).Once()
 
-		// Since there are no MBIDs, loadTracksByMBID should not make any database call
-		// loadTracksByTitle should make a database call for title matching
-		song1 := model.MediaFile{ID: "song-1", Title: "Song One", Artist: "Artist One", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song one"}
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
+		// Title phase-2: tracks must carry RoleArtist participants so back-mapping routes them.
+		participant1 := model.Participant{Artist: model.Artist{ID: "artist-1", Name: "Artist One", OrderArtistName: "artist one"}}
+		song1 := model.MediaFile{
+			ID: "song-1", Title: "Song One", Artist: "Artist One", ArtistID: "artist-1",
+			Participants: model.Participants{model.RoleArtist: model.ParticipantList{participant1}},
+		}
+		song2 := model.MediaFile{
+			ID: "song-2", Title: "Song Two", Artist: "Artist One", ArtistID: "artist-1",
+			Participants: model.Participants{model.RoleArtist: model.ParticipantList{participant1}},
+		}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1, song2}, nil).Once()
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)
@@ -224,6 +234,8 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding the artist
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One", MbzArtistID: "mbid-artist-1"}
 		artistRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.Artists{artist1}, nil).Once()
+		// Matcher phase-1: artist resolution for song2's title-fallback path.
+		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{artist1}, nil).Maybe()
 
 		// Mock agent response with mixed MBID availability
 		agentSongs := []agents.Song{
@@ -236,8 +248,12 @@ var _ = Describe("Provider - TopSongs", func() {
 		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-song-1", OrderTitle: "song one"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
 
-		// Mock the title fallback query (finds song2 by title)
-		song2 := model.MediaFile{ID: "song-2", Title: "Song Two", Artist: "Artist One", ArtistID: "artist-1", MbzRecordingID: "", OrderTitle: "song two"}
+		// Title phase-2: song2 must carry RoleArtist participants for back-mapping.
+		participant1 := model.Participant{Artist: model.Artist{ID: "artist-1", Name: "Artist One", OrderArtistName: "artist one"}}
+		song2 := model.MediaFile{
+			ID: "song-2", Title: "Song Two", Artist: "Artist One", ArtistID: "artist-1",
+			Participants: model.Participants{model.RoleArtist: model.ParticipantList{participant1}},
+		}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song2}, nil).Once()
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)

--- a/core/external/provider_topsongs_test.go
+++ b/core/external/provider_topsongs_test.go
@@ -148,7 +148,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding the artist
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One", MbzArtistID: "mbid-artist-1"}
 		artistRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.Artists{artist1}, nil).Once()
-		// Matcher phase-1: artist resolution for the title-match path (song2 falls through).
+		// Matcher artist resolution for the title-match path (song2 falls through).
 		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{artist1}, nil).Maybe()
 
 		// Mock agent response
@@ -161,7 +161,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding matching tracks (only find song 1 on bulk query)
 		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-song-1"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once() // bulk MBID query
-		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{}, nil).Once()      // title phase-2 for song2: no match
+		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{}, nil).Once()      // title track-fetch for song2: no match
 
 		songs, err := p.TopSongs(ctx, "Artist One", 2)
 
@@ -197,7 +197,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding the artist
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One", MbzArtistID: "mbid-artist-1"}
 		artistRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.Artists{artist1}, nil).Once()
-		// Matcher phase-1: artist resolution for both title-fallback songs.
+		// Matcher artist resolution for both title-fallback songs.
 		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{artist1}, nil).Maybe()
 
 		// Mock agent response with songs that have NO MBID (empty string)
@@ -207,7 +207,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		}
 		ag.On("GetArtistTopSongs", ctx, "artist-1", "Artist One", "mbid-artist-1", 2).Return(agentSongs, nil).Once()
 
-		// Title phase-2: tracks must carry RoleArtist participants so back-mapping routes them.
+		// Title track-fetch: tracks must carry RoleArtist participants so back-mapping routes them.
 		participant1 := model.Participant{Artist: model.Artist{ID: "artist-1", Name: "Artist One", OrderArtistName: "artist one"}}
 		song1 := model.MediaFile{
 			ID: "song-1", Title: "Song One", Artist: "Artist One", ArtistID: "artist-1",
@@ -234,7 +234,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		// Mock finding the artist
 		artist1 := model.Artist{ID: "artist-1", Name: "Artist One", MbzArtistID: "mbid-artist-1"}
 		artistRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.Artists{artist1}, nil).Once()
-		// Matcher phase-1: artist resolution for song2's title-fallback path.
+		// Matcher artist resolution for song2's title-fallback path.
 		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{artist1}, nil).Maybe()
 
 		// Mock agent response with mixed MBID availability
@@ -248,7 +248,7 @@ var _ = Describe("Provider - TopSongs", func() {
 		song1 := model.MediaFile{ID: "song-1", Title: "Song One", ArtistID: "artist-1", MbzRecordingID: "mbid-song-1", OrderTitle: "song one"}
 		mediaFileRepo.On("GetAll", mock.AnythingOfType("model.QueryOptions")).Return(model.MediaFiles{song1}, nil).Once()
 
-		// Title phase-2: song2 must carry RoleArtist participants for back-mapping.
+		// Title track-fetch: song2 must carry RoleArtist participants for back-mapping.
 		participant1 := model.Participant{Artist: model.Artist{ID: "artist-1", Name: "Artist One", OrderArtistName: "artist one"}}
 		song2 := model.MediaFile{
 			ID: "song-2", Title: "Song Two", Artist: "Artist One", ArtistID: "artist-1",

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -246,43 +246,40 @@ func (s matchScore) betterThan(other matchScore) bool {
 // when the same track is scored against multiple queries. The `mf` field is a pointer to avoid
 // copying the large MediaFile struct into each entry of the sanitized slice.
 type sanitizedTrack struct {
-	mf     *model.MediaFile
-	title  string
-	artist string
-	album  string
+	mf         *model.MediaFile
+	title      string
+	artist     string
+	album      string
+	artistMBID string // resolved from the artist table; mf.MbzArtistID is not populated on the bulk path
 }
 
-func newSanitizedTrack(mf *model.MediaFile) sanitizedTrack {
+func newSanitizedTrack(mf *model.MediaFile, artistMBID string) sanitizedTrack {
 	return sanitizedTrack{
-		mf:     mf,
-		title:  str.SanitizeFieldForSorting(mf.Title),
-		artist: str.SanitizeFieldForSortingNoArticle(mf.Artist),
-		album:  str.SanitizeFieldForSorting(mf.Album),
+		mf:         mf,
+		title:      str.SanitizeFieldForSorting(mf.Title),
+		artist:     str.SanitizeFieldForSortingNoArticle(mf.Artist),
+		album:      str.SanitizeFieldForSorting(mf.Album),
+		artistMBID: artistMBID,
 	}
 }
 
 // computeSpecificityLevel determines how well query metadata matches a track (0-5).
-// The track's title, artist, and album fields must be pre-sanitized.
-//
-// TODO: the artist-MBID levels (5, 4, 2) read the deprecated MediaFile.MbzArtistID
-// column, which is not populated — the artist MBID lives in the artist table and is
-// only hydrated by GetWithParticipants, not the bulk GetAll path used here. As a
-// result those levels never fire. To make them work, hydrate the artist participant
-// (or denormalize mbz_artist_id onto media_file) so t.mf carries the artist MBID.
+// The track's title, artist, and album fields must be pre-sanitized, and artistMBID
+// must hold the resolved artist MBID.
 func computeSpecificityLevel(q songQuery, t sanitizedTrack, albumThreshold float64) int {
 	if q.artistMBID != "" && q.albumMBID != "" &&
-		t.mf.MbzArtistID == q.artistMBID && t.mf.MbzAlbumID == q.albumMBID {
+		t.artistMBID == q.artistMBID && t.mf.MbzAlbumID == q.albumMBID {
 		return 5
 	}
 	if q.artistMBID != "" && q.album != "" &&
-		t.mf.MbzArtistID == q.artistMBID && similarityRatio(t.album, q.album) >= albumThreshold {
+		t.artistMBID == q.artistMBID && similarityRatio(t.album, q.album) >= albumThreshold {
 		return 4
 	}
 	if q.artist != "" && q.album != "" &&
 		t.artist == q.artist && similarityRatio(t.album, q.album) >= albumThreshold {
 		return 3
 	}
-	if q.artistMBID != "" && t.mf.MbzArtistID == q.artistMBID {
+	if q.artistMBID != "" && t.artistMBID == q.artistMBID {
 		return 2
 	}
 	if q.artist != "" && t.artist == q.artist {
@@ -353,7 +350,7 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		if key == "" {
 			key = str.SanitizeFieldForSortingNoArticle(tracks[i].Artist)
 		}
-		tracksByArtist[key] = append(tracksByArtist[key], newSanitizedTrack(&tracks[i]))
+		tracksByArtist[key] = append(tracksByArtist[key], newSanitizedTrack(&tracks[i], ""))
 	}
 
 	threshold := float64(conf.Server.Matcher.FuzzyThreshold) / 100.0

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -3,8 +3,9 @@ package matcher
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math"
-	"strings"
+	"slices"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/conf"
@@ -299,116 +300,22 @@ type indexedQuery struct {
 // matchByTitle fills result with fuzzy title+artist matches, skipping songs
 // already matched by a higher-priority loader.
 func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result map[int]model.MediaFile) error {
-	byArtist := map[string][]indexedQuery{}
-	for i, s := range songs {
-		if _, done := result[i]; done {
-			continue
-		}
-		artist := str.SanitizeFieldForSortingNoArticle(s.Artist)
-		if artist == "" {
-			continue // title matching needs an artist to scope the library query
-		}
-		q := songQuery{
-			title:      str.SanitizeFieldForSorting(s.Name),
-			artist:     artist,
-			artistMBID: s.ArtistMBID,
-			album:      str.SanitizeFieldForSorting(s.Album),
-			albumMBID:  s.AlbumMBID,
-			durationMs: s.Duration,
-		}
-		byArtist[artist] = append(byArtist[artist], indexedQuery{index: i, query: q})
-	}
+	byArtist := groupQueriesByArtist(songs, result)
 	if len(byArtist) == 0 {
 		return nil
 	}
 
-	// Collect distinct sanitized artist names and any agent-provided artist MBIDs.
-	names := make([]string, 0, len(byArtist))
-	for artist := range byArtist {
-		names = append(names, artist)
-	}
-	var artistMBIDs []string
-	for _, queries := range byArtist {
-		for _, iq := range queries {
-			if iq.query.artistMBID != "" {
-				artistMBIDs = append(artistMBIDs, iq.query.artistMBID)
-			}
-		}
-	}
-
-	// Phase 1: resolve agent artists to artist-table rows (by sort name or MBID),
-	// so we can match on stable artist IDs and recover the real artist MBID (which
-	// is not denormalized onto media_file).
-	artistFilter := squirrel.Or{squirrel.Eq{"order_artist_name": names}}
-	if len(artistMBIDs) > 0 {
-		artistFilter = append(artistFilter, squirrel.Eq{"mbz_artist_id": artistMBIDs})
-	}
-	artists, err := m.ds.Artist(ctx).GetAll(model.QueryOptions{Filters: artistFilter})
-	if err != nil {
+	resolved, err := m.resolveArtists(ctx, byArtist)
+	if err != nil || len(resolved.allIDs) == 0 {
 		return err
 	}
-	if len(artists) == 0 {
-		return nil
-	}
 
-	// Each query (keyed by sanitized name) owns a set of resolved artist IDs: an
-	// artist row belongs to a query if its order_artist_name equals the query name
-	// OR its mbz_artist_id equals the query's agent ArtistMBID. Routing by ID (not
-	// name) keeps MBID-resolved artists whose order name differs from the query name
-	// from being misrouted.
-	queryArtistIDs := map[string]map[string]bool{} // sanitizedName -> set of artist IDs
-	artistIDToMBID := map[string]string{}
-	resolved := map[string]bool{}
-	allArtistIDs := make([]string, 0, len(artists))
-	for _, a := range artists {
-		artistIDToMBID[a.ID] = a.MbzArtistID
-		resolved[a.ID] = true
-		allArtistIDs = append(allArtistIDs, a.ID)
-		for name, queries := range byArtist {
-			owns := a.OrderArtistName == name
-			if !owns {
-				for _, iq := range queries {
-					if iq.query.artistMBID != "" && a.MbzArtistID == iq.query.artistMBID {
-						owns = true
-						break
-					}
-				}
-			}
-			if owns {
-				if queryArtistIDs[name] == nil {
-					queryArtistIDs[name] = map[string]bool{}
-				}
-				queryArtistIDs[name][a.ID] = true
-			}
-		}
-	}
-
-	// Phase 2: fetch every track credited (role='artist') to a resolved artist, in one
-	// query. role='artist' (not albumartist) avoids tribute/compilation false positives.
-	// Use a non-correlated id IN (subquery): SQLite materializes the matching media_file
-	// ids once from the media_file_artists(artist_id) covering index, then probes by PK —
-	// dramatically cheaper than a correlated EXISTS that re-runs per media_file row.
-	placeholders := strings.Repeat("?,", len(allArtistIDs))
-	placeholders = placeholders[:len(placeholders)-1]
-	artistArgs := make([]any, len(allArtistIDs))
-	for i, id := range allArtistIDs {
-		artistArgs[i] = id
-	}
-	tracks, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
-		Filters: squirrel.And{
-			squirrel.Expr(
-				"media_file.id IN (SELECT media_file_id FROM media_file_artists "+
-					"WHERE role = 'artist' AND artist_id IN ("+placeholders+"))", artistArgs...),
-			squirrel.Eq{"missing": false},
-		},
-		Sort: "starred desc, rating desc, year asc, compilation asc",
-	})
+	tracks, err := m.fetchTracksCreditedTo(ctx, resolved.allIDs)
 	if err != nil {
 		return err
 	}
 
-	tracksByQuery := buildTracksByQuery(tracks, resolved, artistIDToMBID, queryArtistIDs)
-
+	tracksByQuery := resolved.bucketTracks(tracks)
 	threshold := float64(conf.Server.Matcher.FuzzyThreshold) / 100.0
 	for artist, queries := range byArtist {
 		sanitized := tracksByQuery[artist]
@@ -423,39 +330,142 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 	return nil
 }
 
-// buildTracksByQuery maps each sanitized artist name to the set of tracks credited to a resolved
-// artist in that query's bucket. A track is appended at most once per query bucket even if it
-// credits multiple resolved artists in that bucket, preventing duplicate scoring of the same track.
-func buildTracksByQuery(
-	tracks []model.MediaFile,
-	resolved map[string]bool,
-	artistIDToMBID map[string]string,
-	queryArtistIDs map[string]map[string]bool,
-) map[string][]sanitizedTrack {
-	tracksByQuery := map[string][]sanitizedTrack{}
-	addedToQuery := map[string]map[string]bool{} // name -> set of track IDs already appended
-	for i := range tracks {
-		for _, p := range tracks[i].Participants[model.RoleArtist] {
-			if !resolved[p.ID] {
-				continue
-			}
-			st := newSanitizedTrack(&tracks[i], artistIDToMBID[p.ID])
-			for name, ids := range queryArtistIDs {
-				if !ids[p.ID] {
-					continue
-				}
-				if addedToQuery[name] == nil {
-					addedToQuery[name] = map[string]bool{}
-				}
-				if addedToQuery[name][tracks[i].ID] {
-					continue // same track already appended for this bucket; skip to avoid duplicate scoring
-				}
-				addedToQuery[name][tracks[i].ID] = true
-				tracksByQuery[name] = append(tracksByQuery[name], st)
+// groupQueriesByArtist builds the per-artist (sanitized name) buckets of title queries,
+// skipping songs already matched by a higher-priority loader and those without an artist
+// (title matching needs an artist to scope the library query).
+func groupQueriesByArtist(songs []agents.Song, result map[int]model.MediaFile) map[string][]indexedQuery {
+	byArtist := map[string][]indexedQuery{}
+	for i, s := range songs {
+		if _, done := result[i]; done {
+			continue
+		}
+		artist := str.SanitizeFieldForSortingNoArticle(s.Artist)
+		if artist == "" {
+			continue
+		}
+		byArtist[artist] = append(byArtist[artist], indexedQuery{index: i, query: songQuery{
+			title:      str.SanitizeFieldForSorting(s.Name),
+			artist:     artist,
+			artistMBID: s.ArtistMBID,
+			album:      str.SanitizeFieldForSorting(s.Album),
+			albumMBID:  s.AlbumMBID,
+			durationMs: s.Duration,
+		}})
+	}
+	return byArtist
+}
+
+// resolvedArtists holds the result of phase 1: agent artists resolved to artist-table rows.
+// Everything routes by stable artist ID, never by name, so MBID-resolved artists whose order
+// name differs from the query name are not misrouted.
+type resolvedArtists struct {
+	byQuery map[string]map[string]bool // sanitized query name -> set of resolved artist IDs
+	mbid    map[string]string          // artist ID -> its MBID (the real one, from the artist table)
+	allIDs  []string                   // every resolved artist ID, for the phase-2 filter
+}
+
+// resolveArtists runs phase 1: it resolves the queries' artists against the artist table (by
+// sort name or agent-provided MBID) and records, for each query, which artist IDs it owns.
+func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]indexedQuery) (resolvedArtists, error) {
+	names := make([]string, 0, len(byArtist))
+	mbidToQuery := map[string]string{} // agent ArtistMBID -> query name that supplied it
+	for name, queries := range byArtist {
+		names = append(names, name)
+		for _, iq := range queries {
+			if iq.query.artistMBID != "" {
+				mbidToQuery[iq.query.artistMBID] = name
 			}
 		}
 	}
-	return tracksByQuery
+
+	filter := squirrel.Or{squirrel.Eq{"order_artist_name": names}}
+	if len(mbidToQuery) > 0 {
+		filter = append(filter, squirrel.Eq{"mbz_artist_id": slices.Collect(maps.Keys(mbidToQuery))})
+	}
+	artists, err := m.ds.Artist(ctx).GetAll(model.QueryOptions{Filters: filter})
+	if err != nil {
+		return resolvedArtists{}, err
+	}
+
+	res := resolvedArtists{
+		byQuery: map[string]map[string]bool{},
+		mbid:    make(map[string]string, len(artists)),
+		allIDs:  make([]string, 0, len(artists)),
+	}
+	for _, a := range artists {
+		res.mbid[a.ID] = a.MbzArtistID
+		res.allIDs = append(res.allIDs, a.ID)
+		// An artist belongs to a query if its order name matches the query name, or if its
+		// MBID matches the MBID that query supplied. Both are direct map lookups.
+		res.own(a.OrderArtistName, a.ID)
+		if name, ok := mbidToQuery[a.MbzArtistID]; ok && a.MbzArtistID != "" {
+			res.own(name, a.ID)
+		}
+	}
+	return res, nil
+}
+
+// own records that the named query owns the given artist ID (no-op if the name is not a query).
+func (r resolvedArtists) own(name, artistID string) {
+	if r.byQuery == nil {
+		return
+	}
+	if r.byQuery[name] == nil {
+		r.byQuery[name] = map[string]bool{}
+	}
+	r.byQuery[name][artistID] = true
+}
+
+// bucketTracks maps each query name to the tracks credited to one of its resolved artists.
+// A track is bucketed at most once per query even if it credits several of that query's
+// artists, preventing duplicate scoring of the same track.
+func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]sanitizedTrack {
+	byQuery := map[string][]sanitizedTrack{}
+	added := map[string]map[string]bool{} // query name -> set of track IDs already bucketed
+	for i := range tracks {
+		for _, p := range tracks[i].Participants[model.RoleArtist] {
+			mbid, isResolved := r.mbid[p.ID]
+			if !isResolved {
+				continue
+			}
+			st := newSanitizedTrack(&tracks[i], mbid)
+			for name, ids := range r.byQuery {
+				if !ids[p.ID] {
+					continue
+				}
+				if added[name] == nil {
+					added[name] = map[string]bool{}
+				}
+				if added[name][tracks[i].ID] {
+					continue
+				}
+				added[name][tracks[i].ID] = true
+				byQuery[name] = append(byQuery[name], st)
+			}
+		}
+	}
+	return byQuery
+}
+
+// fetchTracksCreditedTo runs phase 2: it fetches every non-missing track credited as the main
+// artist (role='artist', not albumartist — that avoids tribute/compilation false positives) to
+// any of the given artist IDs. The non-correlated id IN (subquery) lets SQLite materialize the
+// matching media_file ids once from the media_file_artists(artist_id) covering index and probe
+// by primary key, which is far cheaper than a correlated EXISTS that re-runs per media_file row.
+func (m *Matcher) fetchTracksCreditedTo(ctx context.Context, artistIDs []string) (model.MediaFiles, error) {
+	args := make([]any, len(artistIDs))
+	for i, id := range artistIDs {
+		args[i] = id
+	}
+	return m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
+		Filters: squirrel.And{
+			squirrel.Expr(
+				"media_file.id IN (SELECT media_file_id FROM media_file_artists "+
+					"WHERE role = 'artist' AND artist_id IN ("+squirrel.Placeholders(len(artistIDs))+"))", args...),
+			squirrel.Eq{"missing": false},
+		},
+		Sort: "starred desc, rating desc, year asc, compilation asc",
+	})
 }
 
 // durationProximity returns a score from 0.0 to 1.0 indicating how close the track's duration

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/conf"
@@ -321,15 +322,80 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		return nil
 	}
 
-	// One batched query (order_artist_name IN ...) instead of one per artist: on a
-	// large library the per-query overhead dominates, so this is the main cost saver.
-	artists := make([]string, 0, len(byArtist))
+	// Collect distinct sanitized artist names and any agent-provided artist MBIDs.
+	names := make([]string, 0, len(byArtist))
 	for artist := range byArtist {
-		artists = append(artists, artist)
+		names = append(names, artist)
+	}
+	var artistMBIDs []string
+	for _, queries := range byArtist {
+		for _, iq := range queries {
+			if iq.query.artistMBID != "" {
+				artistMBIDs = append(artistMBIDs, iq.query.artistMBID)
+			}
+		}
+	}
+
+	// Phase 1: resolve agent artists to artist-table rows (by sort name or MBID),
+	// so we can match on stable artist IDs and recover the real artist MBID (which
+	// is not denormalized onto media_file).
+	artistFilter := squirrel.Or{squirrel.Eq{"order_artist_name": names}}
+	if len(artistMBIDs) > 0 {
+		artistFilter = append(artistFilter, squirrel.Eq{"mbz_artist_id": artistMBIDs})
+	}
+	artists, err := m.ds.Artist(ctx).GetAll(model.QueryOptions{Filters: artistFilter})
+	if err != nil {
+		return err
+	}
+	if len(artists) == 0 {
+		return nil
+	}
+
+	// Each query (keyed by sanitized name) owns a set of resolved artist IDs: an
+	// artist row belongs to a query if its order_artist_name equals the query name
+	// OR its mbz_artist_id equals the query's agent ArtistMBID. Routing by ID (not
+	// name) keeps MBID-resolved artists whose order name differs from the query name
+	// from being misrouted.
+	queryArtistIDs := map[string]map[string]bool{} // sanitizedName -> set of artist IDs
+	artistIDToMBID := map[string]string{}
+	resolved := map[string]bool{}
+	allArtistIDs := make([]string, 0, len(artists))
+	for _, a := range artists {
+		artistIDToMBID[a.ID] = a.MbzArtistID
+		resolved[a.ID] = true
+		allArtistIDs = append(allArtistIDs, a.ID)
+		for name, queries := range byArtist {
+			owns := a.OrderArtistName == name
+			if !owns {
+				for _, iq := range queries {
+					if iq.query.artistMBID != "" && a.MbzArtistID == iq.query.artistMBID {
+						owns = true
+						break
+					}
+				}
+			}
+			if owns {
+				if queryArtistIDs[name] == nil {
+					queryArtistIDs[name] = map[string]bool{}
+				}
+				queryArtistIDs[name][a.ID] = true
+			}
+		}
+	}
+
+	// Phase 2: fetch every track credited (role='artist') to a resolved artist, in one
+	// query. role='artist' (not albumartist) avoids tribute/compilation false positives.
+	placeholders := strings.Repeat("?,", len(allArtistIDs))
+	placeholders = placeholders[:len(placeholders)-1]
+	existsArgs := make([]any, len(allArtistIDs))
+	for i, id := range allArtistIDs {
+		existsArgs[i] = id
 	}
 	tracks, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 		Filters: squirrel.And{
-			squirrel.Eq{"order_artist_name": artists},
+			squirrel.Expr(
+				"EXISTS (SELECT 1 FROM media_file_artists mfa WHERE mfa.media_file_id = media_file.id "+
+					"AND mfa.role = 'artist' AND mfa.artist_id IN ("+placeholders+"))", existsArgs...),
 			squirrel.Eq{"missing": false},
 		},
 		Sort: "starred desc, rating desc, year asc, compilation asc",
@@ -338,24 +404,27 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		return err
 	}
 
-	// Key on order_artist_name — the exact field the query filtered on, which matches
-	// how byArtist is keyed. A track's display Artist can differ (collaborations,
-	// "feat." credits), so re-deriving from Artist would misbucket. This reads the
-	// deprecated MediaFile.OrderArtistName column because the bulk GetAll path does
-	// not hydrate participant detail (only {id, name}), so the participant's order
-	// name is empty here; the column is the only populated source.
-	tracksByArtist := make(map[string][]sanitizedTrack, len(byArtist))
+	// Back-map by artist ID: for each track, for each RoleArtist participant that is a
+	// resolved artist, stamp the resolved MBID and append the track to every query
+	// bucket whose resolved-ID set contains that artist.
+	tracksByQuery := map[string][]sanitizedTrack{}
 	for i := range tracks {
-		key := tracks[i].OrderArtistName
-		if key == "" {
-			key = str.SanitizeFieldForSortingNoArticle(tracks[i].Artist)
+		for _, p := range tracks[i].Participants[model.RoleArtist] {
+			if !resolved[p.ID] {
+				continue
+			}
+			st := newSanitizedTrack(&tracks[i], artistIDToMBID[p.ID])
+			for name, ids := range queryArtistIDs {
+				if ids[p.ID] {
+					tracksByQuery[name] = append(tracksByQuery[name], st)
+				}
+			}
 		}
-		tracksByArtist[key] = append(tracksByArtist[key], newSanitizedTrack(&tracks[i], ""))
 	}
 
 	threshold := float64(conf.Server.Matcher.FuzzyThreshold) / 100.0
 	for artist, queries := range byArtist {
-		sanitized := tracksByArtist[artist]
+		sanitized := tracksByQuery[artist]
 		// Each song is matched independently by index, so two songs with the same
 		// (title, artist) but different durations can resolve to different tracks.
 		for _, iq := range queries {

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -356,17 +356,17 @@ func groupQueriesByArtist(songs []agents.Song, result map[int]model.MediaFile) m
 	return byArtist
 }
 
-// resolvedArtists holds the result of phase 1: agent artists resolved to artist-table rows.
-// Everything routes by stable artist ID, never by name, so MBID-resolved artists whose order
-// name differs from the query name are not misrouted.
+// resolvedArtists holds the agent artists resolved to artist-table rows. Everything routes by
+// stable artist ID, never by name, so MBID-resolved artists whose order name differs from the
+// query name are not misrouted.
 type resolvedArtists struct {
 	byQuery map[string]map[string]struct{} // sanitized query name -> set of resolved artist IDs
 	mbid    map[string]string              // artist ID -> its MBID (the real one, from the artist table)
-	allIDs  []string                       // every resolved artist ID, for the phase-2 filter
+	allIDs  []string                       // every resolved artist ID, for the track lookup
 }
 
-// resolveArtists runs phase 1: it resolves the queries' artists against the artist table (by
-// sort name or agent-provided MBID) and records, for each query, which artist IDs it owns.
+// resolveArtists resolves the queries' artists against the artist table (by sort name or
+// agent-provided MBID) and records, for each query, which artist IDs it owns.
 func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]indexedQuery) (resolvedArtists, error) {
 	names := make([]string, 0, len(byArtist))
 	mbidToQuery := make(map[string]string, len(byArtist)) // agent ArtistMBID -> query name that supplied it
@@ -421,7 +421,7 @@ func (r resolvedArtists) own(name, artistID string) {
 //
 // It reads each track's Participants[RoleArtist] IDs, which the bulk GetAll path populates from
 // the inline participants JSON. That cache carries artist IDs (enough to route here) but not the
-// artist MBID — the MBID comes from r.mbid, resolved against the artist table in phase 1.
+// artist MBID — the MBID comes from r.mbid, resolved against the artist table by resolveArtists.
 func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]sanitizedTrack {
 	byQuery := make(map[string][]sanitizedTrack, len(r.byQuery))
 	added := make(map[string]map[string]struct{}, len(r.byQuery)) // query name -> set of track IDs already bucketed
@@ -449,9 +449,9 @@ func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]san
 	return byQuery
 }
 
-// fetchTracksCreditedTo runs phase 2: it fetches every non-missing track credited as the main
-// artist (role='artist', not albumartist — that avoids tribute/compilation false positives) to
-// any of the given artist IDs. The non-correlated id IN (subquery) lets SQLite materialize the
+// fetchTracksCreditedTo fetches every non-missing track credited as the main artist
+// (role='artist', not albumartist — that avoids tribute/compilation false positives) to any of
+// the given artist IDs. The non-correlated id IN (subquery) lets SQLite materialize the
 // matching media_file ids once from the media_file_artists(artist_id) covering index and probe
 // by primary key, which is far cheaper than a correlated EXISTS that re-runs per media_file row.
 //

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/navidrome/navidrome/core/agents"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/slice"
 	"github.com/navidrome/navidrome/utils/str"
 	"github.com/xrash/smetrics"
 )
@@ -359,16 +360,16 @@ func groupQueriesByArtist(songs []agents.Song, result map[int]model.MediaFile) m
 // Everything routes by stable artist ID, never by name, so MBID-resolved artists whose order
 // name differs from the query name are not misrouted.
 type resolvedArtists struct {
-	byQuery map[string]map[string]bool // sanitized query name -> set of resolved artist IDs
-	mbid    map[string]string          // artist ID -> its MBID (the real one, from the artist table)
-	allIDs  []string                   // every resolved artist ID, for the phase-2 filter
+	byQuery map[string]map[string]struct{} // sanitized query name -> set of resolved artist IDs
+	mbid    map[string]string              // artist ID -> its MBID (the real one, from the artist table)
+	allIDs  []string                       // every resolved artist ID, for the phase-2 filter
 }
 
 // resolveArtists runs phase 1: it resolves the queries' artists against the artist table (by
 // sort name or agent-provided MBID) and records, for each query, which artist IDs it owns.
 func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]indexedQuery) (resolvedArtists, error) {
 	names := make([]string, 0, len(byArtist))
-	mbidToQuery := map[string]string{} // agent ArtistMBID -> query name that supplied it
+	mbidToQuery := make(map[string]string, len(byArtist)) // agent ArtistMBID -> query name that supplied it
 	for name, queries := range byArtist {
 		names = append(names, name)
 		for _, iq := range queries {
@@ -388,7 +389,7 @@ func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]inde
 	}
 
 	res := resolvedArtists{
-		byQuery: map[string]map[string]bool{},
+		byQuery: make(map[string]map[string]struct{}, len(byArtist)),
 		mbid:    make(map[string]string, len(artists)),
 		allIDs:  make([]string, 0, len(artists)),
 	}
@@ -405,42 +406,43 @@ func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]inde
 	return res, nil
 }
 
-// own records that the named query owns the given artist ID (no-op if the name is not a query).
+// own records that the named query owns the given artist ID. byQuery is always initialized by
+// resolveArtists, and a name that is not a query simply gets its own (unused) entry.
 func (r resolvedArtists) own(name, artistID string) {
-	if r.byQuery == nil {
-		return
-	}
 	if r.byQuery[name] == nil {
-		r.byQuery[name] = map[string]bool{}
+		r.byQuery[name] = map[string]struct{}{}
 	}
-	r.byQuery[name][artistID] = true
+	r.byQuery[name][artistID] = struct{}{}
 }
 
 // bucketTracks maps each query name to the tracks credited to one of its resolved artists.
 // A track is bucketed at most once per query even if it credits several of that query's
 // artists, preventing duplicate scoring of the same track.
+//
+// It reads each track's Participants[RoleArtist] IDs, which the bulk GetAll path populates from
+// the inline participants JSON. That cache carries artist IDs (enough to route here) but not the
+// artist MBID — the MBID comes from r.mbid, resolved against the artist table in phase 1.
 func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]sanitizedTrack {
-	byQuery := map[string][]sanitizedTrack{}
-	added := map[string]map[string]bool{} // query name -> set of track IDs already bucketed
+	byQuery := make(map[string][]sanitizedTrack, len(r.byQuery))
+	added := make(map[string]map[string]struct{}, len(r.byQuery)) // query name -> set of track IDs already bucketed
 	for i := range tracks {
 		for _, p := range tracks[i].Participants[model.RoleArtist] {
 			mbid, isResolved := r.mbid[p.ID]
 			if !isResolved {
 				continue
 			}
-			st := newSanitizedTrack(&tracks[i], mbid)
 			for name, ids := range r.byQuery {
-				if !ids[p.ID] {
+				if _, owns := ids[p.ID]; !owns {
 					continue
 				}
 				if added[name] == nil {
-					added[name] = map[string]bool{}
+					added[name] = map[string]struct{}{}
 				}
-				if added[name][tracks[i].ID] {
+				if _, dup := added[name][tracks[i].ID]; dup {
 					continue
 				}
-				added[name][tracks[i].ID] = true
-				byQuery[name] = append(byQuery[name], st)
+				added[name][tracks[i].ID] = struct{}{}
+				byQuery[name] = append(byQuery[name], newSanitizedTrack(&tracks[i], mbid))
 			}
 		}
 	}
@@ -452,11 +454,13 @@ func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]san
 // any of the given artist IDs. The non-correlated id IN (subquery) lets SQLite materialize the
 // matching media_file ids once from the media_file_artists(artist_id) covering index and probe
 // by primary key, which is far cheaper than a correlated EXISTS that re-runs per media_file row.
+//
+// The raw squirrel.Expr keeps schema knowledge (the media_file_artists table) in this layer on
+// purpose: the non-correlated IN-subquery form is not expressible via the repository's existing
+// role filters, which use the slower correlated EXISTS. A dedicated repository method would be
+// the cleaner home if this is reused.
 func (m *Matcher) fetchTracksCreditedTo(ctx context.Context, artistIDs []string) (model.MediaFiles, error) {
-	args := make([]any, len(artistIDs))
-	for i, id := range artistIDs {
-		args[i] = id
-	}
+	args := slice.Map(artistIDs, func(id string) any { return id })
 	return m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 		Filters: squirrel.And{
 			squirrel.Expr(

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -404,23 +404,7 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		return err
 	}
 
-	// Back-map by artist ID: for each track, for each RoleArtist participant that is a
-	// resolved artist, stamp the resolved MBID and append the track to every query
-	// bucket whose resolved-ID set contains that artist.
-	tracksByQuery := map[string][]sanitizedTrack{}
-	for i := range tracks {
-		for _, p := range tracks[i].Participants[model.RoleArtist] {
-			if !resolved[p.ID] {
-				continue
-			}
-			st := newSanitizedTrack(&tracks[i], artistIDToMBID[p.ID])
-			for name, ids := range queryArtistIDs {
-				if ids[p.ID] {
-					tracksByQuery[name] = append(tracksByQuery[name], st)
-				}
-			}
-		}
-	}
+	tracksByQuery := buildTracksByQuery(tracks, resolved, artistIDToMBID, queryArtistIDs)
 
 	threshold := float64(conf.Server.Matcher.FuzzyThreshold) / 100.0
 	for artist, queries := range byArtist {
@@ -434,6 +418,41 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 		}
 	}
 	return nil
+}
+
+// buildTracksByQuery maps each sanitized artist name to the set of tracks credited to a resolved
+// artist in that query's bucket. A track is appended at most once per query bucket even if it
+// credits multiple resolved artists in that bucket, preventing duplicate scoring of the same track.
+func buildTracksByQuery(
+	tracks []model.MediaFile,
+	resolved map[string]bool,
+	artistIDToMBID map[string]string,
+	queryArtistIDs map[string]map[string]bool,
+) map[string][]sanitizedTrack {
+	tracksByQuery := map[string][]sanitizedTrack{}
+	addedToQuery := map[string]map[string]bool{} // name -> set of track IDs already appended
+	for i := range tracks {
+		for _, p := range tracks[i].Participants[model.RoleArtist] {
+			if !resolved[p.ID] {
+				continue
+			}
+			st := newSanitizedTrack(&tracks[i], artistIDToMBID[p.ID])
+			for name, ids := range queryArtistIDs {
+				if !ids[p.ID] {
+					continue
+				}
+				if addedToQuery[name] == nil {
+					addedToQuery[name] = map[string]bool{}
+				}
+				if addedToQuery[name][tracks[i].ID] {
+					continue // same track already appended for this bucket; skip to avoid duplicate scoring
+				}
+				addedToQuery[name][tracks[i].ID] = true
+				tracksByQuery[name] = append(tracksByQuery[name], st)
+			}
+		}
+	}
+	return tracksByQuery
 }
 
 // durationProximity returns a score from 0.0 to 1.0 indicating how close the track's duration

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -385,17 +385,20 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 
 	// Phase 2: fetch every track credited (role='artist') to a resolved artist, in one
 	// query. role='artist' (not albumartist) avoids tribute/compilation false positives.
+	// Use a non-correlated id IN (subquery): SQLite materializes the matching media_file
+	// ids once from the media_file_artists(artist_id) covering index, then probes by PK —
+	// dramatically cheaper than a correlated EXISTS that re-runs per media_file row.
 	placeholders := strings.Repeat("?,", len(allArtistIDs))
 	placeholders = placeholders[:len(placeholders)-1]
-	existsArgs := make([]any, len(allArtistIDs))
+	artistArgs := make([]any, len(allArtistIDs))
 	for i, id := range allArtistIDs {
-		existsArgs[i] = id
+		artistArgs[i] = id
 	}
 	tracks, err := m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 		Filters: squirrel.And{
 			squirrel.Expr(
-				"EXISTS (SELECT 1 FROM media_file_artists mfa WHERE mfa.media_file_id = media_file.id "+
-					"AND mfa.role = 'artist' AND mfa.artist_id IN ("+placeholders+"))", existsArgs...),
+				"media_file.id IN (SELECT media_file_id FROM media_file_artists "+
+					"WHERE role = 'artist' AND artist_id IN ("+placeholders+"))", artistArgs...),
 			squirrel.Eq{"missing": false},
 		},
 		Sort: "starred desc, rating desc, year asc, compilation asc",

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -331,9 +331,8 @@ func (m *Matcher) matchByTitle(ctx context.Context, songs []agents.Song, result 
 	return nil
 }
 
-// groupQueriesByArtist builds the per-artist (sanitized name) buckets of title queries,
-// skipping songs already matched by a higher-priority loader and those without an artist
-// (title matching needs an artist to scope the library query).
+// groupQueriesByArtist buckets the still-unmatched title queries by sanitized artist name.
+// Songs without an artist are skipped: title matching needs one to scope the library query.
 func groupQueriesByArtist(songs []agents.Song, result map[int]model.MediaFile) map[string][]indexedQuery {
 	byArtist := map[string][]indexedQuery{}
 	for i, s := range songs {
@@ -409,8 +408,8 @@ func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]inde
 	return res, nil
 }
 
-// own records that the named query owns the given artist ID. byQuery is always initialized by
-// resolveArtists, and a name that is not a query simply gets its own (unused) entry.
+// own records that the named query owns the given artist ID. A name that is not a query simply
+// gets its own (unused) entry.
 func (r resolvedArtists) own(name, artistID string) {
 	if r.byQuery[name] == nil {
 		r.byQuery[name] = map[string]struct{}{}
@@ -418,13 +417,9 @@ func (r resolvedArtists) own(name, artistID string) {
 	r.byQuery[name][artistID] = struct{}{}
 }
 
-// bucketTracks maps each query name to the tracks credited to one of its resolved artists.
-// A track is bucketed at most once per query even if it credits several of that query's
-// artists, preventing duplicate scoring of the same track.
-//
-// It reads each track's Participants[RoleArtist] IDs, which the bulk GetAll path populates from
-// the inline participants JSON. That cache carries artist IDs (enough to route here) but not the
-// artist MBID — the MBID comes from r.mbid, resolved against the artist table by resolveArtists.
+// bucketTracks groups tracks by query name, at most once per query even when a track credits
+// several of that query's artists, so the same track is not scored twice. The participants JSON
+// on each track carries artist IDs but not their MBID, so the MBID comes from r.mbid instead.
 func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]sanitizedTrack {
 	// Invert byQuery once so each participant maps straight to the queries that own it, instead of
 	// scanning every query per participant.
@@ -458,16 +453,13 @@ func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]san
 	return byQuery
 }
 
-// fetchTracksCreditedTo fetches every non-missing track credited as the main artist
-// (role='artist', not albumartist — that avoids tribute/compilation false positives) to any of
-// the given artist IDs. The non-correlated id IN (subquery) lets SQLite materialize the
-// matching media_file ids once from the media_file_artists(artist_id) covering index and probe
-// by primary key, which is far cheaper than a correlated EXISTS that re-runs per media_file row.
-//
-// The raw squirrel.Expr keeps schema knowledge (the media_file_artists table) in this layer on
-// purpose: the non-correlated IN-subquery form is not expressible via the repository's existing
-// role filters, which use the slower correlated EXISTS. A dedicated repository method would be
-// the cleaner home if this is reused.
+// fetchTracksCreditedTo fetches every non-missing track credited to any of the given artists as
+// the main artist (role='artist', not albumartist — that avoids tribute/compilation false
+// positives). The non-correlated id IN (subquery) materializes the matching ids once from the
+// media_file_artists(artist_id) covering index, far cheaper than a correlated EXISTS that re-runs
+// per row. That form isn't expressible via the repository's role filters, so the raw squirrel.Expr
+// keeps the media_file_artists schema knowledge here; a dedicated repository method would be the
+// cleaner home if this is reused.
 func (m *Matcher) fetchTracksCreditedTo(ctx context.Context, artistIDs []string) (model.MediaFiles, error) {
 	if len(artistIDs) == 0 {
 		return nil, nil

--- a/core/matcher/matcher.go
+++ b/core/matcher/matcher.go
@@ -369,19 +369,19 @@ type resolvedArtists struct {
 // agent-provided MBID) and records, for each query, which artist IDs it owns.
 func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]indexedQuery) (resolvedArtists, error) {
 	names := make([]string, 0, len(byArtist))
-	mbidToQuery := make(map[string]string, len(byArtist)) // agent ArtistMBID -> query name that supplied it
+	mbidToQueries := make(map[string][]string, len(byArtist)) // agent ArtistMBID -> query names that supplied it
 	for name, queries := range byArtist {
 		names = append(names, name)
 		for _, iq := range queries {
 			if iq.query.artistMBID != "" {
-				mbidToQuery[iq.query.artistMBID] = name
+				mbidToQueries[iq.query.artistMBID] = append(mbidToQueries[iq.query.artistMBID], name)
 			}
 		}
 	}
 
 	filter := squirrel.Or{squirrel.Eq{"order_artist_name": names}}
-	if len(mbidToQuery) > 0 {
-		filter = append(filter, squirrel.Eq{"mbz_artist_id": slices.Collect(maps.Keys(mbidToQuery))})
+	if len(mbidToQueries) > 0 {
+		filter = append(filter, squirrel.Eq{"mbz_artist_id": slices.Collect(maps.Keys(mbidToQueries))})
 	}
 	artists, err := m.ds.Artist(ctx).GetAll(model.QueryOptions{Filters: filter})
 	if err != nil {
@@ -396,11 +396,14 @@ func (m *Matcher) resolveArtists(ctx context.Context, byArtist map[string][]inde
 	for _, a := range artists {
 		res.mbid[a.ID] = a.MbzArtistID
 		res.allIDs = append(res.allIDs, a.ID)
-		// An artist belongs to a query if its order name matches the query name, or if its
-		// MBID matches the MBID that query supplied. Both are direct map lookups.
+		// An artist belongs to a query if its order name matches the query name, or if its MBID
+		// matches one a query supplied. The same MBID can come from several queries (agent aliases),
+		// so every one of them owns the artist.
 		res.own(a.OrderArtistName, a.ID)
-		if name, ok := mbidToQuery[a.MbzArtistID]; ok && a.MbzArtistID != "" {
-			res.own(name, a.ID)
+		if a.MbzArtistID != "" {
+			for _, name := range mbidToQueries[a.MbzArtistID] {
+				res.own(name, a.ID)
+			}
 		}
 	}
 	return res, nil
@@ -423,6 +426,15 @@ func (r resolvedArtists) own(name, artistID string) {
 // the inline participants JSON. That cache carries artist IDs (enough to route here) but not the
 // artist MBID — the MBID comes from r.mbid, resolved against the artist table by resolveArtists.
 func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]sanitizedTrack {
+	// Invert byQuery once so each participant maps straight to the queries that own it, instead of
+	// scanning every query per participant.
+	queriesByArtist := make(map[string][]string)
+	for name, ids := range r.byQuery {
+		for id := range ids {
+			queriesByArtist[id] = append(queriesByArtist[id], name)
+		}
+	}
+
 	byQuery := make(map[string][]sanitizedTrack, len(r.byQuery))
 	added := make(map[string]map[string]struct{}, len(r.byQuery)) // query name -> set of track IDs already bucketed
 	for i := range tracks {
@@ -431,10 +443,7 @@ func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]san
 			if !isResolved {
 				continue
 			}
-			for name, ids := range r.byQuery {
-				if _, owns := ids[p.ID]; !owns {
-					continue
-				}
+			for _, name := range queriesByArtist[p.ID] {
 				if added[name] == nil {
 					added[name] = map[string]struct{}{}
 				}
@@ -460,6 +469,9 @@ func (r resolvedArtists) bucketTracks(tracks []model.MediaFile) map[string][]san
 // role filters, which use the slower correlated EXISTS. A dedicated repository method would be
 // the cleaner home if this is reused.
 func (m *Matcher) fetchTracksCreditedTo(ctx context.Context, artistIDs []string) (model.MediaFiles, error) {
+	if len(artistIDs) == 0 {
+		return nil, nil
+	}
 	args := slice.Map(artistIDs, func(id string) any { return id })
 	return m.ds.MediaFile(ctx).GetAll(model.QueryOptions{
 		Filters: squirrel.And{

--- a/core/matcher/matcher_internal_test.go
+++ b/core/matcher/matcher_internal_test.go
@@ -1,6 +1,7 @@
 package matcher
 
 import (
+	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -49,5 +50,18 @@ var _ = Describe("similarityRatio", func() {
 		ratio1 := similarityRatio("hello world", "hello")
 		ratio2 := similarityRatio("hello", "hello world")
 		Expect(ratio1).To(Equal(ratio2))
+	})
+})
+
+var _ = Describe("matcher internals", func() {
+	It("computeSpecificityLevel uses sanitizedTrack.artistMBID for artist-MBID levels", func() {
+		q := songQuery{
+			title:      "song",
+			artistMBID: "artist-mbid-1",
+			albumMBID:  "album-mbid-1",
+		}
+		mf := model.MediaFile{Title: "Song", MbzAlbumID: "album-mbid-1"} // note: mf.MbzArtistID intentionally empty
+		t := newSanitizedTrack(&mf, "artist-mbid-1")                     // resolved MBID supplied here
+		Expect(computeSpecificityLevel(q, t, 0.85)).To(Equal(5))
 	})
 })

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -167,11 +167,7 @@ var _ = Describe("Matcher", func() {
 				}
 				titleMatch := model.MediaFile{
 					ID: "track-title", Title: "Enjoy the Silence", Artist: "Depeche Mode",
-					Participants: model.Participants{
-						model.RoleArtist: model.ParticipantList{
-							{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-						},
-					},
+					Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 				}
 				allowTitlePhase(model.MediaFiles{titleMatch})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -187,11 +183,7 @@ var _ = Describe("Matcher", func() {
 				}
 				fuzzyMatch := model.MediaFile{
 					ID: "track-fuzzy", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
-					Participants: model.Participants{
-						model.RoleArtist: model.ParticipantList{
-							{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
-						},
-					},
+					Participants: artistParticipants(model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}),
 				}
 				allowTitlePhase(model.MediaFiles{fuzzyMatch})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -207,11 +199,7 @@ var _ = Describe("Matcher", func() {
 				}
 				differentTracks := model.MediaFiles{
 					{ID: "different", Title: "Tomorrow Never Knows", Artist: "The Beatles",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}),
 					},
 				}
 				allowTitlePhase(differentTracks)
@@ -230,11 +218,7 @@ var _ = Describe("Matcher", func() {
 				}
 				libraryTrack := model.MediaFile{
 					ID: "br-live", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
-					Participants: model.Participants{
-						model.RoleArtist: model.ParticipantList{
-							{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
-						},
-					},
+					Participants: artistParticipants(model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}),
 				}
 				allowTitlePhase(model.MediaFiles{libraryTrack})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -251,11 +235,7 @@ var _ = Describe("Matcher", func() {
 				}
 				libraryTrack := model.MediaFile{
 					ID: "br", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "A Night at the Opera",
-					Participants: model.Participants{
-						model.RoleArtist: model.ParticipantList{
-							{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
-						},
-					},
+					Participants: artistParticipants(model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}),
 				}
 				allowTitlePhase(model.MediaFiles{libraryTrack})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -297,25 +277,13 @@ var _ = Describe("Matcher", func() {
 				}
 				tracks := model.MediaFiles{
 					{ID: "a", Title: "Song A", Artist: "Artist",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 					},
 					{ID: "b", Title: "Song B", Artist: "Artist",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 					},
 					{ID: "c", Title: "Song C", Artist: "Artist",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 					},
 				}
 				allowTitlePhase(tracks)
@@ -343,12 +311,10 @@ var _ = Describe("Matcher", func() {
 				track := model.MediaFile{
 					ID: "oan-track", Title: "Song A",
 					Artist: "Daft Punk feat. Pharrell",
-					Participants: model.Participants{
-						model.RoleArtist: model.ParticipantList{
-							{Artist: model.Artist{ID: "dp", Name: "Daft Punk", OrderArtistName: "daft punk"}},
-							{Artist: model.Artist{ID: "ph", Name: "Pharrell", OrderArtistName: "pharrell"}},
-						},
-					},
+					Participants: artistParticipants(
+						model.Artist{ID: "dp", Name: "Daft Punk", OrderArtistName: "daft punk"},
+						model.Artist{ID: "ph", Name: "Pharrell", OrderArtistName: "pharrell"},
+					),
 				}
 				allowTitlePhase(model.MediaFiles{track})
 
@@ -366,12 +332,10 @@ var _ = Describe("Matcher", func() {
 				// credited artist participant. Searching INXS must match it.
 				track := model.MediaFile{
 					ID: "collab", Title: "Crazy", Artist: "Par-T-One vs. INXS",
-					Participants: model.Participants{
-						model.RoleArtist: model.ParticipantList{
-							{Artist: model.Artist{ID: "a-partone", Name: "Par-T-One", OrderArtistName: "par-t-one"}},
-							{Artist: model.Artist{ID: "a-inxs", Name: "INXS", OrderArtistName: "inxs"}},
-						},
-					},
+					Participants: artistParticipants(
+						model.Artist{ID: "a-partone", Name: "Par-T-One", OrderArtistName: "par-t-one"},
+						model.Artist{ID: "a-inxs", Name: "INXS", OrderArtistName: "inxs"},
+					),
 				}
 				allowTitlePhase(model.MediaFiles{track})
 
@@ -419,11 +383,7 @@ var _ = Describe("Matcher", func() {
 				}
 				track := model.MediaFile{
 					ID: "by-mbid", Title: "Song A", Artist: "Correct Artist",
-					Participants: model.Participants{
-						model.RoleArtist: model.ParticipantList{
-							{Artist: model.Artist{ID: "a9", Name: "Correct Artist", OrderArtistName: "correct artist", MbzArtistID: "mbid-9"}},
-						},
-					},
+					Participants: artistParticipants(model.Artist{ID: "a9", Name: "Correct Artist", OrderArtistName: "correct artist", MbzArtistID: "mbid-9"}),
 				}
 				// Phase 1 returns the artist matched by mbz_artist_id; its order name
 				// ("correct artist") differs from the query name ("typo artist"), so
@@ -543,20 +503,12 @@ var _ = Describe("Matcher", func() {
 			correctMatch := model.MediaFile{
 				ID: "correct-match", Title: "Similar Song", Artist: "Depeche Mode", Album: "Violator",
 				MbzArtistID: "artist-mbid-123", MbzAlbumID: "album-mbid-456",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid-123"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid-123"}),
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong-match", Title: "Similar Song", Artist: "Depeche Mode", Album: "Some Other Album",
 				MbzArtistID: "artist-mbid-123", MbzAlbumID: "different-album-mbid",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid-123"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid-123"}),
 			}
 			songs := []agents.Song{
 				{Name: "Similar Song", Artist: "Depeche Mode", ArtistMBID: "artist-mbid-123", Album: "Violator", AlbumMBID: "album-mbid-456"},
@@ -574,19 +526,11 @@ var _ = Describe("Matcher", func() {
 		It("matches by title + artist name + album name when MBIDs unavailable", func() {
 			correctMatch := model.MediaFile{
 				ID: "correct-match", Title: "Similar Song", Artist: "depeche mode", Album: "violator",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong-match", Title: "Similar Song", Artist: "Other Artist", Album: "Other Album",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "oa", Name: "Other Artist", OrderArtistName: "other artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "oa", Name: "Other Artist", OrderArtistName: "other artist"}),
 			}
 			songs := []agents.Song{
 				{Name: "Similar Song", Artist: "Depeche Mode", Album: "Violator"},
@@ -604,19 +548,11 @@ var _ = Describe("Matcher", func() {
 		It("matches by title + artist only when album info unavailable", func() {
 			correctMatch := model.MediaFile{
 				ID: "correct-match", Title: "Similar Song", Artist: "depeche mode", Album: "Some Album",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong-match", Title: "Similar Song", Artist: "Other Artist", Album: "Other Album",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "oa", Name: "Other Artist", OrderArtistName: "other artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "oa", Name: "Other Artist", OrderArtistName: "other artist"}),
 			}
 			songs := []agents.Song{
 				{Name: "Similar Song", Artist: "Depeche Mode"},
@@ -646,25 +582,13 @@ var _ = Describe("Matcher", func() {
 
 		It("returns distinct matches for each artist's version (covers scenario)", func() {
 			cover1 := model.MediaFile{ID: "cover-1", Title: "Yesterday", Artist: "The Beatles", Album: "Help!",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}),
 			}
 			cover2 := model.MediaFile{ID: "cover-2", Title: "Yesterday", Artist: "Ray Charles", Album: "Greatest Hits",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ray-charles", Name: "Ray Charles", OrderArtistName: "ray charles"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ray-charles", Name: "Ray Charles", OrderArtistName: "ray charles"}),
 			}
 			cover3 := model.MediaFile{ID: "cover-3", Title: "Yesterday", Artist: "Frank Sinatra", Album: "My Way",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "sinatra", Name: "Frank Sinatra", OrderArtistName: "frank sinatra"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "sinatra", Name: "Frank Sinatra", OrderArtistName: "frank sinatra"}),
 			}
 
 			songs := []agents.Song{
@@ -687,28 +611,16 @@ var _ = Describe("Matcher", func() {
 			preciseMatch := model.MediaFile{
 				ID: "precise", Title: "Song A", Artist: "Artist One", Album: "Album One",
 				MbzArtistID: "mbid-1", MbzAlbumID: "album-mbid-1",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}),
 			}
 			lessAccurateMatch := model.MediaFile{
 				ID: "less-accurate", Title: "Song A", Artist: "Artist One", Album: "Compilation",
-				MbzArtistID: "mbid-1",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}},
-					},
-				},
+				MbzArtistID:  "mbid-1",
+				Participants: artistParticipants(model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}),
 			}
 			artistTwoMatch := model.MediaFile{
 				ID: "artist-two", Title: "Song B", Artist: "Artist Two",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "a2", Name: "Artist Two", OrderArtistName: "artist two"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "a2", Name: "Artist Two", OrderArtistName: "artist two"}),
 			}
 
 			songs := []agents.Song{
@@ -736,19 +648,11 @@ var _ = Describe("Matcher", func() {
 			// chance — verifiable by RED-proof: see task-2-report.md.
 			precise := model.MediaFile{
 				ID: "precise", Title: "Song A", Artist: "Artist One", Album: "Album One", MbzAlbumID: "album-mbid-1",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}),
 			}
 			other := model.MediaFile{
 				ID: "other", Title: "Song A", Artist: "Artist One", Album: "Album One", MbzAlbumID: "wrong-album-mbid",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "a1b", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: ""}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "a1b", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: ""}),
 			}
 			// Phase 1 resolves both a1 (by name+mbid) and a1b (by name).
 			allowTitlePhase(model.MediaFiles{other, precise})
@@ -770,11 +674,7 @@ var _ = Describe("Matcher", func() {
 				}
 				artistTracks := model.MediaFiles{
 					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "rh", Name: "Radiohead", OrderArtistName: "radiohead"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "rh", Name: "Radiohead", OrderArtistName: "radiohead"}),
 					},
 				}
 
@@ -795,11 +695,7 @@ var _ = Describe("Matcher", func() {
 				}
 				artistTracks := model.MediaFiles{
 					{ID: "live", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}),
 					},
 				}
 
@@ -822,11 +718,7 @@ var _ = Describe("Matcher", func() {
 				}
 				artistTracks := model.MediaFiles{
 					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "rh", Name: "Radiohead", OrderArtistName: "radiohead"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "rh", Name: "Radiohead", OrderArtistName: "radiohead"}),
 					},
 				}
 
@@ -848,11 +740,7 @@ var _ = Describe("Matcher", func() {
 				}
 				artistTracks := model.MediaFiles{
 					{ID: "extended", Title: "Song (Extended Mix)", Artist: "Artist",
-						Participants: model.Participants{
-							model.RoleArtist: model.ParticipantList{
-								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-							},
-						},
+						Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 					},
 				}
 
@@ -879,19 +767,11 @@ var _ = Describe("Matcher", func() {
 			}
 			correctMatch := model.MediaFile{
 				ID: "correct", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "A Night at the Opera (2011 Remaster)",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}),
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "Greatest Hits",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
@@ -909,19 +789,11 @@ var _ = Describe("Matcher", func() {
 			}
 			correctMatch := model.MediaFile{
 				ID: "correct", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator (Deluxe Edition)",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "101",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
@@ -939,19 +811,11 @@ var _ = Describe("Matcher", func() {
 			}
 			exactMatch := model.MediaFile{
 				ID: "exact", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 			fuzzyMatch := model.MediaFile{
 				ID: "fuzzy", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator (Deluxe Edition)",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{fuzzyMatch, exactMatch})
@@ -970,20 +834,12 @@ var _ = Describe("Matcher", func() {
 			}
 			albumMatch := model.MediaFile{
 				ID: "album-match", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 			starredTrack := model.MediaFile{
 				ID: "starred", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles",
-				Annotations: model.Annotations{Starred: true},
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Annotations:  model.Annotations{Starred: true},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{albumMatch, starredTrack})
@@ -1002,20 +858,12 @@ var _ = Describe("Matcher", func() {
 			}
 			albumMatch := model.MediaFile{
 				ID: "album-match", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 			ratedTrack := model.MediaFile{
 				ID: "rated", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles",
-				Annotations: model.Annotations{Rating: 4},
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
-					},
-				},
+				Annotations:  model.Annotations{Rating: 4},
+				Participants: artistParticipants(model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{albumMatch, ratedTrack})
@@ -1039,19 +887,11 @@ var _ = Describe("Matcher", func() {
 			}
 			correctMatch := model.MediaFile{
 				ID: "correct", Title: "Similar Song", Artist: "Test Artist", Duration: 180.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 			wrongDuration := model.MediaFile{
 				ID: "wrong", Title: "Similar Song", Artist: "Test Artist", Duration: 240.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{wrongDuration, correctMatch})
@@ -1069,11 +909,7 @@ var _ = Describe("Matcher", func() {
 			}
 			closeDuration := model.MediaFile{
 				ID: "close-duration", Title: "Similar Song", Artist: "Test Artist", Duration: 182.5,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{closeDuration})
@@ -1091,19 +927,11 @@ var _ = Describe("Matcher", func() {
 			}
 			closeDuration := model.MediaFile{
 				ID: "close", Title: "Similar Song", Artist: "Test Artist", Duration: 181.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 			farDuration := model.MediaFile{
 				ID: "far", Title: "Similar Song", Artist: "Test Artist", Duration: 190.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{farDuration, closeDuration})
@@ -1121,11 +949,7 @@ var _ = Describe("Matcher", func() {
 			}
 			differentDuration := model.MediaFile{
 				ID: "different", Title: "Similar Song", Artist: "Test Artist", Duration: 300.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{differentDuration})
@@ -1143,19 +967,11 @@ var _ = Describe("Matcher", func() {
 			}
 			differentTitle := model.MediaFile{
 				ID: "wrong-title", Title: "Different Song", Artist: "Test Artist", Duration: 180.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 			correctTitle := model.MediaFile{
 				ID: "correct-title", Title: "Similar Song", Artist: "Test Artist", Duration: 300.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{differentTitle, correctTitle})
@@ -1173,11 +989,7 @@ var _ = Describe("Matcher", func() {
 			}
 			anyTrack := model.MediaFile{
 				ID: "any", Title: "Similar Song", Artist: "Test Artist", Duration: 999.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{anyTrack})
@@ -1195,11 +1007,7 @@ var _ = Describe("Matcher", func() {
 			}
 			shortTrack := model.MediaFile{
 				ID: "short", Title: "Short Song", Artist: "Test Artist", Duration: 31.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{shortTrack})
@@ -1218,19 +1026,11 @@ var _ = Describe("Matcher", func() {
 			}
 			shortTrack := model.MediaFile{
 				ID: "short", Title: "Same Song", Artist: "Same Artist", Duration: 180.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "sa", Name: "Same Artist", OrderArtistName: "same artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "sa", Name: "Same Artist", OrderArtistName: "same artist"}),
 			}
 			longTrack := model.MediaFile{
 				ID: "long", Title: "Same Song", Artist: "Same Artist", Duration: 240.0,
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "sa", Name: "Same Artist", OrderArtistName: "same artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "sa", Name: "Same Artist", OrderArtistName: "same artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{shortTrack, longTrack})
@@ -1258,11 +1058,7 @@ var _ = Describe("Matcher", func() {
 			}
 			libraryTrack := model.MediaFile{
 				ID: "yesterday", Title: "Yesterday", Artist: "The Beatles", Album: "Help!",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{libraryTrack})
@@ -1282,25 +1078,13 @@ var _ = Describe("Matcher", func() {
 				{Name: "Song C", Artist: "Artist"},
 			}
 			trackA := model.MediaFile{ID: "track-a", Title: "Song A", Artist: "Artist",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 			}
 			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 			}
 			trackC := model.MediaFile{ID: "track-c", Title: "Song C", Artist: "Artist",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{trackA, trackB, trackC})
@@ -1322,18 +1106,10 @@ var _ = Describe("Matcher", func() {
 				{Name: "Song B (Remix)", Artist: "Artist"},
 			}
 			trackA := model.MediaFile{ID: "track-a", Title: "Song A", Artist: "Artist",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 			}
 			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist",
-				Participants: model.Participants{
-					model.RoleArtist: model.ParticipantList{
-						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
-					},
-				},
+				Participants: artistParticipants(model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}),
 			}
 
 			allowTitlePhase(model.MediaFiles{trackA, trackB})
@@ -1424,6 +1200,15 @@ func matchFieldInEq(fieldName string) func(opt model.QueryOptions) bool {
 		_, hasField := eq[fieldName]
 		return hasField
 	}
+}
+
+// artistParticipants builds a Participants map crediting the given artists under RoleArtist.
+func artistParticipants(artists ...model.Artist) model.Participants {
+	list := make(model.ParticipantList, len(artists))
+	for i, a := range artists {
+		list[i] = model.Participant{Artist: a}
+	}
+	return model.Participants{model.RoleArtist: list}
 }
 
 // matchTitlePhase2 matches the phase-2 media_file query, identified by its

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -74,16 +74,16 @@ var _ = Describe("Matcher", func() {
 	allowOtherPhases := func() {
 		allowIdentifierPhases()
 		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{}, nil).Maybe()
-		mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+		mediaFileRepo.On("GetAll", mock.MatchedBy(matchTracksByArtistQuery())).
 			Return(model.MediaFiles{}, nil).Maybe()
 	}
 
-	// allowTitlePhase wires the two-phase title matching from a list of library tracks.
-	// Each track must carry Participants[RoleArtist] with the artist IDs that credit it;
-	// the helper derives the artist rows (id, order_artist_name, mbz_artist_id) returned
-	// by phase 1 from those participants, and returns the tracks from phase 2.
+	// allowTitlePhase wires title matching from a list of library tracks. Each track must carry
+	// Participants[RoleArtist] with the artist IDs that credit it; the helper derives the artist
+	// rows the artist resolution returns from those participants, then returns the tracks from
+	// the track-fetch query.
 	allowTitlePhase := func(tracks model.MediaFiles) {
-		// Phase 1: artist resolve. Build artist rows from the tracks' participants.
+		// Artist resolution: build artist rows from the tracks' participants.
 		seen := map[string]model.Artist{}
 		for _, t := range tracks {
 			for _, p := range t.Participants[model.RoleArtist] {
@@ -97,8 +97,8 @@ var _ = Describe("Matcher", func() {
 			artists = append(artists, a)
 		}
 		artistRepo.On("GetAll", mock.Anything).Return(artists, nil).Maybe()
-		// Phase 2: track fetch (EXISTS on media_file_artists).
-		mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+		// Track fetch (media_file_artists subquery).
+		mediaFileRepo.On("GetAll", mock.MatchedBy(matchTracksByArtistQuery())).
 			Return(tracks, nil).Maybe()
 	}
 
@@ -362,14 +362,14 @@ var _ = Describe("Matcher", func() {
 						},
 					},
 				}
-				// Phase 1 resolves "808 state" only if some artist row matches; here the
-				// album-artist participant exists but is NOT role='artist', so phase 2's
+				// Artist resolution returns "808 state" only if some artist row matches; here the
+				// album-artist participant exists but is NOT role='artist', so the track-fetch query's
 				// EXISTS (role='artist') would not return the track in production. The mock
 				// returns it anyway; back-mapping must drop it because no role='artist'
 				// participant is a resolved artist for the query "808 state".
 				artistRepo.On("GetAll", mock.Anything).
 					Return(model.Artists{{ID: "a-808", Name: "808 State", OrderArtistName: "808 state"}}, nil).Maybe()
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTracksByArtistQuery())).
 					Return(model.MediaFiles{track}, nil).Maybe()
 
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -385,12 +385,12 @@ var _ = Describe("Matcher", func() {
 					ID: "by-mbid", Title: "Song A", Artist: "Correct Artist",
 					Participants: artistParticipants(model.Artist{ID: "a9", Name: "Correct Artist", OrderArtistName: "correct artist", MbzArtistID: "mbid-9"}),
 				}
-				// Phase 1 returns the artist matched by mbz_artist_id; its order name
+				// Artist resolution returns the artist matched by mbz_artist_id; its order name
 				// ("correct artist") differs from the query name ("typo artist"), so
 				// resolution must come from the MBID branch.
 				artistRepo.On("GetAll", mock.Anything).
 					Return(model.Artists{{ID: "a9", Name: "Correct Artist", OrderArtistName: "correct artist", MbzArtistID: "mbid-9"}}, nil).Maybe()
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTracksByArtistQuery())).
 					Return(model.MediaFiles{track}, nil).Maybe()
 
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -400,7 +400,7 @@ var _ = Describe("Matcher", func() {
 			})
 		})
 
-		// These tests register their own phase-2 expectations per-test (to inject
+		// These tests register their own track-fetch expectations per-test (to inject
 		// an error), so they use allowIdentifierPhases — NOT allowOtherPhases, which would
 		// add a .Maybe() title-phase catch-all that masks the injected error.
 		Context("title phase DB errors", func() {
@@ -414,7 +414,7 @@ var _ = Describe("Matcher", func() {
 					{ID: "a1", Name: "Artist One", OrderArtistName: "artist one"},
 					{ID: "a2", Name: "Artist Two", OrderArtistName: "artist two"},
 				}, nil)
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTracksByArtistQuery())).
 					Return(nil, errors.New("db down"))
 
 				_, err := m.MatchSongs(ctx, songs, 5)
@@ -436,7 +436,7 @@ var _ = Describe("Matcher", func() {
 				artistRepo.On("GetAll", mock.Anything).Return(model.Artists{
 					{ID: "fa", Name: "Fuzzy Artist", OrderArtistName: "fuzzy artist"},
 				}, nil)
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTracksByArtistQuery())).
 					Return(nil, errors.New("db down"))
 
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -654,7 +654,7 @@ var _ = Describe("Matcher", func() {
 				ID: "other", Title: "Song A", Artist: "Artist One", Album: "Album One", MbzAlbumID: "wrong-album-mbid",
 				Participants: artistParticipants(model.Artist{ID: "a1b", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: ""}),
 			}
-			// Phase 1 resolves both a1 (by name+mbid) and a1b (by name).
+			// Artist resolution returns both a1 (by name+mbid) and a1b (by name).
 			allowTitlePhase(model.MediaFiles{other, precise})
 
 			result, err := m.MatchSongs(ctx, songs, 5)
@@ -1211,9 +1211,9 @@ func artistParticipants(artists ...model.Artist) model.Participants {
 	return model.Participants{model.RoleArtist: list}
 }
 
-// matchTitlePhase2 matches the phase-2 media_file query, identified by its
+// matchTracksByArtistQuery matches the title phase's track-fetch query, identified by its
 // squirrel.And containing a squirrel.Expr whose SQL references media_file_artists.
-func matchTitlePhase2() func(opt model.QueryOptions) bool {
+func matchTracksByArtistQuery() func(opt model.QueryOptions) bool {
 	return func(opt model.QueryOptions) bool {
 		and, ok := opt.Filters.(squirrel.And)
 		if !ok {

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -1435,11 +1435,9 @@ func matchTitlePhase2() func(opt model.QueryOptions) bool {
 			return false
 		}
 		for _, f := range and {
-			if expr, ok := f.(squirrel.Sqlizer); ok {
-				sql, _, err := expr.ToSql()
-				if err == nil && strings.Contains(sql, "media_file_artists") {
-					return true
-				}
+			sql, _, err := f.ToSql()
+			if err == nil && strings.Contains(sql, "media_file_artists") {
+				return true
 			}
 		}
 		return false

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -398,6 +398,27 @@ var _ = Describe("Matcher", func() {
 				Expect(result).To(HaveLen(1))
 				Expect(result[0].ID).To(Equal("by-mbid"))
 			})
+
+			It("resolves both queries when two share one ArtistMBID under different names", func() {
+				// Two agent results for the same MusicBrainz artist but spelled differently
+				// (an alias). Both must match the artist's track via the shared MBID.
+				songs := []agents.Song{
+					{Name: "Song A", Artist: "Alias One", ArtistMBID: "mbid-shared"},
+					{Name: "Song B", Artist: "Alias Two", ArtistMBID: "mbid-shared"},
+				}
+				artist := model.Artist{ID: "a-shared", Name: "Canonical", OrderArtistName: "canonical", MbzArtistID: "mbid-shared"}
+				trackA := model.MediaFile{ID: "ta", Title: "Song A", Artist: "Canonical", Participants: artistParticipants(artist)}
+				trackB := model.MediaFile{ID: "tb", Title: "Song B", Artist: "Canonical", Participants: artistParticipants(artist)}
+				artistRepo.On("GetAll", mock.Anything).
+					Return(model.Artists{{ID: "a-shared", Name: "Canonical", OrderArtistName: "canonical", MbzArtistID: "mbid-shared"}}, nil).Maybe()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTracksByArtistQuery())).
+					Return(model.MediaFiles{trackA, trackB}, nil).Maybe()
+
+				result, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(2))
+				Expect([]string{result[0].ID, result[1].ID}).To(ConsistOf("ta", "tb"))
+			})
 		})
 
 		// These tests register their own track-fetch expectations per-test (to inject
@@ -1165,7 +1186,11 @@ func newMockArtistRepo() *mockArtistRepo {
 }
 
 func (m *mockArtistRepo) GetAll(options ...model.QueryOptions) (model.Artists, error) {
-	args := m.Called(options)
+	argsSlice := make([]any, len(options))
+	for i, v := range options {
+		argsSlice[i] = v
+	}
+	args := m.Called(argsSlice...)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}

--- a/core/matcher/matcher_test.go
+++ b/core/matcher/matcher_test.go
@@ -3,6 +3,7 @@ package matcher_test
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/conf"
@@ -19,6 +20,7 @@ import (
 var _ = Describe("Matcher", func() {
 	var ds model.DataStore
 	var mediaFileRepo *mockMediaFileRepo
+	var artistRepo *mockArtistRepo
 	var ctx context.Context
 	var m *matcher.Matcher
 
@@ -26,11 +28,13 @@ var _ = Describe("Matcher", func() {
 		ctx = GinkgoT().Context()
 		DeferCleanup(configtest.SetupConfig())
 		mediaFileRepo = newMockMediaFileRepo()
+		artistRepo = newMockArtistRepo()
 		DeferCleanup(func() {
 			mediaFileRepo.AssertExpectations(GinkgoT())
 		})
 		ds = &tests.MockDataStore{
 			MockedMediaFile: mediaFileRepo,
+			MockedArtist:    artistRepo,
 		}
 		m = matcher.New(ds)
 	})
@@ -69,16 +73,33 @@ var _ = Describe("Matcher", func() {
 	// this after expect*Phase for the phases the test actually wants to verify.
 	allowOtherPhases := func() {
 		allowIdentifierPhases()
-		mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
+		artistRepo.On("GetAll", mock.Anything).Return(model.Artists{}, nil).Maybe()
+		mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
 			Return(model.MediaFiles{}, nil).Maybe()
 	}
 
-	// allowTitlePhase is a convenience for fuzzy-match tests that only exercise the
-	// title+artist phase. It uses .Maybe() because the phase may short-circuit when no
-	// songs have an artist.
-	allowTitlePhase := func(artistTracks model.MediaFiles) {
-		mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
-			Return(artistTracks, nil).Maybe()
+	// allowTitlePhase wires the two-phase title matching from a list of library tracks.
+	// Each track must carry Participants[RoleArtist] with the artist IDs that credit it;
+	// the helper derives the artist rows (id, order_artist_name, mbz_artist_id) returned
+	// by phase 1 from those participants, and returns the tracks from phase 2.
+	allowTitlePhase := func(tracks model.MediaFiles) {
+		// Phase 1: artist resolve. Build artist rows from the tracks' participants.
+		seen := map[string]model.Artist{}
+		for _, t := range tracks {
+			for _, p := range t.Participants[model.RoleArtist] {
+				if _, ok := seen[p.ID]; !ok {
+					seen[p.ID] = p.Artist
+				}
+			}
+		}
+		artists := make(model.Artists, 0, len(seen))
+		for _, a := range seen {
+			artists = append(artists, a)
+		}
+		artistRepo.On("GetAll", mock.Anything).Return(artists, nil).Maybe()
+		// Phase 2: track fetch (EXISTS on media_file_artists).
+		mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+			Return(tracks, nil).Maybe()
 	}
 
 	Describe("MatchSongs", func() {
@@ -146,6 +167,11 @@ var _ = Describe("Matcher", func() {
 				}
 				titleMatch := model.MediaFile{
 					ID: "track-title", Title: "Enjoy the Silence", Artist: "Depeche Mode",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+						},
+					},
 				}
 				allowTitlePhase(model.MediaFiles{titleMatch})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -161,6 +187,11 @@ var _ = Describe("Matcher", func() {
 				}
 				fuzzyMatch := model.MediaFile{
 					ID: "track-fuzzy", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
+						},
+					},
 				}
 				allowTitlePhase(model.MediaFiles{fuzzyMatch})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -175,7 +206,13 @@ var _ = Describe("Matcher", func() {
 					{Name: "Yesterday", Artist: "The Beatles"},
 				}
 				differentTracks := model.MediaFiles{
-					{ID: "different", Title: "Tomorrow Never Knows", Artist: "The Beatles"},
+					{ID: "different", Title: "Tomorrow Never Knows", Artist: "The Beatles",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}},
+							},
+						},
+					},
 				}
 				allowTitlePhase(differentTracks)
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -193,6 +230,11 @@ var _ = Describe("Matcher", func() {
 				}
 				libraryTrack := model.MediaFile{
 					ID: "br-live", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
+						},
+					},
 				}
 				allowTitlePhase(model.MediaFiles{libraryTrack})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -209,6 +251,11 @@ var _ = Describe("Matcher", func() {
 				}
 				libraryTrack := model.MediaFile{
 					ID: "br", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "A Night at the Opera",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
+						},
+					},
 				}
 				allowTitlePhase(model.MediaFiles{libraryTrack})
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -249,9 +296,27 @@ var _ = Describe("Matcher", func() {
 					{Name: "Song C", Artist: "Artist"},
 				}
 				tracks := model.MediaFiles{
-					{ID: "a", Title: "Song A", Artist: "Artist"},
-					{ID: "b", Title: "Song B", Artist: "Artist"},
-					{ID: "c", Title: "Song C", Artist: "Artist"},
+					{ID: "a", Title: "Song A", Artist: "Artist",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+							},
+						},
+					},
+					{ID: "b", Title: "Song B", Artist: "Artist",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+							},
+						},
+					},
+					{ID: "c", Title: "Song C", Artist: "Artist",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+							},
+						},
+					},
 				}
 				allowTitlePhase(tracks)
 				result, err := m.MatchSongs(ctx, songs, 2)
@@ -269,15 +334,21 @@ var _ = Describe("Matcher", func() {
 		})
 
 		Context("artist grouping", func() {
-			It("groups title-phase tracks by order_artist_name, not display Artist", func() {
+			It("groups title-phase tracks by participant artist ID, not display Artist", func() {
 				songs := []agents.Song{
 					{Name: "Song A", Artist: "Daft Punk"},
 				}
-				// Display Artist differs from the query artist; only OrderArtistName
-				// matches, so grouping must key on it (a "feat." credit, collaboration, etc.).
+				// Display Artist differs from the query artist; only the participant
+				// with order_artist_name "daft punk" routes to this query bucket.
 				track := model.MediaFile{
 					ID: "oan-track", Title: "Song A",
-					Artist: "Daft Punk feat. Pharrell", OrderArtistName: "daft punk",
+					Artist: "Daft Punk feat. Pharrell",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "dp", Name: "Daft Punk", OrderArtistName: "daft punk"}},
+							{Artist: model.Artist{ID: "ph", Name: "Pharrell", OrderArtistName: "pharrell"}},
+						},
+					},
 				}
 				allowTitlePhase(model.MediaFiles{track})
 
@@ -286,9 +357,90 @@ var _ = Describe("Matcher", func() {
 				Expect(result).To(HaveLen(1))
 				Expect(result[0].ID).To(Equal("oan-track"))
 			})
+
+			It("matches a track that credits the searched artist as a collaborator", func() {
+				songs := []agents.Song{
+					{Name: "Crazy", Artist: "INXS"},
+				}
+				// "Par-T-One vs. INXS" — display Artist is the collaboration, but INXS is a
+				// credited artist participant. Searching INXS must match it.
+				track := model.MediaFile{
+					ID: "collab", Title: "Crazy", Artist: "Par-T-One vs. INXS",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "a-partone", Name: "Par-T-One", OrderArtistName: "par-t-one"}},
+							{Artist: model.Artist{ID: "a-inxs", Name: "INXS", OrderArtistName: "inxs"}},
+						},
+					},
+				}
+				allowTitlePhase(model.MediaFiles{track})
+
+				result, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(result[0].ID).To(Equal("collab"))
+			})
+
+			It("does not match a track where the searched artist is only the album artist", func() {
+				songs := []agents.Song{
+					{Name: "Qmart", Artist: "808 State"},
+				}
+				// Track performed by Björk on an "808 State" compilation: 808 State is the
+				// albumartist, Björk is the performer. Searching 808 State must NOT match it.
+				track := model.MediaFile{
+					ID: "comp", Title: "Qmart", Artist: "Björk",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "a-bjork", Name: "Björk", OrderArtistName: "bjork"}},
+						},
+						model.RoleAlbumArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "a-808", Name: "808 State", OrderArtistName: "808 state"}},
+						},
+					},
+				}
+				// Phase 1 resolves "808 state" only if some artist row matches; here the
+				// album-artist participant exists but is NOT role='artist', so phase 2's
+				// EXISTS (role='artist') would not return the track in production. The mock
+				// returns it anyway; back-mapping must drop it because no role='artist'
+				// participant is a resolved artist for the query "808 state".
+				artistRepo.On("GetAll", mock.Anything).
+					Return(model.Artists{{ID: "a-808", Name: "808 State", OrderArtistName: "808 state"}}, nil).Maybe()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+					Return(model.MediaFiles{track}, nil).Maybe()
+
+				result, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(BeEmpty())
+			})
+
+			It("resolves the artist by ArtistMBID when the name differs", func() {
+				songs := []agents.Song{
+					{Name: "Song A", Artist: "Typo Artist", ArtistMBID: "mbid-9"},
+				}
+				track := model.MediaFile{
+					ID: "by-mbid", Title: "Song A", Artist: "Correct Artist",
+					Participants: model.Participants{
+						model.RoleArtist: model.ParticipantList{
+							{Artist: model.Artist{ID: "a9", Name: "Correct Artist", OrderArtistName: "correct artist", MbzArtistID: "mbid-9"}},
+						},
+					},
+				}
+				// Phase 1 returns the artist matched by mbz_artist_id; its order name
+				// ("correct artist") differs from the query name ("typo artist"), so
+				// resolution must come from the MBID branch.
+				artistRepo.On("GetAll", mock.Anything).
+					Return(model.Artists{{ID: "a9", Name: "Correct Artist", OrderArtistName: "correct artist", MbzArtistID: "mbid-9"}}, nil).Maybe()
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
+					Return(model.MediaFiles{track}, nil).Maybe()
+
+				result, err := m.MatchSongs(ctx, songs, 5)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result).To(HaveLen(1))
+				Expect(result[0].ID).To(Equal("by-mbid"))
+			})
 		})
 
-		// These tests register their own order_artist_name expectation per-test (to inject
+		// These tests register their own phase-2 expectations per-test (to inject
 		// an error), so they use allowIdentifierPhases — NOT allowOtherPhases, which would
 		// add a .Maybe() title-phase catch-all that masks the injected error.
 		Context("title phase DB errors", func() {
@@ -298,7 +450,11 @@ var _ = Describe("Matcher", func() {
 					{Name: "Song B", Artist: "Artist Two"},
 				}
 				allowIdentifierPhases()
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
+				artistRepo.On("GetAll", mock.Anything).Return(model.Artists{
+					{ID: "a1", Name: "Artist One", OrderArtistName: "artist one"},
+					{ID: "a2", Name: "Artist Two", OrderArtistName: "artist two"},
+				}, nil)
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
 					Return(nil, errors.New("db down"))
 
 				_, err := m.MatchSongs(ctx, songs, 5)
@@ -317,7 +473,10 @@ var _ = Describe("Matcher", func() {
 					Return(model.MediaFiles{}, nil).Maybe()
 				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInEq("missing"))).
 					Return(model.MediaFiles{}, nil).Maybe()
-				mediaFileRepo.On("GetAll", mock.MatchedBy(matchFieldInAnd("order_artist_name"))).
+				artistRepo.On("GetAll", mock.Anything).Return(model.Artists{
+					{ID: "fa", Name: "Fuzzy Artist", OrderArtistName: "fuzzy artist"},
+				}, nil)
+				mediaFileRepo.On("GetAll", mock.MatchedBy(matchTitlePhase2())).
 					Return(nil, errors.New("db down"))
 
 				result, err := m.MatchSongs(ctx, songs, 5)
@@ -384,10 +543,20 @@ var _ = Describe("Matcher", func() {
 			correctMatch := model.MediaFile{
 				ID: "correct-match", Title: "Similar Song", Artist: "Depeche Mode", Album: "Violator",
 				MbzArtistID: "artist-mbid-123", MbzAlbumID: "album-mbid-456",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid-123"}},
+					},
+				},
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong-match", Title: "Similar Song", Artist: "Depeche Mode", Album: "Some Other Album",
 				MbzArtistID: "artist-mbid-123", MbzAlbumID: "different-album-mbid",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode", MbzArtistID: "artist-mbid-123"}},
+					},
+				},
 			}
 			songs := []agents.Song{
 				{Name: "Similar Song", Artist: "Depeche Mode", ArtistMBID: "artist-mbid-123", Album: "Violator", AlbumMBID: "album-mbid-456"},
@@ -405,9 +574,19 @@ var _ = Describe("Matcher", func() {
 		It("matches by title + artist name + album name when MBIDs unavailable", func() {
 			correctMatch := model.MediaFile{
 				ID: "correct-match", Title: "Similar Song", Artist: "depeche mode", Album: "violator",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong-match", Title: "Similar Song", Artist: "Other Artist", Album: "Other Album",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "oa", Name: "Other Artist", OrderArtistName: "other artist"}},
+					},
+				},
 			}
 			songs := []agents.Song{
 				{Name: "Similar Song", Artist: "Depeche Mode", Album: "Violator"},
@@ -425,9 +604,19 @@ var _ = Describe("Matcher", func() {
 		It("matches by title + artist only when album info unavailable", func() {
 			correctMatch := model.MediaFile{
 				ID: "correct-match", Title: "Similar Song", Artist: "depeche mode", Album: "Some Album",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong-match", Title: "Similar Song", Artist: "Other Artist", Album: "Other Album",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "oa", Name: "Other Artist", OrderArtistName: "other artist"}},
+					},
+				},
 			}
 			songs := []agents.Song{
 				{Name: "Similar Song", Artist: "Depeche Mode"},
@@ -456,9 +645,27 @@ var _ = Describe("Matcher", func() {
 		})
 
 		It("returns distinct matches for each artist's version (covers scenario)", func() {
-			cover1 := model.MediaFile{ID: "cover-1", Title: "Yesterday", Artist: "The Beatles", Album: "Help!"}
-			cover2 := model.MediaFile{ID: "cover-2", Title: "Yesterday", Artist: "Ray Charles", Album: "Greatest Hits"}
-			cover3 := model.MediaFile{ID: "cover-3", Title: "Yesterday", Artist: "Frank Sinatra", Album: "My Way"}
+			cover1 := model.MediaFile{ID: "cover-1", Title: "Yesterday", Artist: "The Beatles", Album: "Help!",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}},
+					},
+				},
+			}
+			cover2 := model.MediaFile{ID: "cover-2", Title: "Yesterday", Artist: "Ray Charles", Album: "Greatest Hits",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ray-charles", Name: "Ray Charles", OrderArtistName: "ray charles"}},
+					},
+				},
+			}
+			cover3 := model.MediaFile{ID: "cover-3", Title: "Yesterday", Artist: "Frank Sinatra", Album: "My Way",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "sinatra", Name: "Frank Sinatra", OrderArtistName: "frank sinatra"}},
+					},
+				},
+			}
 
 			songs := []agents.Song{
 				{Name: "Yesterday", Artist: "The Beatles", Album: "Help!"},
@@ -480,13 +687,28 @@ var _ = Describe("Matcher", func() {
 			preciseMatch := model.MediaFile{
 				ID: "precise", Title: "Song A", Artist: "Artist One", Album: "Album One",
 				MbzArtistID: "mbid-1", MbzAlbumID: "album-mbid-1",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}},
+					},
+				},
 			}
 			lessAccurateMatch := model.MediaFile{
 				ID: "less-accurate", Title: "Song A", Artist: "Artist One", Album: "Compilation",
 				MbzArtistID: "mbid-1",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}},
+					},
+				},
 			}
 			artistTwoMatch := model.MediaFile{
 				ID: "artist-two", Title: "Song B", Artist: "Artist Two",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "a2", Name: "Artist Two", OrderArtistName: "artist two"}},
+					},
+				},
 			}
 
 			songs := []agents.Song{
@@ -503,6 +725,39 @@ var _ = Describe("Matcher", func() {
 			Expect(result[0].ID).To(Equal("precise"))
 			Expect(result[1].ID).To(Equal("artist-two"))
 		})
+
+		It("uses the resolved artist MBID for specificity (level 5)", func() {
+			songs := []agents.Song{
+				{Name: "Song A", Artist: "Artist One", ArtistMBID: "mbid-1", Album: "Album One", AlbumMBID: "album-mbid-1"},
+			}
+			// Two tracks with the same title and album; only the one whose resolved artist
+			// carries mbid-1 (and whose album MBID matches) wins via Level 5. Without the
+			// resolved MBID, both tracks tie at Level 3 (name+album) and the first wins by
+			// chance — verifiable by RED-proof: see task-2-report.md.
+			precise := model.MediaFile{
+				ID: "precise", Title: "Song A", Artist: "Artist One", Album: "Album One", MbzAlbumID: "album-mbid-1",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "a1", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: "mbid-1"}},
+					},
+				},
+			}
+			other := model.MediaFile{
+				ID: "other", Title: "Song A", Artist: "Artist One", Album: "Album One", MbzAlbumID: "wrong-album-mbid",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "a1b", Name: "Artist One", OrderArtistName: "artist one", MbzArtistID: ""}},
+					},
+				},
+			}
+			// Phase 1 resolves both a1 (by name+mbid) and a1b (by name).
+			allowTitlePhase(model.MediaFiles{other, precise})
+
+			result, err := m.MatchSongs(ctx, songs, 5)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].ID).To(Equal("precise"))
+		})
 	})
 
 	Describe("fuzzy matching thresholds", func() {
@@ -514,7 +769,13 @@ var _ = Describe("Matcher", func() {
 					{Name: "Paranoid Android", Artist: "Radiohead"},
 				}
 				artistTracks := model.MediaFiles{
-					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead"},
+					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "rh", Name: "Radiohead", OrderArtistName: "radiohead"}},
+							},
+						},
+					},
 				}
 
 				allowTitlePhase(artistTracks)
@@ -533,7 +794,13 @@ var _ = Describe("Matcher", func() {
 					{Name: "Bohemian Rhapsody", Artist: "Queen"},
 				}
 				artistTracks := model.MediaFiles{
-					{ID: "live", Title: "Bohemian Rhapsody (Live)", Artist: "Queen"},
+					{ID: "live", Title: "Bohemian Rhapsody (Live)", Artist: "Queen",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
+							},
+						},
+					},
 				}
 
 				allowTitlePhase(artistTracks)
@@ -554,7 +821,13 @@ var _ = Describe("Matcher", func() {
 					{Name: "Paranoid Android", Artist: "Radiohead"},
 				}
 				artistTracks := model.MediaFiles{
-					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead"},
+					{ID: "remastered", Title: "Paranoid Android - Remastered", Artist: "Radiohead",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "rh", Name: "Radiohead", OrderArtistName: "radiohead"}},
+							},
+						},
+					},
 				}
 
 				allowTitlePhase(artistTracks)
@@ -574,7 +847,13 @@ var _ = Describe("Matcher", func() {
 					{Name: "Song", Artist: "Artist"},
 				}
 				artistTracks := model.MediaFiles{
-					{ID: "extended", Title: "Song (Extended Mix)", Artist: "Artist"},
+					{ID: "extended", Title: "Song (Extended Mix)", Artist: "Artist",
+						Participants: model.Participants{
+							model.RoleArtist: model.ParticipantList{
+								{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+							},
+						},
+					},
 				}
 
 				allowTitlePhase(artistTracks)
@@ -600,9 +879,19 @@ var _ = Describe("Matcher", func() {
 			}
 			correctMatch := model.MediaFile{
 				ID: "correct", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "A Night at the Opera (2011 Remaster)",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
+					},
+				},
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong", Title: "Bohemian Rhapsody", Artist: "Queen", Album: "Greatest Hits",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "queen", Name: "Queen", OrderArtistName: "queen"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
@@ -620,9 +909,19 @@ var _ = Describe("Matcher", func() {
 			}
 			correctMatch := model.MediaFile{
 				ID: "correct", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator (Deluxe Edition)",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 			wrongMatch := model.MediaFile{
 				ID: "wrong", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "101",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{wrongMatch, correctMatch})
@@ -640,9 +939,19 @@ var _ = Describe("Matcher", func() {
 			}
 			exactMatch := model.MediaFile{
 				ID: "exact", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 			fuzzyMatch := model.MediaFile{
 				ID: "fuzzy", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator (Deluxe Edition)",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{fuzzyMatch, exactMatch})
@@ -661,9 +970,20 @@ var _ = Describe("Matcher", func() {
 			}
 			albumMatch := model.MediaFile{
 				ID: "album-match", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 			starredTrack := model.MediaFile{
-				ID: "starred", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles", Annotations: model.Annotations{Starred: true},
+				ID: "starred", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles",
+				Annotations: model.Annotations{Starred: true},
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{albumMatch, starredTrack})
@@ -682,9 +1002,20 @@ var _ = Describe("Matcher", func() {
 			}
 			albumMatch := model.MediaFile{
 				ID: "album-match", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Violator",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 			ratedTrack := model.MediaFile{
-				ID: "rated", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles", Annotations: model.Annotations{Rating: 4},
+				ID: "rated", Title: "Enjoy the Silence", Artist: "Depeche Mode", Album: "Singles",
+				Annotations: model.Annotations{Rating: 4},
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "dm", Name: "Depeche Mode", OrderArtistName: "depeche mode"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{albumMatch, ratedTrack})
@@ -708,9 +1039,19 @@ var _ = Describe("Matcher", func() {
 			}
 			correctMatch := model.MediaFile{
 				ID: "correct", Title: "Similar Song", Artist: "Test Artist", Duration: 180.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 			wrongDuration := model.MediaFile{
 				ID: "wrong", Title: "Similar Song", Artist: "Test Artist", Duration: 240.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{wrongDuration, correctMatch})
@@ -728,6 +1069,11 @@ var _ = Describe("Matcher", func() {
 			}
 			closeDuration := model.MediaFile{
 				ID: "close-duration", Title: "Similar Song", Artist: "Test Artist", Duration: 182.5,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{closeDuration})
@@ -745,9 +1091,19 @@ var _ = Describe("Matcher", func() {
 			}
 			closeDuration := model.MediaFile{
 				ID: "close", Title: "Similar Song", Artist: "Test Artist", Duration: 181.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 			farDuration := model.MediaFile{
 				ID: "far", Title: "Similar Song", Artist: "Test Artist", Duration: 190.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{farDuration, closeDuration})
@@ -765,6 +1121,11 @@ var _ = Describe("Matcher", func() {
 			}
 			differentDuration := model.MediaFile{
 				ID: "different", Title: "Similar Song", Artist: "Test Artist", Duration: 300.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{differentDuration})
@@ -782,9 +1143,19 @@ var _ = Describe("Matcher", func() {
 			}
 			differentTitle := model.MediaFile{
 				ID: "wrong-title", Title: "Different Song", Artist: "Test Artist", Duration: 180.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 			correctTitle := model.MediaFile{
 				ID: "correct-title", Title: "Similar Song", Artist: "Test Artist", Duration: 300.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{differentTitle, correctTitle})
@@ -802,6 +1173,11 @@ var _ = Describe("Matcher", func() {
 			}
 			anyTrack := model.MediaFile{
 				ID: "any", Title: "Similar Song", Artist: "Test Artist", Duration: 999.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{anyTrack})
@@ -819,6 +1195,11 @@ var _ = Describe("Matcher", func() {
 			}
 			shortTrack := model.MediaFile{
 				ID: "short", Title: "Short Song", Artist: "Test Artist", Duration: 31.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "ta", Name: "Test Artist", OrderArtistName: "test artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{shortTrack})
@@ -837,9 +1218,19 @@ var _ = Describe("Matcher", func() {
 			}
 			shortTrack := model.MediaFile{
 				ID: "short", Title: "Same Song", Artist: "Same Artist", Duration: 180.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "sa", Name: "Same Artist", OrderArtistName: "same artist"}},
+					},
+				},
 			}
 			longTrack := model.MediaFile{
 				ID: "long", Title: "Same Song", Artist: "Same Artist", Duration: 240.0,
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "sa", Name: "Same Artist", OrderArtistName: "same artist"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{shortTrack, longTrack})
@@ -867,6 +1258,11 @@ var _ = Describe("Matcher", func() {
 			}
 			libraryTrack := model.MediaFile{
 				ID: "yesterday", Title: "Yesterday", Artist: "The Beatles", Album: "Help!",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "beatles", Name: "The Beatles", OrderArtistName: "beatles"}},
+					},
+				},
 			}
 
 			allowTitlePhase(model.MediaFiles{libraryTrack})
@@ -885,9 +1281,27 @@ var _ = Describe("Matcher", func() {
 				{Name: "Song B", Artist: "Artist"},
 				{Name: "Song C", Artist: "Artist"},
 			}
-			trackA := model.MediaFile{ID: "track-a", Title: "Song A", Artist: "Artist"}
-			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist"}
-			trackC := model.MediaFile{ID: "track-c", Title: "Song C", Artist: "Artist"}
+			trackA := model.MediaFile{ID: "track-a", Title: "Song A", Artist: "Artist",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+					},
+				},
+			}
+			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+					},
+				},
+			}
+			trackC := model.MediaFile{ID: "track-c", Title: "Song C", Artist: "Artist",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+					},
+				},
+			}
 
 			allowTitlePhase(model.MediaFiles{trackA, trackB, trackC})
 
@@ -907,8 +1321,20 @@ var _ = Describe("Matcher", func() {
 				{Name: "Song B", Artist: "Artist"},
 				{Name: "Song B (Remix)", Artist: "Artist"},
 			}
-			trackA := model.MediaFile{ID: "track-a", Title: "Song A", Artist: "Artist"}
-			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist"}
+			trackA := model.MediaFile{ID: "track-a", Title: "Song A", Artist: "Artist",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+					},
+				},
+			}
+			trackB := model.MediaFile{ID: "track-b", Title: "Song B", Artist: "Artist",
+				Participants: model.Participants{
+					model.RoleArtist: model.ParticipantList{
+						{Artist: model.Artist{ID: "art", Name: "Artist", OrderArtistName: "artist"}},
+					},
+				},
+			}
 
 			allowTitlePhase(model.MediaFiles{trackA, trackB})
 
@@ -953,6 +1379,23 @@ func (m *mockMediaFileRepo) SetError(hasError bool) {
 	}
 }
 
+type mockArtistRepo struct {
+	mock.Mock
+	model.ArtistRepository
+}
+
+func newMockArtistRepo() *mockArtistRepo {
+	return &mockArtistRepo{}
+}
+
+func (m *mockArtistRepo) GetAll(options ...model.QueryOptions) (model.Artists, error) {
+	args := m.Called(options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(model.Artists), args.Error(1)
+}
+
 // matchFieldInAnd returns a matcher that checks whether QueryOptions.Filters is a
 // squirrel.And whose first element is a squirrel.Eq containing the given field name.
 func matchFieldInAnd(fieldName string) func(opt model.QueryOptions) bool {
@@ -980,5 +1423,25 @@ func matchFieldInEq(fieldName string) func(opt model.QueryOptions) bool {
 		}
 		_, hasField := eq[fieldName]
 		return hasField
+	}
+}
+
+// matchTitlePhase2 matches the phase-2 media_file query, identified by its
+// squirrel.And containing a squirrel.Expr whose SQL references media_file_artists.
+func matchTitlePhase2() func(opt model.QueryOptions) bool {
+	return func(opt model.QueryOptions) bool {
+		and, ok := opt.Filters.(squirrel.And)
+		if !ok {
+			return false
+		}
+		for _, f := range and {
+			if expr, ok := f.(squirrel.Sqlizer); ok {
+				sql, _, err := expr.ToSql()
+				if err == nil && strings.Contains(sql, "media_file_artists") {
+					return true
+				}
+			}
+		}
+		return false
 	}
 }


### PR DESCRIPTION
### Description

This fixes two defects in the matcher's title+artist phase, building on the lookup work in #5635.

The title phase scoped candidate tracks by `media_file.order_artist_name`, the deprecated sort-artist column. That caused two broken behaviors:

1. **Artist-MBID specificity was dead.** `computeSpecificityLevel`'s most precise levels (Title + Artist MBID + Album) read `media_file.mbz_artist_id` — a column that is **not populated**. The artist MBID lives in the `artist` table, not denormalized onto `media_file`, so those levels never fired and an agent result with a known artist MBID got no specificity benefit.
2. **Credited collaborators were missed.** Scoping by the primary sort artist skips tracks where the searched artist is a co-performer but not the album's banner artist — e.g. a track credited "X vs. Y" or "feat. X" was not matched when searching for X.

**The fix — resolve the artist first, then find its tracks:**

1. **Resolve** the agent artists against the `artist` table (by `order_artist_name`, or by `mbz_artist_id` when the agent supplies one). This yields canonical artist IDs **and the real artist MBID**.
2. **Fetch** every non-missing track credited as a main artist (`media_file_artists.role = 'artist'`) to one of those resolved artists, in a single query.
3. **Route** each track back to the queries it satisfies **by artist ID** (never by name, so an MBID-resolved artist whose sort name differs from the agent's name is not misrouted), stamping the resolved MBID so specificity scoring can use it.

`role = 'artist'` is deliberate: it includes genuine collaborations (the searched artist actually performed) while excluding `albumartist`-only credits, which would otherwise pull in tribute/compilation tracks the artist did not perform.

Both public method contracts are unchanged (`MatchSongs` ordered + deduplicated + count-limited; `MatchSongsIndexed` raw). No persistence-layer changes — artist resolution uses the existing `Artist().GetAll`, the track fetch uses `MediaFile().GetAll` with a filter.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Internal to `core/matcher` with no API/config surface change; covered by the package suites:

1. Run the matcher and its consumers:
   ```bash
   make test PKG="./core/matcher ./core/external ./core/sonic"
   ```
   The consumers confirm the public contracts are unchanged.

2. (Optional, end-to-end) With a populated library, exercise "similar songs" / sonic-similarity via a Subsonic client. After the fix: a search for an artist also surfaces tracks where that artist is a credited collaborator (e.g. "X vs. Y" tracks), and matches with a known artist+album MBID rank higher than before.

### Additional Notes

The fix changes title-phase matching behavior in three ways, all pinned by new tests:

- **Broader recall:** tracks crediting the searched artist as a `role='artist'` collaborator now match, where the old sort-artist scoping missed them.
- **Album-banner exclusion:** a track where the searched artist is only the `albumartist` (a comp/tribute performed by others) is intentionally **not** matched.
- **Artist-MBID specificity now works:** the precise specificity levels fire because the artist MBID is resolved from the `artist` table rather than read from the empty `media_file` column.

Performance (validated on a real 95k-track library): the resolve-then-fetch approach is roughly on par with the merged single-query baseline (Batch100 ~0.6–0.9s vs ~0.65s on master), and both are far faster than the pre-#5635 per-artist loop (~6s). The track-fetch query uses a non-correlated `id IN (subquery)` against the `media_file_artists(artist_id)` covering index — an earlier correlated-`EXISTS` form was ~7× slower and was replaced.

One scoping note for reviewers: the track-fetch query uses a small raw `squirrel.Expr` referencing `media_file_artists`, kept in `core/matcher` because the non-correlated form isn't expressible via the repository's existing role filters. A comment marks this as the natural seam for a future `MediaFileRepository` method. No config, no migration, no API change.
