### PR TITLE
fix(ui): bump navidrome-music-player to 4.25.3 (fix transient wrong-song jump)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,7 +23,7 @@
         "inflection": "^3.0.2",
         "jwt-decode": "^4.0.0",
         "lodash.throttle": "^4.1.1",
-        "navidrome-music-player": "4.25.2",
+        "navidrome-music-player": "4.25.3",
         "prop-types": "^15.8.1",
         "ra-data-json-server": "^3.19.12",
         "ra-i18n-polyglot": "^3.19.12",
@@ -129,6 +129,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1743,6 +1744,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1766,6 +1768,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2471,6 +2474,7 @@
       "resolved": "https://registry.npmjs.org/@jsonforms/core/-/core-2.5.2.tgz",
       "integrity": "sha512-tl64cLC2dUrGvu2nTHRDEA5Yv3RfwzMCIlVaoSUSq44LakKLGJdkPl8j/fb07llpFqz0a7gEAmy/8gLdmwgaLQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.3",
         "ajv": "^6.10.2",
@@ -2524,6 +2528,7 @@
       "resolved": "https://registry.npmjs.org/@jsonforms/react/-/react-2.5.2.tgz",
       "integrity": "sha512-kZf2fq4urIBlFTCiBX95eKg8uojkyJj7FVDtIV739aVkJjE5+ihn1+kG1qLxYSxlGC7S24i12BZJzRetSRihBQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash": "^4.17.15",
         "object-hash": "^2.0.0"
@@ -2539,6 +2544,7 @@
       "integrity": "sha512-tr7xekNlM9LjA6pagJmL8QCgZXaubWUwkJnoYcMKd4gw/t4XiyvnTkjdGrUVicyB2BsdaAv1tvow45bPM4sSwQ==",
       "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.4.4",
         "@material-ui/styles": "^4.11.5",
@@ -2585,6 +2591,7 @@
       "resolved": "https://registry.npmjs.org/@material-ui/icons/-/icons-4.11.3.tgz",
       "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.4.4"
       },
@@ -3308,6 +3315,7 @@
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
       "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hoist-non-react-statics": "^3.3.0"
       },
@@ -3360,6 +3368,7 @@
       "integrity": "sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3381,6 +3390,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.91.tgz",
       "integrity": "sha512-xauZca6qMeCU3Moy0KxCM9jtf1vyk6qRYK39Ryf3afUqwgNUjRIGoDdS9BcGWgAMGSg1hvP4XcmlYrM66PtqeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "^0.16",
@@ -3550,6 +3560,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -3883,6 +3894,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4567,6 +4579,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -4942,6 +4955,7 @@
       "resolved": "https://registry.npmjs.org/connected-react-router/-/connected-react-router-6.9.3.tgz",
       "integrity": "sha512-4ThxysOiv/R2Dc4Cke1eJwjKwH1Y51VDwlOrOfs1LjpdYOVvCNjNkZDayo7+sx42EeGJPQUNchWkjAIJdXGIOQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.isequalwith": "^4.4.0",
         "prop-types": "^15.7.2"
@@ -5822,6 +5836,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -6405,6 +6420,7 @@
       "resolved": "https://registry.npmjs.org/final-form/-/final-form-4.20.10.tgz",
       "integrity": "sha512-TL48Pi1oNHeMOHrKv1bCJUrWZDcD3DIG6AGYVNOnyZPr7Bd/pStN0pL+lfzF5BNoj/FclaoiaLenk4XUIFVYng==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.10.0"
       },
@@ -6421,6 +6437,7 @@
       "resolved": "https://registry.npmjs.org/final-form-arrays/-/final-form-arrays-3.1.0.tgz",
       "integrity": "sha512-TWBvun+AopgBLw9zfTFHBllnKMVNEwCEyDawphPuBGGqNsuhGzhT7yewHys64KFFwzIs6KEteGLpKOwvTQEscQ==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "final-form": "^4.20.8"
       }
@@ -6835,6 +6852,7 @@
       "integrity": "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/node": ">=20.0.0",
         "@types/whatwg-mimetype": "^3.0.2",
@@ -6948,6 +6966,7 @@
       "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
       "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.1.2",
         "loose-envify": "^1.2.0",
@@ -8550,6 +8569,7 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
       "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -8593,9 +8613,9 @@
       "license": "MIT"
     },
     "node_modules/navidrome-music-player": {
-      "version": "4.25.2",
-      "resolved": "https://registry.npmjs.org/navidrome-music-player/-/navidrome-music-player-4.25.2.tgz",
-      "integrity": "sha512-k7RXHOOKHeJRCsfmpmQ+TkErndckFfvYMjzwVAKZvViw2PL9ubKWziPfruHZVQr4FiJd2oYKEuTNiWZgAK87CA==",
+      "version": "4.25.3",
+      "resolved": "https://registry.npmjs.org/navidrome-music-player/-/navidrome-music-player-4.25.3.tgz",
+      "integrity": "sha512-0T87Mmbs6ls9g9CgwJwXBL7X11u0+6znBFJTG8HUPgBT0r8W6epVKqJhfdg8vqnT86QDByvvb1Hxp/W2M7Yacw==",
       "license": "MIT",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",
@@ -9298,6 +9318,7 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -9389,6 +9410,7 @@
       "resolved": "https://registry.npmjs.org/ra-core/-/ra-core-3.19.12.tgz",
       "integrity": "sha512-E0cM6OjEUtccaR+dR5mL1MLiVVYML0Yf7aPhpLEq4iue73X3+CKcLztInoBhWgeevPbFQwgAtsXhlpedeyrNNg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "classnames": "~2.3.1",
         "date-fns": "^1.29.0",
@@ -9803,6 +9825,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -9884,6 +9907,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -9956,6 +9980,7 @@
       "resolved": "https://registry.npmjs.org/react-final-form/-/react-final-form-6.5.9.tgz",
       "integrity": "sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4"
       },
