### PR TITLE
feat(subsonic): add OpenSubsonic work and movement attributes

### DIFF
--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -17,6 +17,7 @@ import (
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/gg"
+	"github.com/navidrome/navidrome/utils/number"
 	"github.com/navidrome/navidrome/utils/slice"
 )
 
@@ -149,6 +150,55 @@ func (mf MediaFile) StructuredLyrics() (LyricList, error) {
 // String is mainly used for debugging
 func (mf MediaFile) String() string {
 	return mf.Path
+}
+
+type Work struct {
+	Name      string
+	MbzWorkID string
+}
+
+type Movement struct {
+	Name   string
+	Number int32
+	Count  int32
+}
+
+func (mf MediaFile) Works() []Work {
+	names := mf.Tags.Values(TagWork)
+	if len(names) == 0 {
+		return nil
+	}
+	ids := mf.Tags.Values(TagMusicBrainzWorkID)
+	works := make([]Work, 0, len(names))
+	for i, name := range names {
+		w := Work{Name: name}
+		if i < len(ids) {
+			w.MbzWorkID = ids[i]
+		}
+		works = append(works, w)
+	}
+	return works
+}
+
+func (mf MediaFile) Movements() []Movement {
+	names := mf.Tags.Values(TagMovementName)
+	if len(names) == 0 {
+		return nil
+	}
+	numbers := mf.Tags.Values(TagMovementNumber)
+	counts := mf.Tags.Values(TagMovementTotal)
+	movements := make([]Movement, 0, len(names))
+	for i, name := range names {
+		m := Movement{Name: name}
+		if i < len(numbers) {
+			m.Number = number.ParseInt[int32](numbers[i])
+		}
+		if i < len(counts) {
+			m.Count = number.ParseInt[int32](counts[i])
+		}
+		movements = append(movements, m)
+	}
+	return movements
 }
 
 // Hash returns a hash of the MediaFile based on its tags and audio properties

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -604,6 +604,69 @@ var _ = Describe("MediaFile", func() {
 
 })
 
+var _ = Describe("MediaFile.Works", func() {
+	It("returns nil when there are no work tags", func() {
+		mf := MediaFile{}
+		Expect(mf.Works()).To(BeNil())
+	})
+
+	It("pairs a work name with its MbzWorkID", func() {
+		mf := MediaFile{Tags: Tags{
+			TagWork:              {"Symphony No. 5"},
+			TagMusicBrainzWorkID: {"abc-123"},
+		}}
+		Expect(mf.Works()).To(Equal([]Work{
+			{Name: "Symphony No. 5", MbzWorkID: "abc-123"},
+		}))
+	})
+
+	It("leaves MbzWorkID empty when no id is present", func() {
+		mf := MediaFile{Tags: Tags{TagWork: {"Symphony No. 5"}}}
+		Expect(mf.Works()).To(Equal([]Work{
+			{Name: "Symphony No. 5"},
+		}))
+	})
+
+	It("pairs by index and ignores extra ids", func() {
+		mf := MediaFile{Tags: Tags{
+			TagWork:              {"Work A", "Work B"},
+			TagMusicBrainzWorkID: {"id-a"},
+		}}
+		Expect(mf.Works()).To(Equal([]Work{
+			{Name: "Work A", MbzWorkID: "id-a"},
+			{Name: "Work B"},
+		}))
+	})
+})
+
+var _ = Describe("MediaFile.Movements", func() {
+	It("returns nil when there are no movement tags", func() {
+		mf := MediaFile{}
+		Expect(mf.Movements()).To(BeNil())
+	})
+
+	It("builds a movement with name, number and count", func() {
+		mf := MediaFile{Tags: Tags{
+			TagMovementName:   {"I. Allegro"},
+			TagMovementNumber: {"1"},
+			TagMovementTotal:  {"4"},
+		}}
+		Expect(mf.Movements()).To(Equal([]Movement{
+			{Name: "I. Allegro", Number: 1, Count: 4},
+		}))
+	})
+
+	It("non-numeric number/count yields 0", func() {
+		mf := MediaFile{Tags: Tags{
+			TagMovementName:   {"I. Allegro"},
+			TagMovementNumber: {"not-a-number"},
+		}}
+		Expect(mf.Movements()).To(Equal([]Movement{
+			{Name: "I. Allegro"},
+		}))
+	})
+})
+
 var _ = Describe("MediaFile.Hash", func() {
 	// Guards the upgrade guarantee: converting BPM/BitDepth from int to *int must not change hashes,
 	// or every file would be spuriously re-imported on the next scan.

--- a/model/tag.go
+++ b/model/tag.go
@@ -192,6 +192,10 @@ const (
 	TagISRC           TagName = "isrc"
 	TagBPM            TagName = "bpm"
 	TagExplicitStatus TagName = "explicitstatus"
+	TagWork           TagName = "work"
+	TagMovementName   TagName = "movementname"
+	TagMovementNumber TagName = "movement"
+	TagMovementTotal  TagName = "movementtotal"
 
 	// Dates and years
 
@@ -240,6 +244,7 @@ const (
 	TagMusicBrainzAlbumArtistID  TagName = "musicbrainz_albumartistid"
 	TagMusicBrainzAlbumID        TagName = "musicbrainz_albumid"
 	TagMusicBrainzReleaseGroupID TagName = "musicbrainz_releasegroupid"
+	TagMusicBrainzWorkID         TagName = "musicbrainz_workid"
 
 	TagMusicBrainzComposerID  TagName = "musicbrainz_composerid"
 	TagMusicBrainzLyricistID  TagName = "musicbrainz_lyricistid"

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -290,8 +290,12 @@ func osChildFromMediaFile(ctx context.Context, mf model.MediaFile) *responses.Op
 	}
 	child.Contributors = contributors
 	child.ExplicitStatus = mapExplicitStatus(mf.ExplicitStatus)
-	child.Works = buildWorks(mf.Tags)
-	child.Movements = buildMovements(mf.Tags)
+	child.Works = slice.Map(mf.Works(), func(w model.Work) responses.Work {
+		return responses.Work{Name: w.Name, MusicBrainzId: w.MbzWorkID}
+	})
+	child.Movements = slice.Map(mf.Movements(), func(m model.Movement) responses.Movement {
+		return responses.Movement{Name: m.Name, Number: m.Number, Count: m.Count}
+	})
 	return &child
 }
 
@@ -302,44 +306,6 @@ func artistRefs(participants model.ParticipantList) []responses.ArtistID3Ref {
 			Name: p.Name,
 		}
 	})
-}
-
-func buildWorks(tags model.Tags) []responses.Work {
-	names := tags.Values(model.TagWork)
-	if len(names) == 0 {
-		return nil
-	}
-	ids := tags.Values(model.TagMusicBrainzWorkID)
-	works := make([]responses.Work, 0, len(names))
-	for i, name := range names {
-		w := responses.Work{Name: name}
-		if i < len(ids) {
-			w.MusicBrainzId = ids[i]
-		}
-		works = append(works, w)
-	}
-	return works
-}
-
-func buildMovements(tags model.Tags) []responses.Movement {
-	names := tags.Values(model.TagMovementName)
-	if len(names) == 0 {
-		return nil
-	}
-	numbers := tags.Values(model.TagMovementNumber)
-	counts := tags.Values(model.TagMovementTotal)
-	movements := make([]responses.Movement, 0, len(names))
-	for i, name := range names {
-		m := responses.Movement{Name: name}
-		if i < len(numbers) {
-			m.Number = number.ParseInt[int32](numbers[i])
-		}
-		if i < len(counts) {
-			m.Count = number.ParseInt[int32](counts[i])
-		}
-		movements = append(movements, m)
-	}
-	return movements
 }
 
 func fakePath(mf model.MediaFile) string {

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"slices"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -290,6 +291,8 @@ func osChildFromMediaFile(ctx context.Context, mf model.MediaFile) *responses.Op
 	}
 	child.Contributors = contributors
 	child.ExplicitStatus = mapExplicitStatus(mf.ExplicitStatus)
