### PR TITLE
fix(serve_index): Set Cache-Control: no-cache on index.html - #5766

### DIFF
--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -107,7 +107,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 		addShareData(r, data, shareInfo)
 
 		w.Header().Set("Content-Type", "text/html")
-		w.Header().Set("Cache-Control", "no-cache")
+		w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate")
 		err = t.Execute(w, data)
 		if err != nil {
 			log.Error(r, "Could not execute `index.html` template", err)

--- a/server/serve_index.go
+++ b/server/serve_index.go
@@ -107,6 +107,7 @@ func serveIndex(ds model.DataStore, fs fs.FS, shareInfo *model.Share) http.Handl
 		addShareData(r, data, shareInfo)
 
 		w.Header().Set("Content-Type", "text/html")
+		w.Header().Set("Cache-Control", "no-cache")
 		err = t.Execute(w, data)
 		if err != nil {
 			log.Error(r, "Could not execute `index.html` template", err)


### PR DESCRIPTION
### Description

Sets `Cache-Control: no-cache` on `index.html` responses to prevent browsers from serving a stale version after an upgrade. Without this header, browsers may apply heuristic caching and continue serving an old `index.html` that references outdated JavaScript assets, causing API calls to fail against endpoints that no longer exist.

### Related Issues

Fixes #5766

### Type of Change
- [x] Bug fix

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Run navidrome locally
2. Request the root `/` in a browser or via curl
3. Confirm `Cache-Control: no-cache` is present in the response headers

### Screenshots / Demos (if applicable)

<img width="386" height="253" alt="image" src="https://github.com/user-attachments/assets/b0bc40ff-5496-4030-a4d4-92e7b18f4ea0" />