### PR TITLE
fix(smartplaylist): reject NSP mixing top-level 'any' and 'all'

### DIFF
--- a/core/playlists/parse_nsp_test.go
+++ b/core/playlists/parse_nsp_test.go
@@ -113,6 +113,20 @@ var _ = Describe("parseNSP", func() {
 		Expect(err.Error()).To(ContainSubstring("SmartPlaylist"))
 	})
 
+	It("rejects a NSP that mixes top-level 'any' and 'all' instead of silently dropping a group", func() {
+		nsp := `{
+			"name": "Overplayed Favorites",
+			"any": [{"inPlaylist": {"path": "most-played-favorites.nsp"}}],
+			"all": [{"notInPlaylist": {"path": "favorites-not-played-in-4-yrs.nsp"}}],
+			"sort": "playCount, lastPlayed"
+		}`
+		pls := &model.Playlist{}
+		err := s.parseNSP(ctx, pls, strings.NewReader(nsp))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("SmartPlaylist"))
+		Expect(err.Error()).To(And(ContainSubstring("all"), ContainSubstring("any")))
+	})
+
 	It("gracefully handles non-string name field", func() {
 		nsp := `{"name": 123, "all": [{"is": {"loved": true}}]}`
 		pls := &model.Playlist{Name: "Original"}

--- a/model/criteria/criteria.go
+++ b/model/criteria/criteria.go
@@ -103,38 +103,26 @@ func (c Criteria) MarshalJSON() ([]byte, error) {
 
 func (c *Criteria) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		All          json.RawMessage `json:"all"`
-		Any          json.RawMessage `json:"any"`
-		Sort         string          `json:"sort"`
-		Order        string          `json:"order"`
-		Limit        int             `json:"limit"`
-		LimitPercent int             `json:"limitPercent"`
-		Offset       int             `json:"offset"`
+		All          optionalConjunction `json:"all"`
+		Any          optionalConjunction `json:"any"`
+		Sort         string              `json:"sort"`
+		Order        string              `json:"order"`
+		Limit        int                 `json:"limit"`
+		LimitPercent int                 `json:"limitPercent"`
+		Offset       int                 `json:"offset"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	// Detect presence by key, not slice length: a present-but-empty (or null) group
-	// such as {"any":[],"all":[...]} would otherwise slip past and silently drop a group.
-	if aux.All != nil && aux.Any != nil {
+	// A Criteria has a single top-level group. Reject files that provide both keys
+	// (even when one is [] or null) rather than silently dropping one of them.
+	if aux.All.present && aux.Any.present {
 		return errors.New("invalid criteria json: 'all' and 'any' cannot both be used at the top level; nest one inside the other instead")
 	}
-
-	var all, any unmarshalConjunctionType
-	if aux.All != nil {
-		if err := json.Unmarshal(aux.All, &all); err != nil {
-			return err
-		}
-	}
-	if aux.Any != nil {
-		if err := json.Unmarshal(aux.Any, &any); err != nil {
-			return err
-		}
-	}
-	if len(any) > 0 {
-		c.Expression = Any(any)
-	} else if len(all) > 0 {
-		c.Expression = All(all)
+	if len(aux.Any.rules) > 0 {
+		c.Expression = Any(aux.Any.rules)
+	} else if len(aux.All.rules) > 0 {
+		c.Expression = All(aux.All.rules)
 	} else {
 		return errors.New("invalid criteria json. missing rules (key 'all' or 'any')")
 	}

--- a/model/criteria/criteria.go
+++ b/model/criteria/criteria.go
@@ -114,6 +114,9 @@ func (c *Criteria) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
+	if len(aux.Any) > 0 && len(aux.All) > 0 {
+		return errors.New("invalid criteria json: 'all' and 'any' cannot both be used at the top level; nest one inside the other instead")
+	}
 	if len(aux.Any) > 0 {
 		c.Expression = Any(aux.Any)
 	} else if len(aux.All) > 0 {

--- a/model/criteria/criteria.go
+++ b/model/criteria/criteria.go
@@ -103,24 +103,38 @@ func (c Criteria) MarshalJSON() ([]byte, error) {
 
 func (c *Criteria) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		All          unmarshalConjunctionType `json:"all"`
-		Any          unmarshalConjunctionType `json:"any"`
-		Sort         string                   `json:"sort"`
-		Order        string                   `json:"order"`
-		Limit        int                      `json:"limit"`
-		LimitPercent int                      `json:"limitPercent"`
-		Offset       int                      `json:"offset"`
+		All          json.RawMessage `json:"all"`
+		Any          json.RawMessage `json:"any"`
+		Sort         string          `json:"sort"`
+		Order        string          `json:"order"`
+		Limit        int             `json:"limit"`
+		LimitPercent int             `json:"limitPercent"`
+		Offset       int             `json:"offset"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
-	if len(aux.Any) > 0 && len(aux.All) > 0 {
+	// Detect presence by key, not slice length: a present-but-empty (or null) group
+	// such as {"any":[],"all":[...]} would otherwise slip past and silently drop a group.
+	if aux.All != nil && aux.Any != nil {
 		return errors.New("invalid criteria json: 'all' and 'any' cannot both be used at the top level; nest one inside the other instead")
 	}
-	if len(aux.Any) > 0 {
-		c.Expression = Any(aux.Any)
-	} else if len(aux.All) > 0 {
-		c.Expression = All(aux.All)
+
+	var all, any unmarshalConjunctionType
+	if aux.All != nil {
+		if err := json.Unmarshal(aux.All, &all); err != nil {
+			return err
+		}
+	}
+	if aux.Any != nil {
+		if err := json.Unmarshal(aux.Any, &any); err != nil {
+			return err
+		}
+	}
+	if len(any) > 0 {
+		c.Expression = Any(any)
+	} else if len(all) > 0 {
+		c.Expression = All(all)
 	} else {
 		return errors.New("invalid criteria json. missing rules (key 'all' or 'any')")
 	}

--- a/model/criteria/criteria_test.go
+++ b/model/criteria/criteria_test.go
@@ -80,6 +80,16 @@ var _ = Describe("Criteria", func() {
 		})
 	})
 
+	Context("with both top-level 'all' and 'any'", func() {
+		It("returns an error instead of silently dropping one of the groups", func() {
+			jsonStr := `{"any":[{"inPlaylist":{"path":"a.nsp"}}],"all":[{"notInPlaylist":{"path":"b.nsp"}}]}`
+			var c Criteria
+			err := json.Unmarshal([]byte(jsonStr), &c)
+			gomega.Expect(err).To(gomega.HaveOccurred())
+			gomega.Expect(err.Error()).To(gomega.And(gomega.ContainSubstring("all"), gomega.ContainSubstring("any")))
+		})
+	})
+
 	Describe("LimitPercent", func() {
 		Describe("JSON round-trip", func() {
 			It("marshals and unmarshals limitPercent", func() {

--- a/model/criteria/criteria_test.go
+++ b/model/criteria/criteria_test.go
@@ -88,6 +88,18 @@ var _ = Describe("Criteria", func() {
 			gomega.Expect(err).To(gomega.HaveOccurred())
 			gomega.Expect(err.Error()).To(gomega.And(gomega.ContainSubstring("all"), gomega.ContainSubstring("any")))
 		})
+
+		DescribeTable("rejects both keys even when one group is present but empty",
+			func(jsonStr string) {
+				var c Criteria
+				err := json.Unmarshal([]byte(jsonStr), &c)
+				gomega.Expect(err).To(gomega.HaveOccurred())
+				gomega.Expect(err.Error()).To(gomega.And(gomega.ContainSubstring("all"), gomega.ContainSubstring("any")))
+			},
+			Entry("empty any", `{"any":[],"all":[{"is":{"loved":true}}]}`),
+			Entry("empty all", `{"all":[],"any":[{"is":{"loved":true}}]}`),
+			Entry("null any", `{"any":null,"all":[{"is":{"loved":true}}]}`),
+		)
 	})
 
 	Describe("LimitPercent", func() {

--- a/model/criteria/json.go
+++ b/model/criteria/json.go
@@ -33,6 +33,20 @@ func (uc *unmarshalConjunctionType) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// optionalConjunction is a top-level "all"/"any" value that remembers whether its
+// key was present at all, so a Criteria providing both can be rejected. encoding/json
+// calls UnmarshalJSON even for a JSON null, so present is set whenever the key appears
+// — including as [] or null — while an absent key leaves it false.
+type optionalConjunction struct {
+	present bool
+	rules   unmarshalConjunctionType
+}
+
+func (o *optionalConjunction) UnmarshalJSON(data []byte) error {
+	o.present = true
+	return json.Unmarshal(data, &o.rules)
+}
+
 func unmarshalExpression(opName string, rawValue json.RawMessage) Expression {
 	m := make(map[string]any)
 	err := json.Unmarshal(rawValue, &m)

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing/fstest"
+	"time"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
@@ -210,6 +211,15 @@ var _ = Describe("Scanner", Ordered, func() {
 
 			// Simulate the stale value left by the FTS5 migration's SQL back-fill
 			_, err := db.Db().ExecContext(ctx, "UPDATE artist SET search_normalized = '' WHERE name = 'GØGGS'")
+			Expect(err).ToNot(HaveOccurred())
+
+			// Backdate the folder so the next full scan reliably sees it as outdated.
+			// isOutdated() compares folder.updated_at (written by this scan) against the
+			// next scan's last_scan_started_at with a strict Before(); back-to-back scans
+			// can capture both within one clock tick on Windows (coarse wall-clock), making
+			// the refresh flaky. Backdating forces the comparison to be unambiguous.
+			_, err = db.Db().ExecContext(ctx,
+				"UPDATE folder SET updated_at = ?", time.Now().Add(-time.Hour))
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(runScanner(ctx, true)).To(Succeed())


### PR DESCRIPTION
### Description

A Smart Playlist (`.nsp`) that declared **both** a top-level `any` and a top-level `all` group was imported by silently keeping only the `any` group and discarding `all` (regardless of key order in the file). Because `criteria.Criteria` stores a single top-level `Expression`, it cannot represent two top-level groups, and `Criteria.UnmarshalJSON` picked `any` without reporting the dropped rules — resulting in silent data loss during the scan.

This PR makes `Criteria.UnmarshalJSON` return an error when both `all` and `any` are present at the top level. The scanner now fails loudly (logging the playlist as invalid, exactly like any other malformed `.nsp`) instead of quietly losing rules. Since the validation lives at the single `Criteria` unmarshalling choke point, it also covers the native-API playlist-rules path, not just file import.

The correct way to combine the two logics is to nest one group inside the other, as shown in the documented examples (e.g. "80's Top Songs"). A companion documentation fix corrects the misleading example that triggered this report.

### Related Issues

Fixes #5757

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

> Documentation is handled in a separate PR against the `navidrome/website` repo (the `.nsp` docs live there).

### How to Test

1. Create a file `Bad.nsp` in a library folder with both groups at the top level:
   ```json
   {
     "name": "Overplayed Favorites",
     "any": [{ "inPlaylist": { "path": "most-played-favorites.nsp" } }],
     "all": [{ "notInPlaylist": { "path": "favorites-not-played-in-4-yrs.nsp" } }],
     "sort": "playCount, lastPlayed"
   }
   ```
2. Trigger a scan. The playlist is **not** imported, and the log shows an `Error parsing playlist` entry mentioning that `all` and `any` cannot both be used at the top level (previously it imported silently with only the `any` rule).
3. Rewrite it with a single top-level `all` (nesting where needed) and rescan — it imports correctly with all rules:
   ```json
   {
     "name": "Overplayed Favorites",
     "all": [
       { "inPlaylist": { "path": "most-played-favorites.nsp" } },
       { "notInPlaylist": { "path": "favorites-not-played-in-4-yrs.nsp" } }
     ],
     "sort": "playCount, lastPlayed"
   }
   ```

### Additional Notes

This changes behavior for any existing `.nsp` that (perhaps unknowingly) relied on the old silent-drop behavior: such a playlist will now fail to import until it is rewritten to use a single top-level group. This is intentional — surfacing the problem is preferable to silently discarding rules. The alternative (auto-combining the two groups) would change matching semantics and require round-trip marshalling support, so the loud-rejection approach was chosen per the discussion on the issue.
