### PR TITLE
fix(ui): make self-service profile edits report their outcome

### DIFF
--- a/ui/src/dataProvider/wrapperDataProvider.js
+++ b/ui/src/dataProvider/wrapperDataProvider.js
@@ -137,8 +137,9 @@ const updateUser = async (params) => {
     data: userData,
   })
 
-  // Then handle library associations for non-admin users
-  if (!userData.isAdmin && libraryIds !== undefined) {
+  // Then handle library associations for non-admin users. Only admins can call
+  // this endpoint; for self-edits the server manages library assignments
+  if (isAdmin() && !userData.isAdmin && libraryIds !== undefined) {
     await handleUserLibraryAssociation(userId, libraryIds)
   }
 

--- a/ui/src/dataProvider/wrapperDataProvider.test.js
+++ b/ui/src/dataProvider/wrapperDataProvider.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import wrapperDataProvider from './wrapperDataProvider'
+
+const { mockProvider, mockHttpClient } = vi.hoisted(() => ({
+  mockProvider: {
+    update: vi.fn(),
+    create: vi.fn(),
+    getOne: vi.fn(),
+  },
+  mockHttpClient: vi.fn(),
+}))
+
+vi.mock('ra-data-json-server', () => ({ default: () => mockProvider }))
+vi.mock('./httpClient', () => ({ default: mockHttpClient }))
+
+describe('wrapperDataProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.clear()
+    mockProvider.update.mockResolvedValue({ data: { id: 'u1' } })
+    mockProvider.create.mockResolvedValue({ data: { id: 'u1' } })
+    mockHttpClient.mockResolvedValue({ json: [] })
+  })
+
+  describe('update user', () => {
+    it('sets library associations when an admin edits a non-admin user', async () => {
+      localStorage.setItem('role', 'admin')
+
+      await wrapperDataProvider.update('user', {
+        id: 'u1',
+        data: { name: 'Sam', isAdmin: false, libraryIds: [1] },
+      })
+
+      expect(mockProvider.update).toHaveBeenCalledWith(
+        'user',
+        expect.objectContaining({ id: 'u1' }),
+      )
+      expect(mockHttpClient).toHaveBeenCalledWith('/api/user/u1/library', {
+        method: 'PUT',
+        body: JSON.stringify({ libraryIds: [1] }),
+      })
+    })
+
+    it('does not call the admin-only library endpoint when a non-admin edits their own profile', async () => {
+      localStorage.setItem('role', 'regular')
+
+      await wrapperDataProvider.update('user', {
+        id: 'u1',
+        data: {
+          name: 'Sam',
+          isAdmin: false,
+          libraryIds: [1],
+          currentPassword: 'old',
+          password: 'new',
+        },
+      })
+
+      expect(mockProvider.update).toHaveBeenCalled()
+      expect(mockHttpClient).not.toHaveBeenCalled()
+    })
+
+    it('does not set library associations when the edited user is an admin', async () => {
+      localStorage.setItem('role', 'admin')
+
+      await wrapperDataProvider.update('user', {
+        id: 'u1',
+        data: { name: 'Sam', isAdmin: true, libraryIds: [1] },
+      })
+
+      expect(mockProvider.update).toHaveBeenCalled()
+      expect(mockHttpClient).not.toHaveBeenCalled()
+    })
+
+    it('strips libraryIds from the user update payload', async () => {
+      localStorage.setItem('role', 'admin')
+
+      await wrapperDataProvider.update('user', {
+        id: 'u1',
+        data: { name: 'Sam', isAdmin: false, libraryIds: [1] },
+      })
+
+      expect(mockProvider.update).toHaveBeenCalledWith(
+        'user',
+        expect.objectContaining({
+          data: { name: 'Sam', isAdmin: false },
+        }),
+      )
+    })
+  })
+})

--- a/ui/src/user/UserEdit.jsx
+++ b/ui/src/user/UserEdit.jsx
@@ -96,7 +96,7 @@ const UserEdit = (props) => {
         })
         permissions === 'admin' ? redirect('/user') : refresh()
       } catch (error) {
-        if (error.body?.errors) {
+        if (error?.body?.errors) {
           return error.body.errors
         }
         notify('ra.page.error', 'warning')

--- a/ui/src/user/UserEdit.jsx
+++ b/ui/src/user/UserEdit.jsx
@@ -96,9 +96,10 @@ const UserEdit = (props) => {
         })
         permissions === 'admin' ? redirect('/user') : refresh()
       } catch (error) {
-        if (error.body.errors) {
+        if (error.body?.errors) {
           return error.body.errors
         }
+        notify('ra.page.error', 'warning')
       }
     },
     [mutate, notify, permissions, redirect, refresh],

--- a/ui/src/user/UserEdit.test.jsx
+++ b/ui/src/user/UserEdit.test.jsx
@@ -181,5 +181,15 @@ describe('<UserEdit />', () => {
       expect(hooks.notify).toHaveBeenCalledWith('ra.page.error', 'warning')
       expect(hooks.redirect).not.toHaveBeenCalled()
     })
+
+    it('notifies an error when the update rejects with a non-object error', async () => {
+      hooks.mutate.mockRejectedValue(undefined)
+      render(<UserEdit id="user1" permissions="admin" />)
+
+      await hooks.save({ id: 'user1' })
+
+      expect(hooks.notify).toHaveBeenCalledWith('ra.page.error', 'warning')
+      expect(hooks.redirect).not.toHaveBeenCalled()
+    })
   })
 })

--- a/ui/src/user/UserEdit.test.jsx
+++ b/ui/src/user/UserEdit.test.jsx
@@ -27,6 +27,14 @@ const adminUser = {
   isAdmin: true,
 }
 
