### PR TITLE
fix(jellyfin): honor Recursive=false for library parents

### DIFF
--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -118,6 +118,28 @@ var _ = Describe("Browsing", func() {
 		})
 	})
 
+	// Finamp's download sync asks a library for the tracks outside any album this way; answering
+	// with every track would stream the whole library.
+	Describe("Recursive=false", func() {
+		lib1 := enc("1")
+
+		It("returns no songs for a library parent", func() {
+			q := queryResult(get("/Items?IncludeItemTypes=Audio&ParentId=" + lib1 + "&Recursive=false"))
+			Expect(q.Items).To(BeEmpty())
+			Expect(q.TotalRecordCount).To(BeZero())
+		})
+
+		It("still lists the library's albums", func() {
+			q := queryResult(get("/Items?IncludeItemTypes=MusicAlbum&ParentId=" + lib1 + "&Recursive=false"))
+			Expect(names(q.Items)).To(ConsistOf("Abbey Road", "Help!", "IV", "Kind of Blue", "Singles"))
+		})
+
+		It("still lists an album's tracks", func() {
+			q := queryResult(get("/Items?IncludeItemTypes=Audio&ParentId=" + enc(albumID("Abbey Road")) + "&Recursive=false"))
+			Expect(names(q.Items)).To(ConsistOf("Come Together", "Something"))
+		})
+	})
+
 	// Finamp's artist screen sends ParentId=<libraryId> (scoping) plus AlbumArtistIds/ArtistIds
 	// for the actual artist filter, not ParentId=<artistId>.
 	Describe("artist filtering (AlbumArtistIds / ArtistIds)", func() {

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -223,6 +223,10 @@ type itemsQuery struct {
 	genreIds         []string
 }
 
+// libraryChildTypes are the types directly under a library in the hierarchy this API exposes
+// (library -> album -> track), so no track is ever a library's direct child.
+var libraryChildTypes = []string{"MusicAlbum", "MusicArtist", "MusicGenre", "Playlist"}
+
 // parseItemsQuery also resolves the entity types (inferring them from the parent when
 // IncludeItemTypes is absent) and the library scope. Query keys are read lowercase because
 // normalizeQueryKeys folded them (Jellyfin binds case-insensitively).
@@ -253,6 +257,12 @@ func (api *Router) parseItemsQuery(ctx context.Context, r *http.Request) itemsQu
 
 	q.types = parseTypes(q.rawTypes)
 	q.scopeIDs, q.isLibraryParent = resolveLibraryScope(ctx, q.parentId)
+
+	// Recursive=false asks for direct children only. Finamp's sync probes a library for the tracks
+	// outside any album this way, and every track is a wrong (and unbounded) answer to it.
+	if q.isLibraryParent && !p.BoolOr("recursive", false) {
+		q.types = slices.DeleteFunc(q.types, func(t string) bool { return !slices.Contains(libraryChildTypes, t) })
+	}
 
 	// With no item type, Jellyfin infers the child type from the parent: album parent -> its tracks
 	// (Jellify opens albums this way). An artist parent keeps parseTypes' MusicAlbum default (browse

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -223,10 +223,6 @@ type itemsQuery struct {
 	genreIds         []string
 }
 
-// libraryChildTypes are the types directly under a library in the hierarchy this API exposes
-// (library -> album -> track), so no track is ever a library's direct child.
-var libraryChildTypes = []string{"MusicAlbum", "MusicArtist", "MusicGenre", "Playlist"}
-
 // parseItemsQuery also resolves the entity types (inferring them from the parent when
 // IncludeItemTypes is absent) and the library scope. Query keys are read lowercase because
 // normalizeQueryKeys folded them (Jellyfin binds case-insensitively).
@@ -258,10 +254,10 @@ func (api *Router) parseItemsQuery(ctx context.Context, r *http.Request) itemsQu
 	q.types = parseTypes(q.rawTypes)
 	q.scopeIDs, q.isLibraryParent = resolveLibraryScope(ctx, q.parentId)
 
-	// Recursive=false asks for direct children only. Finamp's sync probes a library for the tracks
-	// outside any album this way, and every track is a wrong (and unbounded) answer to it.
+	// Recursive=false asks for direct children only, and no track is a library's direct child.
+	// Finamp's sync probes a library this way, and every track is a wrong, unbounded answer.
 	if q.isLibraryParent && !p.BoolOr("recursive", false) {
-		q.types = slices.DeleteFunc(q.types, func(t string) bool { return !slices.Contains(libraryChildTypes, t) })
+		q.types = slices.DeleteFunc(q.types, func(t string) bool { return t == "Audio" })
 	}
 
 	// With no item type, Jellyfin infers the child type from the parent: album parent -> its tracks

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -194,6 +194,18 @@ var _ = Describe("Items", func() {
 				Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
 				Expect(res.Items).To(HaveLen(1))
 			})
+
+			// Jellyfin's own default: ItemsController binds `bool? recursive` and reads it as
+			// `recursive ?? false`, so an omitted Recursive is a non-recursive request.
+			It("treats an omitted Recursive as false, like Jellyfin", func() {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("1")+"&IncludeItemTypes=Audio", nil).
+					WithContext(ctxUser())
+				invoke(api.getItems, w, r)
+				var res dto.QueryResult
+				Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+				Expect(res.Items).To(BeEmpty())
+			})
 		})
 
 		It("lists an artist's albums when ParentId is an artist and type is MusicAlbum", func() {

--- a/server/jellyfin/items_test.go
+++ b/server/jellyfin/items_test.go
@@ -133,6 +133,69 @@ var _ = Describe("Items", func() {
 			Expect(w.Code).To(Equal(http.StatusInternalServerError))
 		})
 
+		// Recursive=false asks for direct children only. Finamp's sync probes a library this way
+		// looking for tracks outside any album; answering with every track streams the whole library.
+		Describe("Recursive=false", func() {
+			BeforeEach(func() {
+				ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One"}})
+				ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{{ID: "s1", AlbumID: "a1"}})
+			})
+
+			It("returns no songs for a library parent, as tracks are never its direct children", func() {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("1")+"&IncludeItemTypes=Audio&Recursive=false", nil).
+					WithContext(ctxUser())
+				invoke(api.getItems, w, r)
+				Expect(w.Code).To(Equal(http.StatusOK))
+				var res dto.QueryResult
+				Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+				Expect(res.Items).To(BeEmpty())
+				Expect(res.TotalRecordCount).To(BeZero())
+			})
+
+			It("drops only Audio from a multi-type library query", func() {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("1")+"&IncludeItemTypes=Audio,MusicAlbum&Recursive=false", nil).
+					WithContext(ctxUser())
+				invoke(api.getItems, w, r)
+				var res dto.QueryResult
+				Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+				Expect(res.Items).To(HaveLen(1))
+				Expect(res.Items[0].Type).To(Equal("MusicAlbum"))
+			})
+
+			It("still lists albums for a library parent, as they are its direct children", func() {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("1")+"&IncludeItemTypes=MusicAlbum&Recursive=false", nil).
+					WithContext(ctxUser())
+				invoke(api.getItems, w, r)
+				var res dto.QueryResult
+				Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+				Expect(res.Items).To(HaveLen(1))
+			})
+
+			It("still lists an album's tracks, as they are its direct children", func() {
+				fp.getErr = model.ErrNotFound
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest("GET", "/Items?ParentId="+dto.EncodeID("a1")+"&IncludeItemTypes=Audio&Recursive=false", nil).
+					WithContext(ctxUser())
+				invoke(api.getItems, w, r)
+				var res dto.QueryResult
+				Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+				Expect(res.Items).To(HaveLen(1))
+				Expect(res.Items[0].Id).To(Equal(dto.EncodeID("s1")))
+			})
+
+			It("keeps returning every song when no parent scopes the query", func() {
+				w := httptest.NewRecorder()
+				r := httptest.NewRequest("GET", "/Items?IncludeItemTypes=Audio&Recursive=false", nil).WithContext(ctxUser())
+				invoke(api.getItems, w, r)
+				var res dto.QueryResult
+				Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+				Expect(res.Items).To(HaveLen(1))
+			})
+		})
+
 		It("lists an artist's albums when ParentId is an artist and type is MusicAlbum", func() {
 			ds.Album(context.Background()).(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "a1", Name: "One", AlbumArtistID: "ar1"}})
 			w := httptest.NewRecorder()


