### PR TITLE
test(scanner): fix flaky Windows search_normalized rescan test

### DIFF
--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing/fstest"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
@@ -210,6 +211,15 @@ var _ = Describe("Scanner", Ordered, func() {
 
 			// Simulate the stale value left by the FTS5 migration's SQL back-fill
 			_, err := db.Db().ExecContext(ctx, "UPDATE artist SET search_normalized = '' WHERE name = 'GØGGS'")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Backdate the folder so the next full scan reliably sees it as outdated.
+			// isOutdated() compares folder.updated_at (written by this scan) against the
+			// next scan's last_scan_started_at with a strict Before(); back-to-back scans
+			// can capture both within one clock tick on Windows (coarse wall-clock), making
+			// the refresh flaky. Backdating forces the comparison to be unambiguous.
+			_, err = db.Db().ExecContext(ctx,
+				"UPDATE folder SET updated_at = ?", time.Now().Add(-time.Hour))
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(runScanner(ctx, true)).To(Succeed())


### PR DESCRIPTION
### Description

The scanner spec **"repopulates a stale `search_normalized` on a full rescan"** flakes on the Windows CI job — it has failed on unrelated PRs (including a Dependabot run with no Go changes), confirming flakiness rather than a real regression.

**Root cause:** the spec runs two full scans back-to-back. `folderEntry.isOutdated()` decides whether the second scan refreshes the unchanged artist by comparing `folder.updated_at` (from scan 1) against `library.last_scan_started_at` (scan 2) with a strict `time.Before()`. Both are `time.Now()` values captured milliseconds apart. Windows' coarse wall-clock frequently makes them compare **equal**, so the folder is skipped, the artist isn't re-persisted, and `search_normalized` stays empty.

**Fix:** backdate `folder.updated_at` an hour before the second scan so the comparison is unambiguous on every platform. Test-only timing artifact — real rescans never run milliseconds apart on an unchanged library — so no production code changes.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Run `make test PKG=./scanner` — it passes. The flake only reproduces under Windows' coarse wall-clock, so it can't be triggered on Linux/macOS; backdating guarantees `folder.updated_at < library.last_scan_started_at`, so the full rescan reliably re-persists the artist.

### Additional Notes

Out of scope but observed on the same Windows job: a `fatal error: found pointer to free object` crash in the `persistence` package (likely CGo/go-sqlite3 — no tracking issue yet, worth its own look).
