### PR TITLE
fix(ui): prevent transient jump to wrong song on play (#5441 regression)

### DIFF
--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -173,6 +173,24 @@ const reduceSyncQueue = (state, { data: { audioInfo, audioLists } }) => {
   const hasPendingSwitch =
     state.playIndex != null &&
     (state.clear || state.playIndex !== state.savedPlayIndex)
+
+  // The music player can emit a SYNC_QUEUE carrying its previous (old) queue
+  // while it loads the new one. Adopting that stale list would point playIndex
+  // at a track the user never chose, causing a transient jump to a "random"
+  // song before the correct queue settles. Detect a stale sync by checking that
+  // the synced list actually contains the pending track (state.queue[playIndex]);
+  // if not, ignore it: keep our intended queue and the pending switch so the
+  // next, correct sync is adopted normally.
+  if (hasPendingSwitch) {
+    const pendingTrack = state.queue[state.playIndex]
+    const syncHasPendingTrack =
+      pendingTrack != null &&
+      audioLists.some((item) => item.trackId === pendingTrack.trackId)
+    if (!syncHasPendingTrack) {
+      return state
+    }
+  }
+
   return {
     ...state,
     queue: audioLists,

--- a/ui/src/reducers/playerReducer.test.js
+++ b/ui/src/reducers/playerReducer.test.js
@@ -224,4 +224,125 @@ describe('playerReducer', () => {
       expect(result.playIndex).toBe(0)
     })
   })
+
+  // Regression context for the 0.62 report:
+  //   "When I play a song, it will sometimes skip to a random song, attempt to
+  //    play said song, and then immediately back to the song I chose."
+  //
+  // Root cause: commit 2307a64da (#5441, 0.62-only) widened reduceSyncQueue's
+  // hasPendingSwitch to also keep playIndex alive whenever clear=true. This let
+  // a pending playIndex survive a SYNC_QUEUE that carries the OLD queue (the
+  // music player library can emit a stale onAudioListsChange mid-transition),
+  // leaving playIndex pointing at a track in the WRONG queue. Downstream, the
+  // library's updatePlayIndex(playIndex) played that stale track for an instant
+  // ("random song") before the new queue settled ("back to the song I chose").
+  // The race was timing-dependent, hence "sometimes". The FIX block below guards
+  // reduceSyncQueue against adopting a stale list; these tests pin the delta.
+  describe('0.62 regression context', () => {
+    // 0.61 logic, for contrast: a switch is pending ONLY when the index moved.
+    const hasPendingSwitch061 = (s) =>
+      s.playIndex != null && s.playIndex !== s.savedPlayIndex
+
+    it('0.61 vs 0.62 differ ONLY when playIndex===savedPlayIndex && clear', () => {
+      const hasPendingSwitch062 = (s) =>
+        s.playIndex != null && (s.clear || s.playIndex !== s.savedPlayIndex)
+
+      const cases = [
+        { playIndex: 0, savedPlayIndex: 0, clear: true }, // the regression case
+        { playIndex: 0, savedPlayIndex: 3, clear: true },
+        { playIndex: 2, savedPlayIndex: 2, clear: false },
+        { playIndex: 5, savedPlayIndex: 0, clear: false },
+      ]
+      const diffs = cases.filter(
+        (c) => hasPendingSwitch061(c) !== hasPendingSwitch062(c),
+      )
+      expect(diffs).toEqual([{ playIndex: 0, savedPlayIndex: 0, clear: true }])
+    })
+  })
+
+  // FIX for the 0.62 stale-playIndex regression. A SYNC_QUEUE that does NOT
+  // contain the pending track (state.queue[playIndex]) is a stale snapshot of
+  // the library's previous queue. Adopting it would point playIndex at a track
+  // the user never chose. The fix ignores such a stale sync: it keeps our
+  // intended queue and keeps the pending switch alive so the next (correct)
+  // sync — once the library finishes loading the new queue — is adopted.
+  describe('FIX: SYNC_QUEUE ignores a stale list missing the pending track', () => {
+    it('keeps the intended queue and pending switch when sync is stale', () => {
+      const intendedQueue = [{ trackId: 'b0', uuid: 'B0', name: 'Chosen Song' }]
+      const stateAfterSetTrack = {
+        queue: intendedQueue,
+        current: {},
+        playIndex: 0,
+        savedPlayIndex: 0,
+        clear: true,
+        volume: 1,
+      }
+      const staleOldQueue = [
+        { trackId: 'a0', uuid: 'A0', name: 'Old Song 0' },
+        { trackId: 'a1', uuid: 'A1', name: 'Old Song 1' },
+        { trackId: 'a2', uuid: 'A2', name: 'Old Song 2' },
+      ]
+      const result = playerReducer(stateAfterSetTrack, {
+        type: PLAYER_SYNC_QUEUE,
+        data: { audioInfo: {}, audioLists: staleOldQueue },
+      })
+
+      // Intended queue is preserved; the stale old queue is NOT adopted.
+      expect(result.queue).toBe(intendedQueue)
+      // Pending switch stays alive for the next, correct sync.
+      expect(result.playIndex).toBe(0)
+      expect(result.clear).toBe(true)
+      // playIndex now points at the chosen track, never an old one.
+      expect(result.queue[result.playIndex].name).toBe('Chosen Song')
+    })
+
+    it('adopts a valid sync that contains the pending track (by trackId)', () => {
+      // Mirrors the real flow: state.queue and the synced list share trackIds
+      // but have library-assigned uuids. The pending track (trackId s1) is
+      // present, so the sync is valid and must be adopted.
+      const stateAfterPlayTracks = {
+        queue: [
+          { trackId: 's1', uuid: 'aaa', name: 'Song 1' },
+          { trackId: 's2', uuid: 'bbb', name: 'Song 2' },
+          { trackId: 's3', uuid: 'ccc', name: 'Song 3' },
+        ],
+        current: { uuid: 'ccc', name: 'Song 3' },
+        playIndex: 0,
+        savedPlayIndex: 2,
+        clear: true,
+        volume: 1,
+      }
+      const validSync = [
+        { trackId: 's1', uuid: 'xxx', name: 'Song 1' },
+        { trackId: 's2', uuid: 'yyy', name: 'Song 2' },
+        { trackId: 's3', uuid: 'zzz', name: 'Song 3' },
+      ]
+      const result = playerReducer(stateAfterPlayTracks, {
+        type: PLAYER_SYNC_QUEUE,
+        data: { audioInfo: {}, audioLists: validSync },
+      })
+      expect(result.queue).toBe(validSync)
+      expect(result.playIndex).toBe(0)
+      expect(result.clear).toBe(true)
+    })
+
+    it('adopts the sync normally when no switch is pending', () => {
+      const stateNoPending = {
+        queue: [{ trackId: 's1', uuid: 'aaa', name: 'Song 1' }],
+        current: {},
+        playIndex: undefined,
+        savedPlayIndex: 0,
+        clear: false,
+        volume: 1,
+      }
+      const reordered = [{ trackId: 's1', uuid: 'aaa', name: 'Song 1' }]
+      const result = playerReducer(stateNoPending, {
+        type: PLAYER_SYNC_QUEUE,
+        data: { audioInfo: {}, audioLists: reordered },
+      })
+      expect(result.queue).toBe(reordered)
+      expect(result.playIndex).toBeUndefined()
+      expect(result.clear).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
### Description

Fixes a 0.62 regression where the web player would **sometimes briefly skip to a different (seemingly random) song, attempt to play it, then immediately snap back to the song the user chose.**

Reported symptom:
> When I play a song, it will sometimes skip to a random song, attempt to play said song, and then immediately back to the song I chose. Prior to upgrading to 0.62, I didn't have this bug. I've cleared my cache, tried from an InPrivate/Incognito window, still the symptoms exist.

**Why it happens:** The music player library can emit a `PLAYER_SYNC_QUEUE` (`onAudioListsChange`) carrying its **previous (old) queue** during the brief window while it loads the newly-selected one. Commit 2307a64d (#5441) widened `reduceSyncQueue`'s `hasPendingSwitch` to keep `playIndex` alive whenever `clear=true`. As a side effect, when that stale sync arrives, the old queue was written into state with `playIndex` still pointing at an index — selecting a track the user never chose. Downstream, the library's `updatePlayIndex(playIndex)` plays that stale track for an instant before the correct queue settles. The window is timing-dependent (hence "sometimes"), and because it's purely client-side runtime state, clearing cache / incognito has no effect. The divergence from 0.61 occurs in exactly one case: `playIndex === savedPlayIndex && clear` (e.g. playing a single song / an album from track 1 while the player index is 0).

**How it's fixed:** In `reduceSyncQueue`, when a track switch is pending, only adopt a synced queue that **actually contains the pending track** (`state.queue[playIndex]`, matched by `trackId`). A sync that is missing it is a stale snapshot of the library's old queue and is ignored — keeping the intended queue and the pending switch alive so the next, correct sync is adopted normally. `trackId` (not `uuid`) is the discriminator, since valid syncs carry the same `trackId`s with library-reassigned `uuid`s. This is a reducer-level fix; no `navidrome-music-player` bump is required.

### Related Issues

Regression introduced by #5441.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start the dev server and open the web player.
2. Play an album and advance a few tracks (so the player's internal index is greater than 0).
3. Pick a different single song (or a new album from track 1) — ideally repeatedly / quickly.
4. **Expected:** playback goes straight to the chosen song. It must never momentarily start a different/old track and then snap back.
5. Edge cases to verify: switching while a track is mid-play; closing the player then playing a new album from track 1; reordering the queue ("Play Next") while a track plays (must not restart).

### Additional Notes

- Scope is intentionally minimal: a single guard in `reduceSyncQueue` plus tests. No library changes.
- The deeper trigger lives in `navidrome-music-player` (`UNSAFE_componentWillReceiveProps` runs `updatePlayIndex` synchronously against pre-reset state while the new queue loads via an async `setState`). Fixing it there would require publishing a new library version; the reducer guard addresses the user-visible bug without that.
- The prior in-repo reproduction test block was converted into a "0.62 regression context" block that pins the 0.61-vs-0.62 behavioral delta.