### PR DESCRIPTION
### Description

`/Items` ignored the `Recursive` parameter entirely — it appeared only in tests, never in production code. Every request was answered as if `Recursive=true`.

That mattered because of one specific request Finamp's download sync makes. For a **library** parent it sends `ParentId=<library>&IncludeItemTypes=Audio&Recursive=false` to pick up tracks sitting outside any album, supplementing its recursive per-album fetch. Real Jellyfin answers that with the library's *direct* Audio children — essentially nothing for a normal artist/album layout. We answered it with **every song in the library**.

Measured against a real library via the production logs: **208 MB and 21 s per sync**, versus 20 KB for the album queries alongside it. It fires on every Finamp library sync. Finamp then requires every track twice — once via its album, once directly under the library node.

**Jellyfin 10.10 ground truth.** `Recursive` never reaches SQL. It selects between an in-memory walk of a folder's direct `Children` (false) and a DB ancestor/top-parent query (true), with `IncludeItemTypes` applied as a post-filter over that direct-child list (`ItemsController.cs:308`, `Folder.cs:949-994`). The default is `false`, and neither `IncludeItemTypes` nor `SearchTerm` forces recursion. So `Recursive=false&IncludeItemTypes=Audio` on a music library returns an empty list — which is exactly what Finamp expects and codes for.

