### PR TITLE
fix(ui): bump navidrome-music-player to 4.25.4 (lyric fixes, #5661)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -23,7 +23,7 @@
         "inflection": "^3.0.2",
         "jwt-decode": "^4.0.0",
         "lodash.throttle": "^4.1.1",
-        "navidrome-music-player": "4.25.3",
+        "navidrome-music-player": "4.25.4",
         "prop-types": "^15.8.1",
         "ra-data-json-server": "^3.19.12",
         "ra-i18n-polyglot": "^3.19.12",
@@ -8613,9 +8613,9 @@
       "license": "MIT"
     },
     "node_modules/navidrome-music-player": {
-      "version": "4.25.3",
-      "resolved": "https://registry.npmjs.org/navidrome-music-player/-/navidrome-music-player-4.25.3.tgz",
-      "integrity": "sha512-0T87Mmbs6ls9g9CgwJwXBL7X11u0+6znBFJTG8HUPgBT0r8W6epVKqJhfdg8vqnT86QDByvvb1Hxp/W2M7Yacw==",
+      "version": "4.25.4",
+      "resolved": "https://registry.npmjs.org/navidrome-music-player/-/navidrome-music-player-4.25.4.tgz",
+      "integrity": "sha512-5N7N94aJMIAfKZ0EKFfsHD95q2HBTAnAWyju0JflKnF+2u9Gr3qwnp3ZaaIC2K3z2GA69z0hqK0aOQ40FYsFrw==",
       "license": "MIT",
       "dependencies": {
         "@react-icons/all-files": "^4.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,7 +32,7 @@
     "inflection": "^3.0.2",
     "jwt-decode": "^4.0.0",
     "lodash.throttle": "^4.1.1",
-    "navidrome-music-player": "4.25.3",
+    "navidrome-music-player": "4.25.4",
     "prop-types": "^15.8.1",
     "ra-data-json-server": "^3.19.12",
     "ra-i18n-polyglot": "^3.19.12",


### PR DESCRIPTION
### Description

Bumps the `navidrome-music-player` dependency from `4.25.3` to `4.25.4`, which pulls in a set of lyric display fixes in the player (the library is a Navidrome-maintained fork; the changes were released in [navidrome/react-music-player#7](https://github.com/navidrome/react-music-player/pull/7)).

The player now drives the lyric position from the audio element's real `currentTime` instead of an internal timer that drifted out of sync. Concretely this fixes:

- **Lyric stacking on rapid track changes** — switching songs quickly no longer leaves the previous song's lyrics interleaved with the current one. The parser is now stopped before being replaced, so orphaned timers can't keep writing stale lines.
- **Lyric/audio desync after seeking** — scrubbing the progress bar (while playing *or* paused) now keeps the displayed line in sync with playback.
- **Misleading "No lyrics" during intros** — a `♪` placeholder is shown when a track has lyrics but no line is active yet (e.g. an instrumental intro), reserving "No lyrics" for tracks that genuinely have none.

This is a dependency-only change on the Navidrome side; no Navidrome source code was modified.

### Related Issues

Fixes #5661

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

> Tests for the fix live in the player library (`navidrome/react-music-player`); this PR only bumps the dependency.

### How to Test

1. Have a few tracks with **synced** lyrics in your library (LRC with `[mm:ss.xx]` timestamps).
2. Start playback and open the lyrics panel (♪ button in the player).
3. **Stacking:** click Next/Previous rapidly several times — the panel should only ever show the current song's lines, never two songs interleaved.
4. **Seek sync:** drag the progress bar forward and backward, both while playing and while paused — the displayed line should match the new position.
5. **Intro placeholder:** play a track whose first lyric starts a few seconds in — during the intro the panel shows `♪`; once the first line is reached it shows the lyric. A track with no lyrics still shows "No lyrics".

### Additional Notes

`navidrome-music-player` is pinned to an exact version (`4.25.4`, no caret), matching the previous pin for this fork dependency.
