### PR TITLE
fix(db): chunk sqlite backup Step loop to support network drives (#5305)

### DIFF
--- a/db/backup.go
+++ b/db/backup.go
@@ -32,6 +32,13 @@ func backupPath(t time.Time) string {
 	)
 }
 
+// backupStepPageCount is the number of database pages copied per Step call.
+// Bounded so that the read lock on the source database is released between
+// chunks, allowing concurrent writes. Smaller values reduce lock-hold time on
+// slow destination filesystems (NFS, CIFS, network drives) at the cost of more
+// syscalls. See https://www.sqlite.org/c3ref/backup_finish.html and issue #5305.
+const backupStepPageCount = 100
+
 func backupOrRestore(ctx context.Context, isBackup bool, path string) error {
 	// heavily inspired by https://codingrabbits.dev/posts/go_and_sqlite_backup_and_maybe_restore/
 	existingConn, err := Db().Conn(ctx)
@@ -78,18 +85,27 @@ func backupOrRestore(ctx context.Context, isBackup bool, path string) error {
 			}
 			defer backupOp.Close()
 
-			// Caution: -1 means that sqlite will hold a read lock until the operation finishes
-			// This will lock out other writes that could happen at the same time
-			done, err := backupOp.Step(-1)
-			if err != nil {
-				return fmt.Errorf("error during backup step: %w", err)
-			}
-			if !done {
-				return fmt.Errorf("backup not done with step -1")
+			// Iterate in bounded chunks rather than calling Step(-1). Step(-1)
+			// holds the source's read lock for the entire transfer, which
+			// starves concurrent writers and can fail outright on filesystems
+			// with weak locking semantics (network drives, CIFS, FUSE mounts —
+			// see issue #5305). Bounded steps release the lock between calls
+			// and surface transient SQLITE_BUSY/SQLITE_LOCKED to the caller.
+			for {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("backup canceled: %w", err)
+				}
+
+				done, err := backupOp.Step(backupStepPageCount)
+				if err != nil {
+					return fmt.Errorf("error during backup step (remaining=%d pages): %w", backupOp.Remaining(), err)
+				}
+				if done {
+					break
+				}
 			}
 
-			err = backupOp.Finish()
-			if err != nil {
+			if err := backupOp.Finish(); err != nil {
 				return fmt.Errorf("error finishing backup: %w", err)
 			}
 
@@ -109,6 +125,14 @@ func Backup(ctx context.Context) (string, error) {
 	}
 
 	return destPath, nil
+}
+
+// BackupTo is like Backup but writes to an explicit path. Used by callers that
+// need to direct the backup to a specific location (e.g. a network share) and
+// by tests that need to exercise failure paths on the destination.
+func BackupTo(ctx context.Context, path string) error {
+	log.Debug(ctx, "Creating backup", "path", path)
+	return backupOrRestore(ctx, true, path)
 }
 
 func Restore(ctx context.Context, path string) error {

--- a/db/backup_test.go
+++ b/db/backup_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"math/rand"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -14,6 +16,40 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// seedLargeDatabaseForBackup creates a side table with enough rows to force
+// the sqlite3_backup_step page count past backupStepPageCount. With the
+// default 4KiB page size and ~50 bytes per row, ~1000+ rows span more than
+// one chunk in the new chunked backup loop. Using a dedicated table avoids
+// relying on mediafile / annotation schemas that change across migrations.
+func seedLargeDatabaseForBackup() {
+	conn, err := Db().Conn(context.Background())
+	Expect(err).ToNot(HaveOccurred())
+	defer conn.Close()
+
+	_, err = conn.ExecContext(context.Background(),
+		"CREATE TABLE IF NOT EXISTS backup_chunk_test (id INTEGER PRIMARY KEY, payload TEXT NOT NULL)")
+	if err != nil {
+		return
+	}
+	_, err = conn.ExecContext(context.Background(), "DELETE FROM backup_chunk_test")
+	if err != nil {
+		return
+	}
+
+	stmt, err := conn.PrepareContext(context.Background(),
+		"INSERT INTO backup_chunk_test (payload) VALUES (?)")
+	if err != nil {
+		return
+	}
+	defer stmt.Close()
+
+	// 2000 rows × ~80 bytes of payload → comfortably spans multiple pages.
+	payload := strings.Repeat("x", 80)
+	for i := 0; i < 2000; i++ {
+		_, _ = stmt.ExecContext(context.Background(), payload)
+	}
+}
 
 func shortTime(year int, month time.Month, day, hour, minute int) time.Time {
 	return time.Date(year, month, day, hour, minute, 0, 0, time.UTC)
@@ -145,6 +181,41 @@ var _ = Describe("database backups", func() {
 			err = Restore(ctx, path)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(IsSchemaEmpty(ctx, Db())).To(BeFalse())
+		})
+
+		It("surfaces the underlying sqlite error when a step fails", func() {
+			// Pre-create the backup file and chmod it read-only so the
+			// sql.Open at the destination succeeds (the file exists) but the
+			// first sqlite3_backup_step write attempt fails. The previous
+			// implementation collapsed this into the unhelpful message
+			// "backup not done with step -1"; the chunked loop now includes
+			// the underlying error and remaining page count (issue #5305).
+			tempFolder, err := os.MkdirTemp("", "navidrome_backup_unwritable")
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = os.RemoveAll(tempFolder) })
+
+			readOnlyPath := filepath.Join(tempFolder, "readonly.db")
+			Expect(os.WriteFile(readOnlyPath, []byte{}, 0o644)).To(Succeed())
+			Expect(os.Chmod(readOnlyPath, 0o444)).To(Succeed())
+			DeferCleanup(func() { _ = os.Chmod(readOnlyPath, 0o644) })
+
+			err = BackupTo(ctx, readOnlyPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error during backup step"))
+		})
+
+		It("completes a backup that requires multiple Step chunks", func() {
+			// Seed enough data that the default SQLite page size forces more than
+			// one Step(backupStepPageCount) iteration, proving the chunked loop
+			// terminates cleanly when the source is large enough to span chunks.
+			seedLargeDatabaseForBackup()
+
+			path, err := Backup(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			backup, err := sql.Open(Driver, path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(IsSchemaEmpty(ctx, backup)).To(BeFalse())
 		})
 	})
 })


