### PR TITLE
fix(plugins): populate username for buffered plugin scrobbles

### DIFF
--- a/core/scrobbler/buffered_scrobbler.go
+++ b/core/scrobbler/buffered_scrobbler.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
 )
 
 // Loader is a function that loads a scrobbler by name.
@@ -129,6 +130,14 @@ func (b *bufferedScrobbler) processQueue(ctx context.Context) bool {
 }
 
 func (b *bufferedScrobbler) processUserQueue(ctx context.Context, userId string) bool {
+	// Scrobbles are drained on a background context that no longer carries the
+	// request's authenticated user. Restore it from the buffered userId so that
+	// scrobblers relying on the user in the context (e.g. plugins) still get it.
+	if user, err := b.ds.User(ctx).Get(userId); err != nil {
+		log.Warn(ctx, "Could not load user for buffered scrobble", "userId", userId, "scrobbler", b.service, err)
+	} else {
+		ctx = request.WithUser(ctx, *user)
+	}
 	buffer := b.ds.ScrobbleBuffer(ctx)
 	for {
 		entry, err := buffer.Next(b.service, userId)

--- a/core/scrobbler/buffered_scrobbler_test.go
+++ b/core/scrobbler/buffered_scrobbler_test.go
@@ -20,8 +20,11 @@ var _ = Describe("BufferedScrobbler", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		buffer = tests.CreateMockedScrobbleBufferRepo()
+		userRepo := tests.CreateMockUserRepo()
+		Expect(userRepo.Put(&model.User{ID: "user1", UserName: "alice"})).To(Succeed())
 		ds = &tests.MockDataStore{
 			MockedScrobbleBuffer: buffer,
+			MockedUser:           userRepo,
 		}
 		scr = &fakeScrobbler{Authorized: true}
 		bs = newBufferedScrobbler(ds, scr, "test")
@@ -60,6 +63,16 @@ var _ = Describe("BufferedScrobbler", func() {
 		lastScrobble := scr.LastScrobble.Load()
 		Expect(lastScrobble.MediaFile.ID).To(Equal("123"))
 		Expect(lastScrobble.TimeStamp).To(BeTemporally("==", now))
+	})
+
+	It("restores the user in the context when draining buffered scrobbles", func() {
+		track := model.MediaFile{ID: "123", Title: "Test Track", Artist: "Test Artist"}
+		scrobble := Scrobble{MediaFile: track, TimeStamp: time.Now()}
+
+		Expect(bs.Scrobble(ctx, "user1", scrobble)).To(Succeed())
+
+		Eventually(scr.ScrobbleCalled.Load).Should(BeTrue())
+		Expect(scr.GetUsername()).To(Equal("alice"))
 	})
 
 	It("stops the background goroutine when Stop is called", func() {

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -1091,6 +1091,13 @@ func (f *fakeScrobbler) GetUserID() string {
 	return ""
 }
 
+func (f *fakeScrobbler) GetUsername() string {
+	if p := f.username.Load(); p != nil {
+		return *p
+	}
+	return ""
+}
+
 func (f *fakeScrobbler) GetTrack() *model.MediaFile {
 	return f.track.Load()
 }
@@ -1122,6 +1129,16 @@ func (f *fakeScrobbler) NowPlaying(ctx context.Context, userId string, track *mo
 
 func (f *fakeScrobbler) Scrobble(ctx context.Context, userId string, s Scrobble) error {
 	f.userID.Store(&userId)
+	// Capture username from context (this is what plugin scrobblers do)
+	username, _ := request.UsernameFrom(ctx)
+	if username == "" {
+		if u, ok := request.UserFrom(ctx); ok {
+			username = u.UserName
+		}
+	}
+	if username != "" {
+		f.username.Store(&username)
+	}
 	f.LastScrobble.Store(&s)
 	f.ScrobbleCalled.Store(true)
 	if f.Error != nil {


### PR DESCRIPTION
### Description

Fixes a bug where `ScrobbleRequest.Username` was **always empty** for WASM scrobbler plugins, regardless of which user played the track. `NowPlayingRequest.Username` was unaffected.

**Root cause:** Plugin scrobblers derive the username from the request context (`getUsernameFromContext`). But scrobbles are buffered — `bufferedScrobbler.Scrobble` persists the play to the DB scrobble buffer (which stores only the `userId`) and returns. The buffer is later drained by a background worker that was started on `context.Background()`. That context carries no authenticated user, so by the time the drain calls `ScrobblerPlugin.Scrobble`, `getUsernameFromContext(ctx)` returns `""`. `NowPlaying` isn't buffered — it's dispatched synchronously on `context.WithoutCancel(requestCtx)`, which retains the user — which is why it worked.

Builtin scrobblers (Last.fm/ListenBrainz) never exposed this because they resolve the account from the `userId` argument (stored OAuth tokens), not from the context.

**Fix:** Restore the authenticated user in the drain path. `bufferedScrobbler.processUserQueue` now looks up the user by the buffered `userId` and injects it into the context via `request.WithUser` before dispatching — the same pattern already used in `play_tracker`. This keeps the plugin adapter uniformly context-based (matching `NowPlaying`/`IsAuthorized`) and is a no-op for builtin scrobblers. If the user can no longer be loaded (e.g. deleted), it logs a warning and degrades to the previous behavior rather than dropping the scrobble.

Reported via a plugin developer whose `ScrobbleRequest.Username` came through blank on every scrobble.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run the scrobbler unit tests:
   ```bash
   make test PKG=./core/scrobbler
   ```
   The new spec `BufferedScrobbler restores the user in the context when draining buffered scrobbles` asserts the username reaches the underlying scrobbler. Reverting the change in `buffered_scrobbler.go` makes it fail with an empty username, proving it guards the regression.
2. End-to-end with a plugin: play a track as any non-admin user with a WASM scrobbler plugin installed and confirm the plugin now receives a non-empty `ScrobbleRequest.Username` matching the user who played (previously always empty). `NowPlayingRequest.Username` behavior is unchanged.

### Additional Notes

- The fix adds one `User.Get(userId)` lookup per user per drain cycle (the queue is already drained per-user), which is negligible relative to the existing buffer reads/writes.
- No API or schema changes; no migration.
