### PR TITLE
fix: dedupe and cap concurrent lyrics plugin fetches

### DIFF
--- a/plugins/lyrics_adapter.go
+++ b/plugins/lyrics_adapter.go
@@ -14,6 +14,10 @@ const (
 	FuncLyricsGetLyrics = "nd_lyrics_get_lyrics"
 )
 
+// maxConcurrentLyricsCalls caps in-flight lyrics calls per plugin: clients prefetch
+// lyrics for whole queues, and the resulting burst can rate-limit upstream providers.
+const maxConcurrentLyricsCalls = 2
+
 func init() {
 	registerCapability(
 		CapabilityLyrics,
@@ -34,12 +38,18 @@ type LyricsPlugin struct {
 // GetLyrics calls the plugin to fetch lyrics, then content-sniffs each response
 // via model.ParseLyrics (TTML/SRT/YAML/LRC/plain).
 func (l *LyricsPlugin) GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error) {
+	select {
+	case l.plugin.lyricsSem <- struct{}{}:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 	req := capabilities.GetLyricsRequest{
 		Track: mediaFileToTrackInfo(l.plugin, mf),
 	}
 	resp, err := callPluginFunction[capabilities.GetLyricsRequest, capabilities.GetLyricsResponse](
 		ctx, l.plugin, FuncLyricsGetLyrics, req,
 	)
+	<-l.plugin.lyricsSem
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/lyrics_adapter.go
+++ b/plugins/lyrics_adapter.go
@@ -40,6 +40,7 @@ type LyricsPlugin struct {
 func (l *LyricsPlugin) GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error) {
 	select {
 	case l.plugin.lyricsSem <- struct{}{}:
+		defer func() { <-l.plugin.lyricsSem }()
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}
@@ -49,7 +50,6 @@ func (l *LyricsPlugin) GetLyrics(ctx context.Context, mf *model.MediaFile) (mode
 	resp, err := callPluginFunction[capabilities.GetLyricsRequest, capabilities.GetLyricsResponse](
 		ctx, l.plugin, FuncLyricsGetLyrics, req,
 	)
-	<-l.plugin.lyricsSem
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/lyrics_adapter_test.go
+++ b/plugins/lyrics_adapter_test.go
@@ -3,6 +3,8 @@
 package plugins
 
 import (
+	"context"
+
 	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -69,6 +71,45 @@ var _ = Describe("LyricsPlugin", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(HaveLen(1))
 			Expect(result[0].Lang).To(Equal("xxx"))
+		})
+
+		It("blocks new calls while the per-plugin concurrency cap is saturated", func() {
+			sem := provider.plugin.lyricsSem
+			for range cap(sem) {
+				sem <- struct{}{}
+			}
+
+			ctx := GinkgoT().Context()
+			track := &model.MediaFile{ID: "track-1", Title: "Test Song", Artist: "Test Artist"}
+			done := make(chan error, 1)
+			go func() {
+				_, err := provider.GetLyrics(ctx, track)
+				done <- err
+			}()
+
+			Consistently(done, "500ms").ShouldNot(Receive())
+			<-sem // free one slot; the pending call should now proceed
+			Eventually(done).Should(Receive(BeNil()))
+			for range cap(sem) - 1 {
+				<-sem
+			}
+		})
+
+		It("gives up waiting for a slot when the context is cancelled", func() {
+			sem := provider.plugin.lyricsSem
+			for range cap(sem) {
+				sem <- struct{}{}
+			}
+			defer func() {
+				for range cap(sem) {
+					<-sem
+				}
+			}()
+
+			ctx, cancel := context.WithCancel(GinkgoT().Context())
+			cancel()
+			_, err := provider.GetLyrics(ctx, &model.MediaFile{ID: "track-1"})
+			Expect(err).To(MatchError(context.Canceled))
 		})
 
 		It("returns error when plugin returns error", func() {

--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -421,6 +421,7 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 		allowedUserIDs: allowedUsers,
 		allUsers:       p.AllUsers,
 		libraries:      newLibraryAccess(allowedLibraries, p.AllLibraries),
+		lyricsSem:      make(chan struct{}, maxConcurrentLyricsCalls),
 	}
 	m.mu.Unlock()
 	loaded = true

--- a/plugins/manager_plugin.go
+++ b/plugins/manager_plugin.go
@@ -24,6 +24,7 @@ type plugin struct {
 	allowedUserIDs []string // User IDs this plugin can access (from DB configuration)
 	allUsers       bool     // If true, plugin can access all users
 	libraries      libraryAccess
+	lyricsSem      chan struct{} // Caps concurrent lyrics calls (see LyricsPlugin.GetLyrics)
 }
 
 // instance creates a new plugin instance for the given context.

--- a/server/jellyfin/lyrics.go
+++ b/server/jellyfin/lyrics.go
@@ -13,8 +13,11 @@ import (
 // cachedLyrics resolves lyrics through the full source pipeline (embedded, sidecar, plugins),
 // caching results — including empty: clients poll per played track, so misses are the hot path.
 func (api *Router) cachedLyrics(ctx context.Context, mf *model.MediaFile) model.LyricList {
+	// The load is shared across requests (singleflight) and cached, so don't let one
+	// cancelled request abort it for everybody — detach it from the request's lifetime.
+	loadCtx := context.WithoutCancel(ctx)
 	list, err := api.lyricsCache.GetWithLoader(mf.ID, func(string) (model.LyricList, time.Duration, error) {
-		l, err := api.lyrics.GetLyrics(ctx, mf)
+		l, err := api.lyrics.GetLyrics(loadCtx, mf)
 		return l, 0, err // 0 → cache DefaultTTL
 	})
 	if err != nil {

--- a/server/jellyfin/lyrics.go
+++ b/server/jellyfin/lyrics.go
@@ -10,12 +10,16 @@ import (
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
 )
 
+const lyricsLoadTimeout = time.Minute
+
 // cachedLyrics resolves lyrics through the full source pipeline (embedded, sidecar, plugins),
 // caching results — including empty: clients poll per played track, so misses are the hot path.
 func (api *Router) cachedLyrics(ctx context.Context, mf *model.MediaFile) model.LyricList {
 	// The load is shared across requests (singleflight) and cached, so don't let one
-	// cancelled request abort it for everybody — detach it from the request's lifetime.
-	loadCtx := context.WithoutCancel(ctx)
+	// cancelled request abort it for everybody — detach it from the request's lifetime,
+	// keeping a bound so a hung plugin can't pin the fetch (and its plugin slot) forever.
+	loadCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), lyricsLoadTimeout)
+	defer cancel()
 	list, err := api.lyricsCache.GetWithLoader(mf.ID, func(string) (model.LyricList, time.Duration, error) {
 		l, err := api.lyrics.GetLyrics(loadCtx, mf)
 		return l, 0, err // 0 → cache DefaultTTL

--- a/server/jellyfin/lyrics_test.go
+++ b/server/jellyfin/lyrics_test.go
@@ -22,8 +22,11 @@ type fakeLyricsService struct {
 	calls  int
 }
 
-func (f *fakeLyricsService) GetLyrics(_ context.Context, mf *model.MediaFile) (model.LyricList, error) {
+func (f *fakeLyricsService) GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error) {
 	f.calls++
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	if f.err != nil {
 		return nil, f.err
 	}
@@ -127,6 +130,19 @@ var _ = Describe("getLyrics", func() {
 	It("caches empty results too", func() {
 		Expect(doRequest("s2").Code).To(Equal(http.StatusNotFound))
 		Expect(doRequest("s2").Code).To(Equal(http.StatusNotFound))
+		Expect(fake.calls).To(Equal(1))
+	})
+
+	It("completes and caches the fetch even when the request context is cancelled", func() {
+		fake.lyrics["s1"] = model.LyricList{
+			{Kind: "main", Synced: true, Line: []model.Line{{Start: p(1000), Value: "hello"}}},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		list := api.cachedLyrics(ctx, &model.MediaFile{ID: "s1"})
+		Expect(list).ToNot(BeEmpty())
+		Expect(doRequest("s1").Code).To(Equal(http.StatusOK))
 		Expect(fake.calls).To(Equal(1))
 	})
 })

--- a/server/jellyfin/lyrics_test.go
+++ b/server/jellyfin/lyrics_test.go
@@ -17,13 +17,15 @@ import (
 
 // fakeLyricsService returns canned lyrics per media-file ID and counts calls.
 type fakeLyricsService struct {
-	lyrics map[string]model.LyricList
-	err    error
-	calls  int
+	lyrics      map[string]model.LyricList
+	err         error
+	calls       int
+	hadDeadline bool
 }
 
 func (f *fakeLyricsService) GetLyrics(ctx context.Context, mf *model.MediaFile) (model.LyricList, error) {
 	f.calls++
+	_, f.hadDeadline = ctx.Deadline()
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -144,5 +146,10 @@ var _ = Describe("getLyrics", func() {
 		Expect(list).ToNot(BeEmpty())
 		Expect(doRequest("s1").Code).To(Equal(http.StatusOK))
 		Expect(fake.calls).To(Equal(1))
+	})
+
+	It("bounds the detached fetch with a timeout", func() {
+		Expect(doRequest("s2").Code).To(Equal(http.StatusNotFound))
+		Expect(fake.hadDeadline).To(BeTrue())
 	})
 })

--- a/utils/cache/simple_cache.go
+++ b/utils/cache/simple_cache.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
+	"golang.org/x/sync/singleflight"
 )
 
 type SimpleCache[K comparable, V any] interface {
@@ -61,6 +62,7 @@ const evictionTimeout = 1 * time.Hour
 type simpleCache[K comparable, V any] struct {
 	data             *ttlcache.Cache[K, V]
 	evictionDeadline atomic.Pointer[time.Time]
+	loadGroup        singleflight.Group
 }
 
 func (c *simpleCache[K, V]) Add(key K, value V) error {
@@ -90,29 +92,29 @@ func (c *simpleCache[K, V]) Get(key K) (V, error) {
 	return item.Value(), nil
 }
 
+// GetWithLoader loads misses via the loader, deduplicating concurrent loads of
+// the same key: one loader call runs, and every waiter shares its result (or error).
 func (c *simpleCache[K, V]) GetWithLoader(key K, loader func(key K) (V, time.Duration, error)) (V, error) {
-	var err error
-	loaderWrapper := ttlcache.LoaderFunc[K, V](
-		func(t *ttlcache.Cache[K, V], key K) *ttlcache.Item[K, V] {
-			c.evictExpired()
-			var value V
-			var ttl time.Duration
-			value, ttl, err = loader(key)
-			if err != nil {
-				return nil
-			}
-			return t.Set(key, value, ttl)
-		},
-	)
-	item := c.data.Get(key, ttlcache.WithLoader[K, V](loaderWrapper))
-	if item == nil {
-		var zero V
-		if err != nil {
-			return zero, fmt.Errorf("cache error: loader returned %w", err)
-		}
-		return zero, errors.New("item not found")
+	if item := c.data.Get(key); item != nil {
+		return item.Value(), nil
 	}
-	return item.Value(), nil
+	v, err, _ := c.loadGroup.Do(fmt.Sprintf("%v", key), func() (any, error) {
+		if item := c.data.Get(key); item != nil {
+			return item.Value(), nil
+		}
+		c.evictExpired()
+		value, ttl, err := loader(key)
+		if err != nil {
+			return nil, err
+		}
+		c.data.Set(key, value, ttl)
+		return value, nil
+	})
+	if err != nil {
+		var zero V
+		return zero, fmt.Errorf("cache error: loader returned %w", err)
+	}
+	return v.(V), nil
 }
 
 func (c *simpleCache[K, V]) evictExpired() {

--- a/utils/cache/simple_cache.go
+++ b/utils/cache/simple_cache.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/jellydator/ttlcache/v3"
-	"golang.org/x/sync/singleflight"
 )
 
 type SimpleCache[K comparable, V any] interface {
@@ -45,7 +45,8 @@ func NewSimpleCache[K comparable, V any](options ...Options) SimpleCache[K, V] {
 
 	c := ttlcache.New[K, V](opts...)
 	cache := &simpleCache[K, V]{
-		data: c,
+		data:  c,
+		loads: make(map[K]*flight[V]),
 	}
 	go cache.data.Start()
 
@@ -62,7 +63,23 @@ const evictionTimeout = 1 * time.Hour
 type simpleCache[K comparable, V any] struct {
 	data             *ttlcache.Cache[K, V]
 	evictionDeadline atomic.Pointer[time.Time]
-	loadGroup        singleflight.Group
+	loadsMu          sync.Mutex
+	loads            map[K]*flight[V]
+}
+
+// flight tracks an in-progress load so concurrent misses of the same key share it.
+type flight[V any] struct {
+	done chan struct{}
+	val  V
+	err  error
+}
+
+func (f *flight[V]) result() (V, error) {
+	if f.err != nil {
+		var zero V
+		return zero, fmt.Errorf("cache error: loader returned %w", f.err)
+	}
+	return f.val, nil
 }
 
 func (c *simpleCache[K, V]) Add(key K, value V) error {
@@ -98,24 +115,40 @@ func (c *simpleCache[K, V]) GetWithLoader(key K, loader func(key K) (V, time.Dur
 	if item := c.data.Get(key); item != nil {
 		return item.Value(), nil
 	}
-	v, err, _ := c.loadGroup.Do(fmt.Sprintf("%v", key), func() (any, error) {
-		if item := c.data.Get(key); item != nil {
-			return item.Value(), nil
-		}
-		c.evictExpired()
-		value, ttl, err := loader(key)
-		if err != nil {
-			return nil, err
-		}
-		c.data.Set(key, value, ttl)
-		return value, nil
-	})
-	if err != nil {
-		var zero V
-		return zero, fmt.Errorf("cache error: loader returned %w", err)
+
+	c.loadsMu.Lock()
+	if f, ok := c.loads[key]; ok {
+		c.loadsMu.Unlock()
+		<-f.done
+		return f.result()
 	}
-	return v.(V), nil
+	f := &flight[V]{done: make(chan struct{}), err: errLoaderPanicked}
+	c.loads[key] = f
+	c.loadsMu.Unlock()
+
+	// Deregister even if the loader panics, so waiters get an error instead of
+	// blocking forever on a flight that will never complete.
+	defer func() {
+		close(f.done)
+		c.loadsMu.Lock()
+		delete(c.loads, key)
+		c.loadsMu.Unlock()
+	}()
+
+	if item := c.data.Get(key); item != nil { // a flight may have completed since the miss
+		f.val, f.err = item.Value(), nil
+	} else {
+		c.evictExpired()
+		var ttl time.Duration
+		f.val, ttl, f.err = loader(key)
+		if f.err == nil {
+			c.data.Set(key, f.val, ttl)
+		}
+	}
+	return f.result()
 }
+
+var errLoaderPanicked = errors.New("loader panicked")
 
 func (c *simpleCache[K, V]) evictExpired() {
 	if c.evictionDeadline.Load() == nil || c.evictionDeadline.Load().Before(time.Now()) {

--- a/utils/cache/simple_cache_test.go
+++ b/utils/cache/simple_cache_test.go
@@ -3,6 +3,8 @@ package cache
 import (
 	"errors"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -68,6 +70,92 @@ var _ = Describe("SimpleCache", func() {
 
 			_, err := cache.GetWithLoader("key", loader)
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("suppresses concurrent loads for the same key", func() {
+			var calls atomic.Int32
+			release := make(chan struct{})
+			started := make(chan struct{}, 10)
+			loader := func(key string) (string, time.Duration, error) {
+				calls.Add(1)
+				started <- struct{}{}
+				<-release
+				return "shared", time.Minute, nil
+			}
+
+			const n = 5
+			var wg sync.WaitGroup
+			results := make([]string, n)
+			errs := make([]error, n)
+			for i := range n {
+				wg.Go(func() {
+					results[i], errs[i] = cache.GetWithLoader("key", loader)
+				})
+			}
+
+			Eventually(started).Should(Receive())
+			Consistently(started).ShouldNot(Receive())
+			close(release)
+			wg.Wait()
+
+			Expect(calls.Load()).To(Equal(int32(1)))
+			for i := range n {
+				Expect(errs[i]).ToNot(HaveOccurred())
+				Expect(results[i]).To(Equal("shared"))
+			}
+		})
+
+		It("returns the loader error to all concurrent callers", func() {
+			release := make(chan struct{})
+			started := make(chan struct{}, 10)
+			loader := func(key string) (string, time.Duration, error) {
+				started <- struct{}{}
+				<-release
+				return "", 0, errors.New("load failed")
+			}
+
+			const n = 3
+			var wg sync.WaitGroup
+			errs := make([]error, n)
+			for i := range n {
+				wg.Go(func() {
+					_, errs[i] = cache.GetWithLoader("key", loader)
+				})
+			}
+
+			Eventually(started).Should(Receive())
+			Consistently(started).ShouldNot(Receive())
+			close(release)
+			wg.Wait()
+
+			for i := range n {
+				Expect(errs[i]).To(MatchError(ContainSubstring("load failed")))
+			}
+		})
+
+		It("loads different keys independently", func() {
+			release := make(chan struct{})
+			started := make(chan struct{}, 10)
+			loader := func(key string) (string, time.Duration, error) {
+				started <- struct{}{}
+				<-release
+				return key + "=value", time.Minute, nil
+			}
+
+			var wg sync.WaitGroup
+			for _, key := range []string{"key1", "key2"} {
+				wg.Go(func() {
+					value, err := cache.GetWithLoader(key, loader)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(value).To(Equal(key + "=value"))
+				})
+			}
+
+			// Both loaders must be in flight at once: distinct keys are not suppressed
+			Eventually(started).Should(Receive())
+			Eventually(started).Should(Receive())
+			close(release)
+			wg.Wait()
 		})
 	})
 

--- a/utils/cache/simple_cache_test.go
+++ b/utils/cache/simple_cache_test.go
@@ -133,6 +133,30 @@ var _ = Describe("SimpleCache", func() {
 			}
 		})
 
+		It("supports interface value types with nil results", func() {
+			c := NewSimpleCache[string, any]()
+			v, err := c.GetWithLoader("key", func(string) (any, time.Duration, error) {
+				return nil, time.Minute, nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v).To(BeNil())
+		})
+
+		It("cleans up the in-flight registration when the loader panics", func() {
+			Expect(func() {
+				_, _ = cache.GetWithLoader("key", func(string) (string, time.Duration, error) {
+					panic("boom")
+				})
+			}).To(PanicWith("boom"))
+
+			// Without cleanup this would deadlock on the never-completed flight
+			v, err := cache.GetWithLoader("key", func(string) (string, time.Duration, error) {
+				return "ok", 0, nil
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(v).To(Equal("ok"))
+		})
+
 		It("loads different keys independently", func() {
 			release := make(chan struct{})
 			started := make(chan struct{}, 10)


### PR DESCRIPTION
### Description
Clients that prefetch lyrics for upcoming queue tracks (Finamp fetches previous + current + next 3) fire a burst of concurrent `/Audio/{id}/Lyrics` and `PlaybackInfo` requests. On a cache-cold album, each of those triggers a lyrics plugin call, and the burst can rate-limit the primary provider into a timeout — making the plugin fall back to a lower-quality source and cache a bad result for days (observed in production: garbled foreign-language transcription served for a track whose correct lyrics the primary provider had all along).

Three complementary changes:

1. **Singleflight in `SimpleCache.GetWithLoader`** (`utils/cache`): concurrent loads of the same key are collapsed into one loader call; every waiter shares the winner's result *or error*. Implemented with `golang.org/x/sync/singleflight` directly (rather than ttlcache's `SuppressedLoader`, which is a wrapper around the same primitive but discards loader errors for suppressed callers).
2. **Request-detached lyrics load** (`server/jellyfin`): the cache loader now runs under `context.WithoutCancel`, so a client disconnecting mid-fetch can't abort the shared load for all waiters — the fetch completes and populates the cache.
3. **Per-plugin concurrency cap** (`plugins`): the lyrics adapter caps in-flight plugin calls at 2 per plugin (context-aware queueing). WASM plugins get a fresh instance per call, so they cannot self-limit — the cap has to live host-side.

As a side effect of (1), the cached HTTP client used by the Last.fm, Deezer and ListenBrainz agents also collapses identical concurrent requests into a single upstream call — a win for rate-limited APIs. Cache keys include auth headers/params, so only genuinely identical requests are deduplicated.

### Related Issues

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. `make test PKG=./utils/cache` — new specs: concurrent same-key loads run the loader once, all callers share the result and errors; distinct keys still load in parallel.
2. `make test PKG=./server/jellyfin` — new spec: the lyrics fetch completes and caches even when the request context is already cancelled.
3. `make test PKG=./plugins` — new specs: a saturated per-plugin cap blocks further `GetLyrics` calls until a slot frees, and a cancelled context stops waiting with `context.Canceled`.
4. End-to-end (optional): with a lyrics plugin configured, queue a cache-cold album in a client that prefetches lyrics and watch the logs — plugin calls now run at most 2 at a time per plugin, and duplicate requests for the same track produce a single plugin call.

### Screenshots / Demos (if applicable)

### Additional Notes
- Waiters on a deduplicated load now receive the winner's error instead of failing independently; errors are still not cached, so the next request retries.
- `PlayTracker`'s session map uses `SimpleCache` but never `GetWithLoader`, so it is unaffected.
- The concurrency cap only covers the lyrics capability; other plugin capabilities are untouched.
