### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/download-link-on-pr.yml
+++ b/.github/workflows/download-link-on-pr.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           # This snippet is public-domain, taken from
           # https://github.com/oprypin/nightly.link/blob/master/.github/workflows/pr-comment.yml

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -166,7 +166,7 @@ jobs:
 
       - name: Cache ffmpeg
         id: ffmpeg-cache
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: C:\ffmpeg
           key: ffmpeg-${{ env.FFMPEG_VERSION }}-win64
@@ -323,7 +323,7 @@ jobs:
 
       - name: Set up QEMU for smoke test
         if: env.IS_LINUX == 'true'
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       # The binary is static, so binfmt+qemu runs it directly on the runner.
       # Catches startup crashes in cross-compiled binaries before they ship,


### PR DESCRIPTION
### Description
Bumps the GitHub Actions in our workflows to their latest major versions. All other actions were already on their latest major tag; only these three had a newer one:

| Action | Before | After |
| --- | --- | --- |
| `actions/github-script` | `v7` | `v9` |
| `actions/cache` | `v5` | `v6` |
| `docker/setup-qemu-action` | `v3` | `v4` |

All three were checked for breaking changes: our `github-script` script uses only the injected `github`/`context`/`core`, and the `cache`/`setup-qemu` bumps are ESM/runtime migrations with no input changes.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI / dependency maintenance

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Validated by CI on this PR: the pipeline builds all platforms and produces the expected artifacts (`navidrome-<platform>` binaries, `navidrome-windows-installers`, and the goreleaser `packages` / `navidrome_linux_*` bundles).

### Additional Notes
Only workflow YAML is touched — no production code or tests.
