### PR TITLE
fix(jellyfin): close the unbounded playlist and search paths left by #5783

### DIFF
--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -99,9 +99,9 @@ func (s *playlists) GetPlaylists(ctx context.Context, mediaFileId string) (model
 	return s.ds.Playlist(ctx).GetPlaylists(mediaFileId)
 }
 
-// Tracks scopes a repository to one playlist's tracks, for callers that page or stream them instead
-// of loading every track like GetWithTracks. Gets the playlist first because
-// PlaylistRepository.Tracks logs a warning on an unknown id, and callers probe with arbitrary ids.
+// Tracks scopes a repository to one playlist's tracks, for callers that page or stream them rather
+// than loading every one like GetWithTracks. Gets first because PlaylistRepository.Tracks discards
+// its error behind a nil (and warns), and this is probed with ids that are usually not playlists.
 func (s *playlists) Tracks(ctx context.Context, id string) (model.PlaylistTrackRepository, error) {
 	repo := s.ds.Playlist(ctx)
 	if _, err := repo.Get(id); err != nil {

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -22,6 +22,7 @@ type Playlists interface {
 	GetAll(ctx context.Context, options ...model.QueryOptions) (model.Playlists, error)
 	Get(ctx context.Context, id string) (*model.Playlist, error)
 	GetWithTracks(ctx context.Context, id string) (*model.Playlist, error)
+	Tracks(ctx context.Context, id string) (model.PlaylistTrackRepository, error)
 	GetPlaylists(ctx context.Context, mediaFileId string) (model.Playlists, error)
 
 	// Mutations
@@ -96,6 +97,21 @@ func (s *playlists) GetWithTracks(ctx context.Context, id string) (*model.Playli
 
 func (s *playlists) GetPlaylists(ctx context.Context, mediaFileId string) (model.Playlists, error) {
 	return s.ds.Playlist(ctx).GetPlaylists(mediaFileId)
+}
+
+// Tracks scopes a repository to one playlist's tracks, for callers that page or stream them instead
+// of loading every track like GetWithTracks. Gets the playlist first because
+// PlaylistRepository.Tracks logs a warning on an unknown id, and callers probe with arbitrary ids.
+func (s *playlists) Tracks(ctx context.Context, id string) (model.PlaylistTrackRepository, error) {
+	repo := s.ds.Playlist(ctx)
+	if _, err := repo.Get(id); err != nil {
+		return nil, err
+	}
+	tracks := repo.Tracks(id, true)
+	if tracks == nil {
+		return nil, model.ErrNotFound
+	}
+	return tracks, nil
 }
 
 // --- Mutation operations ---

--- a/core/playlists/playlists_test.go
+++ b/core/playlists/playlists_test.go
@@ -73,6 +73,28 @@ var _ = Describe("Playlists", func() {
 		})
 	})
 
+	Describe("Tracks", func() {
+		var mockTracks *tests.MockPlaylistTrackRepo
+
+		BeforeEach(func() {
+			mockTracks = &tests.MockPlaylistTrackRepo{}
+			mockPlsRepo.Data = map[string]*model.Playlist{
+				"pls-1": {ID: "pls-1", Name: "My Playlist", OwnerID: "user-1"},
+			}
+			mockPlsRepo.TracksRepo = mockTracks
+			ps = playlists.NewPlaylists(ds, core.NewImageUploadService())
+		})
+
+		It("returns the playlist's track repository", func() {
+			Expect(ps.Tracks(ctx, "pls-1")).To(BeIdenticalTo(mockTracks))
+		})
+
+		It("returns ErrNotFound for an unknown or invisible playlist", func() {
+			_, err := ps.Tracks(ctx, "nonexistent")
+			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+	})
+
 	Describe("Create", func() {
 		BeforeEach(func() {
 			mockPlsRepo.Data = map[string]*model.Playlist{

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -157,10 +157,15 @@ func (plt PlaylistTracks) MediaFiles() MediaFiles {
 	return mfs
 }
 
+type PlaylistTrackCursor iter.Seq2[PlaylistTrack, error]
+
 type PlaylistTrackRepository interface {
 	ResourceRepository
+	CountAll(options ...QueryOptions) (int64, error)
 	GetAll(options ...QueryOptions) (PlaylistTracks, error)
+	GetCursor(options ...QueryOptions) (PlaylistTrackCursor, error)
 	GetAlbumIDs(options ...QueryOptions) ([]string, error)
+	GetMediaFileIDs(options ...QueryOptions) ([]string, error)
 	Add(mediaFileIds []string) (int, error)
 	AddAlbums(albumIds []string) (int, error)
 	AddArtists(artistIds []string) (int, error)

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -298,10 +298,11 @@ func (r *playlistRepository) refreshCounters(pls *model.Playlist) error {
 	return nil
 }
 
-func (r *playlistRepository) loadTracks(sel SelectBuilder, id string) (model.PlaylistTracks, error) {
-	sel = r.applyLibraryFilter(sel, "f")
+// tracksQuery is shared by loadTracks and GetCursor, so both hydrate rows identically.
+func (r *playlistRepository) tracksQuery(query SelectBuilder, id string) SelectBuilder {
+	query = r.applyLibraryFilter(query, "f")
 	userID := loggedUser(r.ctx).ID
-	tracksQuery := sel.
+	return query.
 		Columns(
 			"coalesce(starred, 0) as starred",
 			"starred_at",
@@ -321,8 +322,11 @@ func (r *playlistRepository) loadTracks(sel SelectBuilder, id string) (model.Pla
 		Join("media_file f on f.id = media_file_id").
 		Join("library on f.library_id = library.id").
 		Where(Eq{"playlist_id": id})
+}
+
+func (r *playlistRepository) loadTracks(query SelectBuilder, id string) (model.PlaylistTracks, error) {
 	tracks := dbPlaylistTracks{}
-	err := r.queryAll(tracksQuery, &tracks)
+	err := r.queryAll(r.tracksQuery(query, id), &tracks)
 	if err != nil {
 		return nil, err
 	}

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -77,6 +77,14 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 	return p
 }
 
+func (r *playlistTrackRepository) CountAll(options ...model.QueryOptions) (int64, error) {
+	query := Select().
+		Join("media_file f on f.id = media_file_id").
+		Where(Eq{"playlist_id": r.playlistId})
+	query = r.applyLibraryFilter(query, "f")
+	return r.count(query, options...)
+}
+
 func (r *playlistTrackRepository) Count(options ...rest.QueryOptions) (int64, error) {
 	query := Select().
 		LeftJoin("media_file f on f.id = media_file_id").
@@ -114,6 +122,30 @@ func (r *playlistTrackRepository) GetAll(options ...model.QueryOptions) (model.P
 		return nil, err
 	}
 	return tracks, err
+}
+
+func (r *playlistTrackRepository) GetCursor(options ...model.QueryOptions) (model.PlaylistTrackCursor, error) {
+	sel := r.playlistRepo.tracksQuery(r.newSelect(options...), r.playlistId)
+	cursor, err := queryWithStableResults[dbPlaylistTrack](r.sqlRepository, sel)
+	if err != nil {
+		return nil, err
+	}
+	return model.PlaylistTrackCursor(wrapCursor(cursor, func(t dbPlaylistTrack) *model.PlaylistTrack {
+		return t.PlaylistTrack
+	})), nil
+}
+
+// GetMediaFileIDs returns the tracks' song ids, for callers that need every id but no track data.
+func (r *playlistTrackRepository) GetMediaFileIDs(options ...model.QueryOptions) ([]string, error) {
+	query := r.newSelect(options...).Columns("media_file_id").
+		Join("media_file f on f.id = media_file_id").
+		Where(Eq{"playlist_id": r.playlistId})
+	query = r.applyLibraryFilter(query, "f")
+	var ids []string
+	if err := r.queryAllSlice(query, &ids); err != nil {
+		return nil, err
+	}
+	return ids, nil
 }
 
 func (r *playlistTrackRepository) GetAlbumIDs(options ...model.QueryOptions) ([]string, error) {

--- a/persistence/playlist_track_repository_test.go
+++ b/persistence/playlist_track_repository_test.go
@@ -1,0 +1,61 @@
+package persistence
+
+import (
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("PlaylistTrackRepository", func() {
+	var repo model.PlaylistTrackRepository
+
+	BeforeEach(func() {
+		ctx := log.NewContext(GinkgoT().Context())
+		ctx = request.WithUser(ctx, model.User{ID: "userid", UserName: "userid", IsAdmin: true})
+		repo = NewPlaylistRepository(ctx, GetDBXBuilder()).Tracks(plsBest.ID, true)
+	})
+
+	Describe("GetCursor", func() {
+		It("yields the same tracks as GetAll", func() {
+			opts := model.QueryOptions{Sort: "id"}
+			want, err := repo.GetAll(opts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(want).To(HaveLen(2))
+
+			Expect(collectCursor(repo.GetCursor(opts))).To(Equal([]model.PlaylistTrack(want)))
+		})
+
+		It("honors Max and Offset", func() {
+			opts := model.QueryOptions{Sort: "id", Max: 1, Offset: 1}
+			want, err := repo.GetAll(opts)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(want).To(HaveLen(1))
+
+			Expect(collectCursor(repo.GetCursor(opts))).To(Equal([]model.PlaylistTrack(want)))
+		})
+	})
+
+	Describe("CountAll", func() {
+		It("returns the number of tracks in the playlist", func() {
+			Expect(repo.CountAll()).To(Equal(int64(2)))
+		})
+
+		It("ignores Max and Offset", func() {
+			Expect(repo.CountAll(model.QueryOptions{Max: 1, Offset: 1})).To(Equal(int64(2)))
+		})
+	})
+
+	Describe("GetMediaFileIDs", func() {
+		It("returns the song ids in playlist order", func() {
+			Expect(repo.GetMediaFileIDs(model.QueryOptions{Sort: "id"})).
+				To(Equal([]string{songDayInALife.ID, songRadioactivity.ID}))
+		})
+
+		It("honors Max and Offset", func() {
+			Expect(repo.GetMediaFileIDs(model.QueryOptions{Sort: "id", Max: 1, Offset: 1})).
+				To(Equal([]string{songRadioactivity.ID}))
+		})
+	})
+})

--- a/server/jellyfin/api.go
+++ b/server/jellyfin/api.go
@@ -102,6 +102,7 @@ func (api *Router) routes() http.Handler {
 			r.Get("/Users/{userId}/Items/Latest", api.getLatest)
 			r.Get("/Artists", api.getArtists)
 			r.Get("/Artists/AlbumArtists", api.getAlbumArtists)
+			r.Get("/Playlists/{playlistId}/Items", api.getPlaylistItems)
 		})
 
 		r.Get("/Items/{itemId}", api.getItem)
@@ -131,7 +132,6 @@ func (api *Router) routes() http.Handler {
 		r.Post("/Playlists", api.createPlaylist)
 		r.Get("/Playlists/{playlistId}", api.getPlaylist)
 		r.Post("/Playlists/{playlistId}", api.updatePlaylist)
-		r.Get("/Playlists/{playlistId}/Items", api.getPlaylistItems)
 		r.Post("/Playlists/{playlistId}/Items", api.addToPlaylist)
 		r.Delete("/Playlists/{playlistId}/Items", api.removeFromPlaylist)
 		r.Get("/Playlists/{playlistId}/Users", api.getPlaylistUsers)

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -36,7 +36,7 @@ func (api *Router) listArtistsByRole(w http.ResponseWriter, r *http.Request, rol
 		search:   searchTerm(p),
 	}
 	if q.search != "" {
-		opts.Max = clampSearchLimit(opts.Max)
+		opts.Max = clampLimit(opts.Max, defaultSearchLimit, maxSearchLimit)
 	}
 
 	res, err := api.listArtists(ctx, opts, q, role)

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -36,7 +36,7 @@ func (api *Router) listArtistsByRole(w http.ResponseWriter, r *http.Request, rol
 		search:   searchTerm(p),
 	}
 	if q.search != "" {
-		opts.Max = min(opts.Max, maxSearchLimit)
+		opts.Max = clampSearchLimit(opts.Max)
 	}
 
 	res, err := api.listArtists(ctx, opts, q, role)

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -33,7 +33,7 @@ func (api *Router) listArtistsByRole(w http.ResponseWriter, r *http.Request, rol
 	q := itemsQuery{
 		scopeIDs: scopeIDs,
 		genreIds: decodedQueryIDs(r, "genreids"),
-		search:   p.StringOr("searchterm", ""),
+		search:   searchTerm(p),
 	}
 
 	res, err := api.listArtists(ctx, opts, q, role)

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -35,6 +35,9 @@ func (api *Router) listArtistsByRole(w http.ResponseWriter, r *http.Request, rol
 		genreIds: decodedQueryIDs(r, "genreids"),
 		search:   searchTerm(p),
 	}
+	if q.search != "" {
+		opts.Max = min(opts.Max, maxSearchLimit)
+	}
 
 	res, err := api.listArtists(ctx, opts, q, role)
 	if err != nil {

--- a/server/jellyfin/browsing_test.go
+++ b/server/jellyfin/browsing_test.go
@@ -111,6 +111,23 @@ var _ = Describe("Browsing", func() {
 			Expect(res.Items).To(HaveLen(1))
 		})
 
+		It("bounds a search the client left unbounded, and clamps an oversized one", func() {
+			artistRepo := ds.Artist(context.Background()).(*tests.MockArtistRepo)
+			artistRepo.SetData(model.Artists{{ID: "ar1", Name: "Artist"}})
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Artists?SearchTerm=art", nil).WithContext(ctxUser(model.Libraries{{ID: 1}}))
+			invoke(api.getArtists, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(artistRepo.Options.Max).To(Equal(defaultSearchLimit + 1))
+
+			w = httptest.NewRecorder()
+			r = httptest.NewRequest("GET", "/Artists?SearchTerm=art&Limit=999999", nil).WithContext(ctxUser(model.Libraries{{ID: 1}}))
+			invoke(api.getArtists, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(artistRepo.Options.Max).To(Equal(maxSearchLimit + 1))
+		})
+
 		It("forwards StartIndex/Limit as Offset/Max", func() {
 			artistRepo := ds.Artist(context.Background()).(*tests.MockArtistRepo)
 			artistRepo.SetData(model.Artists{{ID: "ar1", Name: "Artist"}})

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -323,13 +323,21 @@ func (api *Router) playlistTracks(ctx context.Context, q itemsQuery) (res itemsR
 func (api *Router) mergeTypes(ctx context.Context, q itemsQuery) (itemsResult, error) {
 	// Each per-type query needs at most offset+limit rows (the worst case where one type fills the
 	// whole [offset, offset+limit) window). Totals are unaffected — they come from CountAll.
+	window := 0
+	if q.limit > 0 {
+		window = q.offset + q.limit
+	}
+	// A search materializes its whole window per type (it can't stream), so StartIndex would drive
+	// that without bound. Below the window the merged rows are exactly the client's page; at it, a
+	// truncated type is followed by the next one's rows, so searchWindow also clips what's served.
+	if q.search != "" {
+		window = min(window, maxSearchLimit)
+	}
 	var results []itemsResult
 	total := 0
 	for _, itemType := range q.types {
 		var opts model.QueryOptions
-		if q.limit > 0 {
-			opts.Max = q.offset + q.limit
-		}
+		opts.Max = window
 		applySort(&opts, itemType, q.sortBy, q.sortOrder)
 		res, err := api.queryItemsOfType(ctx, itemType, opts, q)
 		if err != nil {
@@ -351,7 +359,17 @@ func (api *Router) mergeTypes(ctx context.Context, q itemsQuery) (itemsResult, e
 		}
 		items = append(items, typeItems...)
 	}
-	return materialized(result(paginate(items, q.offset, q.limit), total, q.offset)), nil
+	limit := q.limit
+	if q.search != "" {
+		// Past the window the merged order isn't the true one, so serve nothing rather than another
+		// type's rows, and report a total the client can actually page to.
+		total = min(total, window)
+		limit = max(0, window-q.offset)
+		if limit == 0 {
+			return materialized(result(nil, total, q.offset)), nil
+		}
+	}
+	return materialized(result(paginate(items, q.offset, limit), total, q.offset)), nil
 }
 
 func (api *Router) queryItemsOfType(ctx context.Context, itemType string, opts model.QueryOptions, q itemsQuery) (itemsResult, error) {

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -24,6 +24,12 @@ import (
 // album, artist and media_file).
 var notMissing = squirrel.Eq{"missing": false}
 
+// searchTerm trims, so a whitespace-only term is not a search: doSearch would read it as "match
+// everything" and materialize the library, where the unfiltered path streams.
+func searchTerm(p *req.Values) string {
+	return strings.TrimSpace(p.StringOr("searchterm", ""))
+}
+
 func (api *Router) getItems(w http.ResponseWriter, r *http.Request) {
 	res, err := api.queryItems(r.Context(), r)
 	if err != nil {
@@ -226,7 +232,7 @@ func (api *Router) parseItemsQuery(ctx context.Context, r *http.Request) itemsQu
 		fields:    dto.ParseFields(p.StringOr("fields", "")),
 		ids:       decodedQueryIDs(r, "ids"),
 		rawTypes:  p.StringOr("includeitemtypes", ""),
-		search:    p.StringOr("searchterm", ""),
+		search:    searchTerm(p),
 		sortBy:    p.StringOr("sortby", ""),
 		sortOrder: p.StringOr("sortorder", ""),
 		offset:    p.IntOr("startindex", 0),
@@ -415,20 +421,29 @@ func paginate(items []dto.BaseItemDto, offset, limit int) []dto.BaseItemDto {
 	return items
 }
 
+// Search can't stream (Search returns a slice), so it needs both a default and a ceiling: without
+// the ceiling, Limit=999999 still materializes every match.
+const (
+	defaultSearchLimit = 100
+	maxSearchLimit     = 2000
+)
+
 // searchPage runs a repository Search fetching one extra row to derive TotalRecordCount, since the
 // Search API returns no match count and CountAll can't see the search term. offset+len(rows) is
 // exact once matches end (and a growing lower bound before), so paging terminates at the last match.
 func searchPage[S ~[]E, E any](opts model.QueryOptions, search func(model.QueryOptions) (S, error)) (S, int, error) {
-	fetch := opts
-	if fetch.Max > 0 {
-		fetch.Max++
+	if opts.Max <= 0 {
+		opts.Max = defaultSearchLimit
 	}
+	opts.Max = min(opts.Max, maxSearchLimit)
+	fetch := opts
+	fetch.Max++
 	rows, err := search(fetch)
 	if err != nil {
 		return nil, 0, err
 	}
 	total := opts.Offset + len(rows)
-	if opts.Max > 0 && len(rows) > opts.Max {
+	if len(rows) > opts.Max {
 		rows = rows[:opts.Max]
 	}
 	return rows, total, nil

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -287,11 +287,11 @@ func (api *Router) queryItems(ctx context.Context, r *http.Request) (itemsResult
 	case strings.Contains(q.rawTypes, "ManualPlaylistsFolder"):
 		return materialized(result([]dto.BaseItemDto{playlistsFolder()}, 1, 0)), nil
 	}
-	if res, handled, err := api.playlistTracks(ctx, q); handled {
-		return res, err
+	if repo, ok := api.playlistTracksRepo(ctx, q); ok {
+		return api.playlistTrackPage(repo, q.fields, q.offset, q.limit)
 	}
 	if q.search != "" {
-		q.limit = clampSearchLimit(q.limit)
+		q.limit = clampLimit(q.limit, defaultSearchLimit, maxSearchLimit)
 	}
 	if len(q.types) == 1 {
 		opts := model.QueryOptions{Offset: q.offset, Max: q.limit}
@@ -301,23 +301,19 @@ func (api *Router) queryItems(ctx context.Context, r *http.Request) (itemsResult
 	return api.mergeTypes(ctx, q)
 }
 
-// playlistTracks resolves a playlist parent to its tracks, whatever IncludeItemTypes says: Jellify
-// opens a playlist with ParentId=<playlist>&IncludeItemTypes=Audio, and routing that through
-// listSongs would treat the playlist id as an album id and return nothing.
+// playlistTracksRepo resolves a playlist parent, whatever IncludeItemTypes says: Jellify opens a
+// playlist with ParentId=<playlist>&IncludeItemTypes=Audio, and routing that through listSongs would
+// treat the playlist id as an album id and return nothing.
 //
-// handled is false when ParentId isn't a visible playlist, so the caller falls through to the type
+// ok is false when ParentId isn't a visible playlist, so the caller falls through to the type
 // dispatch: ParentId is usually an album or artist.
-func (api *Router) playlistTracks(ctx context.Context, q itemsQuery) (res itemsResult, handled bool, err error) {
+func (api *Router) playlistTracksRepo(ctx context.Context, q itemsQuery) (model.PlaylistTrackRepository, bool) {
 	if q.parentId == "" || q.isLibraryParent || q.parentId == playlistsFolderID {
-		return itemsResult{}, false, nil
+		return nil, false
 	}
 	// Tracks enforces visibility.
 	repo, err := api.playlists.Tracks(ctx, q.parentId)
-	if err != nil {
-		return itemsResult{}, false, nil //nolint:nilerr // not a playlist: fall through, not a failure
-	}
-	res, err = api.playlistTrackPage(repo, q.fields, q.offset, q.limit)
-	return res, true, err
+	return repo, err == nil
 }
 
 func (api *Router) mergeTypes(ctx context.Context, q itemsQuery) (itemsResult, error) {
@@ -327,9 +323,9 @@ func (api *Router) mergeTypes(ctx context.Context, q itemsQuery) (itemsResult, e
 	if q.limit > 0 {
 		window = q.offset + q.limit
 	}
-	// A search materializes its whole window per type (it can't stream), so StartIndex would drive
-	// that without bound. Below the window the merged rows are exactly the client's page; at it, a
-	// truncated type is followed by the next one's rows, so searchWindow also clips what's served.
+	// A search can't stream, so the window is what each type materializes and StartIndex would drive
+	// it without bound. Only below the window are the merged rows the true order, hence the clip
+	// below too. Non-search stays unbounded in StartIndex: a known gap, fixable with per-type counts.
 	if q.search != "" {
 		window = min(window, maxSearchLimit)
 	}
@@ -359,18 +355,14 @@ func (api *Router) mergeTypes(ctx context.Context, q itemsQuery) (itemsResult, e
 		}
 		items = append(items, typeItems...)
 	}
-	limit := q.limit
 	if q.search != "" {
-		// Past the window the merged order isn't the true one, so serve nothing rather than another
-		// type's rows. The total is what's pageable overall, not this page's window, or a client
-		// paging on it would stop after the first page.
+		// Past the window the merged order isn't the true one, so drop it rather than serve another
+		// type's rows. The total is what's pageable overall, not this page, or a client paging on it
+		// would stop after the first page.
+		items = items[:min(window, len(items))]
 		total = min(total, maxSearchLimit)
-		limit = max(0, window-q.offset)
-		if limit == 0 {
-			return materialized(result(nil, total, q.offset)), nil
-		}
 	}
-	return materialized(result(paginate(items, q.offset, limit), total, q.offset)), nil
+	return materialized(result(paginate(items, q.offset, q.limit), total, q.offset)), nil
 }
 
 func (api *Router) queryItemsOfType(ctx context.Context, itemType string, opts model.QueryOptions, q itemsQuery) (itemsResult, error) {
@@ -450,14 +442,16 @@ const (
 	maxSearchLimit     = 2000
 )
 
-// clampSearchLimit bounds a search's Limit, 0 meaning the client sent none. Applied to the client's
-// Limit rather than inside searchPage, which also sees mergeTypes' larger offset+limit window:
-// bounding that would truncate each type before the merged page is cut, dropping matches.
-func clampSearchLimit(limit int) int {
+// clampLimit bounds a client-supplied limit, 0 or less meaning it sent none, so it can't drive an
+// oversized allocation or provider fetch (flagged by CodeQL as a user-controlled allocation size).
+//
+// Searches clamp their Limit here rather than in searchPage, which also sees mergeTypes' larger
+// offset+limit window: bounding that would truncate each type before the merged page is cut.
+func clampLimit(limit, def, ceiling int) int {
 	if limit <= 0 {
-		return defaultSearchLimit
+		return def
 	}
-	return min(limit, maxSearchLimit)
+	return min(limit, ceiling)
 }
 
 // searchPage runs a repository Search fetching one extra row to derive TotalRecordCount, since the

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -362,8 +362,9 @@ func (api *Router) mergeTypes(ctx context.Context, q itemsQuery) (itemsResult, e
 	limit := q.limit
 	if q.search != "" {
 		// Past the window the merged order isn't the true one, so serve nothing rather than another
-		// type's rows, and report a total the client can actually page to.
-		total = min(total, window)
+		// type's rows. The total is what's pageable overall, not this page's window, or a client
+		// paging on it would stop after the first page.
+		total = min(total, maxSearchLimit)
 		limit = max(0, window-q.offset)
 		if limit == 0 {
 			return materialized(result(nil, total, q.offset)), nil

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -281,8 +281,8 @@ func (api *Router) queryItems(ctx context.Context, r *http.Request) (itemsResult
 	case strings.Contains(q.rawTypes, "ManualPlaylistsFolder"):
 		return materialized(result([]dto.BaseItemDto{playlistsFolder()}, 1, 0)), nil
 	}
-	if res, ok := api.playlistTracks(ctx, q); ok {
-		return res, nil
+	if res, handled, err := api.playlistTracks(ctx, q); handled {
+		return res, err
 	}
 	if len(q.types) == 1 {
 		opts := model.QueryOptions{Offset: q.offset, Max: q.limit}
@@ -295,17 +295,20 @@ func (api *Router) queryItems(ctx context.Context, r *http.Request) (itemsResult
 // playlistTracks resolves a playlist parent to its tracks, whatever IncludeItemTypes says: Jellify
 // opens a playlist with ParentId=<playlist>&IncludeItemTypes=Audio, and routing that through
 // listSongs would treat the playlist id as an album id and return nothing.
-func (api *Router) playlistTracks(ctx context.Context, q itemsQuery) (itemsResult, bool) {
+//
+// handled is false when ParentId isn't a visible playlist, so the caller falls through to the type
+// dispatch: ParentId is usually an album or artist.
+func (api *Router) playlistTracks(ctx context.Context, q itemsQuery) (res itemsResult, handled bool, err error) {
 	if q.parentId == "" || q.isLibraryParent || q.parentId == playlistsFolderID {
-		return itemsResult{}, false
+		return itemsResult{}, false, nil
 	}
-	pls, err := api.playlists.GetWithTracks(ctx, q.parentId)
+	// Tracks enforces visibility.
+	repo, err := api.playlists.Tracks(ctx, q.parentId)
 	if err != nil {
-		return itemsResult{}, false
+		return itemsResult{}, false, nil //nolint:nilerr // not a playlist: fall through, not a failure
 	}
-	// GetWithTracks enforces visibility (public or owned by the current user).
-	items := slice.Map(pls.Tracks, func(t model.PlaylistTrack) dto.BaseItemDto { return trackToBaseItem(t, q.fields) })
-	return materialized(result(paginate(items, q.offset, q.limit), len(items), q.offset)), true
+	res, err = api.playlistTrackPage(repo, q.fields, q.offset, q.limit)
+	return res, true, err
 }
 
 func (api *Router) mergeTypes(ctx context.Context, q itemsQuery) (itemsResult, error) {

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -290,6 +290,10 @@ func (api *Router) queryItems(ctx context.Context, r *http.Request) (itemsResult
 	if res, handled, err := api.playlistTracks(ctx, q); handled {
 		return res, err
 	}
+	// 0 means "no limit", and keeps searchPage's default.
+	if q.search != "" {
+		q.limit = min(q.limit, maxSearchLimit)
+	}
 	if len(q.types) == 1 {
 		opts := model.QueryOptions{Offset: q.offset, Max: q.limit}
 		applySort(&opts, q.types[0], q.sortBy, q.sortOrder)
@@ -422,7 +426,8 @@ func paginate(items []dto.BaseItemDto, offset, limit int) []dto.BaseItemDto {
 }
 
 // Search can't stream (Search returns a slice), so it needs both a default and a ceiling: without
-// the ceiling, Limit=999999 still materializes every match.
+// the ceiling, Limit=999999 still materializes every match. Callers apply the ceiling to the
+// client's Limit, since searchPage also sees mergeTypes' larger offset+limit window.
 const (
 	defaultSearchLimit = 100
 	maxSearchLimit     = 2000
@@ -435,7 +440,6 @@ func searchPage[S ~[]E, E any](opts model.QueryOptions, search func(model.QueryO
 	if opts.Max <= 0 {
 		opts.Max = defaultSearchLimit
 	}
-	opts.Max = min(opts.Max, maxSearchLimit)
 	fetch := opts
 	fetch.Max++
 	rows, err := search(fetch)

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -290,9 +290,8 @@ func (api *Router) queryItems(ctx context.Context, r *http.Request) (itemsResult
 	if res, handled, err := api.playlistTracks(ctx, q); handled {
 		return res, err
 	}
-	// 0 means "no limit", and keeps searchPage's default.
 	if q.search != "" {
-		q.limit = min(q.limit, maxSearchLimit)
+		q.limit = clampSearchLimit(q.limit)
 	}
 	if len(q.types) == 1 {
 		opts := model.QueryOptions{Offset: q.offset, Max: q.limit}
@@ -426,20 +425,26 @@ func paginate(items []dto.BaseItemDto, offset, limit int) []dto.BaseItemDto {
 }
 
 // Search can't stream (Search returns a slice), so it needs both a default and a ceiling: without
-// the ceiling, Limit=999999 still materializes every match. Callers apply the ceiling to the
-// client's Limit, since searchPage also sees mergeTypes' larger offset+limit window.
+// the ceiling, Limit=999999 still materializes every match.
 const (
 	defaultSearchLimit = 100
 	maxSearchLimit     = 2000
 )
 
+// clampSearchLimit bounds a search's Limit, 0 meaning the client sent none. Applied to the client's
+// Limit rather than inside searchPage, which also sees mergeTypes' larger offset+limit window:
+// bounding that would truncate each type before the merged page is cut, dropping matches.
+func clampSearchLimit(limit int) int {
+	if limit <= 0 {
+		return defaultSearchLimit
+	}
+	return min(limit, maxSearchLimit)
+}
+
 // searchPage runs a repository Search fetching one extra row to derive TotalRecordCount, since the
 // Search API returns no match count and CountAll can't see the search term. offset+len(rows) is
 // exact once matches end (and a growing lower bound before), so paging terminates at the last match.
 func searchPage[S ~[]E, E any](opts model.QueryOptions, search func(model.QueryOptions) (S, error)) (S, int, error) {
-	if opts.Max <= 0 {
-		opts.Max = defaultSearchLimit
-	}
 	fetch := opts
 	fetch.Max++
 	rows, err := search(fetch)

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -71,6 +71,59 @@ var _ = Describe("Items", func() {
 			Expect(res.Items[0].Id).To(Equal(dto.EncodeID("s1")))
 		})
 
+		It("lists a playlist's tracks when ParentId is a playlist, whatever the type", func() {
+			fp.getPls = &model.Playlist{ID: "pl1", Tracks: model.PlaylistTracks{
+				{ID: "1", MediaFileID: "s1", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s1"}},
+				{ID: "2", MediaFileID: "s2", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s2"}},
+			}}
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("pl1")+"&IncludeItemTypes=Audio", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).To(HaveLen(2))
+			Expect(res.Items[0].Id).To(Equal(dto.EncodeID("s1")))
+			Expect(res.Items[0].PlaylistItemId).To(Equal(dto.EncodeID("1")))
+			Expect(res.TotalRecordCount).To(Equal(2))
+		})
+
+		It("pages a playlist parent's tracks in the query, not in memory", func() {
+			fp.getPls = &model.Playlist{ID: "pl1", Tracks: model.PlaylistTracks{
+				{ID: "1", MediaFileID: "s1", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s1"}},
+				{ID: "2", MediaFileID: "s2", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s2"}},
+				{ID: "3", MediaFileID: "s3", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s3"}},
+			}}
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("pl1")+"&StartIndex=1&Limit=1", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.TotalRecordCount).To(Equal(3))
+			Expect(res.Items).To(HaveLen(1))
+			Expect(res.Items[0].Id).To(Equal(dto.EncodeID("s2")))
+			Expect(fp.tracksRepo.Options.Offset).To(Equal(1))
+			Expect(fp.tracksRepo.Options.Max).To(Equal(1))
+		})
+
+		It("falls through to the type dispatch when ParentId is not a playlist", func() {
+			fp.getErr = model.ErrNotFound
+			ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One"}})
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{{ID: "s1", AlbumID: "a1"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("a1")+"&IncludeItemTypes=Audio", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).To(HaveLen(1))
+			Expect(res.Items[0].Id).To(Equal(dto.EncodeID("s1")))
+		})
+
 		It("returns 500 when the song cursor fails to open, instead of a truncated 200", func() {
 			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetError(true)
 			w := httptest.NewRecorder()

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -3,6 +3,7 @@ package jellyfin
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -317,6 +318,27 @@ var _ = Describe("Items", func() {
 			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
 			Expect(res.Items).To(HaveLen(2))
 			Expect(albumRepo.SearchQuery).To(BeEmpty())
+		})
+
+		It("pages a multi-type search past the ceiling without dropping matches", func() {
+			// The per-type merge window is offset+limit, not the client's limit: clamping it to the
+			// ceiling would make the merged page skip to the next type.
+			songs := make(model.MediaFiles, maxSearchLimit+1)
+			for i := range songs {
+				songs[i] = model.MediaFile{ID: fmt.Sprintf("s%05d", i), Title: "Song"}
+			}
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(songs)
+			ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET",
+				fmt.Sprintf("/Items?IncludeItemTypes=Audio,MusicAlbum&SearchTerm=song&StartIndex=%d&Limit=1", maxSearchLimit),
+				nil).WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).To(HaveLen(1))
+			Expect(res.Items[0].Id).To(Equal(dto.EncodeID(songs[maxSearchLimit].ID)))
 		})
 
 		It("reports a search total beyond the fetched page instead of the page length", func() {

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -273,6 +273,52 @@ var _ = Describe("Items", func() {
 			Expect(res.Items).To(HaveLen(1))
 		})
 
+		It("caps a search the client left unbounded", func() {
+			albumRepo := ds.Album(context.Background()).(*tests.MockAlbumRepo)
+			albumRepo.SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=MusicAlbum&SearchTerm=one", nil).WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(albumRepo.Options.Max).To(Equal(defaultSearchLimit + 1))
+		})
+
+		It("honors an explicit search Limit up to the ceiling", func() {
+			albumRepo := ds.Album(context.Background()).(*tests.MockAlbumRepo)
+			albumRepo.SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=MusicAlbum&SearchTerm=one&Limit=500", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(albumRepo.Options.Max).To(Equal(501))
+		})
+
+		It("clamps a search Limit that would materialize the library", func() {
+			albumRepo := ds.Album(context.Background()).(*tests.MockAlbumRepo)
+			albumRepo.SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=MusicAlbum&SearchTerm=one&Limit=999999", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(albumRepo.Options.Max).To(Equal(maxSearchLimit + 1))
+		})
+
+		It("treats an all-whitespace SearchTerm as no search, streaming the unfiltered list", func() {
+			albumRepo := ds.Album(context.Background()).(*tests.MockAlbumRepo)
+			albumRepo.SetData(model.Albums{{ID: "a1", Name: "One"}, {ID: "a2", Name: "Two"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=MusicAlbum&SearchTerm=%20%20", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).To(HaveLen(2))
+			Expect(albumRepo.SearchQuery).To(BeEmpty())
+		})
+
 		It("reports a search total beyond the fetched page instead of the page length", func() {
 			ds.Artist(context.Background()).(*tests.MockArtistRepo).SetData(model.Artists{
 				{ID: "r1", Name: "Alpha"}, {ID: "r2", Name: "Beta"}, {ID: "r3", Name: "Gamma"},

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -320,9 +320,22 @@ var _ = Describe("Items", func() {
 			Expect(albumRepo.SearchQuery).To(BeEmpty())
 		})
 
-		It("pages a multi-type search past the ceiling without dropping matches", func() {
-			// The per-type merge window is offset+limit, not the client's limit: clamping it to the
-			// ceiling would make the merged page skip to the next type.
+		It("bounds the multi-type search window however large StartIndex is", func() {
+			albumRepo := ds.Album(context.Background()).(*tests.MockAlbumRepo)
+			albumRepo.SetData(model.Albums{{ID: "a1", Name: "One"}})
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{{ID: "s1", Title: "Song"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=Audio,MusicAlbum&SearchTerm=song&StartIndex=500000&Limit=1", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			// Without the bound this asks each type for ~500001 rows.
+			Expect(albumRepo.Options.Max).To(Equal(maxSearchLimit + 1))
+		})
+
+		It("stops a multi-type search at the ceiling rather than serving another type's rows", func() {
+			// Bounding the per-type window is what keeps StartIndex from driving it without limit, and
+			// past that window the merged order is no longer the true one.
 			songs := make(model.MediaFiles, maxSearchLimit+1)
 			for i := range songs {
 				songs[i] = model.MediaFile{ID: fmt.Sprintf("s%05d", i), Title: "Song"}
@@ -337,8 +350,28 @@ var _ = Describe("Items", func() {
 			Expect(w.Code).To(Equal(http.StatusOK))
 			var res dto.QueryResult
 			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).To(BeEmpty())
+			Expect(res.TotalRecordCount).To(Equal(maxSearchLimit))
+		})
+
+		It("serves the last page below the ceiling in full", func() {
+			songs := make(model.MediaFiles, maxSearchLimit+1)
+			for i := range songs {
+				songs[i] = model.MediaFile{ID: fmt.Sprintf("s%05d", i), Title: "Song"}
+			}
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(songs)
+			ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET",
+				fmt.Sprintf("/Items?IncludeItemTypes=Audio,MusicAlbum&SearchTerm=song&StartIndex=%d&Limit=10", maxSearchLimit-1),
+				nil).WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			// Clipped to the window, and still the real row at that index — not the album behind it.
 			Expect(res.Items).To(HaveLen(1))
-			Expect(res.Items[0].Id).To(Equal(dto.EncodeID(songs[maxSearchLimit].ID)))
+			Expect(res.Items[0].Id).To(Equal(dto.EncodeID(songs[maxSearchLimit-1].ID)))
 		})
 
 		It("bounds an unbounded multi-type search to the default in total, not per type", func() {

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -320,6 +320,24 @@ var _ = Describe("Items", func() {
 			Expect(albumRepo.SearchQuery).To(BeEmpty())
 		})
 
+		It("reports a multi-type search total past the page, so clients keep paging", func() {
+			songs := make(model.MediaFiles, defaultSearchLimit*2)
+			for i := range songs {
+				songs[i] = model.MediaFile{ID: fmt.Sprintf("s%05d", i), Title: "Song"}
+			}
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(songs)
+			ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=Audio,MusicAlbum&SearchTerm=song&Limit=10", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).To(HaveLen(10))
+			Expect(res.TotalRecordCount).To(BeNumerically(">", 10))
+		})
+
 		It("bounds the multi-type search window however large StartIndex is", func() {
 			albumRepo := ds.Album(context.Background()).(*tests.MockAlbumRepo)
 			albumRepo.SetData(model.Albums{{ID: "a1", Name: "One"}})

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -341,6 +341,42 @@ var _ = Describe("Items", func() {
 			Expect(res.Items[0].Id).To(Equal(dto.EncodeID(songs[maxSearchLimit].ID)))
 		})
 
+		It("bounds an unbounded multi-type search to the default in total, not per type", func() {
+			songs := make(model.MediaFiles, defaultSearchLimit*2)
+			for i := range songs {
+				songs[i] = model.MediaFile{ID: fmt.Sprintf("s%05d", i), Title: "Song"}
+			}
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(songs)
+			ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=Audio,MusicAlbum&SearchTerm=song", nil).
+				WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).To(HaveLen(defaultSearchLimit))
+		})
+
+		It("pages an unbounded multi-type search past the default without dropping matches", func() {
+			songs := make(model.MediaFiles, defaultSearchLimit*2)
+			for i := range songs {
+				songs[i] = model.MediaFile{ID: fmt.Sprintf("s%05d", i), Title: "Song"}
+			}
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(songs)
+			ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One"}})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET",
+				fmt.Sprintf("/Items?IncludeItemTypes=Audio,MusicAlbum&SearchTerm=song&StartIndex=%d", defaultSearchLimit+50),
+				nil).WithContext(ctxUser())
+			invoke(api.getItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.Items).ToNot(BeEmpty())
+			Expect(res.Items[0].Id).To(Equal(dto.EncodeID(songs[defaultSearchLimit+50].ID)))
+		})
+
 		It("reports a search total beyond the fetched page instead of the page length", func() {
 			ds.Artist(context.Background()).(*tests.MockArtistRepo).SetData(model.Artists{
 				{ID: "r1", Name: "Alpha"}, {ID: "r2", Name: "Beta"}, {ID: "r3", Name: "Gamma"},

--- a/server/jellyfin/playlists.go
+++ b/server/jellyfin/playlists.go
@@ -125,6 +125,21 @@ func (api *Router) clearPlaylist(ctx context.Context, id string) error {
 	return api.playlists.RemoveTracks(ctx, id, entryIDs)
 }
 
+// playlistTrackPage streams one page of a playlist's tracks. Streams because a playlist can be the
+// whole library (a smart playlist matching everything) and clients may omit Limit. Excludes missing
+// tracks, and counts the same set, like GetWithTracks.
+func (api *Router) playlistTrackPage(repo model.PlaylistTrackRepository, fields dto.Fields, offset, limit int) (itemsResult, error) {
+	total, err := repo.CountAll(model.QueryOptions{Filters: notMissing})
+	if err != nil {
+		return itemsResult{}, err
+	}
+	opts := model.QueryOptions{Sort: "id", Offset: offset, Max: limit, Filters: notMissing}
+	open := streamCursor(func() (func(func(model.PlaylistTrack, error) bool), error) {
+		return repo.GetCursor(opts)
+	}, func(t model.PlaylistTrack) dto.BaseItemDto { return trackToBaseItem(t, fields) })
+	return streamed(open, int(total), offset), nil
+}
+
 // trackToBaseItem maps a playlist entry to a BaseItemDto, tagging it with PlaylistItemId (the
 // entry's id, model.PlaylistTrack.ID, not the song id). Clients echo it back via
 // DELETE .../Items?EntryIds= to remove a specific occurrence, so duplicates of the same song remain
@@ -136,17 +151,28 @@ func trackToBaseItem(t model.PlaylistTrack, fields dto.Fields) dto.BaseItemDto {
 }
 
 // getPlaylist returns a playlist's visibility flag and item ids (Finamp reads OpenAccess before the
-// edit screen). GetWithTracks enforces visibility; any error maps to 404 so private playlists can't
+// edit screen). Get and Tracks enforce visibility; any error maps to 404 so private playlists can't
 // be probed.
 func (api *Router) getPlaylist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := dto.DecodeID(chi.URLParam(r, "playlistId"))
-	pls, err := api.playlists.GetWithTracks(ctx, id)
+	pls, err := api.playlists.Get(ctx, id)
 	if err != nil {
 		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}
-	itemIds := slice.Map(pls.Tracks, func(t model.PlaylistTrack) string { return dto.EncodeID(t.MediaFileID) })
+	repo, err := api.playlists.Tracks(ctx, id)
+	if err != nil {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+	// PlaylistInfo carries every track id, so this can't be paged — but it needs no track data.
+	trackIDs, err := repo.GetMediaFileIDs(model.QueryOptions{Sort: "id", Filters: notMissing})
+	if err != nil {
+		api.internalError(w, r, err)
+		return
+	}
+	itemIds := slice.Map(trackIDs, dto.EncodeID)
 	api.ok(w, r, dto.PlaylistInfo{
 		OpenAccess: pls.Public,
 		Shares:     []dto.PlaylistUserPermissions{},
@@ -154,19 +180,24 @@ func (api *Router) getPlaylist(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// getPlaylistItems relies on GetWithTracks to enforce visibility; any error maps to a generic 404 so
-// a playlist id can't probe for private playlists.
+// getPlaylistItems relies on Tracks to enforce visibility; any error maps to a generic 404 so a
+// playlist id can't probe for private playlists.
 func (api *Router) getPlaylistItems(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := dto.DecodeID(chi.URLParam(r, "playlistId"))
-	pls, err := api.playlists.GetWithTracks(ctx, id)
+	repo, err := api.playlists.Tracks(ctx, id)
 	if err != nil {
 		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}
-	fields := dto.ParseFields(req.Params(r).StringOr("fields", ""))
-	items := slice.Map(pls.Tracks, func(t model.PlaylistTrack) dto.BaseItemDto { return trackToBaseItem(t, fields) })
-	api.ok(w, r, dto.QueryResult{Items: items, TotalRecordCount: len(items)})
+	p := req.Params(r)
+	fields := dto.ParseFields(p.StringOr("fields", ""))
+	res, err := api.playlistTrackPage(repo, fields, p.IntOr("startindex", 0), p.IntOr("limit", 0))
+	if err != nil {
+		api.internalError(w, r, err)
+		return
+	}
+	api.ok(w, r, res)
 }
 
 // queryIDs reads an id-list query param that clients spell two ways: comma-separated in a single

--- a/server/jellyfin/playlists_test.go
+++ b/server/jellyfin/playlists_test.go
@@ -29,8 +29,9 @@ type fakePlaylists struct {
 	createdIds  []string
 	createErr   error
 
-	getPls *model.Playlist
-	getErr error
+	getPls     *model.Playlist
+	getErr     error
+	tracksRepo *tests.MockPlaylistTrackRepo
 
 	getByIDPls *model.Playlist
 	getByIDErr error
@@ -90,6 +91,20 @@ func (f *fakePlaylists) GetWithTracks(_ context.Context, _ string) (*model.Playl
 		return nil, model.ErrNotFound // mirror the real repo: never (nil, nil)
 	}
 	return f.getPls, nil
+}
+
+// Tracks serves the same getPls fixture as GetWithTracks. tracksRepo is kept so tests can assert
+// what was pushed down to the query.
+func (f *fakePlaylists) Tracks(_ context.Context, _ string) (model.PlaylistTrackRepository, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	if f.getPls == nil {
+		return nil, model.ErrNotFound
+	}
+	f.tracksRepo = &tests.MockPlaylistTrackRepo{}
+	f.tracksRepo.SetData(f.getPls.Tracks)
+	return f.tracksRepo, nil
 }
 
 func (f *fakePlaylists) AddTracks(_ context.Context, playlistID string, ids []string) (int, error) {
@@ -184,6 +199,30 @@ var _ = Describe("Playlists", func() {
 			Expect(res.Items[1].PlaylistItemId).To(Equal(dto.EncodeID("2")))
 		})
 
+		It("pages with StartIndex/Limit, pushing them down to the query", func() {
+			fp.getPls = &model.Playlist{
+				ID: "pl1",
+				Tracks: model.PlaylistTracks{
+					{ID: "1", MediaFileID: "s1", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s1"}},
+					{ID: "2", MediaFileID: "s2", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s2"}},
+					{ID: "3", MediaFileID: "s3", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s3"}},
+				},
+			}
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Playlists/pl1/Items?StartIndex=1&Limit=1", nil).
+				WithContext(context.Background())
+			r = withChiURLParam(r, "playlistId", "pl1")
+			invoke(api.getPlaylistItems, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.QueryResult
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.TotalRecordCount).To(Equal(3))
+			Expect(res.Items).To(HaveLen(1))
+			Expect(res.Items[0].Id).To(Equal(dto.EncodeID("s2")))
+			Expect(fp.tracksRepo.Options.Offset).To(Equal(1))
+			Expect(fp.tracksRepo.Options.Max).To(Equal(1))
+		})
+
 		It("returns 404 for a non-owned or absent playlist", func() {
 			fp.getErr = model.ErrNotFound
 			w := httptest.NewRecorder()
@@ -247,7 +286,7 @@ var _ = Describe("Playlists", func() {
 
 	Describe("getPlaylist", func() {
 		It("returns OpenAccess from Public and item ids (encoded media file ids, not entry ids)", func() {
-			fp.getPls = &model.Playlist{
+			pls := &model.Playlist{
 				ID:     "pl1",
 				Public: true,
 				Tracks: model.PlaylistTracks{
@@ -255,6 +294,7 @@ var _ = Describe("Playlists", func() {
 					{ID: "2", MediaFileID: "s2", PlaylistID: "pl1", MediaFile: model.MediaFile{ID: "s2"}},
 				},
 			}
+			fp.getPls, fp.getByIDPls = pls, pls
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", "/Playlists/pl1", nil).WithContext(context.Background())
 			r = withChiURLParam(r, "playlistId", "pl1")

--- a/server/jellyfin/similar.go
+++ b/server/jellyfin/similar.go
@@ -20,7 +20,10 @@ import (
 // tests can shorten it.
 var similarWait = 10 * time.Second
 
-const maxSimilarLimit = 100
+const (
+	defaultSimilarLimit = 20
+	maxSimilarLimit     = 100
+)
 
 // similarFetchTimeout bounds the detached background fetch so a hung provider can't hold a goroutine
 // indefinitely.
@@ -51,7 +54,7 @@ func (api *Router) awaitSimilar(ctx context.Context, id string, limit int, fetch
 // returned. Any provider error degrades to an empty result, not a 404 the client would keep retrying.
 func (api *Router) getSimilarArtists(w http.ResponseWriter, r *http.Request) {
 	id := api.resolveItemID(r.Context(), dto.DecodeID(chi.URLParam(r, "itemId")))
-	limit := clampLimit(req.Params(r).IntOr("limit", 20))
+	limit := clampLimit(req.Params(r).IntOr("limit", 0), defaultSimilarLimit, maxSimilarLimit)
 	api.ok(w, r, api.awaitSimilar(r.Context(), id, limit, func(ctx context.Context) dto.QueryResult {
 		return api.similarArtists(ctx, id, limit)
 	}))
@@ -63,7 +66,7 @@ func (api *Router) getSimilarArtists(w http.ResponseWriter, r *http.Request) {
 func (api *Router) getSimilarItems(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := api.resolveItemID(ctx, dto.DecodeID(chi.URLParam(r, "itemId")))
-	limit := clampLimit(req.Params(r).IntOr("limit", 20))
+	limit := clampLimit(req.Params(r).IntOr("limit", 0), defaultSimilarLimit, maxSimilarLimit)
 
 	entity, err := model.GetEntityByID(ctx, api.ds, id)
 	if err != nil {
@@ -88,7 +91,7 @@ func (api *Router) getSimilarItems(w http.ResponseWriter, r *http.Request) {
 func (api *Router) getInstantMix(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id := api.resolveItemID(ctx, dto.DecodeID(chi.URLParam(r, "itemId")))
-	limit := clampLimit(req.Params(r).IntOr("limit", 20))
+	limit := clampLimit(req.Params(r).IntOr("limit", 0), defaultSimilarLimit, maxSimilarLimit)
 
 	entity, err := model.GetEntityByID(ctx, api.ds, id)
 	if err != nil {
@@ -134,15 +137,6 @@ func (api *Router) similarArtists(ctx context.Context, id string, limit int) dto
 	present := slice.Filter(artist.SimilarArtists, func(a model.Artist) bool { return a.ID != "" })
 	items := slice.Map(present, dto.ArtistToBaseItem)
 	return result(items, len(items), 0)
-}
-
-// clampLimit bounds a client-supplied limit so it can't drive an oversized allocation or provider
-// fetch (flagged by CodeQL as a user-controlled allocation size).
-func clampLimit(limit int) int {
-	if limit <= 0 {
-		return 20
-	}
-	return min(limit, maxSimilarLimit)
 }
 
 func (api *Router) similarSongs(ctx context.Context, id string, limit int) dto.QueryResult {

--- a/tests/mock_album_repo.go
+++ b/tests/mock_album_repo.go
@@ -20,7 +20,7 @@ type MockAlbumRepo struct {
 	All                     model.Albums
 	Err                     bool
 	Options                 model.QueryOptions
-	SearchQuery             string            // empty when Search was never called
+	SearchQuery             string            // last query passed to Search
 	ReassignAnnotationCalls map[string]string // prevID -> newID
 	CopyAttributesCalls     map[string]string // fromID -> toID
 }

--- a/tests/mock_album_repo.go
+++ b/tests/mock_album_repo.go
@@ -20,6 +20,7 @@ type MockAlbumRepo struct {
 	All                     model.Albums
 	Err                     bool
 	Options                 model.QueryOptions
+	SearchQuery             string            // empty when Search was never called
 	ReassignAnnotationCalls map[string]string // prevID -> newID
 	CopyAttributesCalls     map[string]string // fromID -> toID
 }
@@ -134,6 +135,7 @@ func (m *MockAlbumRepo) UpdateExternalInfo(album *model.Album) error {
 }
 
 func (m *MockAlbumRepo) Search(q string, options ...model.QueryOptions) (model.Albums, error) {
+	m.SearchQuery = q
 	if len(options) > 0 {
 		m.Options = options[0]
 	}

--- a/tests/mock_playlist_track_repo.go
+++ b/tests/mock_playlist_track_repo.go
@@ -22,16 +22,18 @@ func (m *MockPlaylistTrackRepo) SetData(tracks model.PlaylistTracks) {
 
 // page applies Max/Offset as the real repository's SQL would.
 func (m *MockPlaylistTrackRepo) page(options ...model.QueryOptions) model.PlaylistTracks {
+	var opts model.QueryOptions
 	if len(options) > 0 {
-		m.Options = options[0]
+		opts = options[0]
+		m.Options = opts
 	}
 	tracks := m.Data
-	if m.Options.Offset >= len(tracks) {
+	if opts.Offset >= len(tracks) {
 		return nil
 	}
-	tracks = tracks[m.Options.Offset:]
-	if m.Options.Max > 0 && m.Options.Max < len(tracks) {
-		tracks = tracks[:m.Options.Max]
+	tracks = tracks[opts.Offset:]
+	if opts.Max > 0 && opts.Max < len(tracks) {
+		tracks = tracks[:opts.Max]
 	}
 	return tracks
 }

--- a/tests/mock_playlist_track_repo.go
+++ b/tests/mock_playlist_track_repo.go
@@ -1,14 +1,74 @@
 package tests
 
-import "github.com/navidrome/navidrome/model"
+import (
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/slice"
+)
 
 type MockPlaylistTrackRepo struct {
 	model.PlaylistTrackRepository
+	Data       model.PlaylistTracks
+	Options    model.QueryOptions
 	AddedIds   []string
 	DeletedIds []string
 	Reordered  bool
 	AddCount   int
 	Err        error
+}
+
+func (m *MockPlaylistTrackRepo) SetData(tracks model.PlaylistTracks) {
+	m.Data = tracks
+}
+
+// page applies Max/Offset as the real repository's SQL would.
+func (m *MockPlaylistTrackRepo) page(options ...model.QueryOptions) model.PlaylistTracks {
+	if len(options) > 0 {
+		m.Options = options[0]
+	}
+	tracks := m.Data
+	if m.Options.Offset >= len(tracks) {
+		return nil
+	}
+	tracks = tracks[m.Options.Offset:]
+	if m.Options.Max > 0 && m.Options.Max < len(tracks) {
+		tracks = tracks[:m.Options.Max]
+	}
+	return tracks
+}
+
+func (m *MockPlaylistTrackRepo) CountAll(_ ...model.QueryOptions) (int64, error) {
+	if m.Err != nil {
+		return 0, m.Err
+	}
+	return int64(len(m.Data)), nil
+}
+
+func (m *MockPlaylistTrackRepo) GetAll(options ...model.QueryOptions) (model.PlaylistTracks, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	return m.page(options...), nil
+}
+
+func (m *MockPlaylistTrackRepo) GetCursor(options ...model.QueryOptions) (model.PlaylistTrackCursor, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	tracks := m.page(options...)
+	return func(yield func(model.PlaylistTrack, error) bool) {
+		for _, t := range tracks {
+			if !yield(t, nil) {
+				return
+			}
+		}
+	}, nil
+}
+
+func (m *MockPlaylistTrackRepo) GetMediaFileIDs(options ...model.QueryOptions) ([]string, error) {
+	if m.Err != nil {
+		return nil, m.Err
+	}
+	return slice.Map(m.page(options...), func(t model.PlaylistTrack) string { return t.MediaFileID }), nil
 }
 
 func (m *MockPlaylistTrackRepo) Add(ids []string) (int, error) {


### PR DESCRIPTION
### Description

#5783 made every Jellyfin collection stream from a DB cursor, but deliberately left two paths materializing to keep that PR reviewable. Both are the same OOM class it fixed — an unbounded request building every row and every DTO in memory — and this closes them.

**Playlist tracks (three call sites, not one).** Every playlist path loaded *all* tracks regardless of what the client asked for, because they all went through `GetWithTracks`. A playlist can be the entire library (a smart playlist matching everything), so this is not a hypothetical: on a 96k-track playlist, `/Items?ParentId=<playlist>&Limit=10` peaked at **1.3 GB to return ten tracks**. Beyond the `ParentId` path that was logged as the follow-up, two others turned up:

- `/Playlists/{id}/Items` was worse — it materialized every track *and silently ignored `StartIndex`/`Limit`*, always returning the whole playlist. Real Jellyfin pages this endpoint.
- `getPlaylist` hydrated every track row (full `media_file` + annotation joins) purely to read their ids.

All three now stream from a cursor, reusing the plumbing #5783 added (`itemsResult`, `streamCursor`, `writeItems`):

- `PlaylistTrackRepository` gains `GetCursor` and `CountAll`, sharing the select builder with `loadTracks` so cursor rows hydrate identically, plus `GetMediaFileIDs` for callers that need every id but no track data.
- `playlists.Tracks(ctx, id)` exposes that repo to the HTTP layer with visibility enforced, returning `ErrNotFound` instead of the repository's nil-and-log-a-warning — `/Items` probes it with arbitrary ids on every album browse, so the warning would be pure log noise.
- The now cursor-backed `/Playlists/{id}/Items` joins the stream-throttled route group.

**Search.** The other collections stream, so an unbounded one costs ~one item of memory. Search can't: the repositories' `Search` returns a slice. Two ways to reach that:

- A **whitespace-only** `SearchTerm`. `" " != ""`, so it entered the search path, where `doSearch` trims it back to empty and hits its *"empty query → return everything in natural order"* branch — with no `LIMIT`, since `executeTwoPhase` only applies one when `Max > 0`. The whole library, materialized. Trimming at the two parse sites makes the `search != ""` checks mean what they appear to: a blank term isn't a search, so it takes the unfiltered *streaming* path — which still returns everything, exactly as real Jellyfin does for an empty term. (A genuinely empty `SearchTerm` was already fine; it never entered the search path.)
- A **real search with no `Limit`**, which needs an actual bound: a default of 100 when the client sends none, plus a ceiling of 2000. Both are required — the default alone leaves `Limit=999999` materializing every match. Both apply to the *client's* Limit (`clampSearchLimit`), not inside `searchPage`, which also sees `mergeTypes`' larger `offset+limit` window.
- **`StartIndex` driving the merge window.** `mergeTypes` asks each type for `offset+limit` rows before paginating the concatenated result, so a large `StartIndex` materialized that many matches per type regardless of the ceiling. The window is now capped at the ceiling *and* the page clipped to it: pages below it are served in full, a page straddling it is cut at it, and past it the result is empty rather than the next type's rows (the merged order is only the true one below the window). `TotalRecordCount` reports what can be paged to, so clients stop rather than request pages that don't exist.

### Related Issues
Related to #5783 — these are the follow-ups called out in that PR's notes.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Needs the experimental Jellyfin API (`ND_JELLYFIN_ENABLED=true`) and a large library. To reproduce the worst case, add a smart playlist that matches everything (`.nsp` rules `{"all":[{"contains":{"title":""}}]}`) owned by the user you log in as — smart playlists only refresh for their owner.

1. Authenticate (`POST /jellyfin/Users/AuthenticateByName`) to get a token.
2. **Playlist parent, paged** — `GET /jellyfin/Items?ParentId=<playlistId>&Limit=10&Fields=MediaSources`
   Expected: 10 tracks, returned promptly, with server memory roughly flat instead of spiking by the size of the whole playlist.
3. **Playlist parent, unbounded** — same without `Limit`: starts streaming almost immediately; memory stays flat. Body unchanged.
4. **Playlist items paging (new)** — `GET /jellyfin/Playlists/<playlistId>/Items?StartIndex=1&Limit=1`
   Expected: exactly 1 item, the *second* track, with `TotalRecordCount` = the full track count. On master this returns the entire playlist.
5. **Whitespace search** — `GET /jellyfin/Items?IncludeItemTypes=MusicAlbum&SearchTerm=%20`
   Expected: the full unfiltered album list, streamed (same as sending no `SearchTerm`), not a materialized search.
6. **Unbounded search** — `GET /jellyfin/Items?IncludeItemTypes=Audio&SearchTerm=love` → at most 100 items.
   `...&SearchTerm=love&Limit=500` → up to 500 (honored). `...&Limit=999999` → capped at 2000.
7. **End to end** — point Finamp/Jellify at the server and open/download a large playlist.

### Additional Notes

**Measured** against a copy of a 96k-track production database, master vs this branch. Each row is an isolated server run firing one request; peak RSS is the delta over idle. Sorted by memory improvement.

| request | peak RSS before | after | mem | TTFB before | after |
|---|---:|---:|---:|---:|---:|
| `/Items?ParentId=<pl>&Limit=10` | 1275 MB | **1 MB** | **1275×** | 8.8s | **3.6s** |
| `/Items?ParentId=<pl>` (unbounded) | 1353 MB | **8 MB** | **169×** | 8.7s | **3.4s** |
| `/Playlists/<pl>/Items` (unbounded) | 1217 MB | **7 MB** | **174×** | 8.8s | **3.4s** |
| `/Playlists/<pl>` (PlaylistInfo) | 1178 MB | **33 MB** | **36×** | 9.1s | **3.8s** |

**All four responses are byte-for-byte identical to master** (`cmp` clean). Those TTFBs are cold (first request against a fresh process); warm, the `Limit=10` case is **4.1s → 0.27s**.

**Trade-off — `TotalRecordCount` now costs a count query** where `GetWithTracks` got it free from `len(tracks)`. It's linear in playlist size: **6ms** on the largest real playlist in that library (2638 tracks), 288ms on the synthetic all-96k one. The old path paid 1.3 GB and 4s+ to avoid it.

That count is the request's dominant cost on huge playlists, and a covering index on `media_file(id, missing)` removes it (cold 3.6s → 0.33s, warm 0.27s → 0.09s, +3 MB on a 263 MB table). **Deliberately not included**: the existing `missing`-leading indexes can't serve it (the join drives *into* `media_file` by id), so it would need a new one that helps *only* these two new queries — nothing else in the codebase joins `media_file` needing just `missing` — while every user pays for it on every `media_file` write during a scan. Not worth a global schema change for a pathological playlist in an experimental API; the lever is measured and available if anyone reports it.

**Behavior changes**, both client-visible:
- `/Playlists/{id}/Items` now honors `StartIndex`/`Limit`. It ignored them before, so a client asking for a page got the whole playlist — this matches real Jellyfin.
- Search is bounded. No released Jellyfin caps `limit` anywhere, but its unreleased `SqlSearchProvider` defaults to 100 (`DefaultSearchLimit`), which is where the default comes from. An explicit `Limit` below the ceiling is honored unclamped, as upstream does. Truncating a *search* is safe in a way truncating `/Items` is not — nothing syncs a library through `searchTerm`, which is why #5783 refused to cap `/Items`.

**Upstream context:** the whitespace hole is Jellyfin's own bug — v10.11's `/Search/Hints` returns the entire library for a whitespace-only term (`ThrowIfNullOrEmpty` passes, then the term trims to empty and the filter is skipped). Their master fixed it by switching to `ThrowIfNullOrWhiteSpace`.

**Known limitation:** the bound above is the *merge's*, not the client's — a single-type search still pages as deep as it likes, since its offset goes to SQL. Only a search spanning several `IncludeItemTypes` is limited to the first 2000 matches, because a concatenated in-memory merge cannot both page deeply and stay bounded: reaching offset N requires N+limit rows from every type, and the repositories' `Search` exposes no count to skip a type cheaply. Non-search multi-type queries keep the unbounded `offset+limit` window — that predates this PR (identical on master, and reachable with no `SearchTerm` at all) and deserves a better fix than a cap: `CountAll` gives exact per-type totals, so whole types could be skipped and the offset pushed into SQL. Filed as a follow-up.

**Known divergence, left alone:** `sql_search.go`'s `len(q) < 2 → return nil` guard (inherited from Subsonic's search3) means `?SearchTerm=a` returns *nothing* through Jellyfin, where real Jellyfin returns matches — upstream enforces no minimum length anywhere. Moving the guard up to Subsonic is viable (`Search` has only two consumers; the native API's `fullTextFilter` bypasses `doSearch`), but it fires on a *normalized* query, so Subsonic would have to mirror `doSearch`'s trimming — real drift risk, and out of scope for an OOM fix.

