### PR TITLE
fix(server): reopen log file on SIGHUP instead of shutting down - #5721

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,10 +2,8 @@ package cmd
 
 import (
 	"context"
-	"os"
 	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/go-chi/chi/v5/middleware"
@@ -103,12 +101,7 @@ func runNavidrome(ctx context.Context) {
 
 // mainContext returns a context that is cancelled when the process receives a signal to exit.
 func mainContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	return signal.NotifyContext(ctx,
-		os.Interrupt,
-		syscall.SIGHUP,
-		syscall.SIGTERM,
-		syscall.SIGABRT,
-	)
+	return signal.NotifyContext(ctx, shutdownSignals...)
 }
 
 // startServer starts the Navidrome web server, adding all the necessary routers.

--- a/cmd/signaller_nounix.go
+++ b/cmd/signaller_nounix.go
@@ -4,7 +4,13 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"syscall"
 )
+
+// SIGHUP is kept as a shutdown signal here, as on Windows it is delivered when the console
+// window is closed, and there is no log rotation convention based on it.
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGHUP, syscall.SIGTERM, syscall.SIGABRT}
 
 // Windows and Plan9 don't support SIGUSR1, so we don't need to start a signaler
 func startSignaller(ctx context.Context) func() error {

--- a/cmd/signaller_unix.go
+++ b/cmd/signaller_unix.go
@@ -9,10 +9,16 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
 )
 
 const triggerScanSignal = syscall.SIGUSR1