**The change.** When the parent is a library and `Recursive` is not true, filter the requested types down to those nested directly under a library. The hierarchy this API exposes is `library -> album -> track`, so no track is ever a library's direct child.

Deliberately narrow — album and playlist parents are untouched, since their tracks are real direct children in Jellyfin (`MusicAlbum.cs:86-89` flattens across disc subfolders; `Playlist.cs:140-167` returns every `LinkedChild`), and Jellify opens playlists with `Recursive=false`. Finamp loses nothing: it still receives every track through the per-album fetch, just without the duplicate library-wide sweep.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Automated coverage (5 unit + 3 e2e):

```bash
make test PKG=./server/jellyfin/...
```

The tests are load-bearing — negating the guard in `parseItemsQuery` fails exactly 3 of them (2 unit, 1 e2e).

Manually, against a server with a music library (library id 1 encodes to `31`):

1. The regression, previously the whole library, now empty:
   `GET /jellyfin/Items?ParentId=31&IncludeItemTypes=Audio&Recursive=false`
   → `{"Items":[],"TotalRecordCount":0,...}`
2. Unchanged — the library's albums are still its direct children:
   `GET /jellyfin/Items?ParentId=31&IncludeItemTypes=MusicAlbum&Recursive=false`
   → all albums
3. Unchanged — an album's tracks:
   `GET /jellyfin/Items?ParentId=<albumId>&IncludeItemTypes=Audio&Recursive=false`
   → that album's tracks
4. Unchanged — the recursive sweep Finamp actually syncs with:
   `GET /jellyfin/Items?ParentId=31&IncludeItemTypes=Audio&Recursive=true`
   → every song

End to end: run a Finamp library download against the server. It should still fetch every track (via albums), without the multi-hundred-MB library-wide request.

### Additional Notes

**Scope.** A library parent is the only case handled. `/Items` with **no** `ParentId` and `Recursive=false` still returns every song, where Jellyfin would return the root folder's children (the libraries, type filter ignored). No observed client sends that shape, and honoring it would surprise any client that merely *omits* `Recursive`, so it's left as a known divergence rather than fixed speculatively.

**On `libraryChildTypes`.** The list is our hierarchy, not Jellyfin's. In real Jellyfin, albums aren't a library's direct children either — they're grandchildren under artist folders. We allow `MusicAlbum` because our hierarchy has no artist level and `parseTypes` already defaults a library parent to `MusicAlbum`; matching Jellyfin literally there would break library browsing for a divergence nobody wants.

**A note on provenance**, since it's the sort of thing worth stating explicitly: this started from a Finamp maintainer's suggestion that the downloads service "progressively discovers items by requesting items with recursive set to false". The progressive-discovery half is right — Finamp walks the graph node-by-node via a worker-pool-drained Isar queue. The `recursive=false` half isn't: `jellyfin_api_helper.dart:259` does `recursive ??= true`, so every sync edge query sends `Recursive=true`, and the single `recursive: false` is the orphan-track probe described above. The production logs corroborate independently — across 768 request URLs there is exactly one `Recursive=false` shape. The suggested mechanism was off, but it pointed straight at a real bug.
