### PR TITLE
fix(playlist/share): apply user library access to import and sharing paths

### DIFF
--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -306,7 +306,7 @@ func (r *mediaFileRepository) FindByPaths(paths []string) (model.MediaFiles, err
 		return model.MediaFiles{}, nil
 	}
 
-	sel := r.newSelect().Columns("*").Where(query)
+	sel := r.applyLibraryFilter(r.newSelect().Columns("*").Where(query))
 	var res dbMediaFiles
 	if err := r.queryAll(sel, &res); err != nil {
 		return nil, err

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -909,8 +909,7 @@ var _ = Describe("MediaRepository", func() {
 
 			AfterEach(func() {
 				adminCtx := request.WithUser(GinkgoT().Context(), adminUser)
-				adminMr := NewMediaFileRepository(adminCtx, GetDBXBuilder()).(*mediaFileRepository)
-				_, _ = adminMr.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": "otherlib-track"}))
+				_ = NewMediaFileRepository(adminCtx, GetDBXBuilder()).Delete("otherlib-track")
 				lr := NewLibraryRepository(adminCtx, GetDBXBuilder()).(*libraryRepository)
 				_ = lr.delete(squirrel.Eq{"id": otherLib.ID})
 			})

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -912,6 +912,7 @@ var _ = Describe("MediaRepository", func() {
 				_ = NewMediaFileRepository(adminCtx, GetDBXBuilder()).Delete("otherlib-track")
 				lr := NewLibraryRepository(adminCtx, GetDBXBuilder()).(*libraryRepository)
 				_ = lr.delete(squirrel.Eq{"id": otherLib.ID})
+				_ = NewUserRepository(adminCtx, GetDBXBuilder()).Delete(restrictedUser.ID)
 			})
 
 			It("does not resolve paths in libraries the user cannot access", func() {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -880,6 +880,58 @@ var _ = Describe("MediaRepository", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(results).To(BeEmpty())
 		})
+
+		Context("when the user has restricted library access", func() {
+			var otherLib model.Library
+			var restrictedUser model.User
+
+			BeforeEach(func() {
+				adminCtx := request.WithUser(GinkgoT().Context(), adminUser)
+				lr := NewLibraryRepository(adminCtx, GetDBXBuilder())
+
+				// A second library the restricted user has no access to
+				otherLib = model.Library{ID: 0, Name: "Other Library", Path: "/other/lib"}
+				Expect(lr.Put(&otherLib)).To(Succeed())
+
+				// A track that lives only in the other library (created as admin)
+				adminMr := NewMediaFileRepository(adminCtx, GetDBXBuilder())
+				Expect(adminMr.Put(&model.MediaFile{
+					ID: "otherlib-track", LibraryID: otherLib.ID,
+					Path: "hidden/test.mp3", Title: "Hidden",
+				})).To(Succeed())
+
+				// Non-admin user with access to library 1 ONLY
+				restrictedUser = createUserWithLibraries("restricted-finder", []int{1})
+				ur := NewUserRepository(adminCtx, GetDBXBuilder())
+				Expect(ur.Put(&restrictedUser)).To(Succeed())
+				Expect(ur.SetUserLibraries(restrictedUser.ID, []int{1})).To(Succeed())
+			})
+
+			AfterEach(func() {
+				adminCtx := request.WithUser(GinkgoT().Context(), adminUser)
+				adminMr := NewMediaFileRepository(adminCtx, GetDBXBuilder()).(*mediaFileRepository)
+				_, _ = adminMr.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": "otherlib-track"}))
+				lr := NewLibraryRepository(adminCtx, GetDBXBuilder()).(*libraryRepository)
+				_ = lr.delete(squirrel.Eq{"id": otherLib.ID})
+			})
+
+			It("does not resolve paths in libraries the user cannot access", func() {
+				userMr := NewMediaFileRepository(request.WithUser(GinkgoT().Context(), restrictedUser), GetDBXBuilder())
+				qualified := fmt.Sprintf("%d:hidden/test.mp3", otherLib.ID)
+				results, err := userMr.FindByPaths([]string{qualified})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).To(BeEmpty(), "a track outside the user's libraries must not be resolvable")
+			})
+
+			It("still resolves the path for an admin", func() {
+				adminMr := NewMediaFileRepository(request.WithUser(GinkgoT().Context(), adminUser), GetDBXBuilder())
+				qualified := fmt.Sprintf("%d:hidden/test.mp3", otherLib.ID)
+				results, err := adminMr.FindByPaths([]string{qualified})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).To(HaveLen(1))
+				Expect(results[0].ID).To(Equal("otherlib-track"))
+			})
+		})
 	})
 
 	Describe("wrapMediaFileCursor", func() {

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -100,9 +100,7 @@ func (r *shareRepository) loadMedia(share *model.Share) error {
 		share.Tracks, err = mfRepo.GetAll(model.QueryOptions{Filters: noMissing(Eq{"album_id": ids}), Sort: "album"})
 		return err
 	case "playlist":
-		// Load the playlist's tracks as the share owner so per-library access
-		// control applies — a shared playlist should only contain tracks the
-		// owner can access.
+		// Load tracks as the share owner so their library access is applied.
 		owner, err := NewUserRepository(r.ctx, r.db).Get(share.UserID)
 		if err != nil {
 			return fmt.Errorf("loading share owner %q: %w", share.UserID, err)

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -100,16 +100,20 @@ func (r *shareRepository) loadMedia(share *model.Share) error {
 		share.Tracks, err = mfRepo.GetAll(model.QueryOptions{Filters: noMissing(Eq{"album_id": ids}), Sort: "album"})
 		return err
 	case "playlist":
-		// Create a context with a fake admin user, to be able to access all playlists
-		ctx := request.WithUser(r.ctx, model.User{IsAdmin: true})
+		// Load the playlist's tracks as the share owner so per-library access
+		// control applies — a shared playlist should only contain tracks the
+		// owner can access.
+		owner, err := NewUserRepository(r.ctx, r.db).Get(share.UserID)
+		if err != nil {
+			return fmt.Errorf("loading share owner %q: %w", share.UserID, err)
+		}
+		ctx := request.WithUser(r.ctx, *owner)
 		plsRepo := NewPlaylistRepository(ctx, r.db)
 		tracks, err := plsRepo.Tracks(ids[0], true).GetAll(model.QueryOptions{Sort: "id", Filters: noMissing(Eq{})})
 		if err != nil {
 			return err
 		}
-		if len(tracks) >= 0 {
-			share.Tracks = tracks.MediaFiles()
-		}
+		share.Tracks = tracks.MediaFiles()
 		return nil
 	case "media_file":
 		mfRepo := NewMediaFileRepository(r.ctx, r.db)

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -110,7 +110,14 @@ func (r *shareRepository) loadMedia(share *model.Share) error {
 		}
 		ctx := request.WithUser(r.ctx, *owner)
 		plsRepo := NewPlaylistRepository(ctx, r.db)
-		tracks, err := plsRepo.Tracks(ids[0], true).GetAll(model.QueryOptions{Sort: "id", Filters: noMissing(Eq{})})
+		// Tracks returns nil when the playlist is no longer visible to the owner
+		// (e.g. it was made private after the share was created); leave the share
+		// with no tracks rather than exposing it.
+		trackRepo := plsRepo.Tracks(ids[0], true)
+		if trackRepo == nil {
+			return nil
+		}
+		tracks, err := trackRepo.GetAll(model.QueryOptions{Sort: "id", Filters: noMissing(Eq{})})
 		if err != nil {
 			return err
 		}

--- a/persistence/share_repository.go
+++ b/persistence/share_repository.go
@@ -105,6 +105,9 @@ func (r *shareRepository) loadMedia(share *model.Share) error {
 		if err != nil {
 			return fmt.Errorf("loading share owner %q: %w", share.UserID, err)
 		}
+		if owner == nil {
+			return fmt.Errorf("share owner %q not found", share.UserID)
+		}
 		ctx := request.WithUser(r.ctx, *owner)
 		plsRepo := NewPlaylistRepository(ctx, r.db)
 		tracks, err := plsRepo.Tracks(ids[0], true).GetAll(model.QueryOptions{Sort: "id", Filters: noMissing(Eq{})})

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -193,12 +193,9 @@ var _ = Describe("ShareRepository", func() {
 			share, err := adminRepo.Get("share-scope")
 			Expect(err).ToNot(HaveOccurred())
 
-			ids := make([]string, 0, len(share.Tracks))
-			for _, t := range share.Tracks {
-				ids = append(ids, t.ID)
-			}
-			Expect(ids).To(ContainElement("share-ok"))
-			Expect(ids).ToNot(ContainElement("share-other"), "a track outside the owner's libraries must not appear in the share")
+			Expect(share.Tracks).To(ContainElement(HaveField("ID", "share-ok")))
+			Expect(share.Tracks).ToNot(ContainElement(HaveField("ID", "share-other")),
+				"a track outside the owner's libraries must not appear in the share")
 		})
 	})
 

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -184,6 +184,7 @@ var _ = Describe("ShareRepository", func() {
 			_, _ = mr.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": []string{"share-other", "share-ok"}}))
 			lr := NewLibraryRepository(adminCtx, b).(*libraryRepository)
 			_ = lr.delete(squirrel.Eq{"id": otherLib.ID})
+			_ = NewUserRepository(adminCtx, b).Delete(owner.ID)
 		})
 
 		It("excludes tracks the owner cannot access from the shared playlist", func() {

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/log"
@@ -129,6 +130,75 @@ var _ = Describe("ShareRepository", func() {
 			Expect(share.ID).To(Equal(shareID))
 			// Albums array should be empty since we used non-existent album ID
 			Expect(share.Albums).To(BeEmpty())
+		})
+	})
+
+	Describe("Playlist share library scoping", func() {
+		var otherLib model.Library
+		var owner model.User
+		var plsID string
+
+		BeforeEach(func() {
+			adminCtx := request.WithUser(log.NewContext(GinkgoT().Context()), adminUser)
+
+			// A second library the owner has no access to, plus a track in it
+			lr := NewLibraryRepository(adminCtx, GetDBXBuilder())
+			otherLib = model.Library{ID: 0, Name: "Share Other Library", Path: "/share/other/lib"}
+			Expect(lr.Put(&otherLib)).To(Succeed())
+			mr := NewMediaFileRepository(adminCtx, GetDBXBuilder())
+			Expect(mr.Put(&model.MediaFile{ID: "share-other", LibraryID: otherLib.ID, Path: "s/other.mp3", Title: "ShareOther"})).To(Succeed())
+			Expect(mr.Put(&model.MediaFile{ID: "share-ok", LibraryID: 1, Path: "s/ok.mp3", Title: "ShareOK"})).To(Succeed())
+
+			// Non-admin owner with access to library 1 only
+			owner = createUserWithLibraries("share-owner", []int{1})
+			ur := NewUserRepository(adminCtx, GetDBXBuilder())
+			Expect(ur.Put(&owner)).To(Succeed())
+			Expect(ur.SetUserLibraries(owner.ID, []int{1})).To(Succeed())
+
+			// Owner-owned playlist containing tracks from both libraries
+			plsID = "share-scope-pls"
+			ownerCtx := request.WithUser(log.NewContext(GinkgoT().Context()), owner)
+			pr := NewPlaylistRepository(ownerCtx, GetDBXBuilder())
+			pls := &model.Playlist{ID: plsID, Name: "Scope Test", OwnerID: owner.ID}
+			pls.AddMediaFiles(model.MediaFiles{{ID: "share-ok"}, {ID: "share-other"}})
+			Expect(pr.Put(pls)).To(Succeed())
+
+			// Share row owned by the non-admin owner
+			_, err := GetDBXBuilder().NewQuery(`
+				INSERT INTO share (id, user_id, description, resource_type, resource_ids, created_at, updated_at)
+				VALUES ({:id}, {:user}, {:desc}, {:type}, {:ids}, {:created}, {:updated})
+			`).Bind(map[string]any{
+				"id": "share-scope", "user": owner.ID, "desc": "Scope test share",
+				"type": "playlist", "ids": plsID, "created": time.Now(), "updated": time.Now(),
+			}).Execute()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			adminCtx := request.WithUser(log.NewContext(GinkgoT().Context()), adminUser)
+			b := GetDBXBuilder()
+			_, _ = b.NewQuery(`DELETE FROM share WHERE id = 'share-scope'`).Execute()
+			pr := NewPlaylistRepository(adminCtx, b)
+			_ = pr.Delete(plsID)
+			mr := NewMediaFileRepository(adminCtx, b).(*mediaFileRepository)
+			_, _ = mr.executeSQL(squirrel.Delete("media_file").Where(squirrel.Eq{"id": []string{"share-other", "share-ok"}}))
+			lr := NewLibraryRepository(adminCtx, b).(*libraryRepository)
+			_ = lr.delete(squirrel.Eq{"id": otherLib.ID})
+		})
+
+		It("excludes tracks the owner cannot access from the shared playlist", func() {
+			// Read the share as admin (mimics the public-share render path, which uses
+			// the share repository's own context). loadMedia must scope to the owner.
+			adminRepo := NewShareRepository(request.WithUser(log.NewContext(GinkgoT().Context()), adminUser), GetDBXBuilder())
+			share, err := adminRepo.Get("share-scope")
+			Expect(err).ToNot(HaveOccurred())
+
+			ids := make([]string, 0, len(share.Tracks))
+			for _, t := range share.Tracks {
+				ids = append(ids, t.ID)
+			}
+			Expect(ids).To(ContainElement("share-ok"))
+			Expect(ids).ToNot(ContainElement("share-other"), "a track outside the owner's libraries must not appear in the share")
 		})
 	})
 

--- a/persistence/share_repository_test.go
+++ b/persistence/share_repository_test.go
@@ -198,6 +198,34 @@ var _ = Describe("ShareRepository", func() {
 			Expect(share.Tracks).ToNot(ContainElement(HaveField("ID", "share-other")),
 				"a track outside the owner's libraries must not appear in the share")
 		})
+
+		It("returns no tracks when the playlist is not visible to the owner", func() {
+			// A private playlist owned by someone else: the share owner can no longer
+			// see it, so Tracks() returns nil. The share must render with no tracks
+			// instead of panicking.
+			privatePlsID := "private-pls"
+			adminCtx := request.WithUser(log.NewContext(GinkgoT().Context()), adminUser)
+			pr := NewPlaylistRepository(adminCtx, GetDBXBuilder())
+			privatePls := &model.Playlist{ID: privatePlsID, Name: "Private", OwnerID: adminUser.ID, Public: false}
+			privatePls.AddMediaFiles(model.MediaFiles{{ID: "share-ok"}})
+			Expect(pr.Put(privatePls)).To(Succeed())
+			DeferCleanup(func() { _ = pr.Delete(privatePlsID) })
+
+			_, err := GetDBXBuilder().NewQuery(`
+				INSERT INTO share (id, user_id, description, resource_type, resource_ids, created_at, updated_at)
+				VALUES ({:id}, {:user}, {:desc}, {:type}, {:ids}, {:created}, {:updated})
+			`).Bind(map[string]any{
+				"id": "share-private", "user": owner.ID, "desc": "Private share",
+				"type": "playlist", "ids": privatePlsID, "created": time.Now(), "updated": time.Now(),
+			}).Execute()
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _, _ = GetDBXBuilder().NewQuery(`DELETE FROM share WHERE id = 'share-private'`).Execute() })
+
+			adminRepo := NewShareRepository(adminCtx, GetDBXBuilder())
+			share, err := adminRepo.Get("share-private")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(share.Tracks).To(BeEmpty())
+		})
 	})
 
 	Describe("Ownership Checks", func() {

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -25,6 +25,7 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	var shareOwner *model.User
 	if info.shareID != "" {
 		share, err := pub.ds.Share(ctx).Get(info.shareID)
 		if err != nil {
@@ -33,6 +34,12 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 		}
 		if expiresAt := V(share.ExpiresAt); !expiresAt.IsZero() && expiresAt.Before(time.Now()) {
 			checkShareError(ctx, w, model.ErrExpired, info.shareID)
+			return
+		}
+		shareOwner, err = pub.ds.User(ctx).Get(share.UserID)
+		if err != nil {
+			log.Error(ctx, "Error retrieving share owner for shared stream", "share", info.shareID, "owner", share.UserID, err)
+			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
 	}
@@ -45,6 +52,14 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 			log.Error(ctx, "Error retrieving media file for shared stream", "id", info.id, err)
 			http.Error(w, "internal error", http.StatusInternalServerError)
 		}
+		return
+	}
+
+	// A shared stream should only serve tracks the share owner can access.
+	// Respond 404 (rather than 403) so the response doesn't reveal whether
+	// the id exists.
+	if shareOwner != nil && !shareOwner.HasLibraryAccess(mf.LibraryID) {
+		http.Error(w, "not found", http.StatusNotFound)
 		return
 	}
 

--- a/server/public/handle_streams.go
+++ b/server/public/handle_streams.go
@@ -55,9 +55,7 @@ func (pub *Router) handleStream(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// A shared stream should only serve tracks the share owner can access.
-	// Respond 404 (rather than 403) so the response doesn't reveal whether
-	// the id exists.
+	// 404 rather than 403 so the response doesn't reveal whether the id exists.
 	if shareOwner != nil && !shareOwner.HasLibraryAccess(mf.LibraryID) {
 		http.Error(w, "not found", http.StatusNotFound)
 		return

--- a/server/public/handle_streams_test.go
+++ b/server/public/handle_streams_test.go
@@ -133,6 +133,12 @@ var _ = Describe("handleStream", func() {
 
 	It("passes all validation and reaches the streamer for a valid token", func() {
 		shareRepo.ID = "share123"
+		shareRepo.Entity = &model.Share{ID: "share123", UserID: "owner1"}
+
+		userRepo := tests.CreateMockUserRepo()
+		Expect(userRepo.Put(&model.User{ID: "owner1", UserName: "owner1", IsAdmin: true})).To(Succeed())
+		ds.MockedUser = userRepo
+
 		mfRepo := tests.CreateMockMediaFileRepo()
 		mfRepo.SetData(model.MediaFiles{{ID: "mf-123", Title: "Test Song"}})
 		ds.MockedMediaFile = mfRepo
@@ -144,6 +150,45 @@ var _ = Describe("handleStream", func() {
 		Expect(streamer.called).To(BeTrue())
 		Expect(streamer.req.Format).To(Equal("mp3"))
 		Expect(streamer.req.BitRate).To(Equal(192))
+	})
+
+	It("returns 404 when the track is outside the share owner's libraries", func() {
+		shareRepo.ID = "share123"
+		shareRepo.Entity = &model.Share{ID: "share123", UserID: "owner1"}
+
+		userRepo := tests.CreateMockUserRepo()
+		Expect(userRepo.Put(&model.User{ID: "owner1", UserName: "owner1", Libraries: model.Libraries{{ID: 1}}})).To(Succeed())
+		ds.MockedUser = userRepo
+
+		mfRepo := tests.CreateMockMediaFileRepo()
+		mfRepo.SetData(model.MediaFiles{{ID: "mf-restricted", Title: "Other Lib Track", LibraryID: 2}})
+		ds.MockedMediaFile = mfRepo
+
+		claims := auth.Claims{ID: "mf-restricted", ShareID: "share123"}
+		token, _ := auth.CreateExpiringPublicToken(time.Now().Add(time.Hour), claims)
+		w := makeRequest(token)
+
+		Expect(w.Code).To(Equal(http.StatusNotFound))
+		Expect(streamer.called).To(BeFalse())
+	})
+
+	It("streams a track inside the share owner's libraries", func() {
+		shareRepo.ID = "share123"
+		shareRepo.Entity = &model.Share{ID: "share123", UserID: "owner1"}
+
+		userRepo := tests.CreateMockUserRepo()
+		Expect(userRepo.Put(&model.User{ID: "owner1", UserName: "owner1", Libraries: model.Libraries{{ID: 1}}})).To(Succeed())
+		ds.MockedUser = userRepo
+
+		mfRepo := tests.CreateMockMediaFileRepo()
+		mfRepo.SetData(model.MediaFiles{{ID: "mf-ok", Title: "OK", LibraryID: 1}})
+		ds.MockedMediaFile = mfRepo
+
+		claims := auth.Claims{ID: "mf-ok", Format: "mp3", ShareID: "share123"}
+		token, _ := auth.CreateExpiringPublicToken(time.Now().Add(time.Hour), claims)
+		makeRequest(token)
+
+		Expect(streamer.called).To(BeTrue())
 	})
 
 	It("returns 400 for an expired token", func() {

--- a/server/public/handle_streams_test.go
+++ b/server/public/handle_streams_test.go
@@ -131,17 +131,24 @@ var _ = Describe("handleStream", func() {
 		return w
 	}
 
-	It("passes all validation and reaches the streamer for a valid token", func() {
+	// shareOwnedBy wires a "share123" share owned by the given user, and a single
+	// media file. It is used by the owner-access tests below.
+	shareOwnedBy := func(owner model.User, mf model.MediaFile) {
 		shareRepo.ID = "share123"
-		shareRepo.Entity = &model.Share{ID: "share123", UserID: "owner1"}
-
+		shareRepo.Entity = &model.Share{ID: "share123", UserID: owner.ID}
 		userRepo := tests.CreateMockUserRepo()
-		Expect(userRepo.Put(&model.User{ID: "owner1", UserName: "owner1", IsAdmin: true})).To(Succeed())
+		Expect(userRepo.Put(&owner)).To(Succeed())
 		ds.MockedUser = userRepo
-
 		mfRepo := tests.CreateMockMediaFileRepo()
-		mfRepo.SetData(model.MediaFiles{{ID: "mf-123", Title: "Test Song"}})
+		mfRepo.SetData(model.MediaFiles{mf})
 		ds.MockedMediaFile = mfRepo
+	}
+
+	It("passes all validation and reaches the streamer for a valid token", func() {
+		shareOwnedBy(
+			model.User{ID: "owner1", UserName: "owner1", IsAdmin: true},
+			model.MediaFile{ID: "mf-123", Title: "Test Song"},
+		)
 
 		claims := auth.Claims{ID: "mf-123", Format: "mp3", BitRate: 192, ShareID: "share123"}
 		token, _ := auth.CreateExpiringPublicToken(time.Now().Add(time.Hour), claims)
@@ -153,16 +160,10 @@ var _ = Describe("handleStream", func() {
 	})
 
 	It("returns 404 when the track is outside the share owner's libraries", func() {
-		shareRepo.ID = "share123"
-		shareRepo.Entity = &model.Share{ID: "share123", UserID: "owner1"}
-
-		userRepo := tests.CreateMockUserRepo()
-		Expect(userRepo.Put(&model.User{ID: "owner1", UserName: "owner1", Libraries: model.Libraries{{ID: 1}}})).To(Succeed())
-		ds.MockedUser = userRepo
-
-		mfRepo := tests.CreateMockMediaFileRepo()
-		mfRepo.SetData(model.MediaFiles{{ID: "mf-restricted", Title: "Other Lib Track", LibraryID: 2}})
-		ds.MockedMediaFile = mfRepo
+		shareOwnedBy(
+			model.User{ID: "owner1", UserName: "owner1", Libraries: model.Libraries{{ID: 1}}},
+			model.MediaFile{ID: "mf-restricted", Title: "Other Lib Track", LibraryID: 2},
+		)
 
 		claims := auth.Claims{ID: "mf-restricted", ShareID: "share123"}
 		token, _ := auth.CreateExpiringPublicToken(time.Now().Add(time.Hour), claims)
@@ -173,16 +174,10 @@ var _ = Describe("handleStream", func() {
 	})
 
 	It("streams a track inside the share owner's libraries", func() {
-		shareRepo.ID = "share123"
-		shareRepo.Entity = &model.Share{ID: "share123", UserID: "owner1"}
-
-		userRepo := tests.CreateMockUserRepo()
-		Expect(userRepo.Put(&model.User{ID: "owner1", UserName: "owner1", Libraries: model.Libraries{{ID: 1}}})).To(Succeed())
-		ds.MockedUser = userRepo
-
-		mfRepo := tests.CreateMockMediaFileRepo()
-		mfRepo.SetData(model.MediaFiles{{ID: "mf-ok", Title: "OK", LibraryID: 1}})
-		ds.MockedMediaFile = mfRepo
+		shareOwnedBy(
+			model.User{ID: "owner1", UserName: "owner1", Libraries: model.Libraries{{ID: 1}}},
+			model.MediaFile{ID: "mf-ok", Title: "OK", LibraryID: 1},
+		)
 
 		claims := auth.Claims{ID: "mf-ok", Format: "mp3", ShareID: "share123"}
 		token, _ := auth.CreateExpiringPublicToken(time.Now().Add(time.Hour), claims)

--- a/server/public/handle_streams_test.go
+++ b/server/public/handle_streams_test.go
@@ -131,8 +131,6 @@ var _ = Describe("handleStream", func() {
 		return w
 	}
 
-	// shareOwnedBy wires a "share123" share owned by the given user, and a single
-	// media file. It is used by the owner-access tests below.
 	shareOwnedBy := func(owner model.User, mf model.MediaFile) {
 		shareRepo.ID = "share123"
 		shareRepo.Entity = &model.Share{ID: "share123", UserID: owner.ID}


### PR DESCRIPTION
### Description

In multi-library setups, a few read paths around playlists and sharing did not consistently apply the per-library access restrictions that the rest of the codebase enforces. As a result, a user with access to only some libraries could end up resolving or being served tracks from libraries they aren't assigned to. This PR makes those three paths respect the user's library access, matching how every other media read already behaves.

The fixes are small and reuse the existing access-control primitives (`applyLibraryFilter` and `User.HasLibraryAccess`):

1. **M3U import path resolution** (`mediafile_repository.go`) — `FindByPaths` is the lookup used when importing an M3U playlist. It was the only `media_file` read that didn't apply the user's library filter, so an imported playlist could resolve paths in libraries the importing user can't access. It now applies `applyLibraryFilter`, exactly like `GetAll`, `CountAll`, etc. The scanner imports playlists under an admin context, so disk-scanned playlists are unaffected (admins bypass the filter).

2. **Shared playlist track loading** (`share_repository.go`) — `loadMedia` loaded a shared playlist's tracks under a synthetic admin context, ignoring the owner's library access. It now loads them as the share owner, so the owner's library access scopes the result. Admin-owned shares are unchanged.

3. **Public share stream handler** (`handle_streams.go`) — a share-scoped stream fetched the media file by id without checking that the track is within the share owner's libraries. It now verifies `owner.HasLibraryAccess(mf.LibraryID)` and returns 404 otherwise. Non-share streams are unaffected.

The remaining commits are a small test-setup tidy-up and a comment trim.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

This is only observable in a multi-library setup with a non-admin user who has access to a subset of libraries.

1. As admin, create two libraries (Lib A and Lib B) and a non-admin user with access to **Lib A only**.
2. **Import path resolution:** as that user, import an M3U playlist that references a track located in Lib B. The Lib B track is not added to the playlist (only paths in accessible libraries resolve).
3. **Shared playlist:** if a playlist owned by that user somehow contains a Lib B track, render/open a share of it — the Lib B track does not appear in the shared track list.
4. **Public stream:** a share-scoped stream URL for a Lib B track returns 404 for that user's shares.
5. As admin (or a user with access to both libraries), all of the above resolve/stream normally — no behavior change.

Automated coverage was added for each path:
- `make test PKG=./persistence` — `FindByPaths` and shared-playlist scoping
- `make test PKG=./server/public` — share stream owner-access gate

### Additional Notes

- No API routes or response contracts change; the Subsonic/OpenSubsonic stream endpoint already applied the user filter and is untouched.
- Behavior change worth noting: a share now reflects the owner's **current** library access. If an owner later loses access to a library, tracks from it stop appearing in their existing shares — this is the intended, consistent behavior.
- Possible follow-ups (not in this PR): the public cover-art handler could apply the same owner check for parity; and `loadMedia`'s other resource types could resolve the owner once above the switch for uniformity.