+	child.Works = buildWorks(mf.Tags)
+	child.Movements = buildMovements(mf.Tags)
 	return &child
 }
 
@@ -300,6 +303,48 @@ func artistRefs(participants model.ParticipantList) []responses.ArtistID3Ref {
 			Name: p.Name,
 		}
 	})
+}
+
+func buildWorks(tags model.Tags) []responses.Work {
+	names := tags.Values(model.TagWork)
+	if len(names) == 0 {
+		return nil
+	}
+	ids := tags.Values(model.TagMusicBrainzWorkID)
+	works := make([]responses.Work, 0, len(names))
+	for i, name := range names {
+		w := responses.Work{Name: name}
+		if i < len(ids) {
+			w.MusicBrainzId = ids[i]
+		}
+		works = append(works, w)
+	}
+	return works
+}
+
+func buildMovements(tags model.Tags) []responses.Movement {
+	names := tags.Values(model.TagMovementName)
+	if len(names) == 0 {
+		return nil
+	}
+	numbers := tags.Values(model.TagMovementNumber)
+	counts := tags.Values(model.TagMovementTotal)
+	movements := make([]responses.Movement, 0, len(names))
+	for i, name := range names {
+		m := responses.Movement{Name: name}
+		if i < len(numbers) {
+			if n, err := strconv.Atoi(numbers[i]); err == nil {
+				m.Number = int32(n)
+			}
+		}
+		if i < len(counts) {
+			if c, err := strconv.Atoi(counts[i]); err == nil {
+				m.Count = int32(c)
+			}
+		}
+		movements = append(movements, m)
+	}
+	return movements
 }
 
 func fakePath(mf model.MediaFile) string {

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"slices"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -333,14 +332,10 @@ func buildMovements(tags model.Tags) []responses.Movement {
 	for i, name := range names {
 		m := responses.Movement{Name: name}
 		if i < len(numbers) {
-			if n, err := strconv.ParseInt(numbers[i], 10, 32); err == nil {
-				m.Number = int32(n)
-			}
+			m.Number = number.ParseInt[int32](numbers[i])
 		}
 		if i < len(counts) {
-			if c, err := strconv.ParseInt(counts[i], 10, 32); err == nil {
-				m.Count = int32(c)
-			}
+			m.Count = number.ParseInt[int32](counts[i])
 		}
 		movements = append(movements, m)
 	}

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -333,12 +333,12 @@ func buildMovements(tags model.Tags) []responses.Movement {
 	for i, name := range names {
 		m := responses.Movement{Name: name}
 		if i < len(numbers) {
-			if n, err := strconv.Atoi(numbers[i]); err == nil {
+			if n, err := strconv.ParseInt(numbers[i], 10, 32); err == nil {
 				m.Number = int32(n)
 			}
 		}
 		if i < len(counts) {
-			if c, err := strconv.Atoi(counts[i]); err == nil {
+			if c, err := strconv.ParseInt(counts[i], 10, 32); err == nil {
 				m.Count = int32(c)
 			}
 		}

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -2,6 +2,7 @@ package subsonic
 
 import (
 	"context"
+	"encoding/json"
 	"net/http/httptest"
 	"time"
 
@@ -382,6 +383,19 @@ var _ = Describe("helpers", func() {
 				Expect(osChild).ToNot(BeNil())
 				Expect(osChild.Works).To(BeNil())
 				Expect(osChild.Movements).To(BeNil())
+			})
+
+			It("serializes works and movements to spec-compliant JSON", func() {
+				mf.Tags = model.Tags{
+					model.TagWork:           {"Symphony No. 5"},
+					model.TagMovementName:   {"I. Allegro"},
+					model.TagMovementNumber: {"1"},
+				}
+				osChild := osChildFromMediaFile(ctx, mf)
+				data, err := json.Marshal(osChild)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(string(data)).To(ContainSubstring(`"works":[{"name":"Symphony No. 5"}]`))
+				Expect(string(data)).To(ContainSubstring(`"movements":[{"name":"I. Allegro","number":1}]`))
 			})
 		})
 

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -358,6 +358,31 @@ var _ = Describe("helpers", func() {
 				Expect(osChild).ToNot(BeNil())
 				Expect(osChild.Comment).To(Equal("Test Comment"))
 			})
+
+			It("populates works and movements from tags", func() {
+				mf.Tags = model.Tags{
+					model.TagWork:              {"Symphony No. 5"},
+					model.TagMusicBrainzWorkID: {"abc-123"},
+					model.TagMovementName:      {"I. Allegro"},
+					model.TagMovementNumber:    {"1"},
+					model.TagMovementTotal:     {"4"},
+				}
+				osChild := osChildFromMediaFile(ctx, mf)
+				Expect(osChild).ToNot(BeNil())
+				Expect(osChild.Works).To(Equal(responses.Array[responses.Work]{
+					{Name: "Symphony No. 5", MusicBrainzId: "abc-123"},
+				}))
+				Expect(osChild.Movements).To(Equal(responses.Array[responses.Movement]{
+					{Name: "I. Allegro", Number: 1, Count: 4},
+				}))
+			})
+
+			It("omits works and movements when no classical tags are present", func() {
+				osChild := osChildFromMediaFile(ctx, mf)
+				Expect(osChild).ToNot(BeNil())
+				Expect(osChild.Works).To(BeNil())
+				Expect(osChild.Movements).To(BeNil())
+			})
 		})
 
 		Context("when legacy clients list is empty", func() {
@@ -378,6 +403,67 @@ var _ = Describe("helpers", func() {
 				osChild := osChildFromMediaFile(ctx, mf)
 				Expect(osChild).ToNot(BeNil())
 			})
+		})
+	})
+
+	Describe("buildWorks", func() {
+		It("returns nil when there are no work tags", func() {
+			Expect(buildWorks(model.Tags{})).To(BeNil())
+		})
+
+		It("pairs a work name with its MusicBrainz id", func() {
+			tags := model.Tags{
+				model.TagWork:              {"Symphony No. 5"},
+				model.TagMusicBrainzWorkID: {"abc-123"},
+			}
+			Expect(buildWorks(tags)).To(Equal([]responses.Work{
+				{Name: "Symphony No. 5", MusicBrainzId: "abc-123"},
+			}))
+		})
+
+		It("leaves MusicBrainzId empty when no id is present", func() {
+			tags := model.Tags{model.TagWork: {"Symphony No. 5"}}
+			Expect(buildWorks(tags)).To(Equal([]responses.Work{
+				{Name: "Symphony No. 5"},
+			}))
+		})
+
+		It("pairs by index and ignores extra ids", func() {
+			tags := model.Tags{
+				model.TagWork:              {"Work A", "Work B"},
+				model.TagMusicBrainzWorkID: {"id-a"},
+			}
+			Expect(buildWorks(tags)).To(Equal([]responses.Work{
+				{Name: "Work A", MusicBrainzId: "id-a"},
+				{Name: "Work B"},
+			}))
+		})
+	})
+
+	Describe("buildMovements", func() {
+		It("returns nil when there are no movement tags", func() {
+			Expect(buildMovements(model.Tags{})).To(BeNil())
+		})
+
+		It("builds a movement with name, number and count", func() {
+			tags := model.Tags{
+				model.TagMovementName:   {"I. Allegro"},
+				model.TagMovementNumber: {"1"},
+				model.TagMovementTotal:  {"4"},
+			}
+			Expect(buildMovements(tags)).To(Equal([]responses.Movement{
+				{Name: "I. Allegro", Number: 1, Count: 4},
+			}))
+		})
+
+		It("omits number and count when non-numeric", func() {
+			tags := model.Tags{
+				model.TagMovementName:   {"I. Allegro"},
+				model.TagMovementNumber: {"not-a-number"},
+			}
+			Expect(buildMovements(tags)).To(Equal([]responses.Movement{
+				{Name: "I. Allegro"},
+			}))
 		})
 	})
 

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -378,7 +378,7 @@ var _ = Describe("helpers", func() {
 				}))
 			})
 