+
+// shutdownSignals does not include SIGHUP: as expected from a daemon, the server handles it
+// by reopening its log file (see handleSignal), so log rotation tools can use it.
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM, syscall.SIGABRT}
 
 func startSignaller(ctx context.Context) func() error {
 	log.Info(ctx, "Starting signaler")
@@ -20,21 +26,41 @@ func startSignaller(ctx context.Context) func() error {
 
 	return func() error {
 		var sigChan = make(chan os.Signal, 1)
-		signal.Notify(sigChan, triggerScanSignal)
+		signal.Notify(sigChan, triggerScanSignal, syscall.SIGHUP)
 
 		for {
 			select {
 			case sig := <-sigChan:
-				log.Info(ctx, "Received signal, triggering a new scan", "signal", sig)
-				start := time.Now()
-				_, err := scanner.ScanAll(ctx, false)
-				if err != nil {
-					log.Error(ctx, "Error scanning", err)
-				}
-				log.Info(ctx, "Triggered scan complete", "elapsed", time.Since(start))
+				handleSignal(ctx, sig, scanner)
 			case <-ctx.Done():
 				return nil
 			}
 		}
+	}
+}
+
+func handleSignal(ctx context.Context, sig os.Signal, scanner model.Scanner) {
+	switch sig {
+	case syscall.SIGHUP:
+		reopenLogFile(ctx, sig)
+	case triggerScanSignal:
+		log.Info(ctx, "Received signal, triggering a new scan", "signal", sig)
+		start := time.Now()
+		_, err := scanner.ScanAll(ctx, false)
+		if err != nil {
+			log.Error(ctx, "Error scanning", err)
+		}
+		log.Info(ctx, "Triggered scan complete", "elapsed", time.Since(start))
+	}
+}
+
+func reopenLogFile(ctx context.Context, sig os.Signal) {
+	if conf.Server.LogFile == "" {
+		log.Debug(ctx, "Received signal, but no log file configured. Ignoring", "signal", sig)
+		return
+	}
+	log.Info(ctx, "Received signal, reopening log file", "signal", sig, "logFile", conf.Server.LogFile)
+	if err := log.SetOutputFile(conf.Server.LogFile); err != nil {
+		log.Error(ctx, "Error reopening log file", "logFile", conf.Server.LogFile, err)
 	}
 }

--- a/cmd/signaller_unix.go
+++ b/cmd/signaller_unix.go
@@ -27,6 +27,7 @@ func startSignaller(ctx context.Context) func() error {
 	return func() error {
 		var sigChan = make(chan os.Signal, 1)
 		signal.Notify(sigChan, triggerScanSignal, syscall.SIGHUP)
+		defer signal.Stop(sigChan)
 
 		for {
 			select {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -367,16 +367,10 @@ func Load(noConfigDump bool) {
 		Server.DbPath = filepath.Join(Server.DataFolder.String(), consts.DefaultDbPath)
 	}
 
-	out := os.Stderr
 	if Server.LogFile != "" {
-		if mkErr := os.MkdirAll(filepath.Dir(Server.LogFile), os.ModePerm); mkErr != nil {
-			logFatal(fmt.Sprintf("Error creating log file directory: %s", mkErr.Error()))
-		}
-		out, err = os.OpenFile(Server.LogFile, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
+		if err := log.SetOutputFile(Server.LogFile); err != nil {
 			logFatal(fmt.Sprintf("Error opening log file %s: %s", Server.LogFile, err.Error()))
 		}
-		log.SetOutput(out)
 	} else if os.Getenv("ND_SYSTEMD_PRIORITY_LOGGING") != "" && os.Getenv("JOURNAL_STREAM") != "" {
 		// When running under systemd, prepend syslog priority prefixes so
 		// journald assigns the correct severity to each log line.
@@ -431,7 +425,7 @@ func Load(noConfigDump bool) {
 		if Server.EnableLogRedacting {
 			prettyConf = log.Redact(prettyConf)
 		}
-		_, _ = fmt.Fprintln(out, prettyConf)
+		_, _ = fmt.Fprintln(log.Output(), prettyConf)
 	}
 
 	if !Server.EnableExternalServices {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -191,7 +191,7 @@ var _ = Describe("Configuration", func() {
 			viper.SetDefault("logfile", filepath.Join(invalidPath, "log.txt"))
 			Expect(func() {
 				conf.Load(true)
-			}).To(PanicWith(ContainSubstring("Error creating log file directory")))
+			}).To(PanicWith(ContainSubstring("creating log file directory")))
 		})
 
 		It("is called when BaseURL is invalid", func() {

--- a/log/log.go
+++ b/log/log.go
@@ -166,18 +166,17 @@ func SetOutputFile(path string) error {
 	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
 		return fmt.Errorf("creating log file directory: %w", err)
 	}
+	outputFileMu.Lock()
+	defer outputFileMu.Unlock()
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
 	SetOutput(f)
-	outputFileMu.Lock()
-	prev := outputFile
-	outputFile = f
-	outputFileMu.Unlock()
-	if prev != nil {
-		_ = prev.Close()
+	if outputFile != nil {
+		_ = outputFile.Close()
 	}
+	outputFile = f
 	return nil
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -173,10 +173,11 @@ func SetOutputFile(path string) error {
 		return err
 	}
 	SetOutput(f)
-	if outputFile != nil {
-		_ = outputFile.Close()
-	}
+	prev := outputFile
 	outputFile = f
+	if prev != nil {
+		_ = prev.Close()
+	}
 	return nil
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -8,6 +8,7 @@ import (
 	"iter"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -143,6 +144,41 @@ func SetOutput(w io.Writer) {
 	loggerMu.Lock()
 	defer loggerMu.Unlock()
 	defaultLogger.SetOutput(w)
+}
+
+// Output returns the current writer used by the default logger.
+func Output() io.Writer {
+	loggerMu.RLock()
+	defer loggerMu.RUnlock()
+	return defaultLogger.Out
+}
+
+var (
+	outputFileMu sync.Mutex
+	outputFile   *os.File
+)
+
+// SetOutputFile opens (or creates) the given file in append mode and sets it as the log
+// output, closing the previously opened log file, if any. Calling it again with the same
+// path reopens the file, allowing external log rotation tools to signal the process
+// (e.g. with SIGHUP) after rotating the log file.
+func SetOutputFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), os.ModePerm); err != nil {
+		return fmt.Errorf("creating log file directory: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	SetOutput(f)
+	outputFileMu.Lock()
+	prev := outputFile
+	outputFile = f
+	outputFileMu.Unlock()
+	if prev != nil {
+		_ = prev.Close()
+	}
+	return nil
 }
 
 // EnableJournalFormat wraps the current logger formatter with syslog

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -92,7 +94,7 @@ var _ = Describe("Logger", func() {
 			SetLogSourceLine(true)
 			Error("A crash happened")
 			// NOTE: This assertion breaks if the line number above changes
-			Expect(hook.LastEntry().Data[" source"]).To(ContainSubstring("/log/log_test.go:93"))
+			Expect(hook.LastEntry().Data[" source"]).To(ContainSubstring("/log/log_test.go:95"))
 			Expect(hook.LastEntry().Message).To(Equal("A crash happened"))
 		})
 
@@ -258,6 +260,41 @@ var _ = Describe("Logger", func() {
 		Describe("Subsonic API password", func() {
 			msg := "getLyrics.view?v=1.2.0&c=iSub&u=user_name&p=first%20and%20other%20words&title=Title"
 			Expect(Redact(msg)).To(Equal("getLyrics.view?v=1.2.0&c=iSub&u=user_name&p=[REDACTED]&title=Title"))
+		})
+	})
+
+	Describe("SetOutputFile", func() {
+		var path string
+
+		BeforeEach(func() {
+			path = filepath.Join(GinkgoT().TempDir(), "logs", "navidrome.log")
+			Expect(SetOutputFile(path)).To(Succeed())
+		})
+
+		It("creates the log file directory and writes log messages to the file", func() {
+			Error("first message")
+
+			content, err := os.ReadFile(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("first message"))
+		})
+
+		It("recreates the log file after it has been rotated away", func() {
+			Error("first message")
+			rotated := path + ".1"
+			Expect(os.Rename(path, rotated)).To(Succeed())
+
+			Expect(SetOutputFile(path)).To(Succeed())
+			Error("second message")
+
+			rotatedContent, err := os.ReadFile(rotated)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(rotatedContent)).To(ContainSubstring("first message"))
+			Expect(string(rotatedContent)).ToNot(ContainSubstring("second message"))
+
+			content, err := os.ReadFile(path)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(content)).To(ContainSubstring("second message"))
 		})
 	})
 })


### PR DESCRIPTION
Closes https://github.com/navidrome/navidrome/issues/5721

## Description

`SIGHUP` currently triggers a graceful shutdown, because `mainContext` registers it in `signal.NotifyContext` alongside `SIGINT`/`SIGTERM`/`SIGABRT`. For a daemon writing to a log file (`ND_LOGFILE`), the standard Unix convention (used by newsyslog, logrotate, etc.) is that `SIGHUP` means "reopen your log files", not "quit".

This PR makes Navidrome on Unix handle `SIGHUP` by reopening the configured log file (or ignoring the signal when no log file is configured), while keeping `SIGHUP` as a shutdown signal on Windows/Plan 9, where it represents console close.

## Changes

- `log`: new `SetOutputFile(path)` — creates the directory, opens the file in append mode, swaps it as the logger output, and closes the previously opened file (no fd leak after rotation). New `Output()` accessor for the current writer. `conf.Load` now uses this same function instead of its inline open logic.
- `cmd/root.go`: `mainContext` now uses a platform-specific `shutdownSignals` list.
- `cmd/signaller_unix.go`: `SIGHUP` removed from shutdown signals and added to the signaller loop — when `LogFile` is set it reopens the file, otherwise the signal is logged and ignored. `SIGUSR1` scan trigger behavior is unchanged.
- `cmd/signaller_nounix.go`: keeps `SIGHUP` as a shutdown signal (console-close semantics on Windows).
- Tests: regression test for `SetOutputFile` covering the rotation scenario (log renamed → `SetOutputFile` again → messages go to the new file, old file untouched).

Note: with this change, non-server subcommands (e.g. `navidrome scan`) terminate with the default `SIGHUP` disposition instead of going through context cancellation — the standard behavior for CLI tools.

## Manual QA (darwin/arm64, `-tags=netgo,sqlite_fts5` build)

Ran the server with `ND_LOGFILE=/tmp/navidrome-qa/logs/navidrome.log`:

1. `kill -HUP $pid` → process stays alive, logs `Received signal, reopening log file`.
2. `mv navidrome.log navidrome.log.1 && kill -HUP $pid` → new `navidrome.log` created and receives subsequent logs; `lsof` shows only the new file open (old fd closed).
3. `kill -USR1 $pid` → still triggers a scan (`Received signal, triggering a new scan` … `Triggered scan complete`).
4. `kill -TERM $pid` → graceful shutdown (`Navidrome stopped, bye.`).

`make lint` (golangci-lint v2.12.0): 0 issues. `go test ./log/... ./conf/... ./cmd/...`: all pass. `GOOS=windows go build ./log/... ./conf/...`: OK.

## Screenshots

N/A (no UI changes).

## Related Issues

- https://github.com/navidrome/navidrome/issues/5721
