### PR TITLE
feat(sharing): enable sharing by default

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -794,7 +794,7 @@ func setViperDefaults() {
 	viper.SetDefault("uiplaybackreportinterval", consts.DefaultUIPlaybackReportInterval)
 	viper.SetDefault("enableartworkupload", true)
 	viper.SetDefault("maximageuploadsize", consts.DefaultMaxImageUploadSize)
-	viper.SetDefault("enablesharing", false)
+	viper.SetDefault("enablesharing", true)
 	viper.SetDefault("shareurl", "")
 	viper.SetDefault("defaultshareexpiration", 8760*time.Hour)
 	viper.SetDefault("defaultdownloadableshare", false)

--- a/server/nativeapi/config_test.go
+++ b/server/nativeapi/config_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Config API", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
+		conf.Server.EnableSharing = false
 		conf.Server.DevUIShowConfig = true // Enable config endpoint for tests
 		ds = &tests.MockDataStore{}
 		auth.Init(ds)

--- a/server/nativeapi/library_test.go
+++ b/server/nativeapi/library_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/auth"
@@ -27,6 +28,7 @@ var _ = Describe("Library API", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
+		conf.Server.EnableSharing = false
 		ds = &tests.MockDataStore{}
 		auth.Init(ds)
 		nativeRouter := New(ds, nil, nil, nil, tests.NewMockLibraryService(), tests.NewMockUserService(), nil, nil, nil)

--- a/server/nativeapi/native_api_song_test.go
+++ b/server/nativeapi/native_api_song_test.go
@@ -32,6 +32,7 @@ var _ = Describe("Song Endpoints", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
+		conf.Server.EnableSharing = false
 		conf.Server.SessionTimeout = time.Minute
 
 		// Setup mock repositories

--- a/server/nativeapi/playlists_test.go
+++ b/server/nativeapi/playlists_test.go
@@ -76,6 +76,7 @@ var _ = Describe("Playlist Tracks Endpoint", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
+		conf.Server.EnableSharing = false
 		conf.Server.SessionTimeout = time.Minute
 
 		plsSvc = &mockPlaylistsService{}

--- a/server/nativeapi/plugin_test.go
+++ b/server/nativeapi/plugin_test.go
@@ -29,6 +29,7 @@ var _ = Describe("Plugin API", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
+		conf.Server.EnableSharing = false
 		conf.Server.Plugins.Enabled = true
 		ds = &tests.MockDataStore{}
 		mockManager = &tests.MockPluginManager{}


### PR DESCRIPTION
### Description

Flip the `EnableSharing` default from `false` to `true` so sharing works out of the box. Admins can still disable it with `EnableSharing = false`. Sharing-agnostic `nativeapi` tests (which pass a `nil` share service) now disable sharing in setup, since the `/share` route is registered by default.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): default config value change

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

With no `EnableSharing` set, sharing is on by default (`shareRole=true`, `/api/share` available). Setting `EnableSharing = false` disables it again.

### Additional Notes

Viper defaults apply when the option isn't set explicitly, so installs that never configured `EnableSharing` will have sharing **enabled after upgrade** — worth a release-note callout.
