### PR TITLE
fix(build): prevent 32-bit startup crash (segfault/SIGILL) in downloads binaries

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -300,6 +300,21 @@ jobs:
             GIT_SHA=${{ env.GIT_SHA }}
             GIT_TAG=${{ env.GIT_TAG }}
 
+      - name: Set up QEMU for smoke test
+        if: env.IS_LINUX == 'true'
+        uses: docker/setup-qemu-action@v3
+
+      # The binary is static, so binfmt+qemu runs it directly on the runner.
+      # Catches startup crashes in cross-compiled binaries before they ship,
+      # e.g. the broken ifunc relocations on 32-bit arm from issue #5738.
+      - name: Smoke-test binary
+        if: env.IS_LINUX == 'true'
+        run: |
+          BIN=./output/${{ env.PLATFORM }}/navidrome
+          chmod +x "$BIN"
+          "$BIN" --help >/dev/null
+          echo "OK: ${{ matrix.platform }} binary starts"
+
       - name: Upload Binaries
         uses: actions/upload-artifact@v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -69,20 +69,15 @@ RUN --mount=type=bind,source=. \
     set -e
     xx-go --wrap
     export CGO_ENABLED=1
-    # Native libwebp (gen2brain/webp) uses ebitengine/purego reverse callbacks,
-    # which purego does not support on 32-bit ARM or x86 and crash with a SIGSEGV
-    # (issue #5597). Build those arches with the "nodynamic" tag so gen2brain/webp
-    # is WASM-only and never links the purego path. 64-bit arches keep native libwebp.
-    BUILD_TAGS=netgo,sqlite_fts5
-    if [ "$(xx-info arch)" = "arm" ] || [ "$(xx-info arch)" = "386" ]; then
-        BUILD_TAGS=${BUILD_TAGS},nodynamic
-    fi
+    BUILD_TAGS=$(./release/build-tags.sh)
     # -latomic is required on 32-bit arm (arm/v6, arm/v7) so SQLite's 64-bit atomics resolve.
     go build -tags=${BUILD_TAGS} -ldflags="-w -s \
         -linkmode=external -extldflags '-latomic' \
         -X github.com/navidrome/navidrome/consts.gitSha=${GIT_SHA} \
         -X github.com/navidrome/navidrome/consts.gitTag=${GIT_TAG}" \
         -o /out/navidrome .
+    # Fail the build if native libwebp (purego) leaked into a 32-bit binary (issue #5738).
+    ./release/verify-binary.sh /out/navidrome
     # Fail the build if the binary is accidentally statically linked: dlopen (and
     # therefore native libwebp detection) only works with a dynamic interpreter.
     file /out/navidrome | grep -q "dynamically linked" || { echo "ERROR: /out/navidrome is not dynamically linked"; file /out/navidrome; exit 1; }
@@ -133,10 +128,13 @@ RUN --mount=type=bind,source=. \
         export EXT=".exe"
     fi
 
-    go build -tags=netgo,sqlite_fts5 -ldflags="${LD_EXTRA} -w -s \
+    BUILD_TAGS=$(./release/build-tags.sh) || exit 1
+    go build -tags=${BUILD_TAGS} -ldflags="${LD_EXTRA} -w -s \
         -X github.com/navidrome/navidrome/consts.gitSha=${GIT_SHA} \
         -X github.com/navidrome/navidrome/consts.gitTag=${GIT_TAG}" \
-        -o /out/navidrome${EXT} .
+        -o /out/navidrome${EXT} . || exit 1
+    # Fail the build if native libwebp (purego) leaked into a 32-bit binary (issue #5738).
+    ./release/verify-binary.sh /out/navidrome* || exit 1
 EOT
 
 # Verify if the binary was built for the correct platform and it is statically linked

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ RUN --mount=type=bind,source=. \
     export CGO_ENABLED=1
     BUILD_TAGS=$(./release/build-tags.sh)
     # -latomic is required on 32-bit arm (arm/v6, arm/v7) so SQLite's 64-bit atomics resolve.
