### PR TITLE
perf(db): add covering index for title-sorted song listings

### DIFF
--- a/db/migrations/20260707012459_add_media_file_title_sort_covering_index.sql
+++ b/db/migrations/20260707012459_add_media_file_title_sort_covering_index.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- Covering index for the title-sorted, library-scoped song listing:
+--   WHERE missing = ? AND library_id = ? ORDER BY order_title LIMIT n OFFSET m
+-- (Jellyfin clients page through the whole library this way; non-admin native and
+-- Subsonic song lists produce the same shape.)
+--
+-- Without it, SQLite walks media_file_order_title and must fetch the table row for
+-- every *skipped* entry just to evaluate the WHERE, so a deep page costs offset+limit
+-- random row reads (seconds on cold spinning disks). With the filter columns in the
+-- index the skip is index-only. `id` is included because the annotation/bookmark
+-- LEFT JOINs run per candidate row and need the join key; without it each skipped
+-- entry still triggers a row fetch.
+create index if not exists media_file_missing_library_order_title
+	on media_file(missing, library_id, order_title, id);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+drop index if exists media_file_missing_library_order_title;
+-- +goose StatementEnd


### PR DESCRIPTION
### Description

Adds a covering index for title-sorted, library-scoped song listings — the query shape clients use
to enumerate the library (`WHERE missing/library_id, ORDER BY order_title LIMIT/OFFSET`).

Deep pagination walked `media_file_order_title` and fetched the table row for every skipped entry
just to evaluate the filter and the join key: offset+limit random reads, seconds per page on cold
disks. The new `(missing, library_id, order_title, id)` index makes the offset skip fully
index-resident; only the emitted page touches table rows. Measured on a 96K-track library: warm
deep pages drop from ~100ms to 24ms, cold deep pages on NAS hardware from ~7s to ~0.5s.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): performance

### Checklist

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

On a sizeable library, run
`EXPLAIN QUERY PLAN SELECT id FROM media_file WHERE missing=0 AND library_id IN (1) ORDER BY order_title LIMIT 100 OFFSET 50000`
before and after: the plan should switch to `USING COVERING INDEX media_file_missing_library_order_title`,
and deep song-list pages (e.g. Subsonic `search3` or a client enumerating all songs) get
correspondingly faster.
