### PR TITLE
ci: validate DB migration order on pull requests

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -104,8 +104,8 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      # Refresh the base branch so the check compares against the CURRENT tip of
-      # master, not the (possibly stale) base the PR was opened against.
+      # Refresh the base branch so the check compares against its CURRENT tip,
+      # not the (possibly stale) commit the PR was opened against.
       - name: Fetch latest base branch
         run: git fetch --no-tags origin "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
       - name: Validate migration ordering and naming

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -104,6 +104,10 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+      # Refresh the base branch so the check compares against the CURRENT tip of
+      # master, not the (possibly stale) base the PR was opened against.
+      - name: Fetch latest base branch
+        run: git fetch --no-tags origin "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
       - name: Validate migration ordering and naming
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -96,6 +96,19 @@ jobs:
             exit 1
           fi
 
+  validate-migrations:
+    name: Validate DB migrations
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Validate migration ordering and naming
+        env:
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+        run: ./.github/workflows/validate-migrations.sh
+
   go:
     name: Test Go code
     runs-on: ubuntu-latest

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -274,7 +274,11 @@ jobs:
 
   build:
     name: Build
-    needs: [js, go, go-windows, go-lint, i18n-lint, git-version, check-push-enabled]
+    needs: [js, go, go-windows, go-lint, i18n-lint, git-version, check-push-enabled, validate-migrations]
+    # validate-migrations only runs on pull_request, so it is "skipped" on push/tag
+    # builds. Run Build unless a dependency actually failed — a *skipped* dependency
+    # (the migration check on non-PR events) must not block release builds.
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       matrix:
         platform: [ linux/amd64, linux/arm64, linux/arm/v5, linux/arm/v6, linux/arm/v7, linux/386, linux/riscv64, darwin/amd64, darwin/arm64, windows/amd64, windows/386 ]

--- a/.github/workflows/validate-migrations.sh
+++ b/.github/workflows/validate-migrations.sh
@@ -94,6 +94,13 @@ while IFS= read -r f; do
     *.go) [[ "$b" == [0-9]* ]] || continue ;;  # non-timestamped .go = helper (e.g. migration.go), skip
     *) continue ;;
   esac
