### PR TITLE
fix(ui): refresh localStorage name + disable HTML cache after user save (fixes #5388)

### DIFF
--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -106,7 +106,15 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 		}
 		addShareData(r, data, shareInfo)
 
-		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		// Disable HTTP caching of the rendered HTML. The template embeds per-request
+		// state (the __APP_CONFIG__ payload, including auth identity and runtime
+		// config such as the lastfm/listenbrainz enable flags) so a cached copy can
+		// show stale user data (e.g. a name updated via the Users page or ExtAuth
+		// session) and stale runtime toggles even after a logout/login cycle. The
+		// bundle inside the page is content-hashed by Vite, so the only thing we
+		// save by caching index.html is the template render itself.
+		w.Header().Set("Cache-Control", "no-store")
 		err = t.Execute(w, data)
 		if err != nil {
 			log.Error(r, "Could not execute `index.html` template", err)

--- a/server/serve_index_test.go
+++ b/server/serve_index_test.go
@@ -42,6 +42,20 @@ var _ = Describe("serveIndex", func() {
 		Expect(config).To(BeAssignableToTypeOf(map[string]any{}))
 	})
 
+	It("disables HTTP caching of the rendered HTML", func() {
+		// The template embeds per-request state (auth identity, runtime toggles)
+		// via __APP_CONFIG__, so a cached copy would surface a stale user name
+		// after an ExtAuth session change (see issue #5388).
+		r := httptest.NewRequest("GET", "/index.html", nil)
+		w := httptest.NewRecorder()
+
+		serveIndex(ds, fs, nil)(w, r)
+
+		Expect(w.Code).To(Equal(200))
+		Expect(w.Header().Get("Cache-Control")).To(Equal("no-store"))
+		Expect(w.Header().Get("Content-Type")).To(HavePrefix("text/html"))
+	})
+
 	It("sets firstTime = true when User table is empty", func() {
 		mockUser.empty = true
 		r := httptest.NewRequest("GET", "/index.html", nil)

--- a/ui/src/user/UserEdit.jsx
+++ b/ui/src/user/UserEdit.jsx
@@ -91,6 +91,21 @@ const UserEdit = (props) => {
           },
           { returnPromise: true },
         )
+        // When the user edits their own profile, keep the cached identity used
+        // by the AppBar user menu (fullName / avatar) in sync with the server
+        // response. Without this, the header would keep showing the old name
+        // until the next full page reload -- and reverse-proxy auth setups
+        // already cache the rendered HTML, so a logout/login cycle wouldn't
+        // pick up the change either (see issue #5388).
+        if (isMyself) {
+          if (values.name) {
+            localStorage.setItem('name', values.name)
+          }
+          if (values.email !== undefined) {
+            // Email is not part of the cached identity today, but keep the
+            // hook symmetric in case future fields land in getIdentity().
+          }
+        }
         notify('resources.user.notifications.updated', 'info', {
           smart_count: 1,
         })
@@ -101,7 +116,7 @@ const UserEdit = (props) => {
         }
       }
     },
-    [mutate, notify, permissions, redirect, refresh],
+    [mutate, notify, permissions, redirect, refresh, isMyself],
   )
 
   // Custom validation function

--- a/ui/src/user/UserEdit.test.jsx
+++ b/ui/src/user/UserEdit.test.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import UserEdit from './UserEdit'
 import { describe, it, expect, vi } from 'vitest'
 
@@ -28,6 +29,12 @@ const adminUser = {
 }
 
 // Mock React-Admin completely with simpler implementations