+const hooks = vi.hoisted(() => ({
+  save: null,
+  mutate: vi.fn(),
+  notify: vi.fn(),
+  redirect: vi.fn(),
+  refresh: vi.fn(),
+}))
+
 // Mock React-Admin completely with simpler implementations
 vi.mock('react-admin', () => ({
   Edit: ({ children, title }) => (
@@ -35,9 +43,10 @@ vi.mock('react-admin', () => ({
       {children}
     </div>
   ),
-  SimpleForm: ({ children }) => (
-    <form data-testid="simple-form">{children}</form>
-  ),
+  SimpleForm: ({ children, save }) => {
+    hooks.save = save
+    return <form data-testid="simple-form">{children}</form>
+  },
   TextInput: ({ source }) => <input data-testid={`text-input-${source}`} />,
   BooleanInput: ({ source }) => (
     <input type="checkbox" data-testid={`boolean-input-${source}`} />
@@ -54,10 +63,10 @@ vi.mock('react-admin', () => ({
   Typography: ({ children }) => <p>{children}</p>,
   required: () => () => null,
   email: () => () => null,
-  useMutation: () => [vi.fn()],
-  useNotify: () => vi.fn(),
-  useRedirect: () => vi.fn(),
-  useRefresh: () => vi.fn(),
+  useMutation: () => [hooks.mutate],
+  useNotify: () => hooks.notify,
+  useRedirect: () => hooks.redirect,
+  useRefresh: () => hooks.refresh,
   usePermissions: () => ({ permissions: 'admin' }),
   useTranslate: () => (key) => key,
 }))
@@ -126,5 +135,51 @@ describe('<UserEdit />', () => {
     // But should still render name and email
     expect(screen.getByTestId('text-input-name')).toBeInTheDocument()
     expect(screen.getByTestId('text-input-email')).toBeInTheDocument()
+  })
+
+  describe('save', () => {
+    beforeEach(() => {
+      vi.clearAllMocks()
+      hooks.save = null
+    })
+
+    it('notifies success and redirects when the update succeeds', async () => {
+      hooks.mutate.mockResolvedValue({ data: defaultUser })
+      render(<UserEdit id="user1" permissions="admin" />)
+
+      await hooks.save({ id: 'user1', name: 'New Name' })
+
+      expect(hooks.notify).toHaveBeenCalledWith(
+        'resources.user.notifications.updated',
+        'info',
+        { smart_count: 1 },
+      )
+      expect(hooks.redirect).toHaveBeenCalledWith('/user')
+    })
+
+    it('returns field errors when the update fails validation', async () => {
+      const fieldErrors = { currentPassword: 'ra.validation.required' }
+      hooks.mutate.mockRejectedValue({ body: { errors: fieldErrors } })
+      render(<UserEdit id="user1" permissions="admin" />)
+
+      const result = await hooks.save({ id: 'user1' })
+
+      expect(result).toEqual(fieldErrors)
+      expect(hooks.notify).not.toHaveBeenCalledWith(
+        'resources.user.notifications.updated',
+        'info',
+        { smart_count: 1 },
+      )
+    })
+
+    it('notifies an error when the update fails without field errors', async () => {
+      hooks.mutate.mockRejectedValue(new Error('Forbidden'))
+      render(<UserEdit id="user1" permissions="admin" />)
+
+      await hooks.save({ id: 'user1' })
+
+      expect(hooks.notify).toHaveBeenCalledWith('ra.page.error', 'warning')
+      expect(hooks.redirect).not.toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
### Description

When a non-admin user saves their own profile (e.g. changing their password, with `EnableUserEditing` on), the UI gives no feedback whatsoever — no success message, no error — making it look like the settings are silently ignored. Worse, the change **is** actually applied: the password silently changes while the user believes nothing happened, so their next attempt fails with "password does not match".

Two stacked problems cause this, present since multi-library support (#4181, shipped in v0.58.0):

1. `updateUser` in `wrapperDataProvider.js` always follows the user update with a call to `PUT /api/user/{id}/library`. That endpoint is mounted under `adminOnlyMiddleware`, so for self-edits by non-admin users it always returns 403, failing the save *after* the user record was already updated.
2. The `save` handler in `UserEdit.jsx` reads `error.body.errors` in its catch block; the 403 response is plain text (no JSON body), so this throws `TypeError: Cannot read properties of null (reading 'errors')` and swallows all user feedback.

The fix: only call the user-library association endpoint when the logged-in user is an admin (for self-edits the server manages library assignments), and make the error handler tolerate error bodies without field errors, showing a generic error notification instead of crashing.

### Related Issues

None filed — reported on the community forum as "can't change preferences for a user other than the original / settings not saving on a new install". Reproduced and root-caused on a fresh install.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start a fresh instance (empty data folder), create the first admin via the signup screen.
2. As admin, create a second, non-admin user with access to a library.
3. Log in as the second user, open the profile (avatar menu → *User*), toggle *Change Password?*, fill in current and new password, and hit *Save*.
4. Expected: a "User updated" notification appears and the new password works on next login.
   Before this fix: no notification at all, a 403 on `PUT /api/user/{id}/library` plus a `TypeError` in the browser console — while the password was still silently changed.
5. Regression check: as admin, edit the non-admin user (rename, change library assignment, toggle admin) — everything still saves, and the library association call is still made (and succeeds).

### Additional Notes

The unit tests cover both layers: the data provider only calls the admin-only endpoint for admin editors (and keeps stripping `libraryIds` from the user payload), and `UserEdit.save` notifies on non-validation errors, passes field errors through to the form, and notifies success + redirects on success.
