### PR TITLE
feat(cli): add a 'navidrome plugin' CLI for managing and inspecting plugins

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -14,6 +14,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// pluginManager is the subset of *plugins.Manager the CLI needs.
+type pluginManager interface {
+	EnablePlugin(ctx context.Context, id string) error
+	DisablePlugin(ctx context.Context, id string) error
+	ValidatePluginConfig(ctx context.Context, id, configJSON string) error
+	UpdatePluginConfig(ctx context.Context, id, configJSON string) error
+	UpdatePluginUsers(ctx context.Context, id, usersJSON string, allUsers bool) error
+	UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries, allowWriteAccess bool) error
+	RescanPlugins(ctx context.Context) error
+}
+
 var pluginOutputFormat string
 
 func init() {
@@ -21,6 +32,8 @@ func init() {
 
 	pluginListCmd.Flags().StringVarP(&pluginOutputFormat, "format", "f", "table", "output format [supported values: table, csv, json]")
 	pluginRoot.AddCommand(pluginListCmd)
+	pluginRoot.AddCommand(pluginEnableCmd)
+	pluginRoot.AddCommand(pluginDisableCmd)
 }
 
 var (
@@ -35,6 +48,34 @@ var (
 		Short: "List installed plugins",
 		Run: func(cmd *cobra.Command, args []string) {
 			runPluginList(cmd.Context())
+		},
+	}
+
+	pluginEnableCmd = &cobra.Command{
+		Use:   "enable <id>",
+		Short: "Enable a plugin",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			requirePluginsEnabled(cmd.Context())
+			_, ctx := getAdminContext(cmd.Context())
+			mgr := GetPluginManager(ctx)
+			if err := enablePlugin(ctx, mgr, args[0]); err != nil {
+				log.Fatal(ctx, "Failed to enable plugin", "id", args[0], err)
+			}
+		},
+	}
+
+	pluginDisableCmd = &cobra.Command{
+		Use:   "disable <id>",
+		Short: "Disable a plugin",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			requirePluginsEnabled(cmd.Context())
+			_, ctx := getAdminContext(cmd.Context())
+			mgr := GetPluginManager(ctx)
+			if err := disablePlugin(ctx, mgr, args[0]); err != nil {
+				log.Fatal(ctx, "Failed to disable plugin", "id", args[0], err)
+			}
 		},
 	}
 )
@@ -104,4 +145,12 @@ func requirePluginsEnabled(ctx context.Context) {
 	if !conf.Server.Plugins.Enabled {
 		log.Fatal(ctx, "Plugin system is disabled (set Plugins.Enabled to use this command)")
 	}
+}
+
+func enablePlugin(ctx context.Context, mgr pluginManager, id string) error {
+	return mgr.EnablePlugin(ctx, id)
+}
+
+func disablePlugin(ctx context.Context, mgr pluginManager, id string) error {
+	return mgr.DisablePlugin(ctx, id)
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -138,11 +138,8 @@ var (
 	}
 )
 
-// isPackagePath reports whether arg refers to an .ndp package file (as opposed
-// to an installed plugin ID). It only checks the extension: a missing file still
-// routes to the off-disk path so ReadManifest can report a precise "no such
-// file" error instead of a misleading "Plugin not found". Plugin IDs are
-// filenames with the .ndp suffix stripped, so an ID can never collide here.
+// isPackagePath checks only the extension (not existence) so a mistyped path
+// still routes to ReadManifest, which reports a precise "no such file" error.
 func isPackagePath(arg string) bool {
 	return strings.HasSuffix(arg, plugins.PackageExtension)
 }
@@ -493,9 +490,8 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, cur *model.Plugin, 
 	return nil
 }
 