-			It("omits works and movements when no classical tags are present", func() {
+			It("returns empty works and movements when no classical tags are present", func() {
 				osChild := osChildFromMediaFile(ctx, mf)
 				Expect(osChild).ToNot(BeNil())
 				Expect(osChild.Works).To(BeEmpty())
@@ -394,8 +394,16 @@ var _ = Describe("helpers", func() {
 				osChild := osChildFromMediaFile(ctx, mf)
 				data, err := json.Marshal(osChild)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(string(data)).To(ContainSubstring(`"works":[{"name":"Symphony No. 5"}]`))
-				Expect(string(data)).To(ContainSubstring(`"movements":[{"name":"I. Allegro","number":1}]`))
+
+				var got map[string]any
+				Expect(json.Unmarshal(data, &got)).To(Succeed())
+				// Required name present; optional musicBrainzId/count omitted (omitempty); number present.
+				Expect(got).To(HaveKeyWithValue("works", []any{
+					map[string]any{"name": "Symphony No. 5"},
+				}))
+				Expect(got).To(HaveKeyWithValue("movements", []any{
+					map[string]any{"name": "I. Allegro", "number": float64(1)},
+				}))
 			})
 		})
 

--- a/server/subsonic/helpers_test.go
+++ b/server/subsonic/helpers_test.go
@@ -381,8 +381,8 @@ var _ = Describe("helpers", func() {
 			It("omits works and movements when no classical tags are present", func() {
 				osChild := osChildFromMediaFile(ctx, mf)
 				Expect(osChild).ToNot(BeNil())
-				Expect(osChild.Works).To(BeNil())
-				Expect(osChild.Movements).To(BeNil())
+				Expect(osChild.Works).To(BeEmpty())
+				Expect(osChild.Movements).To(BeEmpty())
 			})
 
 			It("serializes works and movements to spec-compliant JSON", func() {
@@ -417,67 +417,6 @@ var _ = Describe("helpers", func() {
 				osChild := osChildFromMediaFile(ctx, mf)
 				Expect(osChild).ToNot(BeNil())
 			})
-		})
-	})
-
-	Describe("buildWorks", func() {
-		It("returns nil when there are no work tags", func() {
-			Expect(buildWorks(model.Tags{})).To(BeNil())
-		})
-
-		It("pairs a work name with its MusicBrainz id", func() {
-			tags := model.Tags{
-				model.TagWork:              {"Symphony No. 5"},
-				model.TagMusicBrainzWorkID: {"abc-123"},
-			}
-			Expect(buildWorks(tags)).To(Equal([]responses.Work{
-				{Name: "Symphony No. 5", MusicBrainzId: "abc-123"},
-			}))
-		})
-
-		It("leaves MusicBrainzId empty when no id is present", func() {
-			tags := model.Tags{model.TagWork: {"Symphony No. 5"}}
-			Expect(buildWorks(tags)).To(Equal([]responses.Work{
-				{Name: "Symphony No. 5"},
-			}))
-		})
-
-		It("pairs by index and ignores extra ids", func() {
-			tags := model.Tags{
-				model.TagWork:              {"Work A", "Work B"},
-				model.TagMusicBrainzWorkID: {"id-a"},
-			}
-			Expect(buildWorks(tags)).To(Equal([]responses.Work{
-				{Name: "Work A", MusicBrainzId: "id-a"},
-				{Name: "Work B"},
-			}))
-		})
-	})
-
-	Describe("buildMovements", func() {
-		It("returns nil when there are no movement tags", func() {
-			Expect(buildMovements(model.Tags{})).To(BeNil())
-		})
-
-		It("builds a movement with name, number and count", func() {
-			tags := model.Tags{
-				model.TagMovementName:   {"I. Allegro"},
-				model.TagMovementNumber: {"1"},
-				model.TagMovementTotal:  {"4"},
-			}
-			Expect(buildMovements(tags)).To(Equal([]responses.Movement{
-				{Name: "I. Allegro", Number: 1, Count: 4},
-			}))
-		})
-
-		It("omits number and count when non-numeric", func() {
-			tags := model.Tags{
-				model.TagMovementName:   {"I. Allegro"},
-				model.TagMovementNumber: {"not-a-number"},
-			}
-			Expect(buildMovements(tags)).To(Equal([]responses.Movement{
-				{Name: "I. Allegro"},
-			}))
 		})
 	})
 

--- a/server/subsonic/responses/.snapshots/Responses AlbumList with OS data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumList with OS data should match .JSON
@@ -59,7 +59,9 @@
         "explicitStatus": "explicit",
         "groupings": [
           "Soundtrack"
-        ]
+        ],
+        "works": [],
+        "movements": []
       }
     ]
   }

