### PR TITLE
Mapping "created" date to `created_at`

### DIFF
--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -217,7 +217,7 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 		child.Path = fakePath(mf)
 	}
 	child.DiscNumber = int32(mf.DiscNumber)
-	child.CreatedAt = new(mf.CreatedAt)
+	child.Created = new(mf.CreatedAt)
 	child.AlbumId = mf.AlbumID
 	child.ArtistId = mf.ArtistID
 	child.Type = "music"

--- a/server/subsonic/helpers.go
+++ b/server/subsonic/helpers.go
@@ -217,7 +217,7 @@ func childFromMediaFile(ctx context.Context, mf model.MediaFile) responses.Child
 		child.Path = fakePath(mf)
 	}
 	child.DiscNumber = int32(mf.DiscNumber)
-	child.Created = new(mf.BirthTime)
+	child.CreatedAt = new(mf.CreatedAt)
 	child.AlbumId = mf.AlbumID
 	child.ArtistId = mf.ArtistID
 	child.Type = "music"


### PR DESCRIPTION
### Description
Fixes an inconsistency between API endpoints.

### Related Issues
Fixes #5665

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
* I have not tested it yet, Will the CI generate a Docker image for me to test? Otherwise, is there a way for me to generate it?
* This is a minimal change that fixes the inconsistency, maybe we also want to expose `updated_at` and `birth_time` for parity between API endpoints? (see #5665 for the related discussion)