### PR TITLE
perf(artwork): faster image resize + update gen2brain/webp to v0.6.0

### DIFF
--- a/core/artwork/reader_resized.go
+++ b/core/artwork/reader_resized.go
@@ -153,7 +153,6 @@ func resizeStaticImage(data []byte, size int, square bool) (io.Reader, int, erro
 	if err != nil {
 		return nil, 0, err
 	}
-	original = toFastScaleType(original)
 
 	bounds := original.Bounds()
 	originalSize := max(bounds.Max.X, bounds.Max.Y)
@@ -186,6 +185,7 @@ func resizeStaticImage(data []byte, size int, square bool) (io.Reader, int, erro
 		dst = image.NewNRGBA(image.Rect(0, 0, dstW, dstH))
 		dstRect = dst.Bounds()
 	}
+	original = toFastScaleType(original)
 	xdraw.CatmullRom.Scale(dst, dstRect, original, bounds, draw.Src, nil)
 
 	buf := bufPool.Get().(*bytes.Buffer)

--- a/core/artwork/reader_resized.go
+++ b/core/artwork/reader_resized.go
@@ -132,11 +132,28 @@ func (a *resizedArtworkReader) resizeImage(ctx context.Context, reader io.Reader
 	return resizeStaticImage(data, a.size, a.square)
 }
 
+// toFastScaleType converts images whose concrete type has no optimized scaler
+// in x/image/draw (e.g. *image.NYCbCrA from WebP, *image.Paletted from indexed
+// PNGs) into *image.RGBA, which has a fast path. Without this, CatmullRom.Scale
+// falls back to a generic per-pixel At()/RGBA() loop that is several times
+// slower. Fast-path types are returned unchanged.
+func toFastScaleType(img image.Image) image.Image {
+	switch img.(type) {
+	case *image.RGBA, *image.NRGBA, *image.Gray, *image.YCbCr:
+		return img
+	default:
+		rgba := image.NewRGBA(img.Bounds())
+		draw.Draw(rgba, rgba.Bounds(), img, img.Bounds().Min, draw.Src)
+		return rgba
+	}
+}
+
 func resizeStaticImage(data []byte, size int, square bool) (io.Reader, int, error) {
 	original, format, err := image.Decode(bytes.NewReader(data))
 	if err != nil {
 		return nil, 0, err
 	}
+	original = toFastScaleType(original)
 
 	bounds := original.Bounds()
 	originalSize := max(bounds.Max.X, bounds.Max.Y)

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/extism/go-sdk v1.7.1
 	github.com/fatih/structs v1.1.0
-	github.com/gen2brain/webp v0.5.5
+	github.com/gen2brain/webp v0.6.0
 	github.com/go-chi/chi/v5 v5.3.0
 	github.com/go-chi/cors v1.2.2
 	github.com/go-chi/httprate v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7z
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
 github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
-github.com/gen2brain/webp v0.5.5 h1:MvQR75yIPU/9nSqYT5h13k4URaJK3gf9tgz/ksRbyEg=
-github.com/gen2brain/webp v0.5.5/go.mod h1:xOSMzp4aROt2KFW++9qcK/RBTOVC2S9tJG66ip/9Oc0=
+github.com/gen2brain/webp v0.6.0 h1:VN/cmeDv78sAKbJayyB1YVm9SHlz5qXO06bo4v6V3hY=
+github.com/gen2brain/webp v0.6.0/go.mod h1:iGWMaCSw7t3I/Cv9llzEKmpnR36S8lS8VL/ZVjxU0JE=
 github.com/gkampitakis/ciinfo v0.3.2 h1:JcuOPk8ZU7nZQjdUhctuhQofk7BGHuIy0c9Ez8BNhXs=
 github.com/gkampitakis/ciinfo v0.3.2/go.mod h1:1NIwaOcFChN4fa/B0hEBdAb6npDlFL8Bwx4dfRLRqAo=
 github.com/gkampitakis/go-diff v1.3.2 h1:Qyn0J9XJSDTgnsgHRdz9Zp24RaJeKMUHg2+PDZZdC4M=


### PR DESCRIPTION
### Description

Two related changes to the artwork resize path:

1. **`chore(deps)`: update `gen2brain/webp` to v0.6.0.** v0.6.0 replaces the
   `wazero` WASM runtime with a self-contained `wasm2go`-transpiled WebP
   decoder/encoder. This drops the `webp → wazero` dependency edge (wazero is
   still used by the plugin system) and makes the WASM path (used on 32-bit
   builds and any `nodynamic` build where native libwebp isn't available)
   noticeably faster and far lighter on allocations.

2. **`fix(artwork)`: convert decoded images to a fast-path type before resizing.**
   `x/image/draw`'s CatmullRom scaler only has optimized code paths for
   `*image.RGBA`, `*image.NRGBA`, `*image.Gray` and `*image.YCbCr`. Other
   concrete types — notably `*image.NYCbCrA` (WebP) and `*image.Paletted`
   (indexed PNGs) — fall back to a generic per-pixel `At()/RGBA()` loop that is
   several times slower. We now convert such images to `*image.RGBA` once before
   scaling; fast-path types are returned unchanged.

**Why both together:** the v0.6.0 bump changes the package init order, which
flips the winner of the duplicate `image.RegisterFormat("webp")` registration
(`golang.org/x/image/webp` → `gen2brain/webp`). gen2brain decodes WebP to
`*image.NYCbCrA`, which has no fast scaler — so without change (2), the codec
upgrade would actually **regress** end-to-end WebP cover-art resizing by ~55%.
The fix removes that slow path (and the fragility of relying on decoder
registration order) and also benefits indexed-palette PNGs.

### Benchmarks

Apple M4 Max, darwin/arm64, Go 1.26. WASM path forced via `-tags nodynamic`
so the runtime swap is actually exercised; `benchstat`, n=10. Fixture: a
1250×1120 lossy WebP cover (+ JPEG/PNG conversions). End-to-end numbers are at
a 300px target.

**The codec itself (wasm2go vs wazero), isolated:**

| Operation | v0.5.5 (wazero) | v0.6.0 (wasm2go) | Δ |
|---|---|---|---|
| WebP decode | 14.4 ms | 10.9 ms | **−24%** |
| WebP encode | 51.0 ms | 35.0 ms | **−31%** |
| WebP encode — allocs | 900 | 231 | **−74%** |
| WebP encode — bytes | 24.5 MiB | 11.4 MiB | **−54%** |

**End-to-end artwork resize (decode → CatmullRom → encode):**

| Source | v0.5.5 (before) | v0.6.0 w/o the fix | v0.6.0 **with the fix** |
|---|---|---|---|
| WebP cover | 32.5 ms | 51.8 ms (+59%) | **32.0 ms** |
| Paletted PNG | 115.3 ms | 118.4 ms | **87.5 ms (−26%)** |
| RGB PNG (`*image.RGBA`) | — | — | unchanged (no overhead) |
| JPEG (`*image.YCbCr`) | — | — | unchanged (no overhead) |

(Paletted-PNG timing is independent of the webp version — PNG is decoded by the
standard library — which is exactly why the v0.5.5 and v0.6.0 "no fix" columns
match; the win comes entirely from the scaler fast path.)

Net result: the upgrade keeps its codec wins (faster encode/decode, ~70% fewer
allocations) while the fix lands WebP resizing back at the v0.5.5 baseline and
makes indexed PNGs ~26% faster. Already-fast source types (`RGBA`/`NRGBA`/
`Gray`/`YCbCr`) are byte-for-byte unchanged — the conversion is only paid when
an actual resize is needed and the source type needs it.

**No-op (no-upscale) path:** following review, the fast-path conversion is
deferred until an actual resize is needed, so a request for a size ≥ the source
no longer allocates a throwaway RGBA copy. For large indexed/WebP covers this
drops the no-op path by ~27–40% in time and up to ~79% in memory; the resize
path above is unchanged.

### Related Issues

<!-- none -->

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Dependency update (`gen2brain/webp` v0.6.0)

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

> No new unit test was added for the conversion helper (maintainer decision): the
> behavior is exercised by the existing `resizeImage` tests and was validated
> with the benchmarks above. The change is a pure performance optimization that
> preserves output pixels.

### How to Test

1. Add an album/artist with **WebP** cover art and another with an **indexed
   (palette) PNG** cover.
2. Browse the library and open detail views so thumbnails are requested at
   several sizes (e.g. `/share`, grid, and player).
3. Verify thumbnails render correctly (no color shifts, no artifacts) for WebP,
   PNG (both RGB and paletted), JPEG and GIF sources.
4. Optionally confirm both build variants work: a normal build (native
   libwebp / purego where available) and a `nodynamic` build (WASM-only),
   which is what 32-bit release images use.

### Additional Notes

- No API or output-format changes; this only affects how source pixels are fed
  to the resizer.
- The fix also hardens the resize path against future dependency bumps that
  could again flip which decoder wins the `image.Decode("webp")` registration.

