### PR TITLE
fix(scanner): repair NOT NULL bpm/bit_depth columns left by out-of-order migration

### DIFF
--- a/db/migrations/20260709160132_fix_bpm_bitdepth_not_null.go
+++ b/db/migrations/20260709160132_fix_bpm_bitdepth_not_null.go
@@ -3,7 +3,7 @@ package migrations
 import (
 	"context"
 	"database/sql"
-	"fmt"
+	"errors"
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/pressly/goose/v3"
@@ -72,24 +72,16 @@ func downFixBpmBitdepthNotNull(ctx context.Context, tx *sql.Tx) error {
 }
 
 // columnIsNotNull reports whether the given column of the given table is declared
-// with a NOT NULL constraint, using PRAGMA table_info. The table name is a fixed
-// internal constant, so it is safe to interpolate (PRAGMA cannot bind parameters).
+// with a NOT NULL constraint. "notnull" must be quoted: NOTNULL is an SQLite
+// operator keyword.
 func columnIsNotNull(ctx context.Context, tx *sql.Tx, table, column string) (bool, error) {
-	rows, err := tx.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	var notNull int
+	err := tx.QueryRowContext(ctx, `SELECT "notnull" FROM pragma_table_info(?) WHERE name = ?`, table, column).Scan(&notNull)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
 	if err != nil {
 		return false, err
 	}
-	defer rows.Close()
-	for rows.Next() {
-		var cid, notnull, pk int
-		var name, ctype string
-		var dflt sql.NullString
-		if err = rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
-			return false, err
-		}
-		if name == column {
-			return notnull == 1, nil
-		}
-	}
-	return false, rows.Err()
+	return notNull == 1, nil
 }

--- a/db/migrations/20260709160132_fix_bpm_bitdepth_not_null.go
+++ b/db/migrations/20260709160132_fix_bpm_bitdepth_not_null.go
@@ -1,0 +1,95 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upFixBpmBitdepthNotNull, downFixBpmBitdepthNotNull)
+}
+
+// upFixBpmBitdepthNotNull repairs databases where media_file.bpm/bit_depth are
+// still declared NOT NULL even though migration 20260612222838 (which made them
+// nullable) is recorded as applied. On those instances the scanner writes a NULL
+// bpm for tracks without a BPM tag and the write fails with
+// "NOT NULL constraint failed: media_file.bpm" (issue #5747). Because goose
+// considers the earlier migration already applied, it will never re-run it, so a
+// fresh migration is required. It re-inspects the column definition and only
+// rebuilds a column when it is still NOT NULL, making it a no-op on healthy DBs.
+func upFixBpmBitdepthNotNull(ctx context.Context, tx *sql.Tx) error {
+	repaired := false
+
+	// bpm carries the media_file_bpm index, which must be dropped before the
+	// column can be dropped and recreated after.
+	notNull, err := columnIsNotNull(ctx, tx, "media_file", "bpm")
+	if err != nil {
+		return err
+	}
+	if notNull {
+		if _, err = tx.ExecContext(ctx, `
+drop index if exists media_file_bpm;
+alter table media_file add column bpm_new integer;
+update media_file set bpm_new = nullif(bpm, 0);
+alter table media_file drop column bpm;
+alter table media_file rename column bpm_new to bpm;
+create index if not exists media_file_bpm on media_file (bpm);
+`); err != nil {
+			return err
+		}
+		repaired = true
+	}
+
+	notNull, err = columnIsNotNull(ctx, tx, "media_file", "bit_depth")
+	if err != nil {
+		return err
+	}
+	if notNull {
+		if _, err = tx.ExecContext(ctx, `
+alter table media_file add column bit_depth_new integer;
+update media_file set bit_depth_new = nullif(bit_depth, 0);
+alter table media_file drop column bit_depth;
+alter table media_file rename column bit_depth_new to bit_depth;
+`); err != nil {
+			return err
+		}
+		repaired = true
+	}
+
+	if repaired {
+		log.Warn(ctx, "Repaired media_file.bpm/bit_depth NOT NULL columns left over from an out-of-order migration (issue #5747)")
+	}
+	return nil
+}
+
+func downFixBpmBitdepthNotNull(ctx context.Context, tx *sql.Tx) error {
+	// No-op: re-adding the NOT NULL constraint would reintroduce the bug.
+	return nil
+}
+
+// columnIsNotNull reports whether the given column of the given table is declared
+// with a NOT NULL constraint, using PRAGMA table_info. The table name is a fixed
+// internal constant, so it is safe to interpolate (PRAGMA cannot bind parameters).
+func columnIsNotNull(ctx context.Context, tx *sql.Tx, table, column string) (bool, error) {
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt sql.NullString
+		if err = rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			return false, err
+		}
+		if name == column {
+			return notnull == 1, nil
+		}
+	}
+	return false, rows.Err()
+}


### PR DESCRIPTION
### Description

Some v0.63.0 databases fail every scan with `NOT NULL constraint failed: media_file.bpm`: migration `20260612222838_make_bpm_bitdepth_nullable` is recorded as applied in `goose_db_version`, but its DDL never took effect, so `bpm`/`bit_depth` are still `NOT NULL`. Since #5603 the scanner writes `NULL` for tracks without a BPM tag, which those databases reject. goose never re-runs a recorded migration, so a new one is required.

The new migration checks each column via `pragma_table_info` and only rebuilds the ones still declared `NOT NULL`, converting existing `0` values to `NULL` and preserving the `media_file_bpm` index. On healthy databases it is a no-op (no table rewrite); when it repairs something, it logs a warning.

### Related Issues

Fixes #5747

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. On a fully-migrated database, simulate the broken state:
   ```sql
   -- sqlite3 navidrome.db
   drop index if exists media_file_bpm;
   alter table media_file add column bpm_old integer default 0 not null;
   update media_file set bpm_old = coalesce(bpm,0);
   alter table media_file drop column bpm;
   alter table media_file rename column bpm_old to bpm;
   create index media_file_bpm on media_file (bpm);
   delete from goose_db_version where version_id = 20260709160132;
   ```
2. Start Navidrome — the log shows `Repaired media_file.bpm/bit_depth NOT NULL columns...` and the migration being applied.
3. Scan an MP3 without a BPM tag — the scan completes and the track is stored with `bpm = NULL`. On a healthy database (skip step 1), the migration is a silent no-op.

### Additional Notes

- Verified end-to-end at runtime: fresh-DB no-op, full repair (`0`→`NULL` conversion, index preserved), partial corruption (only one column broken, real values preserved), and idempotency across restarts. No per-migration unit tests, consistent with the rest of `db/migrations/`.
- The `down` migration is intentionally a no-op: restoring `NOT NULL` would reintroduce the bug.
