### PR TITLE
fix: rewrite systemd service template for kardianos/service v1.3.0

### DIFF
--- a/cmd/svc.go
+++ b/cmd/svc.go
@@ -232,22 +232,21 @@ func buildExecuteCmd() *cobra.Command {
 }
 
 const systemdScript = `[Unit]
-Description={{.Description}}
-ConditionFileIsExecutable={{.Path|cmdEscape}}
-{{range $i, $dep := .Dependencies}} 
-{{$dep}} {{end}}
-
+Description={{Description}}
+ConditionFileIsExecutable={{Path | cmdEscape}}
+{{range Dependencies}}{{.}}
+{{end}}
 [Service]
 StartLimitInterval=5
 StartLimitBurst=10
-ExecStart={{.Path|cmdEscape}}{{range .Arguments}} {{.|cmd}}{{end}}
-{{if .WorkingDirectory}}WorkingDirectory={{.WorkingDirectory|cmdEscape}}{{end}}
-{{if .UserName}}User={{.UserName}}{{end}}
-{{if .Restart}}Restart={{.Restart}}{{end}}
-{{if .SuccessExitStatus}}SuccessExitStatus={{.SuccessExitStatus}}{{end}}
+ExecStart={{Path | cmdEscape}}{{range Arguments}} {{. | cmd}}{{end}}
+{{if WorkingDirectory}}WorkingDirectory={{WorkingDirectory | cmdEscape}}{{end}}
+{{if UserName}}User={{UserName}}{{end}}
+{{if Restart}}Restart={{Restart}}{{end}}
+{{if SuccessExitStatus}}SuccessExitStatus={{SuccessExitStatus}}{{end}}
 TimeoutStopSec=20
 RestartSec=120
-EnvironmentFile=-/etc/sysconfig/{{.Name}}
+EnvironmentFile=-/etc/sysconfig/{{Name}}
 Environment="ND_SYSTEMD_PRIORITY_LOGGING=1"
 
 DevicePolicy=closed
@@ -260,7 +259,7 @@ RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
 RestrictNamespaces=yes
 RestrictRealtime=yes
 SystemCallFilter=~@clock @debug @module @mount @obsolete @reboot @setuid @swap
-{{if .WorkingDirectory}}ReadWritePaths={{.WorkingDirectory|cmdEscape}}{{end}}
+{{if WorkingDirectory}}ReadWritePaths={{WorkingDirectory | cmdEscape}}{{end}}
 ProtectSystem=full
 
 [Install]

--- a/cmd/svc_test.go
+++ b/cmd/svc_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"regexp"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("systemdScript template", func() {
+	systemdKeys := map[string]bool{
+		"Description": true, "Path": true, "Name": true, "Dependencies": true,
+		"Arguments": true, "ChRoot": true, "WorkingDirectory": true,
+		"UserName": true, "ReloadSignal": true, "PIDFile": true,
+		"LogDirectory": true, "OutputFileSupport": true, "LimitNOFILE": true,
+		"Restart": true, "SuccessExitStatus": true, "EnvVars": true,
+	}
+	systemdFuncs := map[string]bool{"cmd": true, "cmdEscape": true}
+
+	actionRe := regexp.MustCompile(`\{\{(.*?)\}\}`)
+
+	parseAction := func(action string) (key string, funcs []string) {
+		action = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(action, "-"), "-"))
+		kw, rest, _ := strings.Cut(action, " ")
+		switch kw {
+		case "end", "else":
+			return "", nil
+		case "if", "range":
+			return strings.TrimSpace(rest), nil
+		}
+		parts := strings.Split(action, "|")
+		for _, p := range parts[1:] {
+			funcs = append(funcs, strings.TrimSpace(p))
+		}
+		return strings.TrimSpace(parts[0]), funcs
+	}
+
+	It("only references keys and functions the service library provides", func() {
+		matches := actionRe.FindAllStringSubmatch(systemdScript, -1)
+		Expect(matches).ToNot(BeEmpty())
+
+		for _, m := range matches {
+			key, funcs := parseAction(m[1])
+			if key != "" && key != "." {
+				Expect(systemdKeys).To(HaveKey(key),
+					"template action %q uses a key unknown to kardianos/service", m[0])
+			}
+			for _, fn := range funcs {
+				Expect(systemdFuncs).To(HaveKey(fn),
+					"template action %q uses an unknown pipeline function", m[0])
+			}
+		}
+	})
+})


### PR DESCRIPTION
### Description

`navidrome service install` fails on v0.63.0 with `FATA service: unknown template key ".Description"`, breaking the `.deb` postinst and leaving a masked/empty systemd unit behind.

Root cause: kardianos/service v1.3.0 (bumped in 6c95a66ad, shipped in 0.63.0) replaced `text/template` with a small custom template engine that uses bare keys (`{{Description}}`, `{{Path | cmdEscape}}`). Our custom `SystemdScript` was still written in `text/template` syntax (`{{.Description}}`), which the new engine rejects as an unknown key.

This PR rewrites the template in the new engine's syntax (all hardening directives unchanged) and adds a test that validates every key and pipeline function used in the template against the set the library provides to systemd templates, catching this class of regression at test time.

### Related Issues

Fixes #5742

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. On a Linux machine (or container with `/run/systemd/system` present), build the binary and run `navidrome service install`.
2. Before this fix it dies with `FATA service: unknown template key ".Description"`; with it, `/etc/systemd/system/navidrome.service` is written fully rendered and the service enables/starts normally.

Verified A/B in a `golang:1.26` container: the master binary reproduces the reported error verbatim; the fixed binary generates a complete unit file.

### Additional Notes

Users hit by 0.63.0 may have a leftover empty `/etc/systemd/system/navidrome.service` (the old binary fails after creating the file but before writing it); it must be removed/unmasked before re-running `service install`, or install fails with "Init already exists".