+  if [ "${f%/*}" != "$MIGRATIONS_DIR" ]; then
+    report "$f" "❌ Migration file in a subdirectory: $f
+   Migrations must live directly in $MIGRATIONS_DIR/ — only $MIGRATIONS_DIR/*.sql (and
+   top-level .go migrations) are embedded, so a nested file would be SILENTLY SKIPPED.
+   Move it to $MIGRATIONS_DIR/$b."
+    continue
+  fi
   if ! [[ "$b" =~ $NAME_RE ]]; then
     report "$f" "❌ Malformed migration filename: $f
    Expected YYYYMMDDHHMMSS_lower_snake_name.(sql|go); the name segment must be lowercase.

--- a/.github/workflows/validate-migrations.sh
+++ b/.github/workflows/validate-migrations.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Validates DB migrations added by a pull request:
+#   1. Ordering  - an added migration must be NEWER than the latest migration
+#                  already on the base branch. Goose applies migrations in
+#                  timestamp order, so an older-timestamped migration would be
+#                  silently skipped on databases already upgraded past it.
+#   2. Uniqueness - no two migration files may share a timestamp.
+#   3. Naming     - files must match YYYYMMDDHHMMSS_lower_snake_name.(sql|go).
+#
+# Compares HEAD against $BASE_REF (default origin/master). Requires full history
+# (fetch-depth: 0 in CI).
+set -uo pipefail
+export LC_ALL=C
+
+MIGRATIONS_DIR="db/migrations"
+BASE_REF="${BASE_REF:-origin/master}"
+NAME_RE='^[0-9]{14}_[a-z0-9_]+\.(sql|go)$'
+
+status=0
+fail() {
+  printf '%s\n' "$@" >&2
+  status=1
+}
+
+human_ts() {
+  local t="$1"
+  printf '%s-%s-%s %s:%s:%s' "${t:0:4}" "${t:4:2}" "${t:6:2}" "${t:8:2}" "${t:10:2}" "${t:12:2}"
+}
+
+is_migration() { # $1=basename -> 0 if a .sql/.go file with a 14-digit prefix
+  local b="$1"
+  case "$b" in
+    *.sql | *.go) ;;
+    *) return 1 ;;
+  esac
+  [[ "${b%%_*}" =~ ^[0-9]{14}$ ]]
+}
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  printf '❌ Cannot resolve base ref "%s". In CI, check out with fetch-depth: 0.\n' "$BASE_REF" >&2
+  exit 1
+fi
+
+# --- Newest timestamp already on the base branch ---
+base_max=""
+base_max_file=""
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  b="$(basename "$f")"
+  is_migration "$b" || continue
+  ts="${b%%_*}"
+  if [[ "$ts" > "$base_max" ]]; then
+    base_max="$ts"
+    base_max_file="$f"
+  fi
+done < <(git ls-tree -r --name-only "$BASE_REF" -- "$MIGRATIONS_DIR" 2>/dev/null)
+
+# --- Ordering + naming on files added by this PR ---
+while IFS= read -r f; do
+  [ -z "$f" ] && continue
+  b="$(basename "$f")"
+  case "$b" in
+    *.sql | *.go) ;;
+    *) continue ;;
+  esac
+  if ! [[ "$b" =~ $NAME_RE ]]; then
+    fail \
+      "❌ Malformed migration filename: $f" \
+      "   Expected YYYYMMDDHHMMSS_lower_snake_name.(sql|go); the name segment must be lowercase." \
+      "   Regenerate with: make migration-sql name=<description>  (or make migration-go name=<description>)" \
+      ""
+    continue
+  fi
+  ts="${b%%_*}"
+  if [[ -n "$base_max" ]] && ! [[ "$ts" > "$base_max" ]]; then
+    fail \
+      "❌ Migration ordering error:" \
+      "   $f ($(human_ts "$ts"))" \
+      "   is older than (or equal to) the newest migration already on ${BASE_REF#origin/}:" \
+      "   $base_max_file ($(human_ts "$base_max"))" \
+      "" \
+      "   Goose applies migrations in timestamp order, so databases already upgraded" \
+      "   past that point would SILENTLY SKIP your migration." \
+      "" \
+      "   Fix: regenerate it with a current timestamp:" \
+      "     make migration-sql name=<description>   (or make migration-go name=<description>)" \
+      "   then move your SQL/Go body into the new file and delete the old one." \
+      ""
+  fi
+done < <(git diff --diff-filter=A --name-only "$BASE_REF"...HEAD -- "$MIGRATIONS_DIR" 2>/dev/null)
+
+# --- Duplicate timestamps across the merged set (HEAD) ---
+dups="$(git ls-tree -r --name-only HEAD -- "$MIGRATIONS_DIR" 2>/dev/null | while IFS= read -r f; do
+  b="$(basename "$f")"
+  is_migration "$b" || continue
+  printf '%s\n' "${b%%_*}"
+done | sort | uniq -d)"
+if [ -n "$dups" ]; then
+  while IFS= read -r ts; do
+    [ -z "$ts" ] && continue
+    colliding="$(git ls-tree -r --name-only HEAD -- "$MIGRATIONS_DIR" 2>/dev/null | grep "/${ts}_" || true)"
+    fail \
+      "❌ Duplicate migration timestamp $ts used by multiple files:" \
+      "$(printf '   %s\n' $colliding)" \
+      "   Every migration needs a unique timestamp. Regenerate one with make migration-*." \
+      ""
+  done <<< "$dups"
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "✅ DB migrations OK (ordering, uniqueness, naming)."
+fi
+exit "$status"

--- a/.github/workflows/validate-migrations.sh
+++ b/.github/workflows/validate-migrations.sh
@@ -10,6 +10,9 @@
 #
 # Compares HEAD against $BASE_REF (default origin/master). Requires full history
 # (fetch-depth: 0 in CI).
+# -e is intentionally omitted: the script accumulates violations into $status
+# and must not exit on the first non-zero command (grep no-match, a false [[ ]]
+# in an if, `is_migration || continue`).
 set -uo pipefail
 export LC_ALL=C
 
@@ -61,7 +64,8 @@ while IFS= read -r f; do
   [ -z "$f" ] && continue
   b="$(basename "$f")"
   case "$b" in
-    *.sql | *.go) ;;
+    *.sql) ;;                                  # any .sql in this dir must be a migration
+    *.go) [[ "$b" == [0-9]* ]] || continue ;;  # non-timestamped .go = helper (e.g. migration.go), skip
     *) continue ;;
   esac
   if ! [[ "$b" =~ $NAME_RE ]]; then

--- a/.github/workflows/validate-migrations.sh
+++ b/.github/workflows/validate-migrations.sh
@@ -8,6 +8,10 @@
 #   2. Uniqueness - no two migration files may share a timestamp.
 #   3. Naming     - files must match YYYYMMDDHHMMSS_lower_snake_name.(sql|go).
 #
+# On failure it prints a human-readable message and, when running in GitHub
+# Actions, emits an error annotation bound to the offending file so the message
+# also renders inline in the PR "Files changed" tab.
+#
 # Compares HEAD against $BASE_REF (default origin/master). Requires full history
 # (fetch-depth: 0 in CI).
 # -e is intentionally omitted: the script accumulates violations into $status
@@ -21,9 +25,31 @@ BASE_REF="${BASE_REF:-origin/master}"
 NAME_RE='^[0-9]{14}_[a-z0-9_]+\.(sql|go)$'
 
 status=0
+
+# Log a message to stderr and mark the run as failed.
 fail() {
-  printf '%s\n' "$@" >&2
+  printf '%s\n' "$1" >&2
   status=1
+}
+
+# Emit a GitHub Actions error annotation bound to a file, so the message renders
+# inline on the offending migration in the PR "Files changed" tab. No-op outside
+# CI. `%`, newline and CR are encoded as required by the workflow-command syntax
+# (the `%` replacement must run first so the encodings we add aren't re-escaped).
+annotate() { # $1=file  $2=message
+  [ "${GITHUB_ACTIONS:-}" = "true" ] || return 0
+  local msg="$2"
+  msg="${msg//'%'/%25}"
+  msg="${msg//$'\n'/%0A}"
+  msg="${msg//$'\r'/%0D}"
+  printf '::error file=%s,line=1::%s\n' "$1" "$msg"
+}
+
+# Report a migration problem: log it, annotate the offending file, mark failed.
+report() { # $1=file  $2=message
+  fail "$2"
+  printf '\n' >&2
+  annotate "$1" "$2"
 }
 
 human_ts() {
@@ -69,33 +95,29 @@ while IFS= read -r f; do
     *) continue ;;
   esac
   if ! [[ "$b" =~ $NAME_RE ]]; then
-    fail \
-      "❌ Malformed migration filename: $f" \
-      "   Expected YYYYMMDDHHMMSS_lower_snake_name.(sql|go); the name segment must be lowercase." \
-      "   Regenerate with: make migration-sql name=<description>  (or make migration-go name=<description>)" \
-      ""
+    report "$f" "❌ Malformed migration filename: $f
+   Expected YYYYMMDDHHMMSS_lower_snake_name.(sql|go); the name segment must be lowercase.
+   Regenerate with: make migration-sql name=<description>  (or make migration-go name=<description>)"
     continue
   fi
   ts="${b%%_*}"
   if [[ -n "$base_max" ]] && ! [[ "$ts" > "$base_max" ]]; then
-    fail \
-      "❌ Migration ordering error:" \
-      "   $f ($(human_ts "$ts"))" \
-      "   is older than (or equal to) the newest migration already on ${BASE_REF#origin/}:" \
-      "   $base_max_file ($(human_ts "$base_max"))" \
-      "" \
-      "   Goose applies migrations in timestamp order, so databases already upgraded" \
-      "   past that point would SILENTLY SKIP your migration." \
-      "" \
-      "   Fix: regenerate it with a current timestamp:" \
-      "     make migration-sql name=<description>   (or make migration-go name=<description>)" \
-      "   then move your SQL/Go body into the new file and delete the old one." \
-      ""
+    report "$f" "❌ Migration ordering error: $f ($(human_ts "$ts"))
+   is older than (or equal to) the newest migration already on ${BASE_REF#origin/}:
+   $base_max_file ($(human_ts "$base_max"))
+
+   Goose applies migrations in timestamp order, so databases already upgraded
+   past that point would SILENTLY SKIP your migration.
+
+   Fix: regenerate it with a current timestamp:
+     make migration-sql name=<description>   (or make migration-go name=<description>)
+   then move your SQL/Go body into the new file and delete the old one."
   fi
 done < <(git diff --diff-filter=A --name-only "$BASE_REF"...HEAD -- "$MIGRATIONS_DIR" 2>/dev/null)
 
 # --- Duplicate timestamps across the merged set (HEAD) ---
-dups="$(git ls-tree -r --name-only HEAD -- "$MIGRATIONS_DIR" 2>/dev/null | while IFS= read -r f; do
+all_migs="$(git ls-tree -r --name-only HEAD -- "$MIGRATIONS_DIR" 2>/dev/null)"
+dups="$(printf '%s\n' "$all_migs" | while IFS= read -r f; do
   b="$(basename "$f")"
   is_migration "$b" || continue
   printf '%s\n' "${b%%_*}"
@@ -103,12 +125,15 @@ done | sort | uniq -d)"
 if [ -n "$dups" ]; then
   while IFS= read -r ts; do
     [ -z "$ts" ] && continue
-    colliding="$(git ls-tree -r --name-only HEAD -- "$MIGRATIONS_DIR" 2>/dev/null | grep "/${ts}_" || true)"
-    fail \
-      "❌ Duplicate migration timestamp $ts used by multiple files:" \
-      "$(printf '   %s\n' $colliding)" \
-      "   Every migration needs a unique timestamp. Regenerate one with make migration-*." \
-      ""
+    colliding="$(printf '%s\n' "$all_migs" | grep "/${ts}_" || true)"
+    printf '❌ Duplicate migration timestamp %s used by multiple files:\n' "$ts" >&2
+    while IFS= read -r cf; do
+      [ -z "$cf" ] && continue
+      printf '   %s\n' "$cf" >&2
+      annotate "$cf" "Duplicate migration timestamp $ts — shared by another migration. Timestamps must be unique; regenerate one with make migration-*."
+    done <<< "$colliding"
+    printf '   Every migration needs a unique timestamp. Regenerate one with make migration-*.\n' >&2
+    status=1
   done <<< "$dups"
 fi
 


### PR DESCRIPTION
### Description

Adds a CI check that fails a pull request when a contributed DB migration would be applied **out of order**.

Navidrome's migrations are timestamp-named (`YYYYMMDDHHMMSS_*.{sql,go}`) and Goose applies them in timestamp order. When two contributors branch off `master` in parallel, the one whose branch carries an *older* timestamp can merge **after** a newer migration has already landed — and any database already upgraded past that point silently skips the older migration, leaving the schema broken with no error.

This can only be caught by comparing against the current tip of `master`: a static check on the merged tree can't see it, since filenames always sort consistently after merge. The new `pull_request` job refreshes `master`, diffs the PR's added migrations against it, and fails if any added migration is not strictly newer than the newest migration already on `master`. It also rejects duplicate timestamps and malformed/uppercase filenames, and prints an actionable message telling the author how to fix it (regenerate with `make migration-*`).

It's implemented as a self-contained shell script under `.github/workflows/` (mirroring the existing `validate-translations.sh`), so there's no new build step or dependency. Both `.sql` and `.go` migrations are covered (the check is filename-based).

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI / repository tooling — adds a pipeline check; no runtime/product code changes

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

_On tests: this change only touches `.github/workflows/` (no Go/JS), so there is no unit test to add — the check is verified with the manual steps below and end-to-end against real `master`. Existing Go/JS suites are unaffected._

### How to Test

1. **Out-of-order is rejected.** On a branch, add a migration with a timestamp older than the newest one already on `master`, then run the check against `master`:
   ```bash
   : > db/migrations/20200101000000_too_old.sql
   git add db/migrations/20200101000000_too_old.sql && git commit -m test
   BASE_REF=origin/master ./.github/workflows/validate-migrations.sh
   ```
   Expected: exit 1 with an ordering error naming the offending file and the newest migration currently on `master`.

2. **A current-timestamp migration passes.** Replace it with e.g. `db/migrations/20990101000000_ok.sql` → prints `✅ DB migrations OK`, exit 0.

3. **A PR that touches no migrations** → exit 0.

Edge cases worth checking:
- Two added files sharing a timestamp → fail (duplicate timestamp).
- Malformed or uppercase filename (e.g. `db/migrations/BadName.sql`) → fail.
- A non-migration `.go` helper added under `db/migrations/` (like the existing `migration.go`) → passes (not treated as a migration).
- The first migration added when `master` has none → passes.

### Additional Notes

- **Comparison vs. re-run trigger.** The job refreshes `origin/master` before checking, so it always compares against the *current* tip of `master`. However, GitHub does **not** automatically re-run a PR's checks when the base branch advances (only when the PR itself changes). To make this a bypass-proof merge gate, enable branch protection **“Require branches to be up to date before merging”** (it appears nested under *“Require status checks to pass”*) for `master`, or adopt a merge queue (`merge_group`).
- Targets bash 3.2 (stock macOS) and Ubuntu CI. `actionlint` on the workflow is clean.
- No product/runtime code changed — this is CI tooling only.