-    go build -tags=${BUILD_TAGS} -ldflags="-w -s \
+    go build -tags="${BUILD_TAGS}" -ldflags="-w -s \
         -linkmode=external -extldflags '-latomic' \
         -X github.com/navidrome/navidrome/consts.gitSha=${GIT_SHA} \
         -X github.com/navidrome/navidrome/consts.gitTag=${GIT_TAG}" \
@@ -130,7 +130,7 @@ RUN --mount=type=bind,source=. \
     fi
 
     BUILD_TAGS=$(./release/build-tags.sh)
-    go build -tags=${BUILD_TAGS} -ldflags="${LD_EXTRA} -w -s \
+    go build -tags="${BUILD_TAGS}" -ldflags="${LD_EXTRA} -w -s \
         -X github.com/navidrome/navidrome/consts.gitSha=${GIT_SHA} \
         -X github.com/navidrome/navidrome/consts.gitTag=${GIT_TAG}" \
         -o /out/navidrome${EXT} .

--- a/Dockerfile
+++ b/Dockerfile
@@ -111,11 +111,12 @@ RUN --mount=type=bind,source=. \
     --mount=from=osxcross,src=/osxcross/SDK,target=/xx-sdk,ro \
     --mount=type=cache,target=/root/.cache \
     --mount=type=cache,target=/go/pkg/mod <<EOT
+    set -e
 
     # Setup CGO cross-compilation environment
     xx-go --wrap
     export CGO_ENABLED=1
-    cat $(go env GOENV)
+    cat "$(go env GOENV)" 2>/dev/null || true
 
     # Only Darwin (macOS) requires clang (default), Windows requires gcc, everything else can use any compiler.
     # So let's use gcc for everything except Darwin.
@@ -128,13 +129,13 @@ RUN --mount=type=bind,source=. \
         export EXT=".exe"
     fi
 
-    BUILD_TAGS=$(./release/build-tags.sh) || exit 1
+    BUILD_TAGS=$(./release/build-tags.sh)
     go build -tags=${BUILD_TAGS} -ldflags="${LD_EXTRA} -w -s \
         -X github.com/navidrome/navidrome/consts.gitSha=${GIT_SHA} \
         -X github.com/navidrome/navidrome/consts.gitTag=${GIT_TAG}" \
-        -o /out/navidrome${EXT} . || exit 1
+        -o /out/navidrome${EXT} .
     # Fail the build if native libwebp (purego) leaked into a 32-bit binary (issue #5738).
-    ./release/verify-binary.sh /out/navidrome* || exit 1
+    ./release/verify-binary.sh /out/navidrome*
 EOT
 
 # Verify if the binary was built for the correct platform and it is statically linked

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,14 @@ RUN --mount=type=bind,source=. \
         export CXX=$(xx-info)-g++
         export LD_EXTRA="-extldflags '-static -latomic'"
     fi
+    # GNU ld corrupts the R_ARM_IRELATIVE addends of libatomic's ifunc resolvers
+    # (wrong address, Thumb bit lost) once .text outgrows the 16MB Thumb branch
+    # range, making static arm binaries jump to garbage inside glibc's ifunc
+    # resolution and crash before main() (issue #5738). Link 32-bit arm with LLD,
+    # which emits correct addends.
+    if [ "$(xx-info arch)" = "arm" ]; then
+        export LD_EXTRA="-extldflags '-static -latomic -fuse-ld=lld'"
+    fi
     if [ "$(xx-info os)" = "windows" ]; then
         export EXT=".exe"
     fi

