### PR TITLE
test(db): fix flaky applyLibraryFilter specs on shared DB

### DIFF
--- a/persistence/sql_base_repository_test.go
+++ b/persistence/sql_base_repository_test.go
@@ -296,9 +296,18 @@ var _ = Describe("sqlRepository", func() {
 
 		Context("Regular User who can see all libraries", func() {
 			BeforeEach(func() {
-				// Granted every library in the DB, so the filter would exclude nothing.
+				// Grant every library that currently exists in the (shared) DB, so the filter
+				// would exclude nothing. Querying the real IDs keeps this correct even if other
+				// specs left extra libraries behind, which happens under Ginkgo's randomized order.
+				var ids []int
+				err := r.db.NewQuery("SELECT id FROM library ORDER BY id").Column(&ids)
+				Expect(err).ToNot(HaveOccurred())
+				libs := make(model.Libraries, 0, len(ids))
+				for _, id := range ids {
+					libs = append(libs, model.Library{ID: id})
+				}
 				r.ctx = request.WithUser(context.Background(), model.User{
-					ID: "alllibs", IsAdmin: false, Libraries: model.Libraries{{ID: 1}, {ID: 2}},
+					ID: "alllibs", IsAdmin: false, Libraries: libs,
 				})
 			})
 


### PR DESCRIPTION
### Description

Fixes a flaky test in the `persistence` package that broke the Windows CI on `master` (introduced by #5696).

The `applyLibraryFilter` "sees all libraries" specs hard-coded the user's granted libraries as `{ID: 1}, {ID: 2}` and assumed the *shared* test DB held exactly those two. But `applyLibraryFilter` only skips the filter when `len(grantedLibraries) == CountAll()`, and every persistence spec shares one SQLite DB. When another spec leaves an extra library behind — which happens under Ginkgo's randomized spec order — `CountAll()` returns 3, the filter is applied, and the `Equal("SELECT * FROM test_table")` assertion fails. Windows just drew the seed that exposed it; it reproduces on any platform.

The fix grants the user exactly the library IDs that actually exist in the DB at runtime, instead of hard-coding them. No production code changed — the shipped `applyLibraryFilter` logic was already correct.

### Related Issues

Related to #5696

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Test-only fix (flaky CI)

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

```bash
make test PKG=./persistence/
```

To confirm the flake is fixed, run the suite under the exact seed that failed on Windows, plus a few others:

```bash
for seed in 1782927153 1 2 6; do
  go test -tags netgo,sqlite_fts5 ./persistence/ -count=1 -args -ginkgo.seed=$seed
done
```

Expected: all pass. On `master`, seeds 1/2/6 (and the Windows seed) fail the `applyLibraryFilter` specs.

### Additional Notes

Test-only change; no user-facing behavior is affected.