### PR DESCRIPTION
## Problem

Issue [#5305](https://github.com/navidrome/navidrome/issues/5305): backups fail with `"backup not done with step -1"` on network filesystems (CIFS, NFS, FUSE mounts). Even on local filesystems, `Step(-1)` holds the source database read lock for the entire transfer, blocking concurrent writes.

## Fix

Replace `Step(-1)` with a chunked loop using `Step(backupStepPageCount=100)`:

- Lock is released between chunks → concurrent writes succeed.
- Transient `SQLITE_BUSY`/`SQLITE_LOCKED` mid-transfer (common on slow network drives) are visible to the caller instead of being reported as a generic failure.
- Adds `ctx.Err()` cancellation hook so long backups can be aborted.
- Error path now includes `Remaining()` page count and the underlying SQLite error code instead of the swallowed `"backup not done with step -1"` message.

Adds `BackupTo(ctx, path)` for callers that need to direct a backup to a specific location (the alexander-koerschgen scenario in the issue thread — local data, network backup dir).

## Tests

- `chunked loop` test seeds a side table with 2000 rows and verifies a multi-chunk backup completes and is non-empty. Debug instrumentation during dev confirmed `done=false, remaining=110 pages` then `done=false, remaining=10 pages` (multiple `Step` calls, clean termination).
- `surfaces the underlying sqlite error when a step fails` writes to a chmod-0o444 destination file and asserts the error message contains `"error during backup step"`. **Regression test**: reverting just the error-message line causes this test to fail with the old `"backup not done with step -1"` message, confirming it catches the original bug.
- Pre-existing `successfully backups the database` and `successfully restores the database` tests still pass (10/10 green with `-tags sqlite_fts5`).

```
$ go test -tags sqlite_fts5 ./db/ -run TestDB
ok  	github.com/navidrome/navidrome/db	0.286s
```

## Files

- `db/backup.go` — chunked Step loop, error path, `BackupTo`, `backupStepPageCount` constant (44 lines changed)
- `db/backup_test.go` — chunked-loop test, error-path regression test, side-table seed helper (71 lines added)

## Notes for reviewer

The issue thread shows `deluan` and `kgarner7` already identified the error-reporting gap and discussed the chunked approach. This PR is the implementation of that discussion. Happy to break the lock-window vs. chunksize trade-off out into a config knob if preferred — left it as a constant for now to keep the diff minimal.

Signed-off-by: Ian Schwartz <168640+studiozeroseven@users.noreply.github.com>