-// usersToJSON normalizes a --users value to the JSON-array form the manager
-// stores. A value starting with '[' is treated as JSON (validated as-is);
-// anything else is parsed as a comma-separated list. Empty input yields "[]".
+// usersToJSON accepts either a JSON array (starts with '[') or a comma-separated
+// list and returns the JSON-array form the manager stores.
 func usersToJSON(value string) (string, error) {
 	if strings.TrimSpace(value) == "" {
 		return "[]", nil
@@ -516,9 +512,8 @@ func usersToJSON(value string) (string, error) {
 	return string(b), nil
 }
 
-// librariesToJSON normalizes a --libraries value to the JSON-array form the
-// manager stores. A value starting with '[' is treated as JSON; anything else
-// is parsed as a comma-separated list of integer IDs. Empty input yields "[]".
+// librariesToJSON accepts either a JSON array (starts with '[') or a
+// comma-separated list of integer IDs and returns the JSON-array form stored.
 func librariesToJSON(value string) (string, error) {
 	if strings.TrimSpace(value) == "" {
 		return "[]", nil

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -14,17 +14,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// pluginManager is the subset of *plugins.Manager the CLI needs.
-type pluginManager interface {
-	EnablePlugin(ctx context.Context, id string) error
-	DisablePlugin(ctx context.Context, id string) error
-	ValidatePluginConfig(ctx context.Context, id, configJSON string) error
-	UpdatePluginConfig(ctx context.Context, id, configJSON string) error
-	UpdatePluginUsers(ctx context.Context, id, usersJSON string, allUsers bool) error
-	UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries, allowWriteAccess bool) error
-	RescanPlugins(ctx context.Context) error
-}
-
 var pluginOutputFormat string
 
 func init() {

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"context"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/spf13/cobra"
+)
+
+// pluginManager is the subset of *plugins.Manager the CLI needs.
+type pluginManager interface {
+	EnablePlugin(ctx context.Context, id string) error
+	DisablePlugin(ctx context.Context, id string) error
+	ValidatePluginConfig(ctx context.Context, id, configJSON string) error
+	UpdatePluginConfig(ctx context.Context, id, configJSON string) error
+	UpdatePluginUsers(ctx context.Context, id, usersJSON string, allUsers bool) error
+	UpdatePluginLibraries(ctx context.Context, id, librariesJSON string, allLibraries, allowWriteAccess bool) error
+	RescanPlugins(ctx context.Context) error
+}
+
+var pluginOutputFormat string
+
+func init() {
+	rootCmd.AddCommand(pluginRoot)
+
+	pluginListCmd.Flags().StringVarP(&pluginOutputFormat, "format", "f", "table", "output format [supported values: table, csv, json]")
+	pluginRoot.AddCommand(pluginListCmd)
+}
+
+var (
+	pluginRoot = &cobra.Command{
+		Use:   "plugin",
+		Short: "Manage and inspect plugins",
+		Long:  "List, inspect, enable, disable, configure, rescan, and validate plugins",
+	}
+
+	pluginListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List installed plugins",
+		Run: func(cmd *cobra.Command, args []string) {
+			runPluginList(cmd.Context())
+		},
+	}
+)
+
+// manifestSummary extracts the display name and version from a stored manifest JSON, falling
+// back to the plugin ID when the manifest can't be parsed.
+func manifestSummary(p model.Plugin) (name, version string) {
+	var m struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal([]byte(p.Manifest), &m); err != nil {
+		return p.ID, ""
+	}
+	return m.Name, m.Version
+}
+
+func formatPluginList(list model.Plugins, format string) (string, error) {
+	switch format {
+	case "json":
+		b, err := json.MarshalIndent(list, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	case "csv":
+		var sb strings.Builder
+		w := csv.NewWriter(&sb)
+		_ = w.Write([]string{"id", "name", "version", "enabled", "last error"})
+		for _, p := range list {
+			name, version := manifestSummary(p)
+			_ = w.Write([]string{p.ID, name, version, fmt.Sprintf("%t", p.Enabled), p.LastError})
+		}
+		w.Flush()
+		return sb.String(), w.Error()
+	case "table":
+		var sb strings.Builder
+		w := tabwriter.NewWriter(&sb, 0, 4, 2, ' ', 0)
+		fmt.Fprintln(w, "ID\tNAME\tVERSION\tENABLED\tLAST ERROR")
+		for _, p := range list {
+			name, version := manifestSummary(p)
+			fmt.Fprintf(w, "%s\t%s\t%s\t%t\t%s\n", p.ID, name, version, p.Enabled, p.LastError)
+		}
+		w.Flush()
+		return sb.String(), nil
+	default:
+		return "", fmt.Errorf("invalid output format %q (supported: table, csv, json)", format)
+	}
+}
+
+func runPluginList(ctx context.Context) {
+	requirePluginsEnabled(ctx)
+	ds, ctx := getAdminContext(ctx)
+	list, err := ds.Plugin(ctx).GetAll()
+	if err != nil {
+		log.Fatal(ctx, "Failed to list plugins", err)
+	}
+	out, err := formatPluginList(list, pluginOutputFormat)
+	if err != nil {
+		log.Fatal(ctx, "Failed to format output", err)
+	}
+	fmt.Print(out)
+}
+
+// requirePluginsEnabled aborts the command if the plugin system is disabled.
+func requirePluginsEnabled(ctx context.Context) {
+	if !conf.Server.Plugins.Enabled {
+		log.Fatal(ctx, "Plugin system is disabled (set Plugins.Enabled to use this command)")
+	}
+}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/plugins"
 	"github.com/spf13/cobra"
 )
 
@@ -61,6 +62,10 @@ func init() {
 	pluginEditCmd.Flags().BoolVar(&editNoWrite, "no-write-access", false, "deny the plugin write access to libraries")
 	pluginEditCmd.MarkFlagsMutuallyExclusive("write-access", "no-write-access")
 	pluginRoot.AddCommand(pluginEditCmd)
+
+	pluginInfoCmd.Flags().StringVarP(&pluginOutputFormat, "format", "f", "text", "output format [supported values: text, json]")
+	pluginRoot.AddCommand(pluginInfoCmd)
+	pluginRoot.AddCommand(pluginValidateCmd)
 }
 
 var (
@@ -106,6 +111,129 @@ var (
 		},
 	}
 )
+
+var (
+	pluginInfoCmd = &cobra.Command{
+		Use:   "info <id|file.ndp>",
+		Short: "Show details for an installed plugin or a .ndp package",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runPluginInfo(cmd.Context(), args[0])
+		},
+	}
+
+	pluginValidateCmd = &cobra.Command{
+		Use:   "validate <id|file.ndp>",
+		Short: "Validate an installed plugin or a .ndp package manifest",
+		Args:  cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			runPluginValidate(cmd.Context(), args[0])
+		},
+	}
+)
+
+func isPackagePath(arg string) bool {
+	if !strings.HasSuffix(arg, plugins.PackageExtension) {
+		return false
+	}
+	info, err := os.Stat(arg)
+	return err == nil && !info.IsDir()
+}
+
+func formatPluginInfo(p *model.Plugin, format string) (string, error) {
+	if format == "json" {
+		b, err := json.MarshalIndent(p, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+	name, version := manifestSummary(*p)
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "ID:          %s\n", p.ID)
+	fmt.Fprintf(&sb, "Name:        %s\n", name)
+	fmt.Fprintf(&sb, "Version:     %s\n", version)
+	fmt.Fprintf(&sb, "Enabled:     %t\n", p.Enabled)
+	fmt.Fprintf(&sb, "Path:        %s\n", p.Path)
+	fmt.Fprintf(&sb, "SHA256:      %s\n", p.SHA256)
+	fmt.Fprintf(&sb, "All users:   %t\n", p.AllUsers)
+	fmt.Fprintf(&sb, "All libs:    %t\n", p.AllLibraries)
+	fmt.Fprintf(&sb, "Write access:%t\n", p.AllowWriteAccess)
+	if p.Config != "" {
+		fmt.Fprintf(&sb, "Config:      %s\n", p.Config)
+	}
+	if p.LastError != "" {
+		fmt.Fprintf(&sb, "Last error:  %s\n", p.LastError)
+	}
+	return sb.String(), nil
+}
+
+func formatManifestInfo(m *plugins.Manifest, format string) (string, error) {
+	if format == "json" {
+		b, err := json.MarshalIndent(m, "", "  ")
+		if err != nil {
+			return "", err
+		}
+		return string(b), nil
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Name:    %s\n", m.Name)
+	fmt.Fprintf(&sb, "Version: %s\n", m.Version)
+	fmt.Fprintf(&sb, "Author:  %s\n", m.Author)
+	if m.Description != nil {
+		fmt.Fprintf(&sb, "Description: %s\n", *m.Description)
+	}
+	if m.Website != nil {
+		fmt.Fprintf(&sb, "Website: %s\n", *m.Website)
+	}
+	return sb.String(), nil
+}
+
+func runPluginInfo(ctx context.Context, arg string) {
+	if isPackagePath(arg) {
+		m, err := plugins.ReadPackageManifest(arg)
+		if err != nil {
+			log.Fatal(ctx, "Failed to read package", "path", arg, err)
+		}
+		out, err := formatManifestInfo(m, pluginOutputFormat)
+		if err != nil {
+			log.Fatal(ctx, "Failed to format output", err)
+		}
+		fmt.Print(out)
+		return
+	}
+	requirePluginsEnabled(ctx)
+	ds, ctx := getAdminContext(ctx)
+	p, err := ds.Plugin(ctx).Get(arg)
+	if err != nil {
+		log.Fatal(ctx, "Plugin not found", "id", arg, err)
+	}
+	out, err := formatPluginInfo(p, pluginOutputFormat)
+	if err != nil {
+		log.Fatal(ctx, "Failed to format output", err)
+	}
+	fmt.Print(out)
+}
+
+func runPluginValidate(ctx context.Context, arg string) {
+	if isPackagePath(arg) {
+		if _, err := plugins.ValidatePackage(arg); err != nil {
+			log.Fatal(ctx, "Validation failed", "path", arg, err)
+		}
+		fmt.Printf("%s: OK\n", arg)
+		return
+	}
+	requirePluginsEnabled(ctx)
+	ds, ctx := getAdminContext(ctx)
+	p, err := ds.Plugin(ctx).Get(arg)
+	if err != nil {
+		log.Fatal(ctx, "Plugin not found", "id", arg, err)
+	}
+	if _, err := plugins.ParseManifest([]byte(p.Manifest)); err != nil {
+		log.Fatal(ctx, "Validation failed", "id", arg, err)
+	}
+	fmt.Printf("%s: OK\n", arg)
+}
 
 // manifestSummary extracts the display name and version from a stored manifest JSON, falling
 // back to the plugin ID when the manifest can't be parsed.

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -5,6 +5,8 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"text/tabwriter"
 
@@ -27,6 +29,17 @@ type pluginManager interface {
 
 var pluginOutputFormat string
 
+var (
+	editConfig      string
+	editConfigFile  string
+	editUsers       string
+	editAllUsers    bool
+	editLibraries   string
+	editAllLibs     bool
+	editWriteAccess bool
+	editNoWrite     bool
+)
+
 func init() {
 	rootCmd.AddCommand(pluginRoot)
 
@@ -34,6 +47,20 @@ func init() {
 	pluginRoot.AddCommand(pluginListCmd)
 	pluginRoot.AddCommand(pluginEnableCmd)
 	pluginRoot.AddCommand(pluginDisableCmd)
+
+	pluginEditCmd.Flags().StringVar(&editConfig, "config", "", "plugin config as JSON")
+	pluginEditCmd.Flags().StringVar(&editConfigFile, "config-file", "", "read plugin config JSON from a file ('-' for stdin)")
+	pluginEditCmd.MarkFlagsMutuallyExclusive("config", "config-file")
+	pluginEditCmd.Flags().StringVar(&editUsers, "users", "", "comma-separated usernames the plugin may access")
+	pluginEditCmd.Flags().BoolVar(&editAllUsers, "all-users", false, "grant the plugin access to all users")
+	pluginEditCmd.MarkFlagsMutuallyExclusive("users", "all-users")
+	pluginEditCmd.Flags().StringVar(&editLibraries, "libraries", "", "comma-separated library IDs the plugin may access")
+	pluginEditCmd.Flags().BoolVar(&editAllLibs, "all-libraries", false, "grant the plugin access to all libraries")
+	pluginEditCmd.MarkFlagsMutuallyExclusive("libraries", "all-libraries")
+	pluginEditCmd.Flags().BoolVar(&editWriteAccess, "write-access", false, "allow the plugin write access to libraries")
+	pluginEditCmd.Flags().BoolVar(&editNoWrite, "no-write-access", false, "deny the plugin write access to libraries")
+	pluginEditCmd.MarkFlagsMutuallyExclusive("write-access", "no-write-access")
+	pluginRoot.AddCommand(pluginEditCmd)
 }
 
 var (
@@ -153,4 +180,110 @@ func enablePlugin(ctx context.Context, mgr pluginManager, id string) error {
 
 func disablePlugin(ctx context.Context, mgr pluginManager, id string) error {
 	return mgr.DisablePlugin(ctx, id)
+}
+
+type pluginEditOptions struct {
+	config       *string // nil = leave unchanged
+	users        *string
+	allUsers     *bool
+	libraries    *string
+	allLibraries *bool
+	writeAccess  *bool
+}
+
+var pluginEditCmd = &cobra.Command{
+	Use:   "edit <id>",
+	Short: "Update a plugin's config and/or permissions",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		requirePluginsEnabled(cmd.Context())
+		_, ctx := getAdminContext(cmd.Context())
+		mgr := GetPluginManager(ctx)
+		opts := buildEditOptionsFromFlags(cmd)
+		if err := applyPluginEdit(ctx, mgr, args[0], opts); err != nil {
+			log.Fatal(ctx, "Failed to edit plugin", "id", args[0], err)
+		}
+	},
+}
+
+func buildEditOptionsFromFlags(cmd *cobra.Command) pluginEditOptions {
+	var opts pluginEditOptions
+	switch {
+	case cmd.Flags().Changed("config"):
+		c := editConfig
+		opts.config = &c
+	case cmd.Flags().Changed("config-file"):
+		c := readConfigFile(editConfigFile)
+		opts.config = &c
+	}
+	if cmd.Flags().Changed("users") {
+		u := editUsers
+		opts.users = &u
+	}
+	if cmd.Flags().Changed("all-users") {
+		opts.allUsers = &editAllUsers
+	}
+	if cmd.Flags().Changed("libraries") {
+		l := editLibraries
+		opts.libraries = &l
+	}
+	if cmd.Flags().Changed("all-libraries") {
+		opts.allLibraries = &editAllLibs
+	}
+	if cmd.Flags().Changed("write-access") || cmd.Flags().Changed("no-write-access") {
+		wa := editWriteAccess && !editNoWrite
+		opts.writeAccess = &wa
+	}
+	return opts
+}
+
+func readConfigFile(path string) string {
+	var data []byte
+	var err error
+	if path == "-" {
+		data, err = io.ReadAll(os.Stdin)
+	} else {
+		data, err = os.ReadFile(path)
+	}
+	if err != nil {
+		log.Fatal("Failed to read config file", "path", path, err)
+	}
+	return string(data)
+}
+
+func applyPluginEdit(ctx context.Context, mgr pluginManager, id string, opts pluginEditOptions) error {
+	if opts.config == nil && opts.users == nil && opts.allUsers == nil &&
+		opts.libraries == nil && opts.allLibraries == nil && opts.writeAccess == nil {
+		return fmt.Errorf("nothing to update: provide at least one of --config/--users/--libraries/--write-access")
+	}
+	if opts.config != nil {
+		if err := mgr.ValidatePluginConfig(ctx, id, *opts.config); err != nil {
+			return fmt.Errorf("invalid config: %w", err)
+		}
+		if err := mgr.UpdatePluginConfig(ctx, id, *opts.config); err != nil {
+			return err
+		}
+	}
+	if opts.users != nil || opts.allUsers != nil {
+		users := ""
+		if opts.users != nil {
+			users = *opts.users
+		}
+		allUsers := opts.allUsers != nil && *opts.allUsers
+		if err := mgr.UpdatePluginUsers(ctx, id, users, allUsers); err != nil {
+			return err
+		}
+	}
+	if opts.libraries != nil || opts.allLibraries != nil || opts.writeAccess != nil {
+		libs := ""
+		if opts.libraries != nil {
+			libs = *opts.libraries
+		}
+		allLibs := opts.allLibraries != nil && *opts.allLibraries
+		writeAccess := opts.writeAccess != nil && *opts.writeAccess
+		if err := mgr.UpdatePluginLibraries(ctx, id, libs, allLibs, writeAccess); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -7,8 +7,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
@@ -160,6 +162,19 @@ func formatPluginInfo(p *model.Plugin, format string) (string, error) {
 	fmt.Fprintf(&sb, "All users:   %t\n", p.AllUsers)
 	fmt.Fprintf(&sb, "All libs:    %t\n", p.AllLibraries)
 	fmt.Fprintf(&sb, "Write access:%t\n", p.AllowWriteAccess)
+	if p.Users != "" {
+		fmt.Fprintf(&sb, "Users:       %s\n", p.Users)
+	}
+	if p.Libraries != "" {
+		fmt.Fprintf(&sb, "Libraries:   %s\n", p.Libraries)
+	}
+	if m, err := plugins.ParseManifest([]byte(p.Manifest)); err == nil {
+		if perms := declaredPermissions(m.Permissions); len(perms) > 0 {
+			fmt.Fprintf(&sb, "Permissions: %s\n", strings.Join(perms, ", "))
+		}
+	}
+	fmt.Fprintf(&sb, "Created:     %s\n", p.CreatedAt.Format(time.RFC3339))
+	fmt.Fprintf(&sb, "Updated:     %s\n", p.UpdatedAt.Format(time.RFC3339))
 	if p.Config != "" {
 		fmt.Fprintf(&sb, "Config:      %s\n", p.Config)
 	}
@@ -167,6 +182,46 @@ func formatPluginInfo(p *model.Plugin, format string) (string, error) {
 		fmt.Fprintf(&sb, "Last error:  %s\n", p.LastError)
 	}
 	return sb.String(), nil
+}
+
+// declaredPermissions returns a sorted list of permission names declared in the manifest.
+func declaredPermissions(p *plugins.Permissions) []string {
+	if p == nil {
+		return nil
+	}
+	var names []string
+	if p.Artwork != nil {
+		names = append(names, "artwork")
+	}
+	if p.Cache != nil {
+		names = append(names, "cache")
+	}
+	if p.Http != nil {
+		names = append(names, "http")
+	}
+	if p.Kvstore != nil {
+		names = append(names, "kvstore")
+	}
+	if p.Library != nil {
+		names = append(names, "library")
+	}
+	if p.Scheduler != nil {
+		names = append(names, "scheduler")
+	}
+	if p.Subsonicapi != nil {
+		names = append(names, "subsonicapi")
+	}
+	if p.Taskqueue != nil {
+		names = append(names, "taskqueue")
+	}
+	if p.Users != nil {
+		names = append(names, "users")
+	}
+	if p.Websocket != nil {
+		names = append(names, "websocket")
+	}
+	sort.Strings(names)
+	return names
 }
 
 func formatManifestInfo(m *plugins.Manifest, format string) (string, error) {
@@ -187,6 +242,9 @@ func formatManifestInfo(m *plugins.Manifest, format string) (string, error) {
 	if m.Website != nil {
 		fmt.Fprintf(&sb, "Website: %s\n", *m.Website)
 	}
+	if perms := declaredPermissions(m.Permissions); len(perms) > 0 {
+		fmt.Fprintf(&sb, "Permissions: %s\n", strings.Join(perms, ", "))
+	}
 	return sb.String(), nil
 }
 
@@ -201,6 +259,11 @@ func runPluginInfo(ctx context.Context, arg string) {
 			log.Fatal(ctx, "Failed to format output", err)
 		}
 		fmt.Print(out)
+		if pluginOutputFormat == "text" {
+			if sha, err := plugins.ComputeFileSHA256(arg); err == nil {
+				fmt.Printf("SHA256:  %s\n", sha)
+			}
+		}
 		return
 	}
 	requirePluginsEnabled(ctx)
@@ -232,6 +295,12 @@ func runPluginValidate(ctx context.Context, arg string) {
 	}
 	if _, err := plugins.ParseManifest([]byte(p.Manifest)); err != nil {
 		log.Fatal(ctx, "Validation failed", "id", arg, err)
+	}
+	if p.Config != "" {
+		mgr := GetPluginManager(ctx)
+		if err := mgr.ValidatePluginConfig(ctx, arg, p.Config); err != nil {
+			log.Fatal(ctx, "Config validation failed", "id", arg, err)
+		}
 	}
 	fmt.Printf("%s: OK\n", arg)
 }
@@ -360,6 +429,8 @@ func buildEditOptionsFromFlags(cmd *cobra.Command) pluginEditOptions {
 		opts.allLibraries = &editAllLibs
 	}
 	if cmd.Flags().Changed("write-access") || cmd.Flags().Changed("no-write-access") {
+		// write-access is part of the library-permission group, so setting only
+		// --no-write-access still triggers UpdatePluginLibraries (clearing unspecified library access).
 		wa := editWriteAccess && !editNoWrite
 		opts.writeAccess = &wa
 	}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"sort"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -147,97 +146,68 @@ func isPackagePath(arg string) bool {
 }
 
 func formatPluginInfo(p *model.Plugin, format string) (string, error) {
-	if format == "json" {
+	switch format {
+	case "json":
 		b, err := json.MarshalIndent(p, "", "  ")
 		if err != nil {
 			return "", err
 		}
 		return string(b), nil
+	case "text":
+	default:
+		return "", fmt.Errorf("invalid output format %q (supported: text, json)", format)
 	}
 	name, version := manifestSummary(*p)
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "ID:          %s\n", p.ID)
-	fmt.Fprintf(&sb, "Name:        %s\n", name)
-	fmt.Fprintf(&sb, "Version:     %s\n", version)
-	fmt.Fprintf(&sb, "Enabled:     %t\n", p.Enabled)
-	fmt.Fprintf(&sb, "Path:        %s\n", p.Path)
-	fmt.Fprintf(&sb, "SHA256:      %s\n", p.SHA256)
-	fmt.Fprintf(&sb, "All users:   %t\n", p.AllUsers)
-	fmt.Fprintf(&sb, "All libs:    %t\n", p.AllLibraries)
-	fmt.Fprintf(&sb, "Write access:%t\n", p.AllowWriteAccess)
+	fmt.Fprintf(&sb, "ID:           %s\n", p.ID)
+	fmt.Fprintf(&sb, "Name:         %s\n", name)
+	fmt.Fprintf(&sb, "Version:      %s\n", version)
+	fmt.Fprintf(&sb, "Enabled:      %t\n", p.Enabled)
+	fmt.Fprintf(&sb, "Path:         %s\n", p.Path)
+	fmt.Fprintf(&sb, "SHA256:       %s\n", p.SHA256)
+	fmt.Fprintf(&sb, "All users:    %t\n", p.AllUsers)
+	fmt.Fprintf(&sb, "All libs:     %t\n", p.AllLibraries)
+	fmt.Fprintf(&sb, "Write access: %t\n", p.AllowWriteAccess)
 	if p.Users != "" {
-		fmt.Fprintf(&sb, "Users:       %s\n", p.Users)
+		fmt.Fprintf(&sb, "Users:        %s\n", p.Users)
 	}
 	if p.Libraries != "" {
-		fmt.Fprintf(&sb, "Libraries:   %s\n", p.Libraries)
+		fmt.Fprintf(&sb, "Libraries:    %s\n", p.Libraries)
 	}
 	if m, err := plugins.ParseManifest([]byte(p.Manifest)); err == nil {
-		if perms := declaredPermissions(m.Permissions); len(perms) > 0 {
-			fmt.Fprintf(&sb, "Permissions: %s\n", strings.Join(perms, ", "))
+		if perms := m.Permissions.DeclaredNames(); len(perms) > 0 {
+			fmt.Fprintf(&sb, "Permissions:  %s\n", strings.Join(perms, ", "))
 		}
 	}
 	if !p.CreatedAt.IsZero() {
-		fmt.Fprintf(&sb, "Created:     %s\n", p.CreatedAt.Format(time.RFC3339))
+		fmt.Fprintf(&sb, "Created:      %s\n", p.CreatedAt.Format(time.RFC3339))
 	}
 	if !p.UpdatedAt.IsZero() {
-		fmt.Fprintf(&sb, "Updated:     %s\n", p.UpdatedAt.Format(time.RFC3339))
+		fmt.Fprintf(&sb, "Updated:      %s\n", p.UpdatedAt.Format(time.RFC3339))
 	}
 	if p.Config != "" {
-		fmt.Fprintf(&sb, "Config:      %s\n", p.Config)
+		fmt.Fprintf(&sb, "Config:       %s\n", p.Config)
 	}
 	if p.LastError != "" {
-		fmt.Fprintf(&sb, "Last error:  %s\n", p.LastError)
+		fmt.Fprintf(&sb, "Last error:   %s\n", p.LastError)
 	}
 	return sb.String(), nil
 }
 
-// declaredPermissions returns a sorted list of permission names declared in the manifest.
-func declaredPermissions(p *plugins.Permissions) []string {
-	if p == nil {
-		return nil
-	}
-	var names []string
-	if p.Artwork != nil {
-		names = append(names, "artwork")
-	}
-	if p.Cache != nil {
-		names = append(names, "cache")
-	}
-	if p.Http != nil {
-		names = append(names, "http")
-	}
-	if p.Kvstore != nil {
-		names = append(names, "kvstore")
-	}
-	if p.Library != nil {
-		names = append(names, "library")
-	}
-	if p.Scheduler != nil {
-		names = append(names, "scheduler")
-	}
-	if p.Subsonicapi != nil {
-		names = append(names, "subsonicapi")
-	}
-	if p.Taskqueue != nil {
-		names = append(names, "taskqueue")
-	}
-	if p.Users != nil {
-		names = append(names, "users")
-	}
-	if p.Websocket != nil {
-		names = append(names, "websocket")
-	}
-	sort.Strings(names)
-	return names
-}
-
-func formatManifestInfo(m *plugins.Manifest, format string) (string, error) {
-	if format == "json" {
-		b, err := json.MarshalIndent(m, "", "  ")
+func formatManifestInfo(m *plugins.Manifest, sha256, format string) (string, error) {
+	switch format {
+	case "json":
+		b, err := json.MarshalIndent(struct {
+			*plugins.Manifest
+			SHA256 string `json:"sha256"`
+		}{m, sha256}, "", "  ")
 		if err != nil {
 			return "", err
 		}
 		return string(b), nil
+	case "text":
+	default:
+		return "", fmt.Errorf("invalid output format %q (supported: text, json)", format)
 	}
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "Name:    %s\n", m.Name)
@@ -249,9 +219,10 @@ func formatManifestInfo(m *plugins.Manifest, format string) (string, error) {
 	if m.Website != nil {
 		fmt.Fprintf(&sb, "Website: %s\n", *m.Website)
 	}
-	if perms := declaredPermissions(m.Permissions); len(perms) > 0 {
+	if perms := m.Permissions.DeclaredNames(); len(perms) > 0 {
 		fmt.Fprintf(&sb, "Permissions: %s\n", strings.Join(perms, ", "))
 	}
+	fmt.Fprintf(&sb, "SHA256:  %s\n", sha256)
 	return sb.String(), nil
 }
 
@@ -261,16 +232,15 @@ func runPluginInfo(ctx context.Context, arg string) {
 		if err != nil {
 			log.Fatal(ctx, "Failed to read package", "path", arg, err)
 		}
-		out, err := formatManifestInfo(m, pluginInfoFormat)
+		sha, err := plugins.ComputeFileSHA256(arg)
+		if err != nil {
+			log.Fatal(ctx, "Failed to hash package", "path", arg, err)
+		}
+		out, err := formatManifestInfo(m, sha, pluginInfoFormat)
 		if err != nil {
 			log.Fatal(ctx, "Failed to format output", err)
 		}
 		fmt.Print(out)
-		if pluginInfoFormat == "text" {
-			if sha, err := plugins.ComputeFileSHA256(arg); err == nil {
-				fmt.Printf("SHA256:  %s\n", sha)
-			}
-		}
 		return
 	}
 	requirePluginsEnabled(ctx)
@@ -372,7 +342,8 @@ func runPluginList(ctx context.Context) {
 	fmt.Print(out)
 }
 
-// requirePluginsEnabled aborts the command if the plugin system is disabled.
+// requirePluginsEnabled gates DB/manager-backed commands; off-disk .ndp
+// inspection deliberately skips this so it works without a configured server.
 func requirePluginsEnabled(ctx context.Context) {
 	if !conf.Server.Plugins.Enabled {
 		log.Fatal(ctx, "Plugin system is disabled (set Plugins.Enabled to use this command)")
@@ -402,23 +373,27 @@ var pluginEditCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		requirePluginsEnabled(cmd.Context())
-		_, ctx := getAdminContext(cmd.Context())
+		ds, ctx := getAdminContext(cmd.Context())
+		cur, err := ds.Plugin(ctx).Get(args[0])
+		if err != nil {
+			log.Fatal(ctx, "Plugin not found", "id", args[0], err)
+		}
 		mgr := GetPluginManager(ctx)
-		opts := buildEditOptionsFromFlags(cmd)
-		if err := applyPluginEdit(ctx, mgr, args[0], opts); err != nil {
+		opts := buildEditOptionsFromFlags(ctx, cmd)
+		if err := applyPluginEdit(ctx, mgr, cur, opts); err != nil {
 			log.Fatal(ctx, "Failed to edit plugin", "id", args[0], err)
 		}
 	},
 }
 
-func buildEditOptionsFromFlags(cmd *cobra.Command) pluginEditOptions {
+func buildEditOptionsFromFlags(ctx context.Context, cmd *cobra.Command) pluginEditOptions {
 	var opts pluginEditOptions
 	switch {
 	case cmd.Flags().Changed("config"):
 		c := editConfig
 		opts.config = &c
 	case cmd.Flags().Changed("config-file"):
-		c := readConfigFile(editConfigFile)
+		c := readConfigFile(ctx, editConfigFile)
 		opts.config = &c
 	}
 	if cmd.Flags().Changed("users") {
@@ -426,25 +401,27 @@ func buildEditOptionsFromFlags(cmd *cobra.Command) pluginEditOptions {
 		opts.users = &u
 	}
 	if cmd.Flags().Changed("all-users") {
-		opts.allUsers = &editAllUsers
+		v := editAllUsers
+		opts.allUsers = &v
 	}
 	if cmd.Flags().Changed("libraries") {
 		l := editLibraries
 		opts.libraries = &l
 	}
 	if cmd.Flags().Changed("all-libraries") {
-		opts.allLibraries = &editAllLibs
+		v := editAllLibs
+		opts.allLibraries = &v
 	}
 	if cmd.Flags().Changed("write-access") || cmd.Flags().Changed("no-write-access") {
-		// write-access is part of the library-permission group, so setting only
-		// --no-write-access still triggers UpdatePluginLibraries (clearing unspecified library access).
+		// write-access is part of the library-permission group, so it is updated
+		// alongside the (preserved) library list rather than on its own.
 		wa := editWriteAccess && !editNoWrite
 		opts.writeAccess = &wa
 	}
 	return opts
 }
 
-func readConfigFile(path string) string {
+func readConfigFile(ctx context.Context, path string) string {
 	var data []byte
 	var err error
 	if path == "-" {
@@ -453,16 +430,21 @@ func readConfigFile(path string) string {
 		data, err = os.ReadFile(path)
 	}
 	if err != nil {
-		log.Fatal("Failed to read config file", "path", path, err)
+		log.Fatal(ctx, "Failed to read config file", "path", path, err)
 	}
 	return string(data)
 }
 
-func applyPluginEdit(ctx context.Context, mgr pluginManager, id string, opts pluginEditOptions) error {
+// applyPluginEdit applies the requested changes on top of the plugin's current
+// state. Like the native API, it reads the existing users/libraries before
+// updating so that flipping one flag (e.g. --write-access) does not wipe
+// unspecified fields, and rejects non-JSON users/libraries values.
+func applyPluginEdit(ctx context.Context, mgr pluginManager, cur *model.Plugin, opts pluginEditOptions) error {
 	if opts.config == nil && opts.users == nil && opts.allUsers == nil &&
 		opts.libraries == nil && opts.allLibraries == nil && opts.writeAccess == nil {
 		return fmt.Errorf("nothing to update: provide at least one of --config/--users/--libraries/--write-access")
 	}
+	id := cur.ID
 	if opts.config != nil {
 		if err := mgr.ValidatePluginConfig(ctx, id, *opts.config); err != nil {
 			return fmt.Errorf("invalid config: %w", err)
@@ -472,22 +454,34 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, id string, opts plu
 		}
 	}
 	if opts.users != nil || opts.allUsers != nil {
-		users := ""
+		users, allUsers := cur.Users, cur.AllUsers
 		if opts.users != nil {
+			if *opts.users != "" && !json.Valid([]byte(*opts.users)) {
+				return fmt.Errorf("invalid JSON in --users")
+			}
 			users = *opts.users
 		}
-		allUsers := opts.allUsers != nil && *opts.allUsers
+		if opts.allUsers != nil {
+			allUsers = *opts.allUsers
+		}
 		if err := mgr.UpdatePluginUsers(ctx, id, users, allUsers); err != nil {
 			return err
 		}
 	}
 	if opts.libraries != nil || opts.allLibraries != nil || opts.writeAccess != nil {
-		libs := ""
+		libs, allLibs, writeAccess := cur.Libraries, cur.AllLibraries, cur.AllowWriteAccess
 		if opts.libraries != nil {
+			if *opts.libraries != "" && !json.Valid([]byte(*opts.libraries)) {
+				return fmt.Errorf("invalid JSON in --libraries")
+			}
 			libs = *opts.libraries
 		}
-		allLibs := opts.allLibraries != nil && *opts.allLibraries
-		writeAccess := opts.writeAccess != nil && *opts.writeAccess
+		if opts.allLibraries != nil {
+			allLibs = *opts.allLibraries
+		}
+		if opts.writeAccess != nil {
+			writeAccess = *opts.writeAccess
+		}
 		if err := mgr.UpdatePluginLibraries(ctx, id, libs, allLibs, writeAccess); err != nil {
 			return err
 		}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -30,7 +30,10 @@ type pluginManager interface {
 	RescanPlugins(ctx context.Context) error
 }
 
-var pluginOutputFormat string
+var (
+	pluginListFormat string
+	pluginInfoFormat string
+)
 
 var (
 	editConfig      string
@@ -46,7 +49,7 @@ var (
 func init() {
 	rootCmd.AddCommand(pluginRoot)
 
-	pluginListCmd.Flags().StringVarP(&pluginOutputFormat, "format", "f", "table", "output format [supported values: table, csv, json]")
+	pluginListCmd.Flags().StringVarP(&pluginListFormat, "format", "f", "table", "output format [supported values: table, csv, json]")
 	pluginRoot.AddCommand(pluginListCmd)
 	pluginRoot.AddCommand(pluginEnableCmd)
 	pluginRoot.AddCommand(pluginDisableCmd)
@@ -65,7 +68,7 @@ func init() {
 	pluginEditCmd.MarkFlagsMutuallyExclusive("write-access", "no-write-access")
 	pluginRoot.AddCommand(pluginEditCmd)
 
-	pluginInfoCmd.Flags().StringVarP(&pluginOutputFormat, "format", "f", "text", "output format [supported values: text, json]")
+	pluginInfoCmd.Flags().StringVarP(&pluginInfoFormat, "format", "f", "text", "output format [supported values: text, json]")
 	pluginRoot.AddCommand(pluginInfoCmd)
 	pluginRoot.AddCommand(pluginValidateCmd)
 	pluginRoot.AddCommand(pluginRescanCmd)
@@ -258,12 +261,12 @@ func runPluginInfo(ctx context.Context, arg string) {
 		if err != nil {
 			log.Fatal(ctx, "Failed to read package", "path", arg, err)
 		}
-		out, err := formatManifestInfo(m, pluginOutputFormat)
+		out, err := formatManifestInfo(m, pluginInfoFormat)
 		if err != nil {
 			log.Fatal(ctx, "Failed to format output", err)
 		}
 		fmt.Print(out)
-		if pluginOutputFormat == "text" {
+		if pluginInfoFormat == "text" {
 			if sha, err := plugins.ComputeFileSHA256(arg); err == nil {
 				fmt.Printf("SHA256:  %s\n", sha)
 			}
@@ -276,7 +279,7 @@ func runPluginInfo(ctx context.Context, arg string) {
 	if err != nil {
 		log.Fatal(ctx, "Plugin not found", "id", arg, err)
 	}
-	out, err := formatPluginInfo(p, pluginOutputFormat)
+	out, err := formatPluginInfo(p, pluginInfoFormat)
 	if err != nil {
 		log.Fatal(ctx, "Failed to format output", err)
 	}
@@ -362,7 +365,7 @@ func runPluginList(ctx context.Context) {
 	if err != nil {
 		log.Fatal(ctx, "Failed to list plugins", err)
 	}
-	out, err := formatPluginList(list, pluginOutputFormat)
+	out, err := formatPluginList(list, pluginListFormat)
 	if err != nil {
 		log.Fatal(ctx, "Failed to format output", err)
 	}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -460,6 +460,7 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, cur *model.Plugin, 
 				return err
 			}
 			users = parsed
+			allUsers = false // an explicit list means "restrict to these users"
 		}
 		if opts.allUsers != nil {
 			allUsers = *opts.allUsers
@@ -476,6 +477,7 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, cur *model.Plugin, 
 				return err
 			}
 			libs = parsed
+			allLibs = false // an explicit list means "restrict to these libraries"
 		}
 		if opts.allLibraries != nil {
 			allLibs = *opts.allLibraries

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -56,10 +57,10 @@ func init() {
 	pluginEditCmd.Flags().StringVar(&editConfig, "config", "", "plugin config as JSON")
 	pluginEditCmd.Flags().StringVar(&editConfigFile, "config-file", "", "read plugin config JSON from a file ('-' for stdin)")
 	pluginEditCmd.MarkFlagsMutuallyExclusive("config", "config-file")
-	pluginEditCmd.Flags().StringVar(&editUsers, "users", "", "comma-separated usernames the plugin may access")
+	pluginEditCmd.Flags().StringVar(&editUsers, "users", "", `usernames the plugin may access: comma-separated (alice,bob) or a JSON array (["alice","bob"])`)
 	pluginEditCmd.Flags().BoolVar(&editAllUsers, "all-users", false, "grant the plugin access to all users")
 	pluginEditCmd.MarkFlagsMutuallyExclusive("users", "all-users")
-	pluginEditCmd.Flags().StringVar(&editLibraries, "libraries", "", "comma-separated library IDs the plugin may access")
+	pluginEditCmd.Flags().StringVar(&editLibraries, "libraries", "", `library IDs the plugin may access: comma-separated (1,2) or a JSON array ([1,2])`)
 	pluginEditCmd.Flags().BoolVar(&editAllLibs, "all-libraries", false, "grant the plugin access to all libraries")
 	pluginEditCmd.MarkFlagsMutuallyExclusive("libraries", "all-libraries")
 	pluginEditCmd.Flags().BoolVar(&editWriteAccess, "write-access", false, "allow the plugin write access to libraries")
@@ -137,12 +138,13 @@ var (
 	}
 )
 
+// isPackagePath reports whether arg refers to an .ndp package file (as opposed
+// to an installed plugin ID). It only checks the extension: a missing file still
+// routes to the off-disk path so ReadManifest can report a precise "no such
+// file" error instead of a misleading "Plugin not found". Plugin IDs are
+// filenames with the .ndp suffix stripped, so an ID can never collide here.
 func isPackagePath(arg string) bool {
-	if !strings.HasSuffix(arg, plugins.PackageExtension) {
-		return false
-	}
-	info, err := os.Stat(arg)
-	return err == nil && !info.IsDir()
+	return strings.HasSuffix(arg, plugins.PackageExtension)
 }
 
 func formatPluginInfo(p *model.Plugin, format string) (string, error) {
@@ -456,10 +458,11 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, cur *model.Plugin, 
 	if opts.users != nil || opts.allUsers != nil {
 		users, allUsers := cur.Users, cur.AllUsers
 		if opts.users != nil {
-			if *opts.users != "" && !json.Valid([]byte(*opts.users)) {
-				return fmt.Errorf("invalid JSON in --users")
+			parsed, err := usersToJSON(*opts.users)
+			if err != nil {
+				return err
 			}
-			users = *opts.users
+			users = parsed
 		}
 		if opts.allUsers != nil {
 			allUsers = *opts.allUsers
@@ -471,10 +474,11 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, cur *model.Plugin, 
 	if opts.libraries != nil || opts.allLibraries != nil || opts.writeAccess != nil {
 		libs, allLibs, writeAccess := cur.Libraries, cur.AllLibraries, cur.AllowWriteAccess
 		if opts.libraries != nil {
-			if *opts.libraries != "" && !json.Valid([]byte(*opts.libraries)) {
-				return fmt.Errorf("invalid JSON in --libraries")
+			parsed, err := librariesToJSON(*opts.libraries)
+			if err != nil {
+				return err
 			}
-			libs = *opts.libraries
+			libs = parsed
 		}
 		if opts.allLibraries != nil {
 			allLibs = *opts.allLibraries
@@ -487,6 +491,56 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, cur *model.Plugin, 
 		}
 	}
 	return nil
+}
+
+// usersToJSON normalizes a --users value to the JSON-array form the manager
+// stores. A value starting with '[' is treated as JSON (validated as-is);
+// anything else is parsed as a comma-separated list. Empty input yields "[]".
+func usersToJSON(value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "[]", nil
+	}
+	if strings.HasPrefix(strings.TrimSpace(value), "[") {
+		if !json.Valid([]byte(value)) {
+			return "", fmt.Errorf("invalid JSON in --users")
+		}
+		return value, nil
+	}
+	var names []string
+	for _, u := range strings.Split(value, ",") {
+		if u = strings.TrimSpace(u); u != "" {
+			names = append(names, u)
+		}
+	}
+	b, _ := json.Marshal(names)
+	return string(b), nil
+}
+
+// librariesToJSON normalizes a --libraries value to the JSON-array form the
+// manager stores. A value starting with '[' is treated as JSON; anything else
+// is parsed as a comma-separated list of integer IDs. Empty input yields "[]".
+func librariesToJSON(value string) (string, error) {
+	if strings.TrimSpace(value) == "" {
+		return "[]", nil
+	}
+	if strings.HasPrefix(strings.TrimSpace(value), "[") {
+		if !json.Valid([]byte(value)) {
+			return "", fmt.Errorf("invalid JSON in --libraries")
+		}
+		return value, nil
+	}
+	ids := []int{}
+	for _, l := range strings.Split(value, ",") {
+		if l = strings.TrimSpace(l); l != "" {
+			id, err := strconv.Atoi(l)
+			if err != nil {
+				return "", fmt.Errorf("invalid library ID %q: must be an integer", l)
+			}
+			ids = append(ids, id)
+		}
+	}
+	b, _ := json.Marshal(ids)
+	return string(b), nil
 }
 
 var pluginRescanCmd = &cobra.Command{

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -228,7 +228,7 @@ func formatManifestInfo(m *plugins.Manifest, sha256, format string) (string, err
 
 func runPluginInfo(ctx context.Context, arg string) {
 	if isPackagePath(arg) {
-		m, err := plugins.ReadPackageManifest(arg)
+		m, err := plugins.ReadManifest(arg)
 		if err != nil {
 			log.Fatal(ctx, "Failed to read package", "path", arg, err)
 		}
@@ -258,7 +258,7 @@ func runPluginInfo(ctx context.Context, arg string) {
 
 func runPluginValidate(ctx context.Context, arg string) {
 	if isPackagePath(arg) {
-		if _, err := plugins.ValidatePackage(arg); err != nil {
+		if _, err := plugins.ReadManifest(arg); err != nil {
 			log.Fatal(ctx, "Validation failed", "path", arg, err)
 		}
 		fmt.Printf("%s: OK\n", arg)

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -173,8 +173,12 @@ func formatPluginInfo(p *model.Plugin, format string) (string, error) {
 			fmt.Fprintf(&sb, "Permissions: %s\n", strings.Join(perms, ", "))
 		}
 	}
-	fmt.Fprintf(&sb, "Created:     %s\n", p.CreatedAt.Format(time.RFC3339))
-	fmt.Fprintf(&sb, "Updated:     %s\n", p.UpdatedAt.Format(time.RFC3339))
+	if !p.CreatedAt.IsZero() {
+		fmt.Fprintf(&sb, "Created:     %s\n", p.CreatedAt.Format(time.RFC3339))
+	}
+	if !p.UpdatedAt.IsZero() {
+		fmt.Fprintf(&sb, "Updated:     %s\n", p.UpdatedAt.Format(time.RFC3339))
+	}
 	if p.Config != "" {
 		fmt.Fprintf(&sb, "Config:      %s\n", p.Config)
 	}

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -66,6 +66,7 @@ func init() {
 	pluginInfoCmd.Flags().StringVarP(&pluginOutputFormat, "format", "f", "text", "output format [supported values: text, json]")
 	pluginRoot.AddCommand(pluginInfoCmd)
 	pluginRoot.AddCommand(pluginValidateCmd)
+	pluginRoot.AddCommand(pluginRescanCmd)
 }
 
 var (
@@ -414,4 +415,21 @@ func applyPluginEdit(ctx context.Context, mgr pluginManager, id string, opts plu
 		}
 	}
 	return nil
+}
+
+var pluginRescanCmd = &cobra.Command{
+	Use:   "rescan",
+	Short: "Re-discover plugins in the plugins folder",
+	Run: func(cmd *cobra.Command, args []string) {
+		requirePluginsEnabled(cmd.Context())
+		_, ctx := getAdminContext(cmd.Context())
+		mgr := GetPluginManager(ctx)
+		if err := rescanPlugins(ctx, mgr); err != nil {
+			log.Fatal(ctx, "Failed to rescan plugins", err)
+		}
+	},
+}
+
+func rescanPlugins(ctx context.Context, mgr pluginManager) error {
+	return mgr.RescanPlugins(ctx)
 }

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 
 	"github.com/navidrome/navidrome/model"
@@ -102,5 +103,14 @@ var _ = Describe("applyPluginEdit", func() {
 		mgr := &tests.MockPluginManager{}
 		err := applyPluginEdit(context.Background(), mgr, "alpha", pluginEditOptions{})
 		Expect(err).To(HaveOccurred())
+	})
+
+	It("aborts the config update when validation fails", func() {
+		mgr := &tests.MockPluginManager{ValidateError: errors.New("bad config")}
+		cfg := `{"key":"val"}`
+		err := applyPluginEdit(context.Background(), mgr, "alpha", pluginEditOptions{config: &cfg})
+		Expect(err).To(HaveOccurred())
+		Expect(mgr.ValidatePluginConfigCalls).To(HaveLen(1))
+		Expect(mgr.UpdatePluginConfigCalls).To(BeEmpty())
 	})
 })

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/navidrome/navidrome/model"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var samplePlugins = model.Plugins{
+	{ID: "alpha", Manifest: `{"name":"Alpha","version":"1.0.0","author":"me"}`, Enabled: true},
+	{ID: "beta", Manifest: `{"name":"Beta","version":"2.1.0","author":"me"}`, Enabled: false, LastError: "boom"},
+}
+
+var _ = Describe("formatPluginList", func() {
+	It("renders csv with a header and one row per plugin", func() {
+		out, err := formatPluginList(samplePlugins, "csv")
+		Expect(err).ToNot(HaveOccurred())
+		lines := strings.Split(strings.TrimSpace(out), "\n")
+		Expect(lines).To(HaveLen(3)) // header + 2 rows
+		Expect(lines[0]).To(ContainSubstring("id"))
+		Expect(out).To(ContainSubstring("alpha"))
+		Expect(out).To(ContainSubstring("beta"))
+	})
+
+	It("renders valid json", func() {
+		out, err := formatPluginList(samplePlugins, "json")
+		Expect(err).ToNot(HaveOccurred())
+		var got []map[string]any
+		Expect(json.Unmarshal([]byte(out), &got)).To(Succeed())
+		Expect(got).To(HaveLen(2))
+	})
+
+	It("renders a human table by default", func() {
+		out, err := formatPluginList(samplePlugins, "table")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("Alpha"))
+		Expect(out).To(ContainSubstring("1.0.0"))
+	})
+
+	It("errors on an unknown format", func() {
+		_, err := formatPluginList(samplePlugins, "yaml")
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -184,3 +184,12 @@ var _ = Describe("formatManifestInfo", func() {
 		Expect(out).To(ContainSubstring("\"name\""))
 	})
 })
+
+var _ = Describe("rescanPlugins", func() {
+	It("calls RescanPlugins on the manager", func() {
+		mgr := &tests.MockPluginManager{}
+		err := rescanPlugins(context.Background(), mgr)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.RescanPluginsCalls).To(Equal(1))
+	})
+})

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -83,10 +83,15 @@ var _ = Describe("enable/disable plugin", func() {
 })
 
 var _ = Describe("applyPluginEdit", func() {
+	var cur *model.Plugin
+	BeforeEach(func() {
+		cur = &model.Plugin{ID: "alpha", Users: `["bob"]`, Libraries: `[1,2]`, AllowWriteAccess: true}
+	})
+
 	It("validates then updates config when config is provided", func() {
 		mgr := &tests.MockPluginManager{}
 		cfg := `{"key":"val"}`
-		err := applyPluginEdit(context.Background(), mgr, "alpha", pluginEditOptions{config: &cfg})
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{config: &cfg})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mgr.ValidatePluginConfigCalls).To(HaveLen(1))
 		Expect(mgr.ValidatePluginConfigCalls[0].ConfigJSON).To(Equal(cfg))
@@ -97,7 +102,7 @@ var _ = Describe("applyPluginEdit", func() {
 	It("updates users with allUsers flag", func() {
 		mgr := &tests.MockPluginManager{}
 		all := true
-		err := applyPluginEdit(context.Background(), mgr, "alpha",
+		err := applyPluginEdit(context.Background(), mgr, cur,
 			pluginEditOptions{allUsers: &all})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mgr.UpdatePluginUsersCalls).To(HaveLen(1))
@@ -108,7 +113,7 @@ var _ = Describe("applyPluginEdit", func() {
 		mgr := &tests.MockPluginManager{}
 		all := true
 		wr := true
-		err := applyPluginEdit(context.Background(), mgr, "alpha",
+		err := applyPluginEdit(context.Background(), mgr, cur,
 			pluginEditOptions{allLibraries: &all, writeAccess: &wr})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(mgr.UpdatePluginLibrariesCalls).To(HaveLen(1))
@@ -116,16 +121,42 @@ var _ = Describe("applyPluginEdit", func() {
 		Expect(mgr.UpdatePluginLibrariesCalls[0].AllowWriteAccess).To(BeTrue())
 	})
 
+	It("preserves existing fields when only the write-access flag changes", func() {
+		mgr := &tests.MockPluginManager{}
+		no := false
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{writeAccess: &no})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginLibrariesCalls).To(HaveLen(1))
+		Expect(mgr.UpdatePluginLibrariesCalls[0].LibrariesJSON).To(Equal(`[1,2]`)) // not wiped
+		Expect(mgr.UpdatePluginLibrariesCalls[0].AllowWriteAccess).To(BeFalse())
+	})
+
+	It("preserves existing users when only the all-users flag changes", func() {
+		mgr := &tests.MockPluginManager{}
+		all := true
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{allUsers: &all})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginUsersCalls[0].UsersJSON).To(Equal(`["bob"]`)) // not wiped
+	})
+
+	It("rejects a non-JSON users value", func() {
+		mgr := &tests.MockPluginManager{}
+		users := "alice,bob"
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{users: &users})
+		Expect(err).To(HaveOccurred())
+		Expect(mgr.UpdatePluginUsersCalls).To(BeEmpty())
+	})
+
 	It("does nothing and errors when no fields are set", func() {
 		mgr := &tests.MockPluginManager{}
-		err := applyPluginEdit(context.Background(), mgr, "alpha", pluginEditOptions{})
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{})
 		Expect(err).To(HaveOccurred())
 	})
 
 	It("aborts the config update when validation fails", func() {
 		mgr := &tests.MockPluginManager{ValidateError: errors.New("bad config")}
 		cfg := `{"key":"val"}`
-		err := applyPluginEdit(context.Background(), mgr, "alpha", pluginEditOptions{config: &cfg})
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{config: &cfg})
 		Expect(err).To(HaveOccurred())
 		Expect(mgr.ValidatePluginConfigCalls).To(HaveLen(1))
 		Expect(mgr.UpdatePluginConfigCalls).To(BeEmpty())
@@ -166,7 +197,7 @@ var _ = Describe("formatPluginInfo", func() {
 var _ = Describe("formatManifestInfo", func() {
 	It("renders text with name, version, author", func() {
 		m := &plugins.Manifest{Name: "My Plugin", Version: "2.0.0", Author: "me"}
-		out, err := formatManifestInfo(m, "text")
+		out, err := formatManifestInfo(m, "abc123", "text")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(ContainSubstring("My Plugin"))
 		Expect(out).To(ContainSubstring("2.0.0"))
@@ -175,7 +206,7 @@ var _ = Describe("formatManifestInfo", func() {
 
 	It("omits Description and Website when nil", func() {
 		m := &plugins.Manifest{Name: "X", Version: "1.0.0", Author: "a"}
-		out, err := formatManifestInfo(m, "text")
+		out, err := formatManifestInfo(m, "abc123", "text")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).ToNot(ContainSubstring("Description:"))
 		Expect(out).ToNot(ContainSubstring("Website:"))
@@ -185,7 +216,7 @@ var _ = Describe("formatManifestInfo", func() {
 		desc := "a cool plugin"
 		site := "https://example.com"
 		m := &plugins.Manifest{Name: "X", Version: "1.0.0", Author: "a", Description: &desc, Website: &site}
-		out, err := formatManifestInfo(m, "text")
+		out, err := formatManifestInfo(m, "abc123", "text")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(ContainSubstring("a cool plugin"))
 		Expect(out).To(ContainSubstring("https://example.com"))
@@ -193,34 +224,9 @@ var _ = Describe("formatManifestInfo", func() {
 
 	It("renders valid json", func() {
 		m := &plugins.Manifest{Name: "X", Version: "1.0.0", Author: "a"}
-		out, err := formatManifestInfo(m, "json")
+		out, err := formatManifestInfo(m, "abc123", "json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(ContainSubstring("\"name\""))
-	})
-})
-
-var _ = Describe("declaredPermissions", func() {
-	It("returns nil for nil permissions", func() {
-		Expect(declaredPermissions(nil)).To(BeEmpty())
-	})
-
-	It("returns sorted names for set permissions", func() {
-		p := &plugins.Permissions{
-			Subsonicapi: &plugins.SubsonicAPIPermission{},
-			Users:       &plugins.UsersPermission{},
-		}
-		got := declaredPermissions(p)
-		Expect(got).To(Equal([]string{"subsonicapi", "users"}))
-	})
-
-	It("returns all declared names sorted", func() {
-		p := &plugins.Permissions{
-			Http:    &plugins.HTTPPermission{},
-			Artwork: &plugins.ArtworkPermission{},
-			Cache:   &plugins.CachePermission{},
-		}
-		got := declaredPermissions(p)
-		Expect(got).To(Equal([]string{"artwork", "cache", "http"}))
 	})
 })
 
@@ -275,7 +281,7 @@ var _ = Describe("formatManifestInfo enriched text", func() {
 	It("includes Permissions when declared", func() {
 		p := &plugins.Permissions{Http: &plugins.HTTPPermission{}}
 		m := &plugins.Manifest{Name: "P", Version: "1.0.0", Author: "a", Permissions: p}
-		out, err := formatManifestInfo(m, "text")
+		out, err := formatManifestInfo(m, "abc123", "text")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(ContainSubstring("http"))
 		Expect(out).To(ContainSubstring("Permissions:"))
@@ -283,7 +289,7 @@ var _ = Describe("formatManifestInfo enriched text", func() {
 
 	It("omits Permissions line when no permissions declared", func() {
 		m := &plugins.Manifest{Name: "P", Version: "1.0.0", Author: "a"}
-		out, err := formatManifestInfo(m, "text")
+		out, err := formatManifestInfo(m, "abc123", "text")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).ToNot(ContainSubstring("Permissions:"))
 	})
@@ -291,7 +297,7 @@ var _ = Describe("formatManifestInfo enriched text", func() {
 	It("does not alter json output", func() {
 		p := &plugins.Permissions{Http: &plugins.HTTPPermission{}}
 		m := &plugins.Manifest{Name: "P", Version: "1.0.0", Author: "a", Permissions: p}
-		out, err := formatManifestInfo(m, "json")
+		out, err := formatManifestInfo(m, "abc123", "json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(ContainSubstring(`"name"`))
 	})

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/plugins"
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -145,5 +146,41 @@ var _ = Describe("formatPluginInfo", func() {
 		out, err := formatPluginInfo(p, "json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(ContainSubstring("alpha"))
+	})
+})
+
+var _ = Describe("formatManifestInfo", func() {
+	It("renders text with name, version, author", func() {
+		m := &plugins.Manifest{Name: "My Plugin", Version: "2.0.0", Author: "me"}
+		out, err := formatManifestInfo(m, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("My Plugin"))
+		Expect(out).To(ContainSubstring("2.0.0"))
+		Expect(out).To(ContainSubstring("me"))
+	})
+
+	It("omits Description and Website when nil", func() {
+		m := &plugins.Manifest{Name: "X", Version: "1.0.0", Author: "a"}
+		out, err := formatManifestInfo(m, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).ToNot(ContainSubstring("Description:"))
+		Expect(out).ToNot(ContainSubstring("Website:"))
+	})
+
+	It("includes Description and Website when set", func() {
+		desc := "a cool plugin"
+		site := "https://example.com"
+		m := &plugins.Manifest{Name: "X", Version: "1.0.0", Author: "a", Description: &desc, Website: &site}
+		out, err := formatManifestInfo(m, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("a cool plugin"))
+		Expect(out).To(ContainSubstring("https://example.com"))
+	})
+
+	It("renders valid json", func() {
+		m := &plugins.Manifest{Name: "X", Version: "1.0.0", Author: "a"}
+		out, err := formatManifestInfo(m, "json")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("\"name\""))
 	})
 })

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/navidrome/navidrome/model"
@@ -112,5 +114,36 @@ var _ = Describe("applyPluginEdit", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(mgr.ValidatePluginConfigCalls).To(HaveLen(1))
 		Expect(mgr.UpdatePluginConfigCalls).To(BeEmpty())
+	})
+})
+
+var _ = Describe("isPackagePath", func() {
+	It("is true for an existing .ndp file", func() {
+		dir := GinkgoT().TempDir()
+		p := filepath.Join(dir, "x.ndp")
+		Expect(os.WriteFile(p, []byte("x"), 0600)).To(Succeed())
+		Expect(isPackagePath(p)).To(BeTrue())
+	})
+	It("is false for a bare id", func() {
+		Expect(isPackagePath("my-plugin")).To(BeFalse())
+	})
+	It("is false for a .ndp path that does not exist", func() {
+		Expect(isPackagePath("/nope/x.ndp")).To(BeFalse())
+	})
+})
+
+var _ = Describe("formatPluginInfo", func() {
+	It("renders installed plugin details as text", func() {
+		p := &model.Plugin{ID: "alpha", Manifest: `{"name":"Alpha","version":"1.0.0","author":"me"}`, Enabled: true}
+		out, err := formatPluginInfo(p, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("alpha"))
+		Expect(out).To(ContainSubstring("Alpha"))
+	})
+	It("renders json", func() {
+		p := &model.Plugin{ID: "alpha", Manifest: `{}`}
+		out, err := formatPluginInfo(p, "json")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("alpha"))
 	})
 })

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -21,6 +21,19 @@ var samplePlugins = model.Plugins{
 	{ID: "beta", Manifest: `{"name":"Beta","version":"2.1.0","author":"me"}`, Enabled: false, LastError: "boom"},
 }
 
+var _ = Describe("plugin command format flags", func() {
+	// Regression: list and info must not share a format variable. Binding the
+	// same var on both commands makes the last init() registration clobber the
+	// other's default, breaking `plugin list` with no -f flag.
+	It("defaults `list -f` to table", func() {
+		Expect(pluginListCmd.Flags().Lookup("format").DefValue).To(Equal("table"))
+	})
+
+	It("defaults `info -f` to text", func() {
+		Expect(pluginInfoCmd.Flags().Lookup("format").DefValue).To(Equal("text"))
+	})
+})
+
 var _ = Describe("formatPluginList", func() {
 	It("renders csv with a header and one row per plugin", func() {
 		out, err := formatPluginList(samplePlugins, "csv")

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -139,12 +137,44 @@ var _ = Describe("applyPluginEdit", func() {
 		Expect(mgr.UpdatePluginUsersCalls[0].UsersJSON).To(Equal(`["bob"]`)) // not wiped
 	})
 
-	It("rejects a non-JSON users value", func() {
+	It("parses a comma-separated users value into a JSON array", func() {
 		mgr := &tests.MockPluginManager{}
-		users := "alice,bob"
+		users := "alice, bob"
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{users: &users})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginUsersCalls[0].UsersJSON).To(Equal(`["alice","bob"]`))
+	})
+
+	It("passes a JSON-array users value through unchanged", func() {
+		mgr := &tests.MockPluginManager{}
+		users := `["alice","bob"]`
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{users: &users})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginUsersCalls[0].UsersJSON).To(Equal(`["alice","bob"]`))
+	})
+
+	It("rejects a malformed JSON-array users value", func() {
+		mgr := &tests.MockPluginManager{}
+		users := `["alice"`
 		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{users: &users})
 		Expect(err).To(HaveOccurred())
 		Expect(mgr.UpdatePluginUsersCalls).To(BeEmpty())
+	})
+
+	It("parses a comma-separated libraries value into a JSON array of ints", func() {
+		mgr := &tests.MockPluginManager{}
+		libs := "1, 2"
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{libraries: &libs})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginLibrariesCalls[0].LibrariesJSON).To(Equal(`[1,2]`))
+	})
+
+	It("rejects a non-integer library ID", func() {
+		mgr := &tests.MockPluginManager{}
+		libs := "1,abc"
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{libraries: &libs})
+		Expect(err).To(HaveOccurred())
+		Expect(mgr.UpdatePluginLibrariesCalls).To(BeEmpty())
 	})
 
 	It("does nothing and errors when no fields are set", func() {
@@ -164,17 +194,14 @@ var _ = Describe("applyPluginEdit", func() {
 })
 
 var _ = Describe("isPackagePath", func() {
-	It("is true for an existing .ndp file", func() {
-		dir := GinkgoT().TempDir()
-		p := filepath.Join(dir, "x.ndp")
-		Expect(os.WriteFile(p, []byte("x"), 0600)).To(Succeed())
-		Expect(isPackagePath(p)).To(BeTrue())
+	It("is true for any .ndp path", func() {
+		Expect(isPackagePath("/some/dir/x.ndp")).To(BeTrue())
 	})
-	It("is false for a bare id", func() {
+	It("is true for a non-existent .ndp path (so ReadManifest reports the error)", func() {
+		Expect(isPackagePath("/nope/x.ndp")).To(BeTrue())
+	})
+	It("is false for a bare plugin id", func() {
 		Expect(isPackagePath("my-plugin")).To(BeFalse())
-	})
-	It("is false for a .ndp path that does not exist", func() {
-		Expect(isPackagePath("/nope/x.ndp")).To(BeFalse())
 	})
 })
 

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/plugins"
@@ -182,6 +183,104 @@ var _ = Describe("formatManifestInfo", func() {
 		out, err := formatManifestInfo(m, "json")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(out).To(ContainSubstring("\"name\""))
+	})
+})
+
+var _ = Describe("declaredPermissions", func() {
+	It("returns nil for nil permissions", func() {
+		Expect(declaredPermissions(nil)).To(BeEmpty())
+	})
+
+	It("returns sorted names for set permissions", func() {
+		p := &plugins.Permissions{
+			Subsonicapi: &plugins.SubsonicAPIPermission{},
+			Users:       &plugins.UsersPermission{},
+		}
+		got := declaredPermissions(p)
+		Expect(got).To(Equal([]string{"subsonicapi", "users"}))
+	})
+
+	It("returns all declared names sorted", func() {
+		p := &plugins.Permissions{
+			Http:    &plugins.HTTPPermission{},
+			Artwork: &plugins.ArtworkPermission{},
+			Cache:   &plugins.CachePermission{},
+		}
+		got := declaredPermissions(p)
+		Expect(got).To(Equal([]string{"artwork", "cache", "http"}))
+	})
+})
+
+var _ = Describe("formatPluginInfo enriched text", func() {
+	var fixedTime time.Time
+
+	BeforeEach(func() {
+		fixedTime = time.Date(2025, 1, 15, 12, 0, 0, 0, time.UTC)
+	})
+
+	It("includes Users, Libraries, Permissions, Created, Updated in text output", func() {
+		p := &model.Plugin{
+			ID:        "myplugin",
+			Manifest:  `{"name":"My Plugin","version":"1.0.0","author":"me","permissions":{"users":{},"subsonicapi":{}}}`,
+			Enabled:   true,
+			Users:     "alice,bob",
+			Libraries: "1,2",
+			CreatedAt: fixedTime,
+			UpdatedAt: fixedTime.Add(time.Hour),
+		}
+		out, err := formatPluginInfo(p, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("alice,bob"))
+		Expect(out).To(ContainSubstring("1,2"))
+		Expect(out).To(ContainSubstring("subsonicapi"))
+		Expect(out).To(ContainSubstring("users"))
+		Expect(out).To(ContainSubstring("2025-01-15T12:00:00Z"))
+	})
+
+	It("omits Users and Libraries lines when empty", func() {
+		p := &model.Plugin{
+			ID:        "myplugin",
+			Manifest:  `{"name":"X","version":"1.0.0","author":"me"}`,
+			CreatedAt: fixedTime,
+			UpdatedAt: fixedTime,
+		}
+		out, err := formatPluginInfo(p, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).ToNot(ContainSubstring("Users:"))
+		Expect(out).ToNot(ContainSubstring("Libraries:"))
+	})
+
+	It("does not alter json output", func() {
+		p := &model.Plugin{ID: "x", Manifest: `{}`, Users: "alice"}
+		out, err := formatPluginInfo(p, "json")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring(`"x"`))
+	})
+})
+
+var _ = Describe("formatManifestInfo enriched text", func() {
+	It("includes Permissions when declared", func() {
+		p := &plugins.Permissions{Http: &plugins.HTTPPermission{}}
+		m := &plugins.Manifest{Name: "P", Version: "1.0.0", Author: "a", Permissions: p}
+		out, err := formatManifestInfo(m, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring("http"))
+		Expect(out).To(ContainSubstring("Permissions:"))
+	})
+
+	It("omits Permissions line when no permissions declared", func() {
+		m := &plugins.Manifest{Name: "P", Version: "1.0.0", Author: "a"}
+		out, err := formatManifestInfo(m, "text")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).ToNot(ContainSubstring("Permissions:"))
+	})
+
+	It("does not alter json output", func() {
+		p := &plugins.Permissions{Http: &plugins.HTTPPermission{}}
+		m := &plugins.Manifest{Name: "P", Version: "1.0.0", Author: "a", Permissions: p}
+		out, err := formatManifestInfo(m, "json")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(out).To(ContainSubstring(`"name"`))
 	})
 })
 

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -43,5 +45,21 @@ var _ = Describe("formatPluginList", func() {
 	It("errors on an unknown format", func() {
 		_, err := formatPluginList(samplePlugins, "yaml")
 		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("enable/disable plugin", func() {
+	It("calls EnablePlugin on the manager", func() {
+		mgr := &tests.MockPluginManager{}
+		err := enablePlugin(context.Background(), mgr, "alpha")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.EnablePluginCalls).To(Equal([]string{"alpha"}))
+	})
+
+	It("calls DisablePlugin on the manager", func() {
+		mgr := &tests.MockPluginManager{}
+		err := disablePlugin(context.Background(), mgr, "beta")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.DisablePluginCalls).To(Equal([]string{"beta"}))
 	})
 })

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -63,3 +63,44 @@ var _ = Describe("enable/disable plugin", func() {
 		Expect(mgr.DisablePluginCalls).To(Equal([]string{"beta"}))
 	})
 })
+
+var _ = Describe("applyPluginEdit", func() {
+	It("validates then updates config when config is provided", func() {
+		mgr := &tests.MockPluginManager{}
+		cfg := `{"key":"val"}`
+		err := applyPluginEdit(context.Background(), mgr, "alpha", pluginEditOptions{config: &cfg})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.ValidatePluginConfigCalls).To(HaveLen(1))
+		Expect(mgr.ValidatePluginConfigCalls[0].ConfigJSON).To(Equal(cfg))
+		Expect(mgr.UpdatePluginConfigCalls).To(HaveLen(1))
+		Expect(mgr.UpdatePluginConfigCalls[0].ConfigJSON).To(Equal(cfg))
+	})
+
+	It("updates users with allUsers flag", func() {
+		mgr := &tests.MockPluginManager{}
+		all := true
+		err := applyPluginEdit(context.Background(), mgr, "alpha",
+			pluginEditOptions{allUsers: &all})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginUsersCalls).To(HaveLen(1))
+		Expect(mgr.UpdatePluginUsersCalls[0].AllUsers).To(BeTrue())
+	})
+
+	It("updates libraries with allLibraries and write access", func() {
+		mgr := &tests.MockPluginManager{}
+		all := true
+		wr := true
+		err := applyPluginEdit(context.Background(), mgr, "alpha",
+			pluginEditOptions{allLibraries: &all, writeAccess: &wr})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginLibrariesCalls).To(HaveLen(1))
+		Expect(mgr.UpdatePluginLibrariesCalls[0].AllLibraries).To(BeTrue())
+		Expect(mgr.UpdatePluginLibrariesCalls[0].AllowWriteAccess).To(BeTrue())
+	})
+
+	It("does nothing and errors when no fields are set", func() {
+		mgr := &tests.MockPluginManager{}
+		err := applyPluginEdit(context.Background(), mgr, "alpha", pluginEditOptions{})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/cmd/plugin_test.go
+++ b/cmd/plugin_test.go
@@ -177,6 +177,26 @@ var _ = Describe("applyPluginEdit", func() {
 		Expect(mgr.UpdatePluginLibrariesCalls).To(BeEmpty())
 	})
 
+	It("clears allUsers when an explicit users list is set", func() {
+		mgr := &tests.MockPluginManager{}
+		cur.AllUsers = true
+		users := "alice"
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{users: &users})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginUsersCalls[0].UsersJSON).To(Equal(`["alice"]`))
+		Expect(mgr.UpdatePluginUsersCalls[0].AllUsers).To(BeFalse())
+	})
+
+	It("clears allLibraries when an explicit libraries list is set", func() {
+		mgr := &tests.MockPluginManager{}
+		cur.AllLibraries = true
+		libs := "1"
+		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{libraries: &libs})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.UpdatePluginLibrariesCalls[0].LibrariesJSON).To(Equal(`[1]`))
+		Expect(mgr.UpdatePluginLibrariesCalls[0].AllLibraries).To(BeFalse())
+	})
+
 	It("does nothing and errors when no fields are set", func() {
 		mgr := &tests.MockPluginManager{}
 		err := applyPluginEdit(context.Background(), mgr, cur, pluginEditOptions{})

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -382,7 +382,7 @@ func (m *Manager) ValidatePluginConfig(ctx context.Context, id, configJSON strin
 		return fmt.Errorf("getting plugin from DB: %w", err)
 	}
 
-	manifest, err := readManifest(plugin.Path)
+	manifest, err := ReadManifest(plugin.Path)
 	if err != nil {
 		return fmt.Errorf("reading manifest: %w", err)
 	}
@@ -460,7 +460,7 @@ func (m *Manager) updatePluginSettings(ctx context.Context, id string, updateFn 
 	shouldDisable := false
 	disableReason := ""
 	if wasEnabled {
-		manifest, err := readManifest(plugin.Path)
+		manifest, err := ReadManifest(plugin.Path)
 		if err == nil && manifest.Permissions != nil {
 			if manifest.Permissions.Users != nil && !hasValidUsersConfig(plugin.Users, plugin.AllUsers) {
 				shouldDisable = true
@@ -591,7 +591,7 @@ func (m *Manager) UnloadDisabledPlugins(ctx context.Context) {
 // before a plugin can be enabled. Returns an error if any gate condition fails.
 func (m *Manager) checkPermissionGates(p *model.Plugin) error {
 	// Parse manifest to check permissions
-	manifest, err := readManifest(p.Path)
+	manifest, err := ReadManifest(p.Path)
 	if err != nil {
 		return fmt.Errorf("reading manifest: %w", err)
 	}

--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -155,12 +155,12 @@ func (m *Manager) extractManifest(ndpPath string) (*PluginMetadata, error) {
 		return nil, fmt.Errorf("manager is stopped")
 	}
 
-	manifest, err := readManifest(ndpPath)
+	manifest, err := ReadManifest(ndpPath)
 	if err != nil {
 		return nil, err
 	}
 
-	sha256Hash, err := computeFileSHA256(ndpPath)
+	sha256Hash, err := ComputeFileSHA256(ndpPath)
 	if err != nil {
 		return nil, fmt.Errorf("computing hash: %w", err)
 	}

--- a/plugins/manager_sync.go
+++ b/plugins/manager_sync.go
@@ -36,9 +36,9 @@ func marshalManifest(m *Manifest) string {
 	return string(b)
 }
 
-// computeFileSHA256 computes the SHA-256 hash of a file without loading it into memory.
+// ComputeFileSHA256 computes the SHA-256 hash of a file without loading it into memory.
 // This is used for quick change detection before full plugin compilation.
-func computeFileSHA256(path string) (string, error) {
+func ComputeFileSHA256(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -165,7 +165,7 @@ func (m *Manager) syncPlugins(ctx context.Context, folder string) error {
 		dbPlugin, exists := pluginsInDB[name]
 
 		// Compute SHA256 first (lightweight operation) to check if plugin changed
-		sha256Hash, err := computeFileSHA256(path)
+		sha256Hash, err := ComputeFileSHA256(path)
 		if err != nil {
 			log.Error(ctx, "Failed to compute SHA256 for plugin", "plugin", name, "path", path, err)
 			continue

--- a/plugins/manager_sync_test.go
+++ b/plugins/manager_sync_test.go
@@ -1,0 +1,30 @@
+package plugins
+
+import (
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ComputeFileSHA256", func() {
+	It("returns a consistent 64-char lowercase hex hash for the same file", func() {
+		dir := GinkgoT().TempDir()
+		ndpPath := filepath.Join(dir, "test.ndp")
+		err := createTestPackage(ndpPath, &Manifest{Name: "S", Author: "a", Version: "1.0.0"}, []byte{0x00, 0x61, 0x73, 0x6d})
+		Expect(err).ToNot(HaveOccurred())
+
+		hash1, err := ComputeFileSHA256(ndpPath)
+		Expect(err).ToNot(HaveOccurred())
+		hash2, err := ComputeFileSHA256(ndpPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(hash1).To(Equal(hash2))
+		Expect(hash1).To(MatchRegexp(`^[0-9a-f]{64}$`))
+	})
+
+	It("returns an error for a non-existent path", func() {
+		_, err := ComputeFileSHA256(filepath.Join(GinkgoT().TempDir(), "does-not-exist.ndp"))
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/plugins/manager_watcher.go
+++ b/plugins/manager_watcher.go
@@ -158,7 +158,7 @@ func (m *Manager) processPluginEvent(pluginName string) {
 	switch action {
 	case actionUpdate:
 		// File changed - check SHA256 first, then extract manifest if needed
-		sha256Hash, err := computeFileSHA256(ndpPath)
+		sha256Hash, err := ComputeFileSHA256(ndpPath)
 		if err != nil {
 			log.Error(m.ctx, "Failed to compute SHA256 for changed plugin", "plugin", pluginName, err)
 			return

--- a/plugins/manifest.go
+++ b/plugins/manifest.go
@@ -10,11 +10,9 @@ import (
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
-// DeclaredNames returns the sorted names of the permissions declared in the
-// manifest. The names are derived by reflecting over the Permissions struct's
-// json tags, which are generated from manifest-schema.json — so new permission
-// types are picked up automatically without editing this function. A permission
-// is "declared" when its (pointer) field is non-nil. Nil-safe.
+// DeclaredNames returns the sorted names of the non-nil permission fields. It
+// reflects over the generated json tags so new permission types are picked up
+// automatically rather than via a hand-maintained list.
 func (p *Permissions) DeclaredNames() []string {
 	if p == nil {
 		return nil

--- a/plugins/manifest.go
+++ b/plugins/manifest.go
@@ -3,32 +3,32 @@ package plugins
 import (
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
 
 // DeclaredNames returns the sorted names of the permissions declared in the
-// manifest. It is nil-safe (returns nil for a nil receiver) and co-located with
-// the generated Permissions type so it stays in sync as new permissions appear.
+// manifest. The names are derived by reflecting over the Permissions struct's
+// json tags, which are generated from manifest-schema.json — so new permission
+// types are picked up automatically without editing this function. A permission
+// is "declared" when its (pointer) field is non-nil. Nil-safe.
 func (p *Permissions) DeclaredNames() []string {
 	if p == nil {
 		return nil
 	}
 	var names []string
-	for name, declared := range map[string]bool{
-		"artwork":     p.Artwork != nil,
-		"cache":       p.Cache != nil,
-		"http":        p.Http != nil,
-		"kvstore":     p.Kvstore != nil,
-		"library":     p.Library != nil,
-		"scheduler":   p.Scheduler != nil,
-		"subsonicapi": p.Subsonicapi != nil,
-		"taskqueue":   p.Taskqueue != nil,
-		"users":       p.Users != nil,
-		"websocket":   p.Websocket != nil,
-	} {
-		if declared {
+	v := reflect.ValueOf(*p)
+	t := v.Type()
+	for i := 0; i < t.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() != reflect.Pointer || f.IsNil() {
+			continue
+		}
+		tag := t.Field(i).Tag.Get("json")
+		if name, _, _ := strings.Cut(tag, ","); name != "" && name != "-" {
 			names = append(names, name)
 		}
 	}

--- a/plugins/manifest.go
+++ b/plugins/manifest.go
@@ -3,9 +3,38 @@ package plugins
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
+
+// DeclaredNames returns the sorted names of the permissions declared in the
+// manifest. It is nil-safe (returns nil for a nil receiver) and co-located with
+// the generated Permissions type so it stays in sync as new permissions appear.
+func (p *Permissions) DeclaredNames() []string {
+	if p == nil {
+		return nil
+	}
+	var names []string
+	for name, declared := range map[string]bool{
+		"artwork":     p.Artwork != nil,
+		"cache":       p.Cache != nil,
+		"http":        p.Http != nil,
+		"kvstore":     p.Kvstore != nil,
+		"library":     p.Library != nil,
+		"scheduler":   p.Scheduler != nil,
+		"subsonicapi": p.Subsonicapi != nil,
+		"taskqueue":   p.Taskqueue != nil,
+		"users":       p.Users != nil,
+		"websocket":   p.Websocket != nil,
+	} {
+		if declared {
+			names = append(names, name)
+		}
+	}
+	sort.Strings(names)
+	return names
+}
 
 //go:generate go tool go-jsonschema -p plugins --struct-name-from-title -o manifest_gen.go manifest-schema.json
 

--- a/plugins/manifest_test.go
+++ b/plugins/manifest_test.go
@@ -464,3 +464,27 @@ var _ = Describe("Manifest", func() {
 		})
 	})
 })
+
+var _ = Describe("Permissions.DeclaredNames", func() {
+	It("returns nil for a nil receiver", func() {
+		var p *Permissions
+		Expect(p.DeclaredNames()).To(BeEmpty())
+	})
+
+	It("returns declared names sorted", func() {
+		p := &Permissions{
+			Subsonicapi: &SubsonicAPIPermission{},
+			Users:       &UsersPermission{},
+		}
+		Expect(p.DeclaredNames()).To(Equal([]string{"subsonicapi", "users"}))
+	})
+
+	It("returns all declared names sorted regardless of field order", func() {
+		p := &Permissions{
+			Http:    &HTTPPermission{},
+			Artwork: &ArtworkPermission{},
+			Cache:   &CachePermission{},
+		}
+		Expect(p.DeclaredNames()).To(Equal([]string{"artwork", "cache", "http"}))
+	})
+})

--- a/plugins/package.go
+++ b/plugins/package.go
@@ -107,6 +107,12 @@ func ReadPackageManifest(path string) (*Manifest, error) {
 	return readManifest(path)
 }
 
+// ComputeFileSHA256 returns the hex SHA-256 of a file (e.g. a .ndp package),
+// without loading it into memory.
+func ComputeFileSHA256(path string) (string, error) {
+	return computeFileSHA256(path)
+}
+
 // ValidatePackage reads a .ndp package's manifest and runs cross-field
 // validation. It returns the parsed manifest on success.
 func ValidatePackage(path string) (*Manifest, error) {

--- a/plugins/package.go
+++ b/plugins/package.go
@@ -113,17 +113,10 @@ func ComputeFileSHA256(path string) (string, error) {
 	return computeFileSHA256(path)
 }
 
-// ValidatePackage reads a .ndp package's manifest and runs cross-field
-// validation. It returns the parsed manifest on success.
+// ValidatePackage reads a .ndp package's manifest, which includes JSON-schema
+// and cross-field validation (readManifest -> ParseManifest -> Manifest.Validate).
 func ValidatePackage(path string) (*Manifest, error) {
-	m, err := readManifest(path)
-	if err != nil {
-		return nil, err
-	}
-	if err := m.Validate(); err != nil {
-		return nil, err
-	}
-	return m, nil
+	return readManifest(path)
 }
 
 // readZipFile reads the contents of a file from a zip archive.

--- a/plugins/package.go
+++ b/plugins/package.go
@@ -101,6 +101,25 @@ func readManifest(ndpPath string) (*Manifest, error) {
 	return nil, errors.New("package missing manifest.json")
 }
 
+// ReadPackageManifest reads and parses the manifest from a .ndp package file,
+// without loading the wasm module.
+func ReadPackageManifest(path string) (*Manifest, error) {
+	return readManifest(path)
+}
+
+// ValidatePackage reads a .ndp package's manifest and runs cross-field
+// validation. It returns the parsed manifest on success.
+func ValidatePackage(path string) (*Manifest, error) {
+	m, err := readManifest(path)
+	if err != nil {
+		return nil, err
+	}
+	if err := m.Validate(); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
 // readZipFile reads the contents of a file from a zip archive.
 func readZipFile(f *zip.File) ([]byte, error) {
 	rc, err := f.Open()

--- a/plugins/package.go
+++ b/plugins/package.go
@@ -72,9 +72,10 @@ func openPackage(ndpPath string) (*ndpPackage, error) {
 	}, nil
 }
 
-// readManifest reads only the manifest from an .ndp file without loading the wasm bytes.
-// This is useful for quick plugin discovery.
-func readManifest(ndpPath string) (*Manifest, error) {
+// ReadManifest reads and validates the manifest from a .ndp file without loading
+// the wasm bytes (it runs ParseManifest, so JSON-schema and cross-field
+// validation are applied). Useful for quick plugin discovery and validation.
+func ReadManifest(ndpPath string) (*Manifest, error) {
 	// Open the zip archive
 	zr, err := zip.OpenReader(ndpPath)
 	if err != nil {
@@ -99,24 +100,6 @@ func readManifest(ndpPath string) (*Manifest, error) {
 	}
 
 	return nil, errors.New("package missing manifest.json")
-}
-
-// ReadPackageManifest reads and parses the manifest from a .ndp package file,
-// without loading the wasm module.
-func ReadPackageManifest(path string) (*Manifest, error) {
-	return readManifest(path)
-}
-
-// ComputeFileSHA256 returns the hex SHA-256 of a file (e.g. a .ndp package),
-// without loading it into memory.
-func ComputeFileSHA256(path string) (string, error) {
-	return computeFileSHA256(path)
-}
-
-// ValidatePackage reads a .ndp package's manifest, which includes JSON-schema
-// and cross-field validation (readManifest -> ParseManifest -> Manifest.Validate).
-func ValidatePackage(path string) (*Manifest, error) {
-	return readManifest(path)
 }
 
 // readZipFile reads the contents of a file from a zip archive.

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -132,7 +132,7 @@ var _ = Describe("ndpPackage", func() {
 		})
 	})
 
-	Describe("readManifest", func() {
+	Describe("ReadManifest", func() {
 		It("should read only the manifest without loading wasm", func() {
 			ndpPath := filepath.Join(tmpDir, "test.ndp")
 			manifest := &Manifest{
@@ -146,7 +146,7 @@ var _ = Describe("ndpPackage", func() {
 			err := createTestPackage(ndpPath, manifest, wasmBytes)
 			Expect(err).ToNot(HaveOccurred())
 
-			m, err := readManifest(ndpPath)
+			m, err := ReadManifest(ndpPath)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m.Name).To(Equal("Test Plugin"))
 			Expect(*m.Description).To(Equal("A test plugin"))
@@ -165,7 +165,7 @@ var _ = Describe("ndpPackage", func() {
 			err = zw.close()
 			Expect(err).ToNot(HaveOccurred())
 
-			_, err = readManifest(ndpPath)
+			_, err = ReadManifest(ndpPath)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("missing manifest.json"))
 		})
@@ -184,10 +184,10 @@ var _ = Describe("ndpPackage", func() {
 			err := createTestPackage(ndpPath, manifest, wasmBytes)
 			Expect(err).ToNot(HaveOccurred())
 
-			hash1, err := computeFileSHA256(ndpPath)
+			hash1, err := ComputeFileSHA256(ndpPath)
 			Expect(err).ToNot(HaveOccurred())
 
-			hash2, err := computeFileSHA256(ndpPath)
+			hash2, err := ComputeFileSHA256(ndpPath)
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(hash1).To(Equal(hash2))
@@ -213,40 +213,34 @@ var _ = Describe("ndpPackage", func() {
 		})
 	})
 
-	Describe("ReadPackageManifest / ValidatePackage", func() {
+	Describe("ReadManifest validation", func() {
 		It("reads the manifest from a valid .ndp file", func() {
-			m, err := ReadPackageManifest(filepath.Join(testdataDir, "test-config.ndp"))
+			m, err := ReadManifest(filepath.Join(testdataDir, "test-config.ndp"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(m.Name).ToNot(BeEmpty())
 			Expect(m.Version).ToNot(BeEmpty())
 		})
 
 		It("returns an error for a non-existent file", func() {
-			_, err := ReadPackageManifest(filepath.Join(testdataDir, "does-not-exist.ndp"))
+			_, err := ReadManifest(filepath.Join(testdataDir, "does-not-exist.ndp"))
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("validates a valid package", func() {
-			m, err := ValidatePackage(filepath.Join(testdataDir, "test-config.ndp"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(m).ToNot(BeNil())
-		})
-
-		It("fails validation for a package with an invalid manifest", func() {
+		It("fails for a package with an invalid manifest", func() {
 			dir := GinkgoT().TempDir()
 			ndp := filepath.Join(dir, "bad.ndp")
 			writeNDP(ndp, `{"name":"","version":"","author":""}`)
-			_, err := ValidatePackage(ndp)
+			_, err := ReadManifest(ndp)
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("enforces cross-field validation in ValidatePackage", func() {
+		It("enforces cross-field validation", func() {
 			dir := GinkgoT().TempDir()
 			ndp := filepath.Join(dir, "crossfield.ndp")
 			// subsonicapi permission without users: violates cross-field rule
 			writeNDP(ndp, `{"name":"X","version":"1.0.0","author":"me","permissions":{"subsonicapi":{}}}`)
 
-			_, err := ValidatePackage(ndp)
+			_, err := ReadManifest(ndp)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("subsonicapi"))
 			Expect(err.Error()).To(ContainSubstring("users"))

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -133,7 +133,7 @@ var _ = Describe("ndpPackage", func() {
 	})
 
 	Describe("ReadManifest", func() {
-		It("should read only the manifest without loading wasm", func() {
+		It("parses the manifest from a package that also contains wasm", func() {
 			ndpPath := filepath.Join(tmpDir, "test.ndp")
 			manifest := &Manifest{
 				Name:        "Test Plugin",
@@ -141,9 +141,8 @@ var _ = Describe("ndpPackage", func() {
 				Version:     "1.0.0",
 				Description: new("A test plugin"),
 			}
-			wasmBytes := []byte{0x00, 0x61, 0x73, 0x6d} // wasm header; present but never read
 
-			err := createTestPackage(ndpPath, manifest, wasmBytes)
+			err := createTestPackage(ndpPath, manifest, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			m, err := ReadManifest(ndpPath)

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -152,24 +152,6 @@ var _ = Describe("ndpPackage", func() {
 			Expect(*m.Description).To(Equal("A test plugin"))
 		})
 
-		It("should return error for missing manifest", func() {
-			ndpPath := filepath.Join(tmpDir, "no-manifest.ndp")
-
-			f, err := os.Create(ndpPath)
-			Expect(err).ToNot(HaveOccurred())
-			defer f.Close()
-
-			zw := newTestZipWriter(f)
-			err = zw.addFile("plugin.wasm", []byte{0x00})
-			Expect(err).ToNot(HaveOccurred())
-			err = zw.close()
-			Expect(err).ToNot(HaveOccurred())
-
-			_, err = ReadManifest(ndpPath)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("missing manifest.json"))
-		})
-
 		It("returns an error for a non-existent file", func() {
 			_, err := ReadManifest(filepath.Join(tmpDir, "does-not-exist.ndp"))
 			Expect(err).To(HaveOccurred())

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -195,6 +195,24 @@ var _ = Describe("ndpPackage", func() {
 		})
 	})
 
+	Describe("ComputeFileSHA256", func() {
+		It("returns a 64-char lowercase hex string for an existing file", func() {
+			ndpPath := filepath.Join(tmpDir, "sha-test.ndp")
+			err := createTestPackage(ndpPath, &Manifest{Name: "S", Author: "a", Version: "1.0.0"}, []byte{0x00, 0x61, 0x73, 0x6d})
+			Expect(err).ToNot(HaveOccurred())
+
+			sha, err := ComputeFileSHA256(ndpPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(sha).To(HaveLen(64))
+			Expect(sha).To(MatchRegexp(`^[0-9a-f]{64}$`))
+		})
+
+		It("returns an error for a non-existent path", func() {
+			_, err := ComputeFileSHA256(filepath.Join(tmpDir, "does-not-exist.ndp"))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	Describe("ReadPackageManifest / ValidatePackage", func() {
 		It("reads the manifest from a valid .ndp file", func() {
 			m, err := ReadPackageManifest(filepath.Join(testdataDir, "test-config.ndp"))

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -169,74 +169,21 @@ var _ = Describe("ndpPackage", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("missing manifest.json"))
 		})
-	})
-
-	Describe("ComputePackageSHA256", func() {
-		It("should compute consistent hash for same file", func() {
-			ndpPath := filepath.Join(tmpDir, "test.ndp")
-			manifest := &Manifest{
-				Name:    "Test Plugin",
-				Author:  "Test Author",
-				Version: "1.0.0",
-			}
-			wasmBytes := []byte{0x00, 0x61, 0x73, 0x6d}
-
-			err := createTestPackage(ndpPath, manifest, wasmBytes)
-			Expect(err).ToNot(HaveOccurred())
-
-			hash1, err := ComputeFileSHA256(ndpPath)
-			Expect(err).ToNot(HaveOccurred())
-
-			hash2, err := ComputeFileSHA256(ndpPath)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(hash1).To(Equal(hash2))
-			Expect(hash1).To(HaveLen(64)) // SHA-256 produces 64 hex characters
-		})
-	})
-
-	Describe("ComputeFileSHA256", func() {
-		It("returns a 64-char lowercase hex string for an existing file", func() {
-			ndpPath := filepath.Join(tmpDir, "sha-test.ndp")
-			err := createTestPackage(ndpPath, &Manifest{Name: "S", Author: "a", Version: "1.0.0"}, []byte{0x00, 0x61, 0x73, 0x6d})
-			Expect(err).ToNot(HaveOccurred())
-
-			sha, err := ComputeFileSHA256(ndpPath)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sha).To(HaveLen(64))
-			Expect(sha).To(MatchRegexp(`^[0-9a-f]{64}$`))
-		})
-
-		It("returns an error for a non-existent path", func() {
-			_, err := ComputeFileSHA256(filepath.Join(tmpDir, "does-not-exist.ndp"))
-			Expect(err).To(HaveOccurred())
-		})
-	})
-
-	Describe("ReadManifest validation", func() {
-		It("reads the manifest from a valid .ndp file", func() {
-			m, err := ReadManifest(filepath.Join(testdataDir, "test-config.ndp"))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(m.Name).ToNot(BeEmpty())
-			Expect(m.Version).ToNot(BeEmpty())
-		})
 
 		It("returns an error for a non-existent file", func() {
-			_, err := ReadManifest(filepath.Join(testdataDir, "does-not-exist.ndp"))
+			_, err := ReadManifest(filepath.Join(tmpDir, "does-not-exist.ndp"))
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("fails for a package with an invalid manifest", func() {
-			dir := GinkgoT().TempDir()
-			ndp := filepath.Join(dir, "bad.ndp")
+		It("fails for a package with a schema-invalid manifest", func() {
+			ndp := filepath.Join(tmpDir, "bad.ndp")
 			writeNDP(ndp, `{"name":"","version":"","author":""}`)
 			_, err := ReadManifest(ndp)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("enforces cross-field validation", func() {
-			dir := GinkgoT().TempDir()
-			ndp := filepath.Join(dir, "crossfield.ndp")
+			ndp := filepath.Join(tmpDir, "crossfield.ndp")
 			// subsonicapi permission without users: violates cross-field rule
 			writeNDP(ndp, `{"name":"X","version":"1.0.0","author":"me","permissions":{"subsonicapi":{}}}`)
 

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -141,7 +141,7 @@ var _ = Describe("ndpPackage", func() {
 				Version:     "1.0.0",
 				Description: new("A test plugin"),
 			}
-			wasmBytes := make([]byte, 1024*1024) // 1MB of zeros
+			wasmBytes := []byte{0x00, 0x61, 0x73, 0x6d} // wasm header; present but never read
 
 			err := createTestPackage(ndpPath, manifest, wasmBytes)
 			Expect(err).ToNot(HaveOccurred())
@@ -177,17 +177,26 @@ var _ = Describe("ndpPackage", func() {
 
 		It("fails for a package with a schema-invalid manifest", func() {
 			ndp := filepath.Join(tmpDir, "bad.ndp")
-			writeNDP(ndp, `{"name":"","version":"","author":""}`)
-			_, err := ReadManifest(ndp)
+			// empty required fields violate the manifest JSON schema
+			err := createTestPackage(ndp, &Manifest{}, nil)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = ReadManifest(ndp)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("enforces cross-field validation", func() {
 			ndp := filepath.Join(tmpDir, "crossfield.ndp")
 			// subsonicapi permission without users: violates cross-field rule
-			writeNDP(ndp, `{"name":"X","version":"1.0.0","author":"me","permissions":{"subsonicapi":{}}}`)
+			manifest := &Manifest{
+				Name:        "X",
+				Author:      "me",
+				Version:     "1.0.0",
+				Permissions: &Permissions{Subsonicapi: &SubsonicAPIPermission{}},
+			}
+			err := createTestPackage(ndp, manifest, nil)
+			Expect(err).ToNot(HaveOccurred())
 
-			_, err := ReadManifest(ndp)
+			_, err = ReadManifest(ndp)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("subsonicapi"))
 			Expect(err.Error()).To(ContainSubstring("users"))
@@ -265,17 +274,4 @@ func createTestPackage(ndpPath string, manifest *Manifest, wasmBytes []byte) err
 	}
 
 	return nil
-}
-
-// writeNDP writes a minimal .ndp (zip) containing only manifest.json.
-func writeNDP(path, manifestJSON string) {
-	f, err := os.Create(path)
-	Expect(err).ToNot(HaveOccurred())
-	defer f.Close()
-	zw := zip.NewWriter(f)
-	w, err := zw.Create("manifest.json")
-	Expect(err).ToNot(HaveOccurred())
-	_, err = w.Write([]byte(manifestJSON))
-	Expect(err).ToNot(HaveOccurred())
-	Expect(zw.Close()).To(Succeed())
 }

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -194,6 +194,34 @@ var _ = Describe("ndpPackage", func() {
 			Expect(hash1).To(HaveLen(64)) // SHA-256 produces 64 hex characters
 		})
 	})
+
+	Describe("ReadPackageManifest / ValidatePackage", func() {
+		It("reads the manifest from a valid .ndp file", func() {
+			m, err := ReadPackageManifest(filepath.Join(testdataDir, "test-config.ndp"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m.Name).ToNot(BeEmpty())
+			Expect(m.Version).ToNot(BeEmpty())
+		})
+
+		It("returns an error for a non-existent file", func() {
+			_, err := ReadPackageManifest(filepath.Join(testdataDir, "does-not-exist.ndp"))
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("validates a valid package", func() {
+			m, err := ValidatePackage(filepath.Join(testdataDir, "test-config.ndp"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(m).ToNot(BeNil())
+		})
+
+		It("fails validation for a package with an invalid manifest", func() {
+			dir := GinkgoT().TempDir()
+			ndp := filepath.Join(dir, "bad.ndp")
+			writeNDP(ndp, `{"name":"","version":"","author":""}`)
+			_, err := ValidatePackage(ndp)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })
 
 // testZipHelper is a helper for creating test zip files with specific contents
@@ -266,4 +294,17 @@ func createTestPackage(ndpPath string, manifest *Manifest, wasmBytes []byte) err
 	}
 
 	return nil
+}
+
+// writeNDP writes a minimal .ndp (zip) containing only manifest.json.
+func writeNDP(path, manifestJSON string) {
+	f, err := os.Create(path)
+	Expect(err).ToNot(HaveOccurred())
+	defer f.Close()
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("manifest.json")
+	Expect(err).ToNot(HaveOccurred())
+	_, err = w.Write([]byte(manifestJSON))
+	Expect(err).ToNot(HaveOccurred())
+	Expect(zw.Close()).To(Succeed())
 }

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -221,6 +221,18 @@ var _ = Describe("ndpPackage", func() {
 			_, err := ValidatePackage(ndp)
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("enforces cross-field validation in ValidatePackage", func() {
+			dir := GinkgoT().TempDir()
+			ndp := filepath.Join(dir, "crossfield.ndp")
+			// subsonicapi permission without users: violates cross-field rule
+			writeNDP(ndp, `{"name":"X","version":"1.0.0","author":"me","permissions":{"subsonicapi":{}}}`)
+
+			_, err := ValidatePackage(ndp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("subsonicapi"))
+			Expect(err.Error()).To(ContainSubstring("users"))
+		})
 	})
 })
 

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -156,6 +156,20 @@ var _ = Describe("ndpPackage", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("returns a specific error for a package missing manifest.json", func() {
+			ndpPath := filepath.Join(tmpDir, "no-manifest.ndp")
+			f, err := os.Create(ndpPath)
+			Expect(err).ToNot(HaveOccurred())
+			defer f.Close()
+			zw := newTestZipWriter(f)
+			Expect(zw.addFile("plugin.wasm", []byte{0x00})).To(Succeed())
+			Expect(zw.close()).To(Succeed())
+
+			_, err = ReadManifest(ndpPath)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing manifest.json"))
+		})
+
 		It("fails for a package with a schema-invalid manifest", func() {
 			ndp := filepath.Join(tmpDir, "bad.ndp")
 			// empty required fields violate the manifest JSON schema


### PR DESCRIPTION
### Description

This PR adds a `navidrome plugin` command-line interface for managing and inspecting plugins, filling a gap where plugin administration was only possible through the Native API, the Web UI, or hand-editing the plugins folder.

The command works **directly in-process** — it opens the database and plugin manager the same way the existing `user`, `backup`, and `scan` commands do (`getAdminContext` + `GetPluginManager`), so it needs no running server and no credentials. It is a thin shell over the **same `plugins.Manager` methods the Native API already calls**, so the CLI, API, and UI stay behaviorally identical.

Subcommands:

| Command | Purpose |
|---|---|
| `plugin list` | List installed plugins (`-f table\|csv\|json`) |
| `plugin info <id\|file.ndp>` | Show details for an installed plugin or an on-disk `.ndp` package (`-f text\|json`) |
| `plugin enable` / `disable <id>` | Enable/disable a plugin |
| `plugin edit <id>` | Atomically update config and/or permissions |
| `plugin rescan` | Re-discover plugins in the plugins folder |
| `plugin validate <id\|file.ndp>` | Validate an installed plugin or a `.ndp` package manifest |

Design notes:

- **Off-disk inspection** — `info` and `validate` accept either an installed plugin ID or a `.ndp` file path (auto-detected by the `.ndp` suffix + file existence; exploded folders are intentionally not supported). The off-disk path never touches the database and works even when the plugin system is disabled, making it a useful developer/CI pre-flight tool. All other commands require `Plugins.Enabled` and fail fast otherwise.
- **`edit` mirrors the Native API's read-modify-write semantics** — it loads the current plugin first and only overwrites the fields you explicitly set, so flipping one flag (e.g. `--write-access`) never wipes unspecified fields. It also validates that `--users`/`--libraries` values are JSON and that config passes the plugin's schema before persisting.
- A couple of small helpers in the `plugins` package were exported for reuse (`ReadManifest`, `ComputeFileSHA256`) and `Permissions.DeclaredNames()` was added as the single source of truth for permission names.

Scope is intentionally limited to **managing/inspecting plugins that already exist on disk** — there is no package installer/downloader.

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Plugin management is admin-scoped and requires the plugin system enabled. The off-disk `info`/`validate` paths work without a running server.

1. **Set up an environment with plugins enabled** and an admin user (e.g. `Plugins.Enabled=true`, a data folder, and at least one admin). Drop a `.ndp` package into the plugins folder (the repo's `plugins/testdata/test-config.ndp` works).
2. **List:**
   ```
   navidrome plugin list
   navidrome plugin list -f json
   ```
   Expect the installed plugin to appear; `-f json`/`-f csv` produce machine-readable output.
3. **Inspect (installed and off-disk):**
   ```
   navidrome plugin info test-config
   navidrome plugin info /path/to/test-config.ndp
   navidrome plugin info /path/to/test-config.ndp -f json
   ```
   Off-disk shows the manifest summary, declared permissions, and sha256 without touching the DB.
4. **Enable / disable round-trip:**
   ```
   navidrome plugin enable test-config && navidrome plugin list -f csv   # enabled,true
   navidrome plugin disable test-config && navidrome plugin list -f csv  # enabled,false
   ```
5. **Edit (config + permissions):**
   ```
   navidrome plugin edit test-config --config '{"api_key":"secret"}'
   navidrome plugin edit test-config --libraries '[1,2]' --write-access
   navidrome plugin edit test-config --no-write-access   # libraries [1,2] preserved
   ```
   Verify with `navidrome plugin info test-config`. Edge cases that should fail clearly: invalid config JSON / schema, `--users alice,bob` (non-JSON), no flags at all, and `--users x --all-users` (mutually exclusive).
6. **Validate:**
   ```
   navidrome plugin validate /path/to/test-config.ndp   # "<path>: OK"
   ```
   A malformed/invalid `.ndp` exits non-zero with a descriptive error.
7. **Guard / off-disk exception:** with `Plugins.Enabled=false`, `list`/`enable`/`rescan` fail with "Plugin system is disabled", while off-disk `validate`/`info` of a `.ndp` still work.

### Additional Notes

- **No new public API or UI surface, and no changes to existing routes** — the CLI reuses the existing `plugins.Manager` interface. The diff touches only `cmd/plugin.go`, a few exported helpers in `plugins/`, and tests.
- **Concurrency caveat:** like the existing `user`/`backup` CLI commands, mutating subcommands open the SQLite database directly. SQLite is single-writer, so running them while the server is live can briefly contend on the DB. This matches the behavior of the other CLI commands and is documented behavior, not new.
- This branch contains some follow-up refactor/test-cleanup commits (exporting helpers over thin wrappers, consolidating test files) made while polishing the feature; they're behavior-preserving.