@@ -9973,6 +9998,7 @@
       "resolved": "https://registry.npmjs.org/react-final-form-arrays/-/react-final-form-arrays-3.1.4.tgz",
       "integrity": "sha512-siVFAolUAe29rMR6u8VwepoysUcUdh6MLV2OWnCtKpsPRUdT9VUgECjAPaVMAH2GROZNiVB9On1H9MMrm9gdpg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.19.4"
       },
@@ -10078,6 +10104,7 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
       "integrity": "sha512-Gx4L3uM182jEEayZfRbI/G11ZpYdNAnBs70lFVMNdHJI76XYtR+7m0MN+eAs7UHBPhWXcnFPaS+9owSCJQHNpQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@types/react-redux": "^7.1.20",
@@ -10113,6 +10140,7 @@
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
       "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -10133,6 +10161,7 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
       "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.13",
         "history": "^4.9.0",
@@ -10314,6 +10343,7 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -10323,6 +10353,7 @@
       "resolved": "https://registry.npmjs.org/redux-saga/-/redux-saga-1.4.2.tgz",
       "integrity": "sha512-QLIn/q+7MX/B+MkGJ/K6R3//60eJ4QNy65eqPsJrfGezbxdh1Jx+37VRKE2K4PsJnNET5JufJtgWdT30WBa+6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@redux-saga/core": "^1.4.2"
       }
@@ -10582,6 +10613,7 @@
       "integrity": "sha512-FAfGj5Ferzyna11iUwGdkYus/Y9d/H75PEpsseP5DZOsEsyPvP/Q7mJiSXhUYSEmyfHPaZyC8EsJCjqzDbtcfg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -11511,6 +11543,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11732,6 +11765,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11976,6 +12010,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -12100,6 +12135,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12113,6 +12149,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -12632,6 +12669,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
       "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -12741,6 +12779,7 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.80.0.tgz",
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
     "inflection": "^3.0.2",
     "jwt-decode": "^4.0.0",
     "lodash.throttle": "^4.1.1",
-    "navidrome-music-player": "4.25.2",
+    "navidrome-music-player": "4.25.3",
     "prop-types": "^15.8.1",
     "ra-data-json-server": "^3.19.12",
     "ra-i18n-polyglot": "^3.19.12",


### PR DESCRIPTION
### Description

Fixes a web-player bug where playing a song would **sometimes briefly skip to a different (seemingly random) song, play it, then immediately switch back to the song the user chose.**

Reported symptom:
> When I play a song, it will sometimes skip to a random song, attempt to play said song, and then immediately back to the song I chose. Prior to upgrading to 0.62, I didn't have this bug. I've cleared my cache, tried from an InPrivate/Incognito window, still the symptoms exist.

**Root cause (reproduced live in the browser, 10/10).** The bug lives in the player library (`navidrome-music-player`). When a new audio list is loaded, the library picked the *initial* track to play using its stale **internal** play index from the previous queue (`this.state.playIndex`), rather than the requested `playIndex` prop. So when a new queue is loaded at a non-zero index — e.g. playing a different album/playlist starting from a track other than the first, or playing a new album after advancing + closing the player — the library first loaded and played whatever track sat at the *previous* index in the *new* list, then `updatePlayIndex` corrected it to the chosen track a moment later. That correction is the audible "skip to a random song, then back". Because it's purely client-side runtime timing, clearing cache / incognito had no effect.

This was surfaced (made visible) by #5441, which kept `playIndex` alive across the queue sync so the wrong track gets *corrected* rather than silently stuck — but the underlying stale-index selection is a long-standing library issue.

**Fix.** Bump `navidrome-music-player` to **4.25.3** (navidrome/react-music-player). The library now derives the initial track of a freshly-loaded list from the requested `playIndex` instead of the stale internal index, so the correct track loads directly with no transient jump.

This PR is a dependency bump only — no Navidrome source changes.

### Related Issues

Surfaced by #5441 (the close-player → play-from-track-1 case). No separate GitHub issue filed for the user report.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

> Note on tests: the fix is in the player library and was verified live via an A/B browser reproduction (original: transient wrong track 6/6; fixed: 0/6; no regression to play-from-track-1, single-song, or Play Next/quietUpdate). The library's own Jest suite is currently unrunnable under Node 24 (jsdom/parse5 toolchain), so a library-level unit test was not added. Navidrome's existing UI tests pass.

### How to Test

1. Start the web player and play an album/playlist.
2. Advance a few tracks (so the player is not on track 1).
3. Play a **different** album/playlist, selecting a track other than the first (or: close the player, then play a new album from track 1).
4. **Expected:** playback goes straight to the chosen track. It must never momentarily start a different track and then snap back.
5. Edge cases to verify: switching mid-play; "Play Next" while a track plays (must not restart the current track); playing a single song.

### Additional Notes

- Scope is a single dependency bump (`ui/package.json` + `ui/package-lock.json`).
- Library change: navidrome/react-music-player `v4.25.3` (published to npm).
