### PR TITLE
fix(ui): favourite button disabled after queue ends - #5560

### DIFF
--- a/ui/src/reducers/playerReducer.js
+++ b/ui/src/reducers/playerReducer.js
@@ -182,7 +182,7 @@ const reduceSyncQueue = (state, { data: { audioInfo, audioLists } }) => {
 }
 
 const reduceCurrent = (state, { data }) => {
-  const current = data.ended ? {} : data
+  const current = data.ended ? { ...data, paused: true } : data
   const savedPlayIndex = state.queue.findIndex(
     (item) => item.uuid === current.uuid,
   )


### PR DESCRIPTION
### Description
<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->
When a song is finished playing, and the queue ends, the favourite button is greyed out

### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->
https://github.com/navidrome/navidrome/issues/5560

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] All existing and new tests pass

### How to Test
<!-- Describe the steps to test your changes. Include setup, commands, and expected results. -->
1. Play song
2. make sure its the last/only song in queue
3. let song finish
4. Now try to click on fav button