### PR TITLE
feat(ui): add Radio to Default View options

### DIFF
--- a/ui/src/personal/defaultViews.js
+++ b/ui/src/personal/defaultViews.js
@@ -1,6 +1,6 @@
 import albumLists, { defaultAlbumList } from '../album/albumLists'
 
-export const resourceDefaultViews = ['artist', 'song', 'playlist']
+export const resourceDefaultViews = ['artist', 'song', 'playlist', 'radio']
 
 export const isResourceDefaultView = (defaultView) =>
   resourceDefaultViews.includes(defaultView)

--- a/ui/src/personal/defaultViews.test.js
+++ b/ui/src/personal/defaultViews.test.js
@@ -25,6 +25,7 @@ describe('defaultViews', () => {
         { id: 'artist', name: 'resources.artist.name:2' },
         { id: 'song', name: 'resources.song.name:2' },
         { id: 'playlist', name: 'resources.playlist.name:2' },
+        { id: 'radio', name: 'resources.radio.name:2' },
       ]),
     )
   })
@@ -33,6 +34,7 @@ describe('defaultViews', () => {
     expect(isResourceDefaultView('artist')).toBe(true)
     expect(isResourceDefaultView('song')).toBe(true)
     expect(isResourceDefaultView('playlist')).toBe(true)
+    expect(isResourceDefaultView('radio')).toBe(true)
     expect(isResourceDefaultView('recentlyAdded')).toBe(false)
   })
 


### PR DESCRIPTION
### Description
Adds **Radio** to the Personal page **Default View** selector, so a user can have the app open directly on the Radio list.

This follows up on #5754, which generalized the Default View selector beyond album lists via a `resourceDefaultViews` array in `ui/src/personal/defaultViews.js`. Any resource name in that array automatically becomes a dropdown choice and is redirected to `/<resource>` by `AlbumList`. Radio is already an unconditional top-level resource with an existing `resources.radio.name` translation, so the change is simply adding `'radio'` to that array — no redirect, i18n, or component changes needed. Radio appears last in the list, matching the resource order.

Consistent with the other resource-backed views (e.g. Playlists), there is intentionally no special empty-state handling: a user with no radio stations who selects this lands on an empty Radio list, exactly as they would for an empty Playlists view.

### Related Issues
Related to #3032 (discussion requesting Artists, Songs, and Radio as default views — #5754 delivered the first two).

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Open **Personal** settings and set **Default View** to **Radios**.
2. Navigate to Home (or reload) and confirm you land on the Radio list (`/radio`).
3. Switch back to an album list (e.g. Recently Added) and confirm the album redirect still works.

### Additional Notes
Purely additive UI change; existing Default View options are unaffected.