--- a/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses AlbumWithSongsID3 with data should match .JSON
@@ -171,7 +171,9 @@
         "groupings": [
           "Soundtrack",
           "Live"
-        ]
+        ],
+        "works": [],
+        "movements": []
       },
       {
         "id": "2",
@@ -217,7 +219,9 @@
         "contributors": [],
         "displayComposer": "",
         "explicitStatus": "",
-        "groupings": []
+        "groupings": [],
+        "works": [],
+        "movements": []
       }
     ]
   }

--- a/server/subsonic/responses/.snapshots/Responses Child with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses Child with data should match .JSON
@@ -114,7 +114,9 @@
         "groupings": [
           "Soundtrack",
           "Live"
-        ]
+        ],
+        "works": [],
+        "movements": []
       },
       {
         "id": "",
@@ -146,7 +148,9 @@
         "contributors": [],
         "displayComposer": "",
         "explicitStatus": "",
-        "groupings": []
+        "groupings": [],
+        "works": [],
+        "movements": []
       }
     ],
     "id": "1",

--- a/server/subsonic/responses/.snapshots/Responses Child with data should match .JSON
+++ b/server/subsonic/responses/.snapshots/Responses Child with data should match .JSON
@@ -115,8 +115,22 @@
           "Soundtrack",
           "Live"
         ],
