### PR TITLE
build(ui): fix typechecking command doing nothing

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,7 @@
     "test:watch": "vitest",
     "test": "vitest --watch=false",
     "test:coverage": "vitest run --coverage --watch=false",
-    "type-check": "tsc --noEmit",
+    "type-check": "tsc -b --noEmit",
     "lint": "eslint . --ext ts,tsx,js,jsx --report-unused-disable-directives --max-warnings 0",
     "prettier": "prettier --write ./src",
     "check-formatting": "prettier -c ./src",

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -10,6 +10,7 @@
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "allowJs": true,
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -5,9 +5,10 @@
     "skipLibCheck": true,
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "allowJs": true,
     "allowSyntheticDefaultImports": true,
     "strict": true,
     "noEmit": true
   },
-  "include": ["vite.config.ts"]
+  "include": ["vite.config.js"]
 }


### PR DESCRIPTION
### Description

* `type-check` command did nothing because it didn't have the `-b` for composite projects
* after enabled it was complaining that the node config was referencing a file that didn't exist
* Extra: I added `allowJs` because that way I can find references in the UI source easily, they are still excluded from typechecking.

This doesn't need extra check, the existing ones should still work.

### Related Issues

None

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [X] Refactor - I guess?
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test

run the `type-check` command with `npm run type-check`. It won't exit immediately. You can also use find all references and other things in VSCode.

### Screenshots / Demos (if applicable)

--

### Additional Notes

I have a question. I was really setting up to start to include files in TS type checking. Are you ok with follow-up PRs doing just that? If yes there are 2 ways I can do it:

* Keep JS files and add JSDoc comments. Benefit is that it's still JS (if that's what you want), downside is that strict type checking can only be turned on at the very end
* Convert JS files to TS one by one (starting with files with no imports), fix type errors as they arise. Benefit is that you get the type checking for those files immediately (even if I need to convert some files together). Downside is that they will be in Typescript, if you see that as a con.
 

Note that if I came across bugs I would just document them with FIXMEs in the code, not fix them. I consider the 2 ways above documentation changes so logic changes would not be allowed.