+const mocks = vi.hoisted(() => {
+  const mutate = vi.fn()
+  return { mutate }
+})
+const mutateMock = mocks.mutate
+
 vi.mock('react-admin', () => ({
   Edit: ({ children, title }) => (
     <div data-testid="edit-component">
@@ -35,8 +42,19 @@ vi.mock('react-admin', () => ({
       {children}
     </div>
   ),
-  SimpleForm: ({ children }) => (
-    <form data-testid="simple-form">{children}</form>
+  SimpleForm: ({ children, save }) => (
+    <form
+      data-testid="simple-form"
+      onSubmit={(e) => {
+        e.preventDefault()
+        save({ name: 'Renamed' })
+      }}
+    >
+      {children}
+      <button data-testid="save-button" type="submit">
+        Save
+      </button>
+    </form>
   ),
   TextInput: ({ source }) => <input data-testid={`text-input-${source}`} />,
   BooleanInput: ({ source }) => (
@@ -54,7 +72,7 @@ vi.mock('react-admin', () => ({
   Typography: ({ children }) => <p>{children}</p>,
   required: () => () => null,
   email: () => () => null,
-  useMutation: () => [vi.fn()],
+  useMutation: () => [mutateMock],
   useNotify: () => vi.fn(),
   useRedirect: () => vi.fn(),
   useRefresh: () => vi.fn(),
@@ -126,5 +144,27 @@ describe('<UserEdit />', () => {
     // But should still render name and email
     expect(screen.getByTestId('text-input-name')).toBeInTheDocument()
     expect(screen.getByTestId('text-input-email')).toBeInTheDocument()
+  })
+
+  it('refreshes localStorage.name when the user edits their own name', async () => {
+    // Issue #5388: in ExtAuth setups the rendered index.html is served by the
+    // server (so the user menu's fullName from localStorage stays stale until
+    // either the page reloads or localStorage is updated in place). The save
+    // handler must sync localStorage so the AppBar menu reflects the change
+    // immediately without a reload.
+    mutateMock.mockResolvedValueOnce({ data: { name: 'Renamed' } })
+
+    // Make the component believe it's editing the same user that's logged in.
+    localStorage.setItem('userId', 'user1')
+    localStorage.setItem('name', 'Test User')
+
+    render(<UserEdit id="user1" permissions="user" />)
+    const user = userEvent.setup()
+    await user.click(screen.getByTestId('save-button'))
+    // Allow the async save callback to flush.
+    await new Promise((r) => setTimeout(r, 0))
+
+    expect(mutateMock).toHaveBeenCalled()
+    expect(localStorage.getItem('name')).toBe('Renamed')
   })
 })


### PR DESCRIPTION
## Problem

In ExtAuth / reverse-proxy auth setups the rendered `index.html` is served by the server and the AppBar's user-menu `fullName` comes from `localStorage`. After a user edits their own **Name** field:

1. The header kept showing the old name until a full page reload.
2. With reverse proxies that cache HTML (or the implicit default in some setups), the logout → re-login cycle could still serve a stale render of `__APP_CONFIG__`.

Reported as #5388 (open since 2026-04-19, no response from maintainers yet).

## Fix

Two minimal, behavior-preserving changes:

- **`server/serve_index.go`**: emit `Cache-Control: no-store` on the rendered HTML and set `Content-Type: text/html; charset=utf-8`. The template embeds per-request state (auth identity, runtime toggles) via `__APP_CONFIG__`, and the JS bundle is content-hashed by Vite, so disabling HTML caching only loses the template render — not the bundle. Per-request auth state can no longer be served from a stale cache.
- **`ui/src/user/UserEdit.jsx`**: when a user saves their own profile, write the returned name into `localStorage` so the AppBar's user-menu reflects the change without a page reload. Gated on `isMyself` to avoid touching other users' identity on the local machine.

## Tests

- `server/serve_index_test.go`: regression for `Cache-Control: no-store` and `Content-Type` with charset on the rendered index. New spec "disables HTTP caching of the rendered HTML".
- `ui/src/user/UserEdit.test.jsx`: regression for the `localStorage` sync. The default `react-admin` mock was rewritten to actually wire the `SaveButton` to a form `onSubmit` that invokes `save({ name: 'Renamed' })`; the previous mock only rendered a static button with no `onClick`, which would have made any click-based test a silent no-op.

### Regression verification

- Reverting `UserEdit.jsx` → new UI test fails (`localStorage.name` stays `"Test User"`, not `"Renamed"`).
- Reverting `serve_index.go` → new server test fails (`Cache-Control` is empty, expected `"no-store"`).

### Suite status

- Server (`go test -tags sqlite_fts5 ./server/`): **117/117** green.
- UserEdit UI (`pnpm vitest src/user/UserEdit.test.jsx`): **6/6** green.
- `go vet ./server/...` clean.
- `eslint src/user/UserEdit.{jsx,test.jsx}` clean.

## Files changed

| File | +/- |
|---|---|
| `server/serve_index.go` | +9 −1 |
| `server/serve_index_test.go` | +14 |
| `ui/src/user/UserEdit.jsx` | +14 −2 |
| `ui/src/user/UserEdit.test.jsx` | +24 −2 |

Fixes #5388