-        "works": [],
-        "movements": []
+        "works": [
+          {
+            "name": "Symphony No. 5",
+            "musicBrainzId": "mbz-work-1"
+          },
+          {
+            "name": "Encore"
+          }
+        ],
+        "movements": [
+          {
+            "name": "I. Allegro",
+            "number": 1,
+            "count": 4
+          }
+        ]
       },
       {
         "id": "",

--- a/server/subsonic/responses/.snapshots/Responses Child with data should match .XML
+++ b/server/subsonic/responses/.snapshots/Responses Child with data should match .XML
@@ -26,6 +26,9 @@
       </contributors>
       <groupings>Soundtrack</groupings>
       <groupings>Live</groupings>
+      <works name="Symphony No. 5" musicBrainzId="mbz-work-1"></works>
+      <works name="Encore"></works>
+      <movements name="I. Allegro" number="1" count="4"></movements>
     </child>
     <child id="" isDir="false" title="">
       <replayGain trackGain="0" albumGain="0" trackPeak="0" albumPeak="0" baseGain="0" fallbackGain="0"></replayGain>

--- a/server/subsonic/responses/.snapshots/Responses Child without data should match OpenSubsonic .JSON
+++ b/server/subsonic/responses/.snapshots/Responses Child without data should match OpenSubsonic .JSON
@@ -29,7 +29,9 @@
         "contributors": [],
         "displayComposer": "",
         "explicitStatus": "",
-        "groupings": []
+        "groupings": [],
+        "works": [],
+        "movements": []
       }
     ],
     "id": "",

