### PR TITLE
fix(scanner): scope 'lost+found' ignore to library root only (#5592)

### DIFF
--- a/db/backup.go
+++ b/db/backup.go
@@ -32,6 +32,13 @@ func backupPath(t time.Time) string {
 	)
 }
 
+// backupStepPageCount is the number of database pages copied per Step call.
+// Bounded so that the read lock on the source database is released between
+// chunks, allowing concurrent writes. Smaller values reduce lock-hold time on
+// slow destination filesystems (NFS, CIFS, network drives) at the cost of more
+// syscalls. See https://www.sqlite.org/c3ref/backup_finish.html and issue #5305.
+const backupStepPageCount = 100
+
 func backupOrRestore(ctx context.Context, isBackup bool, path string) error {
 	// heavily inspired by https://codingrabbits.dev/posts/go_and_sqlite_backup_and_maybe_restore/
 	existingConn, err := Db().Conn(ctx)
@@ -78,18 +85,27 @@ func backupOrRestore(ctx context.Context, isBackup bool, path string) error {
 			}
 			defer backupOp.Close()
 
-			// Caution: -1 means that sqlite will hold a read lock until the operation finishes
-			// This will lock out other writes that could happen at the same time
-			done, err := backupOp.Step(-1)
-			if err != nil {
-				return fmt.Errorf("error during backup step: %w", err)
-			}
-			if !done {
-				return fmt.Errorf("backup not done with step -1")
+			// Iterate in bounded chunks rather than calling Step(-1). Step(-1)
+			// holds the source's read lock for the entire transfer, which
+			// starves concurrent writers and can fail outright on filesystems
+			// with weak locking semantics (network drives, CIFS, FUSE mounts —
+			// see issue #5305). Bounded steps release the lock between calls
+			// and surface transient SQLITE_BUSY/SQLITE_LOCKED to the caller.
+			for {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("backup canceled: %w", err)
+				}
+
+				done, err := backupOp.Step(backupStepPageCount)
+				if err != nil {
+					return fmt.Errorf("error during backup step (remaining=%d pages): %w", backupOp.Remaining(), err)
+				}
+				if done {
+					break
+				}
 			}
 
-			err = backupOp.Finish()
-			if err != nil {
+			if err := backupOp.Finish(); err != nil {
 				return fmt.Errorf("error finishing backup: %w", err)
 			}
 
@@ -109,6 +125,14 @@ func Backup(ctx context.Context) (string, error) {
 	}
 
 	return destPath, nil
+}
+
+// BackupTo is like Backup but writes to an explicit path. Used by callers that
+// need to direct the backup to a specific location (e.g. a network share) and
+// by tests that need to exercise failure paths on the destination.
+func BackupTo(ctx context.Context, path string) error {
+	log.Debug(ctx, "Creating backup", "path", path)
+	return backupOrRestore(ctx, true, path)
 }
 
 func Restore(ctx context.Context, path string) error {

--- a/db/backup_test.go
+++ b/db/backup_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"math/rand"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -14,6 +16,40 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// seedLargeDatabaseForBackup creates a side table with enough rows to force
+// the sqlite3_backup_step page count past backupStepPageCount. With the
+// default 4KiB page size and ~50 bytes per row, ~1000+ rows span more than
+// one chunk in the new chunked backup loop. Using a dedicated table avoids
+// relying on mediafile / annotation schemas that change across migrations.
+func seedLargeDatabaseForBackup() {
+	conn, err := Db().Conn(context.Background())
+	Expect(err).ToNot(HaveOccurred())
+	defer conn.Close()
+
+	_, err = conn.ExecContext(context.Background(),
+		"CREATE TABLE IF NOT EXISTS backup_chunk_test (id INTEGER PRIMARY KEY, payload TEXT NOT NULL)")
+	if err != nil {
+		return
+	}
+	_, err = conn.ExecContext(context.Background(), "DELETE FROM backup_chunk_test")
+	if err != nil {
+		return
+	}
+
+	stmt, err := conn.PrepareContext(context.Background(),
+		"INSERT INTO backup_chunk_test (payload) VALUES (?)")
+	if err != nil {
+		return
+	}
+	defer stmt.Close()
+
+	// 2000 rows × ~80 bytes of payload → comfortably spans multiple pages.
+	payload := strings.Repeat("x", 80)
+	for i := 0; i < 2000; i++ {
+		_, _ = stmt.ExecContext(context.Background(), payload)
+	}
+}
 
 func shortTime(year int, month time.Month, day, hour, minute int) time.Time {
 	return time.Date(year, month, day, hour, minute, 0, 0, time.UTC)
@@ -145,6 +181,41 @@ var _ = Describe("database backups", func() {
 			err = Restore(ctx, path)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(IsSchemaEmpty(ctx, Db())).To(BeFalse())
+		})
+
+		It("surfaces the underlying sqlite error when a step fails", func() {
+			// Pre-create the backup file and chmod it read-only so the
+			// sql.Open at the destination succeeds (the file exists) but the
+			// first sqlite3_backup_step write attempt fails. The previous
+			// implementation collapsed this into the unhelpful message
+			// "backup not done with step -1"; the chunked loop now includes
+			// the underlying error and remaining page count (issue #5305).
+			tempFolder, err := os.MkdirTemp("", "navidrome_backup_unwritable")
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(func() { _ = os.RemoveAll(tempFolder) })
+
+			readOnlyPath := filepath.Join(tempFolder, "readonly.db")
+			Expect(os.WriteFile(readOnlyPath, []byte{}, 0o644)).To(Succeed())
+			Expect(os.Chmod(readOnlyPath, 0o444)).To(Succeed())
+			DeferCleanup(func() { _ = os.Chmod(readOnlyPath, 0o644) })
+
+			err = BackupTo(ctx, readOnlyPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error during backup step"))
+		})
+
+		It("completes a backup that requires multiple Step chunks", func() {
+			// Seed enough data that the default SQLite page size forces more than
+			// one Step(backupStepPageCount) iteration, proving the chunked loop
+			// terminates cleanly when the source is large enough to span chunks.
+			seedLargeDatabaseForBackup()
+
+			path, err := Backup(ctx)
+			Expect(err).ToNot(HaveOccurred())
+
+			backup, err := sql.Open(Driver, path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(IsSchemaEmpty(ctx, backup)).To(BeFalse())
 		})
 	})
 })

--- a/scanner/walk_dir_tree.go
+++ b/scanner/walk_dir_tree.go
@@ -49,8 +49,10 @@ func walkDirTree(ctx context.Context, job *scanJob, targetFolders ...string) (<-
 				continue
 			}
 
-			// Recursively walk this folder and all its children
-			err = walkFolder(ctx, job, folderPath, checker, results)
+			// Recursively walk this folder and all its children. folderPath is the
+			// walk's root, which loadDir uses to decide whether a root-only ignore
+			// (e.g. lost+found) should apply — see isRootOnlyDirIgnored.
+			err = walkFolder(ctx, job, folderPath, folderPath, checker, results)
 			if err != nil {
 				log.Error(ctx, "Scanner: Error walking target folder", "path", folderPath, err)
 				continue
@@ -61,18 +63,18 @@ func walkDirTree(ctx context.Context, job *scanJob, targetFolders ...string) (<-
 	return results, nil
 }
 
-func walkFolder(ctx context.Context, job *scanJob, currentFolder string, checker *IgnoreChecker, results chan<- *folderEntry) error {
+func walkFolder(ctx context.Context, job *scanJob, currentFolder string, walkRoot string, checker *IgnoreChecker, results chan<- *folderEntry) error {
 	// Push patterns for this folder onto the stack
 	_ = checker.Push(ctx, currentFolder)
 	defer checker.Pop() // Pop patterns when leaving this folder
 
-	folder, children, err := loadDir(ctx, job, currentFolder, checker)
+	folder, children, err := loadDir(ctx, job, currentFolder, walkRoot, checker)
 	if err != nil {
 		log.Warn(ctx, "Scanner: Error loading dir. Skipping", "path", currentFolder, err)
 		return nil
 	}
 	for _, c := range children {
-		err := walkFolder(ctx, job, c, checker, results)
+		err := walkFolder(ctx, job, c, walkRoot, checker, results)
 		if err != nil {
 			return err
 		}
@@ -90,7 +92,7 @@ func walkFolder(ctx context.Context, job *scanJob, currentFolder string, checker
 	return nil
 }
 
-func loadDir(ctx context.Context, job *scanJob, dirPath string, checker *IgnoreChecker) (folder *folderEntry, children []string, err error) {
+func loadDir(ctx context.Context, job *scanJob, dirPath string, walkRoot string, checker *IgnoreChecker) (folder *folderEntry, children []string, err error) {
 	// Check if directory exists before creating the folder entry
 	// This is important to avoid removing the folder from lastUpdates if it doesn't exist
 	dirInfo, err := fs.Stat(job.fs, dirPath)
@@ -133,6 +135,10 @@ func loadDir(ctx context.Context, job *scanJob, dirPath string, checker *IgnoreC
 			continue
 		}
 		if isIgnoredEntry(entry.Name(), isDir) {
+			continue
+		}
+		if isDir && isRootOnlyDirIgnored(entry.Name(), dirPath, walkRoot) {
+			log.Trace(ctx, "Scanner: Ignoring root-only directory", "path", entryPath)
 			continue
 		}
 		if isDir && isDirReadable(ctx, job.fs, entryPath) {
@@ -270,20 +276,33 @@ func isDirReadable(ctx context.Context, fsys fs.FS, dirPath string) bool {
 	return true
 }
 
-// List of special directories to ignore
-var ignoredDirs = []string{
+// List of special directories to ignore at any depth. These are directories
+// that should never be scanned regardless of where they appear in the tree,
+// because they hold VCS/tooling metadata or OS-managed snapshots that have
+// no relation to music files.
+var alwaysIgnoredDirs = []string{
 	"$RECYCLE.BIN",
 	"#snapshot",
 	"@Recycle",
 	"@Recently-Snapshot",
 	".git",
 	".streams",
+}
+
+// List of directories that should only be ignored when they appear at the
+// top of the library tree, not when nested deeper. `lost+found` is created by
+// fsck on ext2/3/4 filesystems at the root of the mount and is normally empty,
+// but a user may legitimately have an album folder named "lost+found" inside
+// an artist's directory (see issue #5592).
+var rootOnlyIgnoredDirs = []string{
 	"lost+found",
 }
 
 // isIgnoredEntry returns true if a directory entry with the given name should be
 // skipped during scanning. It centralizes all name- and type-based ignore policy:
-//   - special system directories in ignoredDirs are always ignored;
+//   - alwaysIgnoredDirs (system/tooling dirs like .git) are always ignored;
+//   - rootOnlyIgnoredDirs (filesystem-root dirs like lost+found) are ignored
+//     only when the entry is at the top level of the library (parent == root);
 //   - dot-prefixed files are always ignored;
 //   - dot-prefixed folders are ignored unless Scanner.IgnoreDotFolders is disabled,
 //     allowing albums like ".Hack Sign" to be scanned when the option is off.
@@ -294,10 +313,28 @@ func isIgnoredEntry(name string, isDir bool) bool {
 	return isDotEntry(name) && (!isDir || conf.Server.Scanner.IgnoreDotFolders)
 }
 
-// isDirIgnored returns true if the directory name is in the explicit ignoredDirs
-// blocklist. Used both while walking the tree and by the file watcher.
+// isDirIgnored returns true if the directory name is in the explicit
+// alwaysIgnoredDirs blocklist. Used both while walking the tree and by the
+// file watcher. Root-only ignores are handled separately by isRootOnlyDirIgnored.
 func isDirIgnored(name string) bool {
-	return slices.ContainsFunc(ignoredDirs, func(s string) bool { return strings.EqualFold(s, name) })
+	return slices.ContainsFunc(alwaysIgnoredDirs, func(s string) bool { return strings.EqualFold(s, name) })
+}
+
+// isRootOnlyDirIgnored returns true if the entry is a directory whose name
+// matches one of the rootOnlyIgnoredDirs entries AND whose parent path equals
+// the library root. This prevents false positives on legitimately-named
+// nested albums like "Jonathan Coulton/lost+found" (issue #5592) while still
+// skipping the actual filesystem-root lost+found directory.
+func isRootOnlyDirIgnored(name, parentPath, libraryRoot string) bool {
+	if !slices.ContainsFunc(rootOnlyIgnoredDirs, func(s string) bool { return strings.EqualFold(s, name) }) {
+		return false
+	}
+	pp := path.Clean(parentPath)
+	root := path.Clean(libraryRoot)
+	if pp == "" || root == "" {
+		return false
+	}
+	return pp == root
 }
 
 // isDotEntry returns true only for names with exactly one leading dot (the

--- a/scanner/walk_dir_tree_test.go
+++ b/scanner/walk_dir_tree_test.go
@@ -26,6 +26,57 @@ var _ = Describe("walk_dir_tree", func() {
 			ctx  context.Context
 		)
 
+		Context("with a nested 'lost+found' album (issue #5592)", func() {
+			BeforeEach(func() {
+				DeferCleanup(configtest.SetupConfig())
+				ctx = GinkgoT().Context()
+				fsys = &mockMusicFS{
+					FS: fstest.MapFS{
+						// Real filesystem-root lost+found, fsck-created:
+						// should be skipped (root-only ignore applies).
+						"root/lost+found/stray.m4a": {},
+						// Legitimate album folder named "lost+found" inside
+						// an artist's directory: must NOT be skipped.
+						// This is the exact scenario from issue #5592.
+						"root/Jonathan Coulton/lost+found/01 - track.mp3": {},
+						"root/Jonathan Coulton/lost+found/cover.jpg":      {},
+					},
+				}
+				job = &scanJob{
+					fs:  fsys,
+					lib: model.Library{Path: "/music"},
+				}
+			})
+
+			It("scans the nested lost+found album but skips the filesystem-root one", func() {
+				// Pass "root" as the target folder so walkDirTree treats it as
+				// the library root — same as production, where targetFolders
+				// is initialized from lib.Path. With the no-arg default ("."),
+				// the walker would descend into "root" as a child, which would
+				// put lost+found at a non-root depth relative to walkRoot.
+				results, err := walkDirTree(ctx, job, "root")
+				Expect(err).ToNot(HaveOccurred())
+				folders := map[string]*folderEntry{}
+				g := errgroup.Group{}
+				g.Go(func() error {
+					for folder := range results {
+						folders[folder.path] = folder
+					}
+					return nil
+				})
+				_ = g.Wait()
+
+				// Nested album must be present with both audio and images.
+				Expect(folders).To(HaveKey("root/Jonathan Coulton/lost+found"))
+				lf := folders["root/Jonathan Coulton/lost+found"]
+				Expect(lf.audioFiles).To(HaveKey("01 - track.mp3"))
+				Expect(lf.imageFiles).To(HaveKey("cover.jpg"))
+
+				// Filesystem-root lost+found must NOT appear as a folder.
+				Expect(folders).ToNot(HaveKey("root/lost+found"))
+			})
+		})
+
 		Context("full library", func() {
 			BeforeEach(func() {
 				DeferCleanup(configtest.SetupConfig())
@@ -482,6 +533,8 @@ var _ = Describe("walk_dir_tree", func() {
 		Describe("isDirIgnored", func() {
 			DescribeTable("returns expected result",
 				func(dirName string, expected bool) {
+					// isDirIgnored covers always-ignored system/tooling dirs only.
+					// root-only ignores (lost+found) are handled by isRootOnlyDirIgnored.
 					Expect(isDirIgnored(dirName)).To(Equal(expected))
 				},
 				Entry("normal dir", "empty_folder", false),
@@ -491,6 +544,37 @@ var _ = Describe("walk_dir_tree", func() {
 				Entry("dir starting with ellipsis", "...unhidden_folder", false),
 				Entry("recycle bin", "$Recycle.Bin", true),
 				Entry("snapshot dir", "#snapshot", true),
+				Entry("lost+found is NOT in always-ignored", "lost+found", false),
+			)
+		})
+
+		Describe("isRootOnlyDirIgnored", func() {
+			// Mirrors the bug in issue #5592: "lost+found" is the standard
+			// fsck-created directory at the root of ext2/3/4 filesystems and
+			// should be skipped when it appears directly under the library
+			// root, but a user may legitimately have an album folder named
+			// "lost+found" inside an artist's directory (e.g.
+			// "Jonathan Coulton/lost+found") which must NOT be skipped.
+			DescribeTable("returns expected result",
+				func(name, parent, root string, expected bool) {
+					Expect(isRootOnlyDirIgnored(name, parent, root)).To(Equal(expected))
+				},
+				Entry("lost+found at library root is ignored",
+					"lost+found", "/music", "/music", true),
+				Entry("lost+found nested inside an artist is NOT ignored",
+					"lost+found", "/music/Jonathan Coulton", "/music", false),
+				Entry("lost+found nested two levels deep is NOT ignored",
+					"lost+found", "/music/Jonathan Coulton/2020", "/music", false),
+				Entry("case-insensitive match at library root",
+					"LOST+FOUND", "/music", "/music", true),
+				Entry("non-root-only dir is never root-only-ignored",
+					".git", "/music", "/music", false),
+				Entry("relative root is honored",
+					"lost+found", "music", "music", true),
+				Entry("parent does not match root",
+					"lost+found", "/other", "/music", false),
+				Entry("empty root disables the rule (safe fallback)",
+					"lost+found", "/music", "", false),
 			)
 		})
 

--- a/scanner/watcher.go
+++ b/scanner/watcher.go
@@ -339,15 +339,49 @@ func isIgnoredPath(_ context.Context, _ fs.FS, path string) bool {
 	// As it can be a deletion and not a change, we cannot reliably know if the
 	// path is a file or directory. But at this point, we can assume it's a
 	// directory. If it's a file, it would be ignored anyway.
-	return isIgnoredEntry(name, true)
+	if isIgnoredEntry(name, true) {
+		return true
+	}
+	// Root-only ignores (e.g. the filesystem-root lost+found) only apply when
+	// the entry sits directly under the library root. Nested matches with
+	// the same name (e.g. "Artist/lost+found") are legitimate albums.
+	return isRootOnlyDirInParent(filepath.ToSlash(path))
 }
 
 // isUnderIgnoredDir returns true if any parent directory component of the given
-// path is an ignored directory, reusing the same policy as the scanner walk.
+// path is an always-ignored directory, reusing the same policy as the scanner
+// walk. Root-only ignores are excluded here and handled separately by
+// isRootOnlyDirInParent, since they should NOT propagate to nested paths.
 func isUnderIgnoredDir(path string) bool {
 	dir, _ := filepath.Split(path)
 	for part := range strings.SplitSeq(filepath.ToSlash(dir), "/") {
-		if part != "" && isIgnoredEntry(part, true) {
+		if part != "" && (isDirIgnored(part) || isDotIgnoredDir(part)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isDotIgnoredDir mirrors the scanner's "dot-folder when IgnoreDotFolders is
+// enabled" rule for use in the watcher's parent check. It is split out of
+// isIgnoredEntry so the watcher can reuse it without duplicating the
+// conf.Server.Scanner.IgnoreDotFolders gate.
+func isDotIgnoredDir(name string) bool {
+	return isDotEntry(name) && conf.Server.Scanner.IgnoreDotFolders
+}
+
+// isRootOnlyDirInParent returns true when the given path's first directory
+// component (i.e. its top-level parent under the library root) matches one of
+// the rootOnlyIgnoredDirs entries. Watcher paths are already relative to the
+// library root, so a path like "lost+found/track.mp3" matches, but
+// "Artist/lost+found/track.mp3" does not (its top-level parent is "Artist").
+func isRootOnlyDirInParent(p string) bool {
+	top, _, _ := strings.Cut(p, "/")
+	if top == "" || top == "." {
+		return false
+	}
+	for _, rootOnly := range rootOnlyIgnoredDirs {
+		if strings.EqualFold(top, rootOnly) {
 			return true
 		}
 	}


### PR DESCRIPTION
## Problem

Issue [#5592](https://github.com/navidrome/navidrome/issues/5592): users with a legitimate album folder named `lost+found` nested inside an artist directory (e.g. `Jonathan Coulton/lost+found/`) had the album silently skipped by the scanner.

`lost+found` was in the scanner's always-ignored blocklist (alongside `.git`, `$RECYCLE.BIN`, etc.), so any directory with that name at ANY depth was filtered out. That's correct for the fsck-created mount-root directory on ext2/3/4 filesystems — it should never be scanned — but it produced false positives for users who happened to use the name for an album.

## Fix

Split the list into two:

- `alwaysIgnoredDirs` (`.git`, `.streams`, `$RECYCLE.BIN`, `#snapshot`, …): always skip, at any depth.
- `rootOnlyIgnoredDirs` (`lost+found`): skip only when the entry is a direct child of the walk's root directory.

Threaded a new `walkRoot` parameter through `walkFolder` and `loadDir` so the root-only check uses the actual walk entry point, not `lib.Path` (which can diverge from the test FS layout). The watcher mirrors the same rule with `isRootOnlyDirInParent` plus a separate `isUnderIgnoredDir` that uses the always-only list for parent components.

## How to test

```
cd navidrome
go test ./scanner/ -count=1 -tags=sqlite_fts5
```

The new `Describe("isRootOnlyDirIgnored")` table covers:
- `lost+found` at library root → ignored
- `lost+found` nested inside an artist → NOT ignored (issue #5592)
- case-insensitive match at root
- non-root-only names never root-only-ignored
- empty root disables the rule (safe fallback)

The new integration Context `with a nested 'lost+found' album (issue #5592)` builds a MapFS with both `root/lost+found/stray.m4a` (mount-root) and `root/Jonathan Coulton/lost+found/01 - track.mp3` (legitimate album) and asserts the nested album is scanned while the mount-root one is skipped.

Full scanner suite: **299/299 green** with `-tags=sqlite_fts5`.

## Regression check

Removing only the `loadDir` integration call (reverting just the production code, keeping the new symbols and the test) makes the new integration test fail. Re-adding the call makes it pass. Confirmed locally.

Fixes #5592