### PR TITLE
fix(plugins): discard buffered scrobbles when a plugin is removed

### DIFF
--- a/core/scrobbler/play_tracker.go
+++ b/core/scrobbler/play_tracker.go
@@ -491,3 +491,10 @@ func Register(name string, init Constructor) {
 	}
 	constructors[name] = init
 }
+
+// IsBuiltinScrobbler reports whether name belongs to a registered builtin
+// scrobbler (e.g. "lastfm", "listenbrainz").
+func IsBuiltinScrobbler(name string) bool {
+	_, ok := constructors[name]
+	return ok
+}

--- a/core/scrobbler/play_tracker_test.go
+++ b/core/scrobbler/play_tracker_test.go
@@ -104,6 +104,13 @@ var _ = Describe("PlayTracker", func() {
 		Expect(tracker.builtinScrobblers).ToNot(HaveKey("disabled"))
 	})
 
+	Describe("IsBuiltinScrobbler", func() {
+		It("reports whether the name belongs to a registered builtin scrobbler", func() {
+			Expect(IsBuiltinScrobbler("fake")).To(BeTrue())
+			Expect(IsBuiltinScrobbler("some-plugin")).To(BeFalse())
+		})
+	})
+
 	Describe("GetNowPlaying", func() {
 		It("returns current playing music", func() {
 			track2 := track

--- a/model/scrobble_buffer.go
+++ b/model/scrobble_buffer.go
@@ -20,4 +20,5 @@ type ScrobbleBufferRepository interface {
 	Next(service string, userId string) (*ScrobbleEntry, error)
 	Dequeue(entry *ScrobbleEntry) error
 	Length() (int64, error)
+	Discard(service string) error
 }

--- a/persistence/scrobble_buffer_repository.go
+++ b/persistence/scrobble_buffer_repository.go
@@ -93,6 +93,10 @@ func (r *scrobbleBufferRepository) Dequeue(entry *model.ScrobbleEntry) error {
 	return r.delete(Eq{"id": entry.ID})
 }
 
+func (r *scrobbleBufferRepository) Discard(service string) error {
+	return r.delete(Eq{"service": service})
+}
+
 func (r *scrobbleBufferRepository) Length() (int64, error) {
 	return r.count(Select())
 }

--- a/persistence/scrobble_buffer_repository_test.go
+++ b/persistence/scrobble_buffer_repository_test.go
@@ -191,6 +191,28 @@ var _ = Describe("ScrobbleBufferRepository", func() {
 
 		})
 
+		Describe("Discard", func() {
+			It("deletes all entries for a service, keeping other services intact", func() {
+				Expect(scrobble.Discard("a")).To(Succeed())
+
+				count, err := scrobble.Length()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(count).To(Equal(int64(1)))
+
+				entry, err := scrobble.Next("b", "2222")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(entry).ToNot(BeNil())
+			})
+
+			It("is a no-op for a service without entries", func() {
+				Expect(scrobble.Discard("nonexistent")).To(Succeed())
+
+				count, err := scrobble.Length()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(count).To(Equal(int64(4)))
+			})
+		})
+
 		Describe("UserIds", func() {
 			It("should return ordered list for services", func() {
 				ids, err := scrobble.UserIDs("a")

--- a/plugins/manager_sync.go
+++ b/plugins/manager_sync.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/navidrome/navidrome/core/scrobbler"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
@@ -109,7 +110,12 @@ func (m *Manager) removePluginFromDB(ctx context.Context, repo model.PluginRepos
 	}
 	// Discard any scrobbles still buffered for the removed plugin, so they are
 	// not delivered to an unrelated plugin that reuses the same name later.
-	if err := m.ds.ScrobbleBuffer(ctx).Discard(pluginID); err != nil {
+	// Skip names owned by builtin scrobblers: buffer entries are keyed by
+	// service name, so removing a plugin file named e.g. "lastfm.ndp" must not
+	// wipe the builtin Last.fm retry queue.
+	if scrobbler.IsBuiltinScrobbler(pluginID) {
+		log.Debug(ctx, "Keeping buffered scrobbles: name is owned by a builtin scrobbler", "plugin", pluginID)
+	} else if err := m.ds.ScrobbleBuffer(ctx).Discard(pluginID); err != nil {
 		log.Error(ctx, "Error discarding buffered scrobbles for removed plugin", "plugin", pluginID, err)
 	}
 	log.Info(ctx, "Plugin removed", "plugin", pluginID)

--- a/plugins/manager_sync.go
+++ b/plugins/manager_sync.go
@@ -107,6 +107,11 @@ func (m *Manager) removePluginFromDB(ctx context.Context, repo model.PluginRepos
 	if err := repo.Delete(pluginID); err != nil {
 		return fmt.Errorf("deleting plugin from DB: %w", err)
 	}
+	// Discard any scrobbles still buffered for the removed plugin, so they are
+	// not delivered to an unrelated plugin that reuses the same name later.
+	if err := m.ds.ScrobbleBuffer(ctx).Discard(pluginID); err != nil {
+		log.Error(ctx, "Error discarding buffered scrobbles for removed plugin", "plugin", pluginID, err)
+	}
 	log.Info(ctx, "Plugin removed", "plugin", pluginID)
 	m.sendPluginRefreshEvent(ctx, events.Any)
 	return nil

--- a/plugins/manager_sync_test.go
+++ b/plugins/manager_sync_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/navidrome/navidrome/core/scrobbler"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
@@ -22,9 +23,10 @@ var _ = Describe("removePluginFromDB", func() {
 		plugin := model.Plugin{ID: "my-plugin", Enabled: false}
 		repo.SetData(model.Plugins{plugin})
 
+		// No broker: sendPluginRefreshEvent is nil-safe, and testBroker is
+		// defined in manager_test.go, which is excluded on Windows.
 		m := &Manager{
-			ds:     &tests.MockDataStore{MockedScrobbleBuffer: buffer},
-			broker: &testBroker{},
+			ds: &tests.MockDataStore{MockedScrobbleBuffer: buffer},
 		}
 		Expect(m.removePluginFromDB(ctx, repo, &plugin)).To(Succeed())
 
@@ -37,6 +39,26 @@ var _ = Describe("removePluginFromDB", func() {
 		entry, err := buffer.Next("other-plugin", "user1")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(entry).ToNot(BeNil(), "entries of other services must be kept")
+	})
+
+	It("keeps buffered scrobbles of a builtin scrobbler sharing the removed plugin's name", func() {
+		ctx := context.Background()
+		scrobbler.Register("builtin-svc", func(model.DataStore) scrobbler.Scrobbler { return nil })
+		buffer := tests.CreateMockedScrobbleBufferRepo()
+		Expect(buffer.Enqueue("builtin-svc", "user1", "track1", time.Now())).To(Succeed())
+
+		repo := tests.CreateMockPluginRepo()
+		plugin := model.Plugin{ID: "builtin-svc", Enabled: false}
+		repo.SetData(model.Plugins{plugin})
+
+		m := &Manager{
+			ds: &tests.MockDataStore{MockedScrobbleBuffer: buffer},
+		}
+		Expect(m.removePluginFromDB(ctx, repo, &plugin)).To(Succeed())
+
+		remaining, err := buffer.Length()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(remaining).To(Equal(int64(1)), "builtin scrobbler queue must not be wiped")
 	})
 })
 

--- a/plugins/manager_sync_test.go
+++ b/plugins/manager_sync_test.go
@@ -1,11 +1,44 @@
 package plugins
 
 import (
+	"context"
 	"path/filepath"
+	"time"
 
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("removePluginFromDB", func() {
+	It("discards buffered scrobbles for the removed plugin", func() {
+		ctx := context.Background()
+		buffer := tests.CreateMockedScrobbleBufferRepo()
+		Expect(buffer.Enqueue("my-plugin", "user1", "track1", time.Now())).To(Succeed())
+		Expect(buffer.Enqueue("other-plugin", "user1", "track2", time.Now())).To(Succeed())
+
+		repo := tests.CreateMockPluginRepo()
+		plugin := model.Plugin{ID: "my-plugin", Enabled: false}
+		repo.SetData(model.Plugins{plugin})
+
+		m := &Manager{
+			ds:     &tests.MockDataStore{MockedScrobbleBuffer: buffer},
+			broker: &testBroker{},
+		}
+		Expect(m.removePluginFromDB(ctx, repo, &plugin)).To(Succeed())
+
+		_, err := repo.Get("my-plugin")
+		Expect(err).To(MatchError(model.ErrNotFound))
+
+		remaining, err := buffer.Length()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(remaining).To(Equal(int64(1)))
+		entry, err := buffer.Next("other-plugin", "user1")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(entry).ToNot(BeNil(), "entries of other services must be kept")
+	})
+})
 
 var _ = Describe("ComputeFileSHA256", func() {
 	It("returns a consistent 64-char lowercase hex hash for the same file", func() {

--- a/tests/mock_scrobble_buffer_repo.go
+++ b/tests/mock_scrobble_buffer_repo.go
@@ -83,6 +83,22 @@ func (m *MockedScrobbleBufferRepo) Dequeue(entry *model.ScrobbleEntry) error {
 	return nil
 }
 
+func (m *MockedScrobbleBufferRepo) Discard(service string) error {
+	if m.Error != nil {
+		return m.Error
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	newData := model.ScrobbleEntries{}
+	for _, e := range m.Data {
+		if e.Service != service {
+			newData = append(newData, e)
+		}
+	}
+	m.Data = newData
+	return nil
+}
+
 func (m *MockedScrobbleBufferRepo) Length() (int64, error) {
 	if m.Error != nil {
 		return 0, m.Error


### PR DESCRIPTION
### Description

Fixes orphaned scrobble-buffer entries when a WASM scrobbler plugin is removed.

**The problem:** Scrobbles are buffered in the `scrobble_buffer` table keyed by service (the plugin name). When a plugin is removed (file deleted from the plugins folder, detected by the sync at startup or rescan), `removePluginFromDB` unloads the plugin and deletes its DB record — but its buffered entries were never touched. The behavior today is:

1. Until the next dispatch event triggers the scrobbler refresh, the orphaned drain goroutine retries every 5 seconds, logging `"Scrobbler not available, will retry later"` each time (the missing-loader path is treated as retry-later, never as a discardable error).
2. After the refresh, the drain goroutine is stopped and the rows go dormant — never retried, never discarded, surviving restarts.
3. If a plugin with the *same name* is installed later, its fresh buffered scrobbler drains the stale entries into it — potentially a completely unrelated plugin that just reuses the name, receiving plays the user never authorized for it.

**The fix:** Add `Discard(service string)` to `ScrobbleBufferRepository` and call it from `removePluginFromDB` right after the plugin record is deleted. A `Discard` failure is logged but does not fail the removal (degrades to today's behavior).

**Deliberately unaffected:**
- **Disabling** a plugin keeps its buffered scrobbles, so they deliver on re-enable — consistent with the buffer's purpose of surviving temporary outages (and with auto-disable on permission loss).
- **Transient unload/reload cycles** during plugin config updates never delete the plugin record, so they never trigger the discard. This is why the purge is hooked into `removePluginFromDB` and not into the play tracker's scrobbler-refresh diff, which sees plugins vanish transiently.

Follow-up to #5736, found while reviewing the buffered-scrobble drain path.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Unit tests:
   ```bash
   make test PKG=./persistence   # ScrobbleBufferRepository Discard specs
   make test PKG=./plugins       # removePluginFromDB discards buffered scrobbles
   ```
   The new plugins spec fails if the `Discard` call is removed from `removePluginFromDB`; the persistence specs verify `Discard` deletes only the target service's rows.
2. End-to-end: with a scrobbler plugin installed that returns `retry later` (or while it is unreachable), play a few tracks to build up buffered entries (`SELECT service, count(*) FROM scrobble_buffer` in navidrome.db). Delete the plugin's `.ndp` from the plugins folder and trigger a rescan (or restart). The plugin's rows are gone; entries for other services (e.g. Last.fm) are untouched.

### Additional Notes

- Entries for a plugin that is *disabled* (not removed) are intentionally kept — see Description.
- No migration needed; the change only adds a `DELETE ... WHERE service = ?` used at plugin-removal time.