--- a/server/subsonic/responses/responses.go
+++ b/server/subsonic/responses/responses.go
@@ -190,6 +190,8 @@ type OpenSubsonicChild struct {
 	DisplayComposer    string              `xml:"displayComposer,attr,omitempty"    json:"displayComposer"`
 	ExplicitStatus     string              `xml:"explicitStatus,attr,omitempty"     json:"explicitStatus"`
 	Groupings          Array[string]       `xml:"groupings,omitempty"               json:"groupings"`
+	Works              Array[Work]         `xml:"works,omitempty"                   json:"works"`
+	Movements          Array[Movement]     `xml:"movements,omitempty"               json:"movements"`
 }
 
 type Songs struct {
@@ -596,6 +598,17 @@ type OpenSubsonicExtensions []OpenSubsonicExtension
 
 type ItemGenre struct {
 	Name string `xml:"name,attr" json:"name"`
+}
+
+type Work struct {
+	Name          string `xml:"name,attr"                    json:"name"`
+	MusicBrainzId string `xml:"musicBrainzId,attr,omitempty" json:"musicBrainzId,omitempty"`
+}
+
+type Movement struct {
+	Name   string `xml:"name,attr"             json:"name"`
+	Number int32  `xml:"number,attr,omitempty" json:"number,omitempty"`
+	Count  int32  `xml:"count,attr,omitempty"  json:"count,omitempty"`
 }
 
 type ReplayGain struct {

--- a/server/subsonic/responses/responses_test.go
+++ b/server/subsonic/responses/responses_test.go
@@ -239,6 +239,13 @@ var _ = Describe("Responses", func() {
 						{Role: "composer", Artist: ArtistID3Ref{Id: "4", Name: "composer2"}},
 					},
 					ExplicitStatus: "clean",
+					Works: []Work{
+						{Name: "Symphony No. 5", MusicBrainzId: "mbz-work-1"},
+						{Name: "Encore"},
+					},
+					Movements: []Movement{
+						{Name: "I. Allegro", Number: 1, Count: 4},
+					},
 				}
 				child[1].OpenSubsonicChild = &OpenSubsonicChild{
 					ReplayGain: ReplayGain{TrackGain: new(0.0), AlbumGain: new(0.0), TrackPeak: new(0.0), AlbumPeak: new(0.0), BaseGain: new(0.0), FallbackGain: new(0.0)},


### PR DESCRIPTION
### Description
Adds the OpenSubsonic `works` and `movements` attributes to the Subsonic `Child` response, per the merged spec [opensubsonic/open-subsonic-api#212](https://github.com/opensubsonic/open-subsonic-api/pull/212). These surface classical-music metadata so clients can group tracks by work and display movement titles.

- `works`: array of `{ name, musicBrainzId }`
- `movements`: array of `{ name, number, count }`

The source tags (`work`, `musicbrainz_workid`, `movementname`, `movement`, `movementtotal`) are **already scanned and persisted** by Navidrome (they live in the `additional:` section of `mappings.yaml` and survive into the `tags` JSON column), so this is a surfacing-only change — no migration, no new tag mappings, no rescan.

Parsing lives on `model.MediaFile` as `Works()`/`Movements()` methods returning new `model.Work`/`model.Movement` types; the Subsonic layer maps these to the response types. Work names are paired with work IDs by index, tolerating length mismatches (a work commonly has a name but no MusicBrainz ID, since non-UUID values are dropped at scan time).

### Related Issues
<!-- None — implements a merged OpenSubsonic spec. -->

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Tag an audio file with classical metadata — `WORK`, `MUSICBRAINZ_WORKID` (a valid UUID), `MOVEMENTNAME`, `MOVEMENT` (number), `MOVEMENTTOTAL`.
2. Scan it into a library.
3. Call `getSong` (or `getAlbum` / `getMusicDirectory`) with `f=json` and verify the song includes:
   ```json
   "works":     [{ "name": "Symphony No. 5 in C minor, Op. 67", "musicBrainzId": "..." }],
   "movements": [{ "name": "I. Allegro con brio", "number": 1, "count": 4 }]
   ```
4. A song with no classical tags returns `"works": []` and `"movements": []`, consistent with other OpenSubsonic array fields like `isrc` / `moods`.

### Additional Notes
- `musicBrainzId` is often absent in real libraries: the `musicbrainz_workid` tag is UUID-validated at scan time, so malformed values are dropped — the index-paired builder handles a work name with no ID gracefully.
- Empty arrays serialize as `[]` (never omitted or `null`), matching every other OpenSubsonic array field via the existing `Array[T]` type. The XML form omits empty elements (no `MarshalXML` on `Array[T]`), so response snapshots only change in JSON.
- Verified end-to-end on a running server with a real tagged file, in both JSON and XML.
