### PR TITLE
docs: fix duplicated word in listenbrainz client comment

### DIFF
--- a/adapters/listenbrainz/client.go
+++ b/adapters/listenbrainz/client.go
@@ -208,7 +208,7 @@ func (c *client) makeGenericRequest(ctx context.Context, method string, endpoint
 		return nil, err
 	}
 
-	// On a 200 code, there is no code. Decode using using error message if it exists
+	// On a 200 code, there is no code. Decode using error message if it exists
 	if resp.StatusCode != 200 {
 		defer resp.Body.Close()
 		decoder := json.NewDecoder(resp.Body)


### PR DESCRIPTION
### Description
Removes a duplicated word ("using using") in a code comment in the ListenBrainz client. Documentation-only change; no behavior is affected.

### Related Issues
None.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed (this change updates a code comment)
- [x] I have added tests that prove my fix/feature works (or explain why not): comment-only change, no tests needed
- [x] All existing and new tests pass

### How to Test
No functional change. The edit only removes a repeated word in a comment; `gofmt -l adapters/listenbrainz/client.go` reports no formatting issues.

### Screenshots / Demos (if applicable)
N/A

### Additional Notes
Comment-only fix in `adapters/listenbrainz/client.go`.
