### PR TITLE
feat(jellyfin): lyrics endpoint and Lyric stream advertising

### DIFF
--- a/cmd/wire_gen.go
+++ b/cmd/wire_gen.go
@@ -137,7 +137,8 @@ func CreateJellyfinAPIRouter(ctx context.Context) *jellyfin.Router {
 	imageUploadService := core.NewImageUploadService()
 	playlistsPlaylists := playlists.NewPlaylists(dataStore, imageUploadService)
 	sonicSonic := sonic.New(dataStore, manager, matcherMatcher)
-	router := jellyfin.New(dataStore, artworkArtwork, mediaStreamer, transcodeDecider, players, playTracker, playlistsPlaylists, provider, sonicSonic)
+	lyricsLyrics := lyrics.NewLyrics(dataStore, manager)
+	router := jellyfin.New(dataStore, artworkArtwork, mediaStreamer, transcodeDecider, players, playTracker, playlistsPlaylists, provider, sonicSonic, lyricsLyrics)
 	return router
 }
 

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -147,6 +147,12 @@ func (mf MediaFile) StructuredLyrics() (LyricList, error) {
 	return lyrics, nil
 }
 
+// HasEmbeddedLyrics reports whether the lyrics column holds any lyrics. It is never "" post-scan;
+// no-lyrics is normalized to the "[]" sentinel, so string emptiness alone is meaningless.
+func (mf MediaFile) HasEmbeddedLyrics() bool {
+	return mf.Lyrics != "" && mf.Lyrics != "[]"
+}
+
 // String is mainly used for debugging
 func (mf MediaFile) String() string {
 	return mf.Path

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -604,6 +604,15 @@ var _ = Describe("MediaFile", func() {
 
 })
 
+var _ = DescribeTable("MediaFile.HasEmbeddedLyrics",
+	func(lyrics string, expected bool) {
+		Expect(MediaFile{Lyrics: lyrics}.HasEmbeddedLyrics()).To(Equal(expected))
+	},
+	Entry("empty string (never-scanned zero value)", "", false),
+	Entry(`the post-scan "[]" no-lyrics sentinel`, "[]", false),
+	Entry("a stored lyric list", `[{"lang":"eng","line":[{"value":"la"}]}]`, true),
+)
+
 var _ = Describe("MediaFile.Works", func() {
 	It("returns nil when there are no work tags", func() {
 		mf := MediaFile{}

--- a/server/jellyfin/README.md
+++ b/server/jellyfin/README.md
@@ -338,11 +338,21 @@ make test PKG=./server/jellyfin/...
   working session instead of 404-loop-reconnecting, but it never pushes anything. A follow-up
   would broadcast real session/playstate and library-change events over it (via `server/events`),
   mirroring Jellyfin's session messages.
-- **No lyrics endpoint (follow-up).** `GET Audio/{id}/Lyrics` is unimplemented (404), but Finamp
-  and Jellify both request it. Navidrome already has line-synced lyrics, so a follow-up would serve
-  Jellyfin's `LyricsResponse` (`Lyrics: [{Text, Start}]`, `Start` in 100ns ticks) — enough for both
-  clients' synced view. (Finamp also renders word-level `Cues`, but Navidrome has only line-level
-  timing, so word-sync is out of scope.)
+- **Lyrics.** `GET Audio/{id}/Lyrics` serves the main lyric track as a `LyricDto` (`Start` in
+  100ns ticks, word-level `Cues` when present), resolved through the full `core/lyrics` pipeline
+  (embedded, `.lrc` sidecars, plugins per `LyricsPriority`) behind a 5-minute TTL cache that also
+  caches misses — Jellify fetches for every played track, Feishin per song change, so lyric-less
+  tracks are the hot path. No lyrics → 404 (never an empty 200), which all three clients degrade
+  gracefully. Finamp gates its lyrics view on a `Lyric` `MediaStream` (not `HasLyrics`, which is
+  just a list badge): browse lists advertise it from embedded lyrics only (the `"[]"` sentinel
+  check — the column is never `""` post-scan), while `PlaybackInfo` runs the full pipeline per
+  track so sidecar/plugin lyrics also light up. Feishin additionally requires server version
+  ≥ 10.9 — the reason `jellyfinVersion` is 10.9.11.
+  Follow-ups: the lyrics cache loader is not singleflighted, so concurrent misses on the same
+  track can double-invoke the plugin pipeline (fix belongs in `utils/cache.SimpleCache` via
+  ttlcache's `SuppressedLoader`, affecting all callers — separate change); tracks whose only
+  lyrics are sidecar/plugin-sourced show no `HasLyrics` badge in lists (request-time sources
+  can't be known at list time without per-row I/O).
 - **No sonic similarity (follow-up).** `Items/{id}/InstantMix` and the `/Similar` endpoints are
   backed only by external metadata agents (Last.fm), not sonic analysis: an instant mix is the seed
   track followed by the provider's similar songs (with agents disabled it degrades to a seed-only

--- a/server/jellyfin/api.go
+++ b/server/jellyfin/api.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/httprate"
@@ -13,6 +14,7 @@ import (
 	"github.com/navidrome/navidrome/core"
 	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/core/external"
+	"github.com/navidrome/navidrome/core/lyrics"
 	"github.com/navidrome/navidrome/core/playlists"
 	"github.com/navidrome/navidrome/core/scrobbler"
 	"github.com/navidrome/navidrome/core/sonic"
@@ -21,6 +23,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
+	"github.com/navidrome/navidrome/utils/cache"
 )
 
 type Router struct {
@@ -34,6 +37,8 @@ type Router struct {
 	playlists        playlists.Playlists
 	provider         external.Provider
 	sonic            sonic.Engine
+	lyrics           lyrics.Lyrics
+	lyricsCache      cache.SimpleCache[string, model.LyricList]
 	similarFlight    singleflight.Group
 	serverIDMu       sync.Mutex
 	serverIDVal      string
@@ -42,11 +47,15 @@ type Router struct {
 func New(ds model.DataStore, artwork artwork.Artwork, streamer stream.MediaStreamer,
 	transcodeDecider stream.TranscodeDecider, players core.Players,
 	scrobbler scrobbler.PlayTracker, playlists playlists.Playlists, provider external.Provider,
-	sonicSvc sonic.Engine) *Router {
+	sonicSvc sonic.Engine, lyricsSvc lyrics.Lyrics) *Router {
 	r := &Router{
 		ds: ds, artwork: artwork, streamer: streamer, transcodeDecider: transcodeDecider,
 		players: players, scrobbler: scrobbler, playlists: playlists, provider: provider,
-		sonic: sonicSvc,
+		sonic: sonicSvc, lyrics: lyricsSvc,
+		lyricsCache: cache.NewSimpleCache[string, model.LyricList](cache.Options{
+			SizeLimit:  1000,
+			DefaultTTL: 5 * time.Minute,
+		}),
 	}
 	r.Handler = r.routes()
 	return r
@@ -155,6 +164,7 @@ func (api *Router) routes() http.Handler {
 		r.Get("/audio/{itemId}/main.m3u8", api.streamHls)
 		r.Get("/items/{itemId}/playbackinfo", api.getPlaybackInfo)
 		r.Post("/items/{itemId}/playbackinfo", api.getPlaybackInfo)
+		r.Get("/audio/{itemId}/lyrics", api.getLyrics)
 		// Direct-file endpoints: some clients (Finamp's just_audio) fetch here instead of
 		// /Audio/{id}/stream; /Download reuses the direct-play handler as Jellyfin serves the same file.
 		r.Get("/items/{itemId}/file", api.streamFile)

--- a/server/jellyfin/api_test.go
+++ b/server/jellyfin/api_test.go
@@ -18,7 +18,7 @@ import (
 var _ = Describe("Router", func() {
 	It("serves the public handshake through the mounted handler", func() {
 		ds := &tests.MockDataStore{}
-		api := New(ds, nil, nil, nil, nil, nil, nil, nil, nil)
+		api := New(ds, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/System/Info/Public", nil)
 		api.ServeHTTP(w, r)
@@ -26,7 +26,7 @@ var _ = Describe("Router", func() {
 	})
 
 	It("returns 404 JSON for unknown routes", func() {
-		api := New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		api := New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/Nonexistent/Route", nil)
 		api.ServeHTTP(w, r)
@@ -36,7 +36,7 @@ var _ = Describe("Router", func() {
 	})
 
 	It("returns 404 JSON for a known path with an unsupported method", func() {
-		api := New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		api := New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("PATCH", "/System/Info/Public", nil)
 		api.ServeHTTP(w, r)
@@ -53,7 +53,7 @@ var _ = Describe("Router", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		fp := &fakePlayers{}
-		api := New(ds, nil, nil, nil, fp, nil, nil, nil, nil)
+		api := New(ds, nil, nil, nil, fp, nil, nil, nil, nil, nil)
 
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest("GET", "/Users/Me", nil)
@@ -70,7 +70,7 @@ var _ = Describe("Router", func() {
 		DeferCleanup(configtest.SetupConfig())
 		conf.Server.AuthRequestLimit = 2
 		conf.Server.AuthWindowLength = time.Minute
-		api := New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		api := New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 
 		login := func() int {
 			w := httptest.NewRecorder()

--- a/server/jellyfin/dto/dto.go
+++ b/server/jellyfin/dto/dto.go
@@ -256,3 +256,32 @@ type PlaybackInfoResponse struct {
 	MediaSources  []MediaSourceInfo `json:"MediaSources"`
 	PlaySessionId string            `json:"PlaySessionId"`
 }
+
+// LyricDto mirrors Jellyfin's GET /Audio/{itemId}/Lyrics response. Feishin and Jellify read only
+// Lyrics[].Text and Start (ticks); Metadata is for completeness/Finamp.
+type LyricDto struct {
+	Metadata LyricMetadata `json:"Metadata"`
+	Lyrics   []LyricLine   `json:"Lyrics"`
+}
+
+type LyricMetadata struct {
+	Artist   string `json:"Artist,omitempty"`
+	Album    string `json:"Album,omitempty"`
+	Title    string `json:"Title,omitempty"`
+	Length   int64  `json:"Length,omitempty"`
+	Offset   *int64 `json:"Offset,omitempty"`
+	IsSynced bool   `json:"IsSynced"`
+}
+
+type LyricLine struct {
+	Text  string         `json:"Text"`
+	Start *int64         `json:"Start,omitempty"`
+	Cues  []LyricLineCue `json:"Cues,omitempty"`
+}
+
+type LyricLineCue struct {
+	Position    int    `json:"Position"`
+	EndPosition int    `json:"EndPosition"`
+	Start       int64  `json:"Start"`
+	End         *int64 `json:"End,omitempty"`
+}

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -59,6 +59,19 @@ func channelLayout(n int) string {
 // Shared by SongToBaseItem and getPlaybackInfo so Size/Bitrate match across browse and /PlaybackInfo
 // responses (Finamp's download dialog reads MediaSources[0].Size from the browse response).
 func MediaSourceFromMediaFile(mf model.MediaFile) MediaSourceInfo {
+	streams := []MediaStream{{
+		Type:          "Audio",
+		Index:         0,
+		Codec:         mf.Codec,
+		BitRate:       mf.BitRate * 1000, // Navidrome stores kbps; Jellyfin's BitRate is bps.
+		Channels:      mf.Channels,
+		SampleRate:    mf.SampleRate,
+		ChannelLayout: channelLayout(mf.Channels),
+	}}
+	// Finamp gates its lyrics view on a Lyric stream in PlaybackInfo, not on HasLyrics.
+	if mf.Lyrics != "" {
+		streams = append(streams, MediaStream{Type: "Lyric", Index: 1, IsExternal: true})
+	}
 	return MediaSourceInfo{
 		Id:                   EncodeID(mf.ID),
 		Protocol:             "Http",
@@ -73,17 +86,9 @@ func MediaSourceFromMediaFile(mf model.MediaFile) MediaSourceInfo {
 		SupportsTranscoding:  true,
 		IsRemote:             false,
 		SupportsProbing:      true,
-		MediaStreams: []MediaStream{{
-			Type:          "Audio",
-			Index:         0,
-			Codec:         mf.Codec,
-			BitRate:       mf.BitRate * 1000, // Navidrome stores kbps; Jellyfin's BitRate is bps.
-			Channels:      mf.Channels,
-			SampleRate:    mf.SampleRate,
-			ChannelLayout: channelLayout(mf.Channels),
-		}},
-		MediaAttachments: []any{},
-		Formats:          []string{},
+		MediaStreams:         streams,
+		MediaAttachments:     []any{},
+		Formats:              []string{},
 	}
 }
 

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -270,8 +270,7 @@ func PlaylistToBaseItem(p model.Playlist) BaseItemDto {
 func TicksFromMillis(ms int64) int64 { return ms * 10_000 }
 
 // LyricDtoFromLyrics maps one lyric track to Jellyfin's LyricDto. Clients infer synced-vs-plain
-// from per-line Start presence, so it is all-or-nothing: synced drops start-less lines, unsynced
-// never emits Start.
+// from per-line Start presence, so synced drops start-less lines and unsynced never emits Start.
 func LyricDtoFromLyrics(mf model.MediaFile, lyrics model.Lyrics) LyricDto {
 	d := LyricDto{
 		Metadata: LyricMetadata{

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -8,7 +8,16 @@ import (
 	"github.com/navidrome/navidrome/model"
 )
 
-func TicksFromSeconds(sec float32) int64 { return int64(float64(sec) * 1e7) }
+// Jellyfin wire times are ticks: 100ns units, i.e. 10,000 per millisecond.
+const ticksPerMillis = 10_000
+
+func TicksFromSeconds(sec float32) int64 { return int64(float64(sec) * 1000 * ticksPerMillis) }
+
+// TicksFromMillis converts milliseconds (Navidrome lyric timestamps) to ticks.
+func TicksFromMillis(ms int64) int64 { return ms * ticksPerMillis }
+
+// MillisFromTicks converts ticks (client-reported playback positions) to milliseconds.
+func MillisFromTicks(ticks int64) int64 { return ticks / ticksPerMillis }
 
 // premiereDate converts a possibly partial date tag ("2007", "2007-02") into the ISO 8601
 // PremiereDate clients parse, falling back to year; nil when neither exists.
@@ -260,9 +269,6 @@ func PlaylistToBaseItem(p model.Playlist) BaseItemDto {
 		UserData:          UserData(p.Annotations, p.ID),
 	}
 }
-
-// TicksFromMillis converts milliseconds (Navidrome lyric timestamps) to Jellyfin 100ns ticks.
-func TicksFromMillis(ms int64) int64 { return ms * 10_000 }
 
 // LyricDtoFromLyrics maps one lyric track to Jellyfin's LyricDto. Clients infer synced-vs-plain
 // from per-line Start presence, so synced drops start-less lines and unsynced never emits Start.

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -254,3 +254,53 @@ func PlaylistToBaseItem(p model.Playlist) BaseItemDto {
 		UserData:          UserData(p.Annotations, p.ID),
 	}
 }
+
+// TicksFromMillis converts milliseconds (Navidrome lyric timestamps) to Jellyfin 100ns ticks.
+func TicksFromMillis(ms int64) int64 { return ms * 10_000 }
+
+// LyricDtoFromLyrics maps one lyric track to Jellyfin's LyricDto. Clients infer synced-vs-plain
+// from per-line Start presence, so it is all-or-nothing: synced drops start-less lines, unsynced
+// never emits Start.
+func LyricDtoFromLyrics(mf model.MediaFile, lyrics model.Lyrics) LyricDto {
+	d := LyricDto{
+		Metadata: LyricMetadata{
+			Artist:   cmp.Or(lyrics.DisplayArtist, mf.Artist),
+			Album:    mf.Album,
+			Title:    cmp.Or(lyrics.DisplayTitle, mf.Title),
+			Length:   TicksFromSeconds(mf.Duration),
+			IsSynced: lyrics.Synced,
+		},
+		Lyrics: make([]LyricLine, 0, len(lyrics.Line)),
+	}
+	if lyrics.Offset != nil {
+		offset := TicksFromMillis(*lyrics.Offset)
+		d.Metadata.Offset = &offset
+	}
+	for _, line := range lyrics.Line {
+		out := LyricLine{Text: line.Value}
+		if lyrics.Synced {
+			if line.Start == nil {
+				continue
+			}
+			start := TicksFromMillis(*line.Start)
+			out.Start = &start
+			for _, cue := range line.Cue {
+				if cue.Start == nil {
+					continue
+				}
+				c := LyricLineCue{
+					Position:    cue.ByteStart,
+					EndPosition: cue.ByteEnd,
+					Start:       TicksFromMillis(*cue.Start),
+				}
+				if cue.End != nil {
+					end := TicksFromMillis(*cue.End)
+					c.End = &end
+				}
+				out.Cues = append(out.Cues, c)
+			}
+		}
+		d.Lyrics = append(d.Lyrics, out)
+	}
+	return d
+}

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -55,16 +55,10 @@ func channelLayout(n int) string {
 	}
 }
 
-// hasEmbeddedLyrics reports whether mf carries a non-empty embedded lyric track. mf.Lyrics is
-// never the empty string post-scan (the persistence layer normalizes no-lyrics to the JSON "[]"
-// sentinel), so this must parse rather than compare against "".
+// hasEmbeddedLyrics reports whether mf carries embedded lyrics. The column is never "" post-scan;
+// no-lyrics is normalized to the "[]" sentinel, so string emptiness alone is meaningless.
 func hasEmbeddedLyrics(mf model.MediaFile) bool {
-	list, err := mf.StructuredLyrics()
-	if err != nil {
-		return false
-	}
-	main, found := list.Main()
-	return found && !main.IsEmpty()
+	return mf.Lyrics != "" && mf.Lyrics != "[]"
 }
 
 // MediaSourceFromMediaFile builds the MediaSourceInfo for direct playback of mf's source file.

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -55,6 +55,18 @@ func channelLayout(n int) string {
 	}
 }
 
+// hasEmbeddedLyrics reports whether mf carries a non-empty embedded lyric track. mf.Lyrics is
+// never the empty string post-scan (the persistence layer normalizes no-lyrics to the JSON "[]"
+// sentinel), so this must parse rather than compare against "".
+func hasEmbeddedLyrics(mf model.MediaFile) bool {
+	list, err := mf.StructuredLyrics()
+	if err != nil {
+		return false
+	}
+	main, found := list.Main()
+	return found && !main.IsEmpty()
+}
+
 // MediaSourceFromMediaFile builds the MediaSourceInfo for direct playback of mf's source file.
 // Shared by SongToBaseItem and getPlaybackInfo so Size/Bitrate match across browse and /PlaybackInfo
 // responses (Finamp's download dialog reads MediaSources[0].Size from the browse response).
@@ -69,7 +81,7 @@ func MediaSourceFromMediaFile(mf model.MediaFile) MediaSourceInfo {
 		ChannelLayout: channelLayout(mf.Channels),
 	}}
 	// Finamp gates its lyrics view on a Lyric stream in PlaybackInfo, not on HasLyrics.
-	if mf.Lyrics != "" {
+	if hasEmbeddedLyrics(mf) {
 		streams = append(streams, MediaStream{Type: "Lyric", Index: 1, IsExternal: true})
 	}
 	return MediaSourceInfo{
@@ -124,7 +136,7 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 		MediaType:         "Audio",
 		IsFolder:          false,
 		LocationType:      "FileSystem",
-		HasLyrics:         mf.Lyrics != "",
+		HasLyrics:         hasEmbeddedLyrics(mf),
 		ParentId:          EncodeID(mf.AlbumID),
 		Album:             mf.Album,
 		AlbumId:           EncodeID(mf.AlbumID),

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -55,17 +55,12 @@ func channelLayout(n int) string {
 	}
 }
 
-// hasEmbeddedLyrics reports whether mf carries embedded lyrics. The column is never "" post-scan;
-// no-lyrics is normalized to the "[]" sentinel, so string emptiness alone is meaningless.
-func hasEmbeddedLyrics(mf model.MediaFile) bool {
-	return mf.Lyrics != "" && mf.Lyrics != "[]"
-}
-
 // MediaSourceFromMediaFile builds the MediaSourceInfo for direct playback of mf's source file.
 // Shared by SongToBaseItem and getPlaybackInfo so Size/Bitrate match across browse and /PlaybackInfo
 // responses (Finamp's download dialog reads MediaSources[0].Size from the browse response).
 func MediaSourceFromMediaFile(mf model.MediaFile) MediaSourceInfo {
-	streams := []MediaStream{{
+	streams := make([]MediaStream, 1, 2)
+	streams[0] = MediaStream{
 		Type:          "Audio",
 		Index:         0,
 		Codec:         mf.Codec,
@@ -73,9 +68,9 @@ func MediaSourceFromMediaFile(mf model.MediaFile) MediaSourceInfo {
 		Channels:      mf.Channels,
 		SampleRate:    mf.SampleRate,
 		ChannelLayout: channelLayout(mf.Channels),
-	}}
+	}
 	// Finamp gates its lyrics view on a Lyric stream in PlaybackInfo, not on HasLyrics.
-	if hasEmbeddedLyrics(mf) {
+	if mf.HasEmbeddedLyrics() {
 		streams = append(streams, MediaStream{Type: "Lyric", Index: 1, IsExternal: true})
 	}
 	return MediaSourceInfo{
@@ -130,7 +125,7 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 		MediaType:         "Audio",
 		IsFolder:          false,
 		LocationType:      "FileSystem",
-		HasLyrics:         hasEmbeddedLyrics(mf),
+		HasLyrics:         mf.HasEmbeddedLyrics(),
 		ParentId:          EncodeID(mf.AlbumID),
 		Album:             mf.Album,
 		AlbumId:           EncodeID(mf.AlbumID),

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -39,7 +39,7 @@ var _ = Describe("mappers", func() {
 
 	Describe("Fields gating (matches real Jellyfin)", func() {
 		mf := model.MediaFile{ID: "s1", Title: "Song", Size: 2_500_000, Suffix: "mp3", Duration: 60,
-			SortTitle: "sort song", Lyrics: `[{"line":"la"}]`}
+			SortTitle: "sort song", Lyrics: `[{"line":[{"value":"la"}]}]`}
 
 		It("omits MediaSources and SortName when Fields does not ask for them", func() {
 			item := SongToBaseItem(mf, nil)
@@ -60,6 +60,8 @@ var _ = Describe("mappers", func() {
 		It("sets HasLyrics from the media file's lyrics", func() {
 			Expect(SongToBaseItem(mf, nil).HasLyrics).To(BeTrue())
 			Expect(SongToBaseItem(model.MediaFile{ID: "s2", Title: "No Lyrics"}, nil).HasLyrics).To(BeFalse())
+			// Post-scan the column is never "", but the JSON "no lyrics" sentinel "[]" — must not read as HasLyrics.
+			Expect(SongToBaseItem(model.MediaFile{ID: "s3", Title: "Empty Lyrics", Lyrics: "[]"}, nil).HasLyrics).To(BeFalse())
 		})
 	})
 
@@ -164,6 +166,11 @@ var _ = Describe("mappers", func() {
 			src := MediaSourceFromMediaFile(model.MediaFile{ID: "s1"})
 			Expect(src.MediaStreams).To(HaveLen(1))
 			Expect(src.MediaStreams[0].Type).To(Equal("Audio"))
+		})
+
+		It("emits only the Audio stream for the post-scan empty-lyrics sentinel", func() {
+			src := MediaSourceFromMediaFile(model.MediaFile{ID: "s1", Lyrics: "[]"})
+			Expect(src.MediaStreams).To(HaveLen(1))
 		})
 	})
 

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -278,3 +278,73 @@ var _ = Describe("mappers", func() {
 		Expect(PlaylistToBaseItem(p).ImageTags).To(Equal(PlaylistToBaseItem(p).ImageTags))
 	})
 })
+
+var _ = Describe("LyricDtoFromLyrics", func() {
+	ms := func(v int64) *int64 { return &v }
+
+	mf := model.MediaFile{ID: "s1", Title: "Song", Artist: "Artist", Album: "Album", Duration: 100}
+
+	It("maps synced lyrics with tick conversion", func() {
+		l := model.Lyrics{
+			DisplayArtist: "Display Artist",
+			DisplayTitle:  "Display Title",
+			Synced:        true,
+			Offset:        ms(-150),
+			Line: []model.Line{
+				{Start: ms(1000), Value: "line one"},
+				{Start: ms(2500), Value: "line two"},
+			},
+		}
+		d := LyricDtoFromLyrics(mf, l)
+		Expect(d.Metadata.Artist).To(Equal("Display Artist"))
+		Expect(d.Metadata.Title).To(Equal("Display Title"))
+		Expect(d.Metadata.Album).To(Equal("Album"))
+		Expect(d.Metadata.IsSynced).To(BeTrue())
+		Expect(*d.Metadata.Offset).To(Equal(int64(-1_500_000)))
+		Expect(d.Metadata.Length).To(Equal(TicksFromSeconds(100)))
+		Expect(d.Lyrics).To(HaveLen(2))
+		Expect(d.Lyrics[0].Text).To(Equal("line one"))
+		Expect(*d.Lyrics[0].Start).To(Equal(int64(10_000_000)))
+		Expect(*d.Lyrics[1].Start).To(Equal(int64(25_000_000)))
+	})
+
+	It("falls back to the media file's artist and title", func() {
+		d := LyricDtoFromLyrics(mf, model.Lyrics{Line: []model.Line{{Value: "x"}}})
+		Expect(d.Metadata.Artist).To(Equal("Artist"))
+		Expect(d.Metadata.Title).To(Equal("Song"))
+	})
+
+	It("drops start-less lines from synced lyrics", func() {
+		l := model.Lyrics{Synced: true, Line: []model.Line{
+			{Start: ms(0), Value: "kept"},
+			{Value: "dropped"},
+		}}
+		d := LyricDtoFromLyrics(mf, l)
+		Expect(d.Lyrics).To(HaveLen(1))
+		Expect(d.Lyrics[0].Text).To(Equal("kept"))
+	})
+
+	It("emits no Start on unsynced lyrics even when lines have one", func() {
+		l := model.Lyrics{Synced: false, Line: []model.Line{{Start: ms(1000), Value: "plain"}}}
+		d := LyricDtoFromLyrics(mf, l)
+		Expect(d.Lyrics).To(HaveLen(1))
+		Expect(d.Lyrics[0].Start).To(BeNil())
+		Expect(d.Metadata.IsSynced).To(BeFalse())
+	})
+
+	It("maps word cues", func() {
+		end := int64(1500)
+		l := model.Lyrics{Synced: true, Line: []model.Line{{
+			Start: ms(1000),
+			Value: "word cue",
+			Cue:   []model.Cue{{Start: ms(1000), End: &end, Value: "word", ByteStart: 0, ByteEnd: 4}},
+		}}}
+		d := LyricDtoFromLyrics(mf, l)
+		Expect(d.Lyrics[0].Cues).To(HaveLen(1))
+		c := d.Lyrics[0].Cues[0]
+		Expect(c.Position).To(Equal(0))
+		Expect(c.EndPosition).To(Equal(4))
+		Expect(c.Start).To(Equal(int64(10_000_000)))
+		Expect(*c.End).To(Equal(int64(15_000_000)))
+	})
+})

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -372,4 +372,21 @@ var _ = Describe("LyricDtoFromLyrics", func() {
 		Expect(c.Start).To(Equal(int64(10_000_000)))
 		Expect(*c.End).To(Equal(int64(15_000_000)))
 	})
+
+	It("skips a start-less cue while keeping its sibling", func() {
+		l := model.Lyrics{Synced: true, Line: []model.Line{{
+			Start: ms(1000),
+			Value: "word cue",
+			Cue: []model.Cue{
+				{Start: nil, Value: "dropped", ByteStart: 0, ByteEnd: 7},
+				{Start: ms(1000), Value: "kept", ByteStart: 8, ByteEnd: 12},
+			},
+		}}}
+		d := LyricDtoFromLyrics(mf, l)
+		Expect(d.Lyrics[0].Cues).To(HaveLen(1))
+		c := d.Lyrics[0].Cues[0]
+		Expect(c.Position).To(Equal(8))
+		Expect(c.EndPosition).To(Equal(12))
+		Expect(c.Start).To(Equal(int64(10_000_000)))
+	})
 })

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -149,6 +149,24 @@ var _ = Describe("mappers", func() {
 		Expect(j).To(ContainSubstring(`"SupportsExternalStream":false`))
 	})
 
+	Describe("Lyric media stream advertising", func() {
+		It("adds a Lyric media stream when the file has embedded lyrics", func() {
+			mf := model.MediaFile{ID: "s1", Lyrics: `[{"line":[{"value":"la"}]}]`}
+			src := MediaSourceFromMediaFile(mf)
+			Expect(src.MediaStreams).To(HaveLen(2))
+			Expect(src.MediaStreams[0].Type).To(Equal("Audio"))
+			Expect(src.MediaStreams[1].Type).To(Equal("Lyric"))
+			Expect(src.MediaStreams[1].Index).To(Equal(1))
+			Expect(src.MediaStreams[1].IsExternal).To(BeTrue())
+		})
+
+		It("emits only the Audio stream without lyrics", func() {
+			src := MediaSourceFromMediaFile(model.MediaFile{ID: "s1"})
+			Expect(src.MediaStreams).To(HaveLen(1))
+			Expect(src.MediaStreams[0].Type).To(Equal("Audio"))
+		})
+	})
+
 	It("omits IndexNumber and ParentIndexNumber when track/disc numbers are untagged", func() {
 		mf := model.MediaFile{
 			ID: "song-2", Title: "Song", Album: "Alb", AlbumID: "alb-1",

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -60,7 +60,7 @@ var _ = Describe("mappers", func() {
 		It("sets HasLyrics from the media file's lyrics", func() {
 			Expect(SongToBaseItem(mf, nil).HasLyrics).To(BeTrue())
 			Expect(SongToBaseItem(model.MediaFile{ID: "s2", Title: "No Lyrics"}, nil).HasLyrics).To(BeFalse())
-			// Post-scan the column is never "", but the JSON "no lyrics" sentinel "[]" — must not read as HasLyrics.
+			// "[]" is the no-lyrics sentinel, not a truthy value.
 			Expect(SongToBaseItem(model.MediaFile{ID: "s3", Title: "Empty Lyrics", Lyrics: "[]"}, nil).HasLyrics).To(BeFalse())
 		})
 	})

--- a/server/jellyfin/e2e/e2e_suite_test.go
+++ b/server/jellyfin/e2e/e2e_suite_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/core/auth"
 	"github.com/navidrome/navidrome/core/external"
-	lyricssvc "github.com/navidrome/navidrome/core/lyrics"
+	"github.com/navidrome/navidrome/core/lyrics"
 	"github.com/navidrome/navidrome/core/matcher"
 	"github.com/navidrome/navidrome/core/playlists"
 	"github.com/navidrome/navidrome/core/scrobbler"
@@ -328,7 +328,7 @@ func setupTestDB() {
 		playlists.NewPlaylists(ds, core.NewImageUploadService()),
 		providerFake,
 		sonicSvc,
-		lyricssvc.NewLyrics(ds, nil),
+		lyrics.NewLyrics(ds, nil),
 	)
 }
 

--- a/server/jellyfin/e2e/e2e_suite_test.go
+++ b/server/jellyfin/e2e/e2e_suite_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/navidrome/navidrome/core/artwork"
 	"github.com/navidrome/navidrome/core/auth"
 	"github.com/navidrome/navidrome/core/external"
+	lyricssvc "github.com/navidrome/navidrome/core/lyrics"
 	"github.com/navidrome/navidrome/core/matcher"
 	"github.com/navidrome/navidrome/core/playlists"
 	"github.com/navidrome/navidrome/core/scrobbler"
@@ -325,6 +326,7 @@ func setupTestDB() {
 		playlists.NewPlaylists(ds, core.NewImageUploadService()),
 		providerFake,
 		sonicSvc,
+		lyricssvc.NewLyrics(ds, nil),
 	)
 }
 

--- a/server/jellyfin/e2e/e2e_suite_test.go
+++ b/server/jellyfin/e2e/e2e_suite_test.go
@@ -120,9 +120,11 @@ func buildTestFS() storagetest.FakeFS {
 		"Rock/The Beatles/Abbey Road/01 - Something.mp3":     abbeyRoad(track(1, "Something")),
 		"Rock/The Beatles/Abbey Road/02 - Come Together.mp3": abbeyRoad(track(2, "Come Together")),
 		"Rock/The Beatles/Help!/01 - Help.mp3":               help(track(1, "Help!")),
-		"Rock/Led Zeppelin/IV/01 - Stairway To Heaven.mp3":   ledZepIV(track(1, "Stairway To Heaven")),
-		"Jazz/Miles Davis/Kind of Blue/01 - So What.mp3":     kindOfBlue(track(1, "So What")),
-		"Pop/Solo Artist/Singles/01 - Standalone Track.mp3":  singles(track(1, "Standalone Track")),
+		"Rock/Led Zeppelin/IV/01 - Stairway To Heaven.mp3": ledZepIV(track(1, "Stairway To Heaven", _t{
+			"lyrics:eng": "[00:01.00]There's a lady who's sure\n[00:05.50]All that glitters is gold",
+		})),
+		"Jazz/Miles Davis/Kind of Blue/01 - So What.mp3":    kindOfBlue(track(1, "So What")),
+		"Pop/Solo Artist/Singles/01 - Standalone Track.mp3": singles(track(1, "Standalone Track")),
 		// "Featured Guest" is the track artist here (album artist stays "Solo Artist"), so it's a
 		// performer but not an album artist — lets tests tell /Artists from /Artists/AlbumArtists.
 		"Pop/Solo Artist/Singles/02 - Duet.mp3": singles(track(2, "Duet", _t{"artist": "Featured Guest"})),

--- a/server/jellyfin/e2e/lyrics_test.go
+++ b/server/jellyfin/e2e/lyrics_test.go
@@ -1,0 +1,71 @@
+package e2e
+
+import (
+	"net/http"
+
+	"github.com/navidrome/navidrome/server/jellyfin/dto"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Lyrics", func() {
+	BeforeEach(func() { setupTestDB() })
+
+	Describe("PlaybackInfo", func() {
+		It("advertises a Lyric stream for a track with embedded lyrics", func() {
+			id := songID("Stairway To Heaven")
+			var info dto.PlaybackInfoResponse
+			parseInto(get("/Items/"+enc(id)+"/PlaybackInfo"), &info)
+			var found bool
+			for _, s := range info.MediaSources[0].MediaStreams {
+				if s.Type == "Lyric" {
+					found = true
+				}
+			}
+			Expect(found).To(BeTrue())
+		})
+
+		It("does not advertise a Lyric stream for a track without lyrics", func() {
+			id := songID("So What")
+			var info dto.PlaybackInfoResponse
+			parseInto(get("/Items/"+enc(id)+"/PlaybackInfo"), &info)
+			for _, s := range info.MediaSources[0].MediaStreams {
+				Expect(s.Type).ToNot(Equal("Lyric"))
+			}
+		})
+	})
+
+	Describe("GET /Audio/{id}/Lyrics", func() {
+		It("returns the LyricDto for a track with embedded synced lyrics", func() {
+			id := songID("Stairway To Heaven")
+			var lyrics dto.LyricDto
+			parseInto(get("/Audio/"+enc(id)+"/Lyrics"), &lyrics)
+			Expect(lyrics.Lyrics).To(HaveLen(2))
+			Expect(lyrics.Lyrics[0].Text).To(Equal("There's a lady who's sure"))
+			Expect(lyrics.Lyrics[0].Start).ToNot(BeNil())
+			Expect(*lyrics.Lyrics[0].Start).To(Equal(int64(10000000)))
+			Expect(lyrics.Metadata.IsSynced).To(BeTrue())
+		})
+
+		It("returns 404 for a track without lyrics", func() {
+			id := songID("So What")
+			Expect(get("/Audio/" + enc(id) + "/Lyrics").Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 404 for a fabricated id", func() {
+			Expect(get("/Audio/" + enc("nope") + "/Lyrics").Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
+	Describe("HasLyrics badge", func() {
+		It("is true for a track with embedded lyrics and omitted/false otherwise", func() {
+			var stairway dto.BaseItemDto
+			parseInto(get("/Items/"+enc(songID("Stairway To Heaven"))), &stairway)
+			Expect(stairway.HasLyrics).To(BeTrue())
+
+			var soWhat dto.BaseItemDto
+			parseInto(get("/Items/"+enc(songID("So What"))), &soWhat)
+			Expect(soWhat.HasLyrics).To(BeFalse())
+		})
+	})
+})

--- a/server/jellyfin/lyrics.go
+++ b/server/jellyfin/lyrics.go
@@ -1,0 +1,42 @@
+package jellyfin
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/server/jellyfin/dto"
+)
+
+// cachedLyrics resolves lyrics through the full source pipeline (embedded, sidecar, plugins),
+// caching results — including empty — so per-track fetches from clients that poll every song
+// don't re-run plugin lookups. core/lyrics degrades source errors to empty, which we accept
+// caching for the TTL.
+func (api *Router) cachedLyrics(ctx context.Context, mf *model.MediaFile) model.LyricList {
+	list, err := api.lyricsCache.GetWithLoader(mf.ID, func(string) (model.LyricList, time.Duration, error) {
+		l, err := api.lyrics.GetLyrics(ctx, mf)
+		return l, 0, err // 0 → cache DefaultTTL
+	})
+	if err != nil {
+		log.Error(ctx, "Error getting lyrics", "id", mf.ID, "title", mf.Title, err)
+		return nil
+	}
+	return list
+}
+
+// getLyrics serves GET /Audio/{itemId}/Lyrics. Jellyfin returns 404 when a track has no lyrics
+// (never an empty 200); all surveyed clients treat that gracefully.
+func (api *Router) getLyrics(w http.ResponseWriter, r *http.Request) {
+	mf, ok := api.mediaFileForRequest(w, r)
+	if !ok {
+		return
+	}
+	main, found := api.cachedLyrics(r.Context(), mf).Main()
+	if !found || main.IsEmpty() {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+	api.ok(w, r, dto.LyricDtoFromLyrics(*mf, main))
+}

--- a/server/jellyfin/lyrics.go
+++ b/server/jellyfin/lyrics.go
@@ -11,9 +11,7 @@ import (
 )
 
 // cachedLyrics resolves lyrics through the full source pipeline (embedded, sidecar, plugins),
-// caching results — including empty — so per-track fetches from clients that poll every song
-// don't re-run plugin lookups. core/lyrics degrades source errors to empty, which we accept
-// caching for the TTL.
+// caching results — including empty: clients poll per played track, so misses are the hot path.
 func (api *Router) cachedLyrics(ctx context.Context, mf *model.MediaFile) model.LyricList {
 	list, err := api.lyricsCache.GetWithLoader(mf.ID, func(string) (model.LyricList, time.Duration, error) {
 		l, err := api.lyrics.GetLyrics(ctx, mf)

--- a/server/jellyfin/lyrics.go
+++ b/server/jellyfin/lyrics.go
@@ -31,10 +31,17 @@ func (api *Router) getLyrics(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	main, found := api.cachedLyrics(r.Context(), mf).Main()
-	if !found || main.IsEmpty() {
+	main, found := servableLyric(api.cachedLyrics(r.Context(), mf))
+	if !found {
 		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}
 	api.ok(w, r, dto.LyricDtoFromLyrics(*mf, main))
+}
+
+// servableLyric is the single predicate for both serving and advertising, so PlaybackInfo never
+// advertises a Lyric stream that this endpoint would 404.
+func servableLyric(list model.LyricList) (model.Lyrics, bool) {
+	main, found := list.Main()
+	return main, found && !main.IsEmpty()
 }

--- a/server/jellyfin/lyrics_test.go
+++ b/server/jellyfin/lyrics_test.go
@@ -62,8 +62,10 @@ var _ = Describe("getLyrics", func() {
 	doRequest := func(id string) *httptest.ResponseRecorder {
 		w := httptest.NewRecorder()
 		ctx := request.WithUser(context.Background(), model.User{ID: "u1", Libraries: model.Libraries{{ID: 1}}})
-		r := httptest.NewRequest("GET", "/Audio/"+id+"/Lyrics", nil).WithContext(ctx)
-		r = withChiURLParam(r, "itemId", id)
+		// Clients send hex-encoded ids (matching real traffic and the other handler tests).
+		enc := dto.EncodeID(id)
+		r := httptest.NewRequest("GET", "/Audio/"+enc+"/Lyrics", nil).WithContext(ctx)
+		r = withChiURLParam(r, "itemId", enc)
 		invoke(api.getLyrics, w, r)
 		return w
 	}
@@ -99,6 +101,12 @@ var _ = Describe("getLyrics", func() {
 
 	It("returns 404 when the service returns no lyrics", func() {
 		w := doRequest("s2")
+		Expect(w.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("returns 404 when the main lyric has no lines", func() {
+		fake.lyrics["s1"] = model.LyricList{{Kind: "main", Lang: "eng"}}
+		w := doRequest("s1")
 		Expect(w.Code).To(Equal(http.StatusNotFound))
 	})
 

--- a/server/jellyfin/lyrics_test.go
+++ b/server/jellyfin/lyrics_test.go
@@ -36,6 +36,10 @@ func (f *fakeLyricsService) GetLyricsByArtistTitle(context.Context, string, stri
 
 func p(ms int64) *int64 { return &ms }
 
+func newTestLyricsCache() cache.SimpleCache[string, model.LyricList] {
+	return cache.NewSimpleCache[string, model.LyricList](cache.Options{SizeLimit: 1000})
+}
+
 var _ = Describe("getLyrics", func() {
 	var api *Router
 	var ds *tests.MockDataStore
@@ -49,12 +53,9 @@ var _ = Describe("getLyrics", func() {
 		})
 		fake = &fakeLyricsService{lyrics: map[string]model.LyricList{}}
 		api = &Router{
-			ds:     ds,
-			lyrics: fake,
-			lyricsCache: cache.NewSimpleCache[string, model.LyricList](cache.Options{
-				SizeLimit:  1000,
-				DefaultTTL: 0,
-			}),
+			ds:          ds,
+			lyrics:      fake,
+			lyricsCache: newTestLyricsCache(),
 		}
 	})
 

--- a/server/jellyfin/lyrics_test.go
+++ b/server/jellyfin/lyrics_test.go
@@ -1,0 +1,123 @@
+package jellyfin
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/server/jellyfin/dto"
+	"github.com/navidrome/navidrome/tests"
+	"github.com/navidrome/navidrome/utils/cache"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// fakeLyricsService returns canned lyrics per media-file ID and counts calls.
+type fakeLyricsService struct {
+	lyrics map[string]model.LyricList
+	err    error
+	calls  int
+}
+
+func (f *fakeLyricsService) GetLyrics(_ context.Context, mf *model.MediaFile) (model.LyricList, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return f.lyrics[mf.ID], nil
+}
+
+func (f *fakeLyricsService) GetLyricsByArtistTitle(context.Context, string, string) (model.LyricList, error) {
+	return nil, nil
+}
+
+func p(ms int64) *int64 { return &ms }
+
+var _ = Describe("getLyrics", func() {
+	var api *Router
+	var ds *tests.MockDataStore
+	var fake *fakeLyricsService
+
+	BeforeEach(func() {
+		ds = &tests.MockDataStore{}
+		ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
+			{ID: "s1", Title: "Song", LibraryID: 1},
+			{ID: "s2", Title: "Silent Song", LibraryID: 1},
+		})
+		fake = &fakeLyricsService{lyrics: map[string]model.LyricList{}}
+		api = &Router{
+			ds:     ds,
+			lyrics: fake,
+			lyricsCache: cache.NewSimpleCache[string, model.LyricList](cache.Options{
+				SizeLimit:  1000,
+				DefaultTTL: 0,
+			}),
+		}
+	})
+
+	doRequest := func(id string) *httptest.ResponseRecorder {
+		w := httptest.NewRecorder()
+		ctx := request.WithUser(context.Background(), model.User{ID: "u1", Libraries: model.Libraries{{ID: 1}}})
+		r := httptest.NewRequest("GET", "/Audio/"+id+"/Lyrics", nil).WithContext(ctx)
+		r = withChiURLParam(r, "itemId", id)
+		invoke(api.getLyrics, w, r)
+		return w
+	}
+
+	It("returns 200 with a LyricDto for a track with synced lyrics", func() {
+		fake.lyrics["s1"] = model.LyricList{
+			{Kind: "main", Synced: true, Line: []model.Line{{Start: p(1000), Value: "hello"}}},
+		}
+		w := doRequest("s1")
+
+		Expect(w.Code).To(Equal(http.StatusOK))
+		var res dto.LyricDto
+		Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+		Expect(res.Lyrics).To(HaveLen(1))
+		Expect(res.Lyrics[0].Text).To(Equal("hello"))
+		Expect(res.Lyrics[0].Start).ToNot(BeNil())
+		Expect(*res.Lyrics[0].Start).To(Equal(int64(10000000)))
+	})
+
+	It("serves the main-kind lyric when a translation is also present", func() {
+		fake.lyrics["s1"] = model.LyricList{
+			{Kind: "translation", Synced: true, Line: []model.Line{{Start: p(1000), Value: "bonjour"}}},
+			{Kind: "main", Synced: true, Line: []model.Line{{Start: p(1000), Value: "hello"}}},
+		}
+		w := doRequest("s1")
+
+		Expect(w.Code).To(Equal(http.StatusOK))
+		var res dto.LyricDto
+		Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+		Expect(res.Lyrics).To(HaveLen(1))
+		Expect(res.Lyrics[0].Text).To(Equal("hello"))
+	})
+
+	It("returns 404 when the service returns no lyrics", func() {
+		w := doRequest("s2")
+		Expect(w.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("returns 404 for an unknown item id", func() {
+		w := doRequest("unknown")
+		Expect(w.Code).To(Equal(http.StatusNotFound))
+	})
+
+	It("caches results so a second request doesn't re-invoke the service", func() {
+		fake.lyrics["s1"] = model.LyricList{
+			{Kind: "main", Synced: true, Line: []model.Line{{Start: p(1000), Value: "hello"}}},
+		}
+		Expect(doRequest("s1").Code).To(Equal(http.StatusOK))
+		Expect(doRequest("s1").Code).To(Equal(http.StatusOK))
+		Expect(fake.calls).To(Equal(1))
+	})
+
+	It("caches empty results too", func() {
+		Expect(doRequest("s2").Code).To(Equal(http.StatusNotFound))
+		Expect(doRequest("s2").Code).To(Equal(http.StatusNotFound))
+		Expect(fake.calls).To(Equal(1))
+	})
+})

--- a/server/jellyfin/routing_test.go
+++ b/server/jellyfin/routing_test.go
@@ -19,7 +19,7 @@ var _ = Describe("Case-insensitive routing", func() {
 	var api *Router
 
 	BeforeEach(func() {
-		api = New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil)
+		api = New(&tests.MockDataStore{}, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 	})
 
 	It("serves a fully lowercase path directly", func() {

--- a/server/jellyfin/sessions.go
+++ b/server/jellyfin/sessions.go
@@ -49,7 +49,7 @@ func (api *Router) reportPlaybackStart(w http.ResponseWriter, r *http.Request) {
 	clientId, clientName := clientIdentity(ctx)
 	err := api.scrobbler.ReportPlayback(ctx, scrobbler.ReportPlaybackParams{
 		MediaId:      body.ItemId,
-		PositionMs:   body.PositionTicks / 10_000,
+		PositionMs:   dto.MillisFromTicks(body.PositionTicks),
 		State:        scrobbler.StatePlaying,
 		PlaybackRate: 1.0,
 		ClientId:     clientId,
@@ -73,7 +73,7 @@ func (api *Router) reportPlaybackProgress(w http.ResponseWriter, r *http.Request
 	clientId, clientName := clientIdentity(ctx)
 	err := api.scrobbler.ReportPlayback(ctx, scrobbler.ReportPlaybackParams{
 		MediaId:      body.ItemId,
-		PositionMs:   body.PositionTicks / 10_000,
+		PositionMs:   dto.MillisFromTicks(body.PositionTicks),
 		State:        state,
 		PlaybackRate: 1.0,
 		ClientId:     clientId,
@@ -97,7 +97,7 @@ func (api *Router) reportPlaybackStopped(w http.ResponseWriter, r *http.Request)
 
 	err := api.scrobbler.ReportPlayback(ctx, scrobbler.ReportPlaybackParams{
 		MediaId:    body.ItemId,
-		PositionMs: body.PositionTicks / 10_000,
+		PositionMs: dto.MillisFromTicks(body.PositionTicks),
 		State:      scrobbler.StateStopped,
 		ClientId:   clientId,
 		ClientName: clientName,

--- a/server/jellyfin/socket_test.go
+++ b/server/jellyfin/socket_test.go
@@ -94,7 +94,7 @@ var _ = Describe("handleSocket", func() {
 			Expect(err).ToNot(HaveOccurred())
 			token = t
 
-			api = New(ds, nil, nil, nil, nil, nil, nil, nil, nil)
+			api = New(ds, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		})
 
 		It("upgrades when authenticated via the api_key query parameter", func() {

--- a/server/jellyfin/stream.go
+++ b/server/jellyfin/stream.go
@@ -48,7 +48,7 @@ func (api *Router) getPlaybackInfo(w http.ResponseWriter, r *http.Request) {
 	// The mapper only sees embedded lyrics; per-track we can afford the full pipeline
 	// (sidecars, plugins) so Finamp's Lyric-stream gate reflects every source.
 	if !slices.ContainsFunc(src.MediaStreams, func(s dto.MediaStream) bool { return s.Type == "Lyric" }) {
-		if list := api.cachedLyrics(r.Context(), mf); len(list) > 0 {
+		if _, found := servableLyric(api.cachedLyrics(r.Context(), mf)); found {
 			src.MediaStreams = append(src.MediaStreams, dto.MediaStream{
 				Type: "Lyric", Index: len(src.MediaStreams), IsExternal: true,
 			})

--- a/server/jellyfin/stream.go
+++ b/server/jellyfin/stream.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -44,6 +45,15 @@ func (api *Router) getPlaybackInfo(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	src := dto.MediaSourceFromMediaFile(*mf)
+	// The mapper only sees embedded lyrics; per-track we can afford the full pipeline
+	// (sidecars, plugins) so Finamp's Lyric-stream gate reflects every source.
+	if !slices.ContainsFunc(src.MediaStreams, func(s dto.MediaStream) bool { return s.Type == "Lyric" }) {
+		if list := api.cachedLyrics(r.Context(), mf); len(list) > 0 {
+			src.MediaStreams = append(src.MediaStreams, dto.MediaStream{
+				Type: "Lyric", Index: len(src.MediaStreams), IsExternal: true,
+			})
+		}
+	}
 	// Embed the caller's token in the stream URL: Jellify's native player fetches TranscodingUrl
 	// verbatim without an auth header, so a non-self-authenticating URL would 401. Direct-play clients
 	// (Finamp) build their own /File?ApiKey URL and ignore this. Include the /jellyfin mount prefix so

--- a/server/jellyfin/stream_test.go
+++ b/server/jellyfin/stream_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
 	"github.com/navidrome/navidrome/tests"
+	"github.com/navidrome/navidrome/utils/cache"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -33,7 +34,11 @@ var _ = Describe("Stream", func() {
 		ds = &tests.MockDataStore{}
 		streamer = &fakeMediaStreamer{}
 		decider = &fakeTranscodeDecider{}
-		api = &Router{ds: ds, streamer: streamer, transcodeDecider: decider}
+		api = &Router{
+			ds: ds, streamer: streamer, transcodeDecider: decider,
+			lyrics:      &fakeLyricsService{lyrics: map[string]model.LyricList{}},
+			lyricsCache: cache.NewSimpleCache[string, model.LyricList](cache.Options{SizeLimit: 1000}),
+		}
 	})
 
 	Describe("getPlaybackInfo", func() {
@@ -75,6 +80,56 @@ var _ = Describe("Stream", func() {
 			api.getPlaybackInfo(w, r)
 
 			Expect(w.Code).To(Equal(http.StatusNotFound))
+		})
+
+		playbackInfo := func() dto.PlaybackInfoResponse {
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("POST", "/Items/"+dto.EncodeID("s1")+"/PlaybackInfo", nil).WithContext(ctxUser())
+			r = withChiURLParam(r, "itemId", dto.EncodeID("s1"))
+			api.getPlaybackInfo(w, r)
+			var res dto.PlaybackInfoResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			return res
+		}
+
+		lyricStreams := func(res dto.PlaybackInfoResponse) []dto.MediaStream {
+			var out []dto.MediaStream
+			for _, s := range res.MediaSources[0].MediaStreams {
+				if s.Type == "Lyric" {
+					out = append(out, s)
+				}
+			}
+			return out
+		}
+
+		It("advertises a Lyric stream for plugin/sidecar-sourced lyrics not embedded in the file", func() {
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
+				{ID: "s1", Title: "Song", Suffix: "mp3", LibraryID: 1},
+			})
+			api.lyrics = &fakeLyricsService{lyrics: map[string]model.LyricList{
+				"s1": {{Kind: "main", Synced: true, Line: []model.Line{{Value: "hello"}}}},
+			}}
+
+			Expect(lyricStreams(playbackInfo())).To(HaveLen(1))
+		})
+
+		It("advertises no Lyric stream when the pipeline finds nothing", func() {
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
+				{ID: "s1", Title: "Song", Suffix: "mp3", LibraryID: 1},
+			})
+
+			Expect(lyricStreams(playbackInfo())).To(BeEmpty())
+		})
+
+		It("doesn't duplicate the Lyric stream when lyrics are already embedded", func() {
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
+				{ID: "s1", Title: "Song", Suffix: "mp3", LibraryID: 1, Lyrics: `[{"lang":"xxx","line":[]}]`},
+			})
+			api.lyrics = &fakeLyricsService{lyrics: map[string]model.LyricList{
+				"s1": {{Kind: "main", Synced: true, Line: []model.Line{{Value: "hello"}}}},
+			}}
+
+			Expect(lyricStreams(playbackInfo())).To(HaveLen(1))
 		})
 	})
 

--- a/server/jellyfin/stream_test.go
+++ b/server/jellyfin/stream_test.go
@@ -120,6 +120,17 @@ var _ = Describe("Stream", func() {
 			Expect(lyricStreams(playbackInfo())).To(BeEmpty())
 		})
 
+		It("advertises no Lyric stream when the lyrics endpoint would 404 (main lyric has no lines)", func() {
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
+				{ID: "s1", Title: "Song", Suffix: "mp3", LibraryID: 1},
+			})
+			api.lyrics = &fakeLyricsService{lyrics: map[string]model.LyricList{
+				"s1": {{Kind: "main", Lang: "eng"}},
+			}}
+
+			Expect(lyricStreams(playbackInfo())).To(BeEmpty())
+		})
+
 		It("doesn't duplicate the Lyric stream when lyrics are already embedded", func() {
 			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
 				{ID: "s1", Title: "Song", Suffix: "mp3", LibraryID: 1, Lyrics: `[{"lang":"xxx","line":[]}]`},

--- a/server/jellyfin/stream_test.go
+++ b/server/jellyfin/stream_test.go
@@ -131,6 +131,27 @@ var _ = Describe("Stream", func() {
 
 			Expect(lyricStreams(playbackInfo())).To(HaveLen(1))
 		})
+
+		It("still returns 200 with a valid MediaSource and no Lyric stream when the lyrics pipeline errors", func() {
+			// Own ID: an erroring loader isn't cached, but a shared ID could still pick up
+			// another test's cached (non-error) result and mask this assertion.
+			ds.MediaFile(context.Background()).(*tests.MockMediaFileRepo).SetData(model.MediaFiles{
+				{ID: "s-err", Title: "Song", Suffix: "mp3", Duration: 100, Size: 1000, LibraryID: 1},
+			})
+			api.lyrics = &fakeLyricsService{err: errors.New("boom")}
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("POST", "/Items/"+dto.EncodeID("s-err")+"/PlaybackInfo", nil).WithContext(ctxUser())
+			r = withChiURLParam(r, "itemId", dto.EncodeID("s-err"))
+			api.getPlaybackInfo(w, r)
+
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.PlaybackInfoResponse
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.MediaSources).To(HaveLen(1))
+			Expect(res.MediaSources[0].Id).To(Equal(dto.EncodeID("s-err")))
+			Expect(lyricStreams(res)).To(BeEmpty())
+		})
 	})
 
 	Describe("streamAudio", func() {

--- a/server/jellyfin/stream_test.go
+++ b/server/jellyfin/stream_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
 	"github.com/navidrome/navidrome/tests"
-	"github.com/navidrome/navidrome/utils/cache"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -37,7 +36,7 @@ var _ = Describe("Stream", func() {
 		api = &Router{
 			ds: ds, streamer: streamer, transcodeDecider: decider,
 			lyrics:      &fakeLyricsService{lyrics: map[string]model.LyricList{}},
-			lyricsCache: cache.NewSimpleCache[string, model.LyricList](cache.Options{SizeLimit: 1000}),
+			lyricsCache: newTestLyricsCache(),
 		}
 	})
 

--- a/server/jellyfin/system.go
+++ b/server/jellyfin/system.go
@@ -17,8 +17,9 @@ import (
 )
 
 // jellyfinVersion is the Jellyfin API version advertised in the handshake. Clients feature-gate
-// on it, so it must stay a real Jellyfin release, not Navidrome's own version.
-const jellyfinVersion = "10.8.13"
+// on it, so it must stay a real Jellyfin release, not Navidrome's own version. 10.9+ is required
+// for Feishin to use the server lyrics endpoint.
+const jellyfinVersion = "10.9.11"
 
 func (api *Router) serverName() string {
 	if conf.Server.Jellyfin.ServerName != "" {


### PR DESCRIPTION
### Description

Implements lyrics support in the experimental Jellyfin-compatible API. Until now the API advertised `HasLyrics` on songs but had no lyrics endpoint, so no Jellyfin client could display lyrics.

**What this adds:**

- **`GET /Audio/{itemId}/Lyrics`** — serves the main lyric track as a Jellyfin `LyricDto` (`Lyrics[].Text` + `Start` in 100ns ticks, word-level `Cues` when present). Lyrics are resolved through the full `core/lyrics` pipeline (embedded tags, `.lrc` sidecars, lyrics plugins, per `LyricsPriority`) — same sources as the OpenSubsonic `getLyricsBySongId` endpoint. No lyrics → 404 (matching real Jellyfin, which never returns an empty 200).
- **`Lyric` MediaStream advertising** — Finamp gates its lyrics view on a `MediaStream` of type `Lyric` in the PlaybackInfo response, not on `HasLyrics` (which it only uses as a list badge). Browse lists advertise the stream cheaply from embedded lyrics; `PlaybackInfo` runs the full pipeline for the one requested track, so sidecar- and plugin-sourced lyrics light up too.
- **TTL cache (5 min)** in front of the pipeline, caching misses as well: Jellify fetches lyrics for *every* played track and Feishin refetches per song change, so lyric-less tracks are the hot path and must not re-invoke lyrics plugins per request.
- **Advertised server version bumped `10.8.13` → `10.9.11`** — Feishin feature-gates its Jellyfin lyrics support on server ≥ 10.9. An audit of all three clients' version gates confirmed the bump changes nothing else: Finamp and Jellify use the version string for display only, and Feishin's other 10.9 gate (`IsPublic` on playlist bodies) is already handled by our playlist endpoints.
- **Bug fix the new e2e coverage exposed:** the pre-existing `HasLyrics: mf.Lyrics != ""` check was always true post-scan, because the persistence layer normalizes no-lyrics to the `"[]"` JSON sentinel — every track advertised lyrics. Now checked via a new `model.MediaFile.HasEmbeddedLyrics()` helper.

**Client behavior verified against source** (Finamp redesign, Jellify, Feishin):

| Client | Lyrics trigger | 404 handling |
|---|---|---|
| Finamp | `Lyric` MediaStream in PlaybackInfo | graceful empty state |
| Jellify | unconditional per played track | swallowed, no retry |
| Feishin | server ≥ 10.9 + lyrics panel open | falls back to internet providers |

### Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Enable the Jellyfin API (`Jellyfin.Enabled = true`) and start the server with a library containing a track with embedded lyrics (synced or unsynced).
2. Authenticate and fetch `GET /jellyfin/Audio/{itemId}/Lyrics` — expect a `LyricDto` with `Metadata.IsSynced` and `Lyrics[].Start` in ticks (ms × 10,000); for a track without lyrics expect 404.
3. `POST /jellyfin/Items/{itemId}/PlaybackInfo` — expect `MediaSources[0].MediaStreams` to contain a `{"Type": "Lyric"}` entry for the lyric track, absent otherwise.
4. Client check: connect Finamp (beta/redesign) — tracks with lyrics show the lyrics view during playback. Feishin now uses server lyrics (its lyrics panel shows the local source) instead of falling back to lrclib/genius.
5. Sidecar/plugin check: a track with only a `.lrc` sidecar (no embedded tag) shows no lyrics badge in lists, but PlaybackInfo advertises the stream and the endpoint serves it.

Automated coverage: mapper unit tests (tick math, synced/unsynced invariant, cue mapping), handler tests (main-track selection, 404s, cache single-invocation incl. cached misses, pipeline-error resilience), and e2e tests against a real scanned LRC tag.

### Additional Notes

- The `EnableLyricManagement` policy flag remains `false`; the upload/delete/remote-search lyrics endpoints are intentionally not implemented.
- `core/lyrics` is untouched — Subsonic behavior is unchanged.
- Known follow-ups (documented in `server/jellyfin/README.md`): the lyrics cache loader is not singleflighted (concurrent misses can double-invoke the plugin pipeline; fix belongs in `utils/cache.SimpleCache` as a separate change), and sidecar/plugin-only tracks show no `HasLyrics` badge in lists (request-time sources can't be known at list time without per-row I/O).
