### PR TITLE
fix(build): derive version from reachable git tag

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Determine git current SHA and latest tag
         id: git-version
         run: |
-          GIT_TAG=$(git describe --tags --abbrev=0)
+          GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || true)
           if [ -n "$GIT_TAG" ]; then
             if [[ "$GITHUB_REF" != refs/tags/* ]]; then
               GIT_TAG=${GIT_TAG}-SNAPSHOT

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Show git version info
         run: |
           echo "git describe (dirty): $(git describe --dirty --always --tags)"
-          echo "git describe --tags: $(git describe --tags `git rev-list --tags --max-count=1`)"
+          echo "git describe --tags --abbrev=0: $(git describe --tags --abbrev=0)"
           echo "git tag: $(git tag --sort=-committerdate | head -n 1)"
           echo "github_ref: $GITHUB_REF"
           echo "github_head_sha: ${{ github.event.pull_request.head.sha }}"
@@ -40,7 +40,7 @@ jobs:
       - name: Determine git current SHA and latest tag
         id: git-version
         run: |
-          GIT_TAG=$(git tag --sort=-committerdate | head -n 1)
+          GIT_TAG=$(git describe --tags --abbrev=0)
           if [ -n "$GIT_TAG" ]; then
             if [[ "$GITHUB_REF" != refs/tags/* ]]; then
               GIT_TAG=${GIT_TAG}-SNAPSHOT

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export ND_ENABLEINSIGHTSCOLLECTOR=false
 
 ifneq ("$(wildcard .git/HEAD)","")
 GIT_SHA=$(shell git rev-parse --short HEAD)
-GIT_TAG=$(shell git describe --tags `git rev-list --tags --max-count=1`)-SNAPSHOT
+GIT_TAG=$(shell git describe --tags --abbrev=0)-SNAPSHOT
 else
 GIT_SHA=source_archive
 GIT_TAG=$(patsubst navidrome-%,v%,$(notdir $(PWD)))-SNAPSHOT

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ export ND_ENABLEINSIGHTSCOLLECTOR=false
 
 ifneq ("$(wildcard .git/HEAD)","")
 GIT_SHA=$(shell git rev-parse --short HEAD)
-GIT_TAG=$(shell git describe --tags --abbrev=0)-SNAPSHOT
+GIT_TAG=$(shell git describe --tags --abbrev=0 2>/dev/null || echo v0.0.0)-SNAPSHOT
 else
 GIT_SHA=source_archive
 GIT_TAG=$(patsubst navidrome-%,v%,$(notdir $(PWD)))-SNAPSHOT


### PR DESCRIPTION
### Description
Building from a checkout of an older tag reported the newest tag in the repo instead of the checked-out one, because `GIT_TAG` was derived from the most recently created tag. Derive it with `git describe --tags --abbrev=0` instead, so the version reflects the nearest tag reachable from the checked-out commit. When no tag is reachable, the Makefile falls back to `v0.0.0` and the CI `git-version` step to an empty tag (previous behavior), so tagless checkouts don't break the build or the pipeline.

### Related Issues
Fixes #4043

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. In a full clone, check out a tag older than the newest one (e.g. `git checkout v0.61.0`).
2. Run `make build` and `./navidrome --version`.
3. Expected: `0.61.0-SNAPSHOT (...)`, instead of the newest tag in the repo.
4. Edge case: in a tagless clone (`git clone --no-tags --single-branch ...`), `make build` still works and the version falls back to `0.0.0-SNAPSHOT`, with no git errors.

### Additional Notes
Makefile/workflow-only change, so no automated tests; verified manually as above, including the CI step script under `bash -e` with and without reachable tags. Snapshot versions on branches now name the nearest reachable tag rather than the newest repo tag, which is the intended semantics from the issue.
