### PR TITLE
ci: don't skip release jobs after the DB migration check on tag pushes

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -99,16 +99,22 @@ jobs:
   validate-migrations:
     name: Validate DB migrations
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    # The PR-only gate is at step level, NOT job level: a skipped job propagates
+    # "skipped" transitively through the needs chain (actions/runner#491), which
+    # skipped every release job after Build on tag pushes. With all steps skipped
+    # the job still concludes "success", so downstream jobs run normally.
     steps:
       - uses: actions/checkout@v7
+        if: github.event_name == 'pull_request'
         with:
           fetch-depth: 0
       # Refresh the base branch so the check compares against its CURRENT tip,
       # not the (possibly stale) commit the PR was opened against.
       - name: Fetch latest base branch
+        if: github.event_name == 'pull_request'
         run: git fetch --no-tags origin "+refs/heads/${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}"
       - name: Validate migration ordering and naming
+        if: github.event_name == 'pull_request'
         env:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
         run: ./.github/workflows/validate-migrations.sh
@@ -275,10 +281,6 @@ jobs:
   build:
     name: Build
     needs: [js, go, go-windows, go-lint, i18n-lint, git-version, check-push-enabled, validate-migrations]
-    # validate-migrations only runs on pull_request, so it is "skipped" on push/tag
-    # builds. Run Build unless a dependency actually failed — a *skipped* dependency
-    # (the migration check on non-PR events) must not block release builds.
-    if: ${{ !cancelled() && !failure() }}
     strategy:
       matrix:
         platform: [ linux/amd64, linux/arm64, linux/arm/v5, linux/arm/v6, linux/arm/v7, linux/386, linux/riscv64, darwin/amd64, darwin/arm64, windows/amd64, windows/386 ]

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -99,10 +99,8 @@ jobs:
   validate-migrations:
     name: Validate DB migrations
     runs-on: ubuntu-latest
-    # The PR-only gate is at step level, NOT job level: a skipped job propagates
-    # "skipped" transitively through the needs chain (actions/runner#491), which
-    # skipped every release job after Build on tag pushes. With all steps skipped
-    # the job still concludes "success", so downstream jobs run normally.
+    # PR-only gate is at step level: a job-level skip would propagate through
+    # the needs chain (actions/runner#491) and skip all release jobs on tag pushes.
     steps:
       - uses: actions/checkout@v7
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
### Description

The v0.63.2 release run ([29137526788](https://github.com/navidrome/navidrome/actions/runs/29137526788)) built all binaries but skipped every job after Build — Push to GHCR/Docker Hub, Windows installers, Package/Release, and all Linux PKG uploads — so no release artifacts were published.

Root cause: the `validate-migrations` job introduced in #5750 is gated at **job level** with `if: github.event_name == 'pull_request'`, so on tag pushes it concludes `skipped`. GitHub Actions propagates a skipped job **transitively** through the `needs` chain (actions/runner#491): the `!cancelled() && !failure()` override added to Build let Build itself run, but every job downstream of Build still failed its implicit `success()` gate (which evaluates the whole ancestry) and was skipped. Jobs with an explicit `if` lacking a status-check function (the `push-manifest-*` jobs) get an implicit `success() &&` prefix, so they were skipped too.

Fix: move the `pull_request` gate from the job to its steps. On non-PR events all steps are skipped and the job concludes `success`, so the skip cascade disappears and release jobs run normally. This also lets Build go back to the default `success()` gate (override removed), preserving the fail-fast behavior on PRs with a bad migration: a failing check still fails the job and skips Build.

### Related Issues

Related to #5750

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (CI workflow change; validated via YAML parse and by the pipeline run on this PR)
- [x] All existing and new tests pass

### How to Test

1. On this PR (a `pull_request` event), the "Validate DB migrations" job must **run** its steps and conclude `success`, and Build must run — confirming the PR-time gating still works.
2. After merging, the next tag push must show "Validate DB migrations" concluding `success` (steps skipped) and all downstream jobs (Push to GHCR/Docker Hub, Windows installers, Package/Release, PKG uploads) executing — this is what v0.63.2 will verify when re-tagged.
3. Fail-fast is preserved: a PR adding an out-of-order migration still fails the check job, which skips Build via the default `success()` gate.

### Additional Notes

The v0.63.2 tag was deleted (local and remote) so the release can be re-tagged on a commit containing this fix — push events use the workflow file from the pushed ref, so re-running the old workflow would hit the same bug.