--- a/release/build-tags.sh
+++ b/release/build-tags.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Print the Go build tags for the xx-cc target platform (used by the Dockerfile).
+#
+# gen2brain/webp's native libwebp backend links ebitengine/purego, whose reverse
+# callbacks are unsupported on 32-bit ARM and x86 and SIGSEGV at package-init time,
+# taking the whole process down at startup (issues #5597 / #5606 / #5738). Force the
+# WASM-only path there with the "nodynamic" tag; 64-bit arches keep native libwebp.
+#
+# This is the single source of truth for the tag decision: both Dockerfile build
+# stages (Docker-image and standalone downloads) call it so they cannot drift apart.
+set -e
+
+tags="netgo,sqlite_fts5"
+case "$(xx-info arch)" in
+    arm | 386) tags="${tags},nodynamic" ;;
+esac
+printf '%s' "${tags}"

--- a/release/build-tags.sh
+++ b/release/build-tags.sh
@@ -10,8 +10,13 @@
 # stages (Docker-image and standalone downloads) call it so they cannot drift apart.
 set -e
 
+# Prefer xx-info (the cross-build target arch); fall back to `go env GOARCH` so the
+# script is still correct when run outside the xx environment. Both report the
+# cross-compilation target, unlike `uname -m`, which would report the build host.
+arch=$(xx-info arch 2>/dev/null || go env GOARCH)
+
 tags="netgo,sqlite_fts5"
-case "$(xx-info arch)" in
+case "${arch}" in
     arm | 386) tags="${tags},nodynamic" ;;
 esac
 printf '%s' "${tags}"

--- a/release/verify-binary.sh
+++ b/release/verify-binary.sh
@@ -10,12 +10,22 @@
 # Usage: verify-binary.sh <binary> [<binary>...]
 set -e
 
-case "$(xx-info arch)" in
+# Prefer xx-info (the cross-build target arch); fall back to `go env GOARCH` so the
+# check is still correct when run outside the xx environment.
+arch=$(xx-info arch 2>/dev/null || go env GOARCH)
+
+case "${arch}" in
     arm | 386) ;;
     *) exit 0 ;; # 64-bit arches legitimately link purego for native libwebp
 esac
 
 for bin in "$@"; do
+    # Fail loudly if the expected binary is missing (e.g. an unmatched glob), rather
+    # than letting `go version -m` fail inside the pipeline and silently pass.
+    if [ ! -f "${bin}" ]; then
+        echo "ERROR: expected binary '${bin}' not found; purego verification did not run."
+        exit 1
+    fi
     if go version -m "${bin}" | grep -q "ebitengine/purego"; then
         echo "ERROR: 32-bit binary '${bin}' links ebitengine/purego; it will SIGSEGV at startup (issue #5738)."
         echo "       Ensure the 'nodynamic' build tag is applied (see release/build-tags.sh)."

--- a/release/verify-binary.sh
+++ b/release/verify-binary.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Fail the build if a 32-bit ARM/x86 binary links ebitengine/purego, which would
+# SIGSEGV at startup on those arches (issue #5738).
+#
+# Independent safety net for build-tags.sh: it inspects the actual build metadata
+# recorded in the binary (survives stripping) instead of trusting the requested
+# tags, so it still fires if the tag decision is wrong or gen2brain/webp changes
+# its build-tag semantics. Runs in the Dockerfile, where xx-info and go are present.
+#
+# Usage: verify-binary.sh <binary> [<binary>...]
+set -e
+
+case "$(xx-info arch)" in
+    arm | 386) ;;
+    *) exit 0 ;; # 64-bit arches legitimately link purego for native libwebp
+esac
+
+for bin in "$@"; do
+    if go version -m "${bin}" | grep -q "ebitengine/purego"; then
+        echo "ERROR: 32-bit binary '${bin}' links ebitengine/purego; it will SIGSEGV at startup (issue #5738)."
+        echo "       Ensure the 'nodynamic' build tag is applied (see release/build-tags.sh)."
+        exit 1
+    fi
+done


### PR DESCRIPTION
### Description

The 0.63.0 standalone binaries for 32-bit ARM (armv7/v6/v5 tarballs, deb/rpm) crash at startup, before any log output, with a bare `Segmentation fault` or `Illegal instruction` (#5738, #5735). This PR contains two fixes and a regression guard.

**1. The startup crash (the actual #5738/#5735 bug)**

The binaries were mis-linked. The static build links `-latomic`, whose entry points use ifunc resolvers that glibc calls before `main()`, through `R_ARM_IRELATIVE` relocations. When the binary's `.text` grows past the 16MB Thumb branch range, GNU ld writes corrupt addends for those relocations: the address is off by a few bytes and the Thumb bit is lost. glibc's startup then jumps into garbage and the process dies before it can log anything. A core dump under qemu shows the mechanism exactly (caller `lr` inside Thumb glibc, `r3` holding the corrupt resolver address straight from the relocation).

0.62.0 worked because its `.text` was 15.1MB, still under the limit. 0.63.0 reached 17.5MB, so every 32-bit ARM build of that tree crashes. I bisected the other suspects to be sure: go1.26.4 and go1.26.5 both crash, and downgrading sqlite makes no difference.

The fix is to link 32-bit ARM with LLD (already installed in the build stage), which emits correct addends. Verified under qemu for armv7, v6 and v5: the artifact from the unchanged pipeline boots to "Navidrome server is ready", with SQLite migrations running, where the previous binary segfaulted at the first instruction.

**2. WebP/purego hardening (the #5597 crash class)**

The `nodynamic` fix from #5606 was only applied to the Docker-image build stage. The standalone stage still linked `ebitengine/purego`, which crashes on 32-bit ARM/x86 on the first artwork request. The tag decision now lives in a shared `release/build-tags.sh` used by both stages so they can't drift, and `release/verify-binary.sh` fails the build if purego ever leaks into a 32-bit binary.

**3. CI smoke test**

Every cross-compiled Linux binary now runs `--help` under binfmt/qemu right after being built. Any "binary crashes at startup on some arch" regression fails the pipeline instead of shipping in a release. It's already active on this PR: the arm and 386 build jobs run it and pass.

### Related Issues

Fixes #5738
Fixes #5735

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [ ] All existing and new tests pass

> Build-configuration change, no Go code touched. The tests are the new CI smoke test (fails on the exact 0.63.0 regression) and the build-time purego guard, both verified locally and in CI on this PR.

### How to Test

The binaries are static, so binfmt/qemu can run them directly:

```bash
# The broken release crashes at startup under qemu, same as on real hardware:
curl -sL https://github.com/navidrome/navidrome/releases/download/v0.63.0/navidrome_0.63.0_linux_armv7.tar.gz | tar xz navidrome
docker run --rm -v $PWD/navidrome:/nd:ro alpine:3.20 /nd --help
#   qemu: uncaught target signal 11 (Segmentation fault)

# Build from this branch and boot it:
make docker-build PLATFORMS=linux/arm/v7
docker run --rm -v $PWD/binaries/navidrome:/nd:ro alpine:3.20 /nd --help          # prints help, exit 0
docker run --rm -v $PWD/binaries/navidrome:/nd:ro alpine:3.20 sh -c \
  'mkdir -p /data /music && timeout 60 env ND_DATAFOLDER=/data ND_MUSICFOLDER=/music /nd'
#   ----> Navidrome server is ready!
```

To see the root cause directly: `readelf -r` on the v0.63.0 binary shows two `R_ARM_IRELATIVE` entries with even (Thumb-bit-less, mis-aimed) targets; on the LLD-linked binary they are correct.

### Additional Notes

- The LLD switch is scoped to `xx-info arch = arm` (v5/v6/v7). amd64/386/arm64/riscv64/windows/darwin keep their current linkers.
- The Docker image build (`build-alpine`, dynamic musl) is unaffected, musl doesn't use ifunc here.
- The deb/rpm packages ship these same binaries, so they are fixed too.
- The underlying GNU ld bug (ARM IRELATIVE addend corruption with large text sections) deserves an upstream binutils report; the core dump analysis here is the evidence.
