### PR TITLE
feat(ui): playlist favourites (heart, list filter, sidebar favourites-only toggle)

### DIFF
--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -51,8 +51,9 @@ func NewPlaylistRepository(ctx context.Context, db dbx.Builder) model.PlaylistRe
 	r.ctx = ctx
 	r.db = db
 	r.registerModel(&model.Playlist{}, map[string]filterFunc{
-		"q":     playlistFilter,
-		"smart": smartPlaylistFilter,
+		"q":       playlistFilter,
+		"smart":   smartPlaylistFilter,
+		"starred": annotationBoolFilter("starred"),
 	})
 	r.setSortMappings(map[string]string{
 		"owner_name": "owner_name",

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -51,6 +51,7 @@ func NewPlaylistRepository(ctx context.Context, db dbx.Builder) model.PlaylistRe
 	r.ctx = ctx
 	r.db = db
 	r.registerModel(&model.Playlist{}, map[string]filterFunc{
+		"id":      idFilter("playlist"),
 		"q":       playlistFilter,
 		"smart":   smartPlaylistFilter,
 		"starred": annotationBoolFilter("starred"),

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -176,6 +176,14 @@ var _ = Describe("PlaylistRepository", func() {
 			Expect(res.(model.Playlists)).ToNot(ContainElement(HaveField("ID", plsID)))
 		})
 
+		It("reads a playlist by id through the REST id filter without ambiguity", func() {
+			res, err := repo.(model.ResourceRepository).ReadAll(rest.QueryOptions{
+				Filters: map[string]any{"id": plsID},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.(model.Playlists)).To(ContainElement(HaveField("ID", plsID)))
+		})
+
 		It("does not leak an annotation row of another item_type sharing the playlist id", func() {
 			// Older builds (and the star fallthrough) can leave a media_file-typed row
 			// under a playlist id; the item_type-scoped join must not surface or dupe it.

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
@@ -153,6 +154,26 @@ var _ = Describe("PlaylistRepository", func() {
 			count, err := repo.CountAll(options)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(int64(len(starred))))
+		})
+
+		It("filters starred playlists through the registered REST filter", func() {
+			Expect(repo.SetStar(true, plsID)).To(Succeed())
+
+			res, err := repo.(model.ResourceRepository).ReadAll(rest.QueryOptions{
+				Filters: map[string]any{"starred": "true"},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			starred := res.(model.Playlists)
+			Expect(starred).To(ContainElement(HaveField("ID", plsID)))
+			for _, p := range starred {
+				Expect(p.Starred).To(BeTrue())
+			}
+
+			res, err = repo.(model.ResourceRepository).ReadAll(rest.QueryOptions{
+				Filters: map[string]any{"starred": "false"},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res.(model.Playlists)).ToNot(ContainElement(HaveField("ID", plsID)))
 		})
 
 		It("does not leak an annotation row of another item_type sharing the playlist id", func() {

--- a/ui/src/actions/settings.js
+++ b/ui/src/actions/settings.js
@@ -1,6 +1,8 @@
 export const SET_NOTIFICATIONS_STATE = 'SET_NOTIFICATIONS_STATE'
 export const SET_TOGGLEABLE_FIELDS = 'SET_TOGGLEABLE_FIELDS'
 export const SET_OMITTED_FIELDS = 'SET_OMITTED_FIELDS'
+export const SET_SIDEBAR_PLAYLISTS_FAVOURITES =
+  'SET_SIDEBAR_PLAYLISTS_FAVOURITES'
 
 export const setNotificationsState = (enabled) => ({
   type: SET_NOTIFICATIONS_STATE,
@@ -15,4 +17,9 @@ export const setToggleableFields = (obj) => ({
 export const setOmittedFields = (obj) => ({
   type: SET_OMITTED_FIELDS,
   data: obj,
+})
+
+export const setSidebarPlaylistsOnlyFavourites = (enabled) => ({
+  type: SET_SIDEBAR_PLAYLISTS_FAVOURITES,
+  data: enabled,
 })

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -635,6 +635,7 @@
     },
     "albumList": "Albums",
     "playlists": "Playlists",
+    "onlyFavourites": "Only show favourites",
     "sharedPlaylists": "Shared Playlists",
     "about": "About"
   },

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -210,7 +210,8 @@
         "songCount": "Songs",
         "comment": "Comment",
         "sync": "Auto-import",
-        "path": "Import from"
+        "path": "Import from",
+        "starred": "Favourite"
       },
       "actions": {
         "selectPlaylist": "Select a playlist:",

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -63,6 +63,9 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const onlyFavourites = useSelector(
     (state) => state.settings.sidebarPlaylistsOnlyFavourites,
   )
+  // Ignore a persisted preference when the feature is off, so disabling it later
+  // (with the toggle now hidden) doesn't strand the user on a filtered sidebar
+  const showFavouritesOnly = config.enableFavourites && onlyFavourites
   const playlistData = useSelector(
     (state) => state.admin.resources.playlist?.data,
   )
@@ -79,9 +82,10 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
 
   // Only the favourites-only view depends on star state changing elsewhere;
   // when showing all playlists a star event from another client changes nothing
+  // async because useRefreshOnEvents calls .catch() on the returned value
   const onRefresh = useCallback(async () => {
-    if (onlyFavourites) setRefreshCount((count) => count + 1)
-  }, [onlyFavourites])
+    if (showFavouritesOnly) setRefreshCount((count) => count + 1)
+  }, [showFavouritesOnly])
   useRefreshOnEvents({ events: ['playlist'], onRefresh })
 
   // A changed payload signature makes useQueryWithStore refetch
@@ -94,7 +98,7 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
         perPage: config.maxSidebarPlaylists,
       },
       sort: { field: 'name' },
-      ...(onlyFavourites && {
+      ...(showFavouritesOnly && {
         filter: { starred: true },
         starFingerprint,
         refresh: refreshCount,

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -63,14 +63,23 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const onlyFavourites = useSelector(
     (state) => state.settings.sidebarPlaylistsOnlyFavourites,
   )
+  // Fingerprint of local star state; changes only when a playlist is (un)starred,
+  // so a local toggle refetches the sidebar without the SSE echo the actor never gets
+  const starFingerprint = useSelector((state) => {
+    const data = state.admin.resources.playlist?.data || {}
+    return Object.keys(data)
+      .filter((id) => data[id]?.starred)
+      .sort()
+      .join(',')
+  })
   const [refreshCount, setRefreshCount] = useState(0)
 
-  // A changed payload signature makes useQueryWithStore refetch on SSE events
   const onRefresh = useCallback(async () => {
     setRefreshCount((count) => count + 1)
   }, [])
   useRefreshOnEvents({ events: ['playlist'], onRefresh })
 
+  // A changed payload signature makes useQueryWithStore refetch
   const { data, loaded } = useQueryWithStore({
     type: 'getList',
     resource: 'playlist',
@@ -82,6 +91,7 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
       sort: { field: 'name' },
       ...(onlyFavourites && { filter: { starred: true } }),
       refresh: refreshCount,
+      starFingerprint,
     },
   })
 

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -1,19 +1,24 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
 import {
   MenuItemLink,
   useDataProvider,
   useNotify,
   useQueryWithStore,
+  useTranslate,
 } from 'react-admin'
 import { useHistory } from 'react-router-dom'
 import QueueMusicIcon from '@material-ui/icons/QueueMusic'
 import { Typography } from '@material-ui/core'
 import QueueMusicOutlinedIcon from '@material-ui/icons/QueueMusicOutlined'
+import FavoriteIcon from '@material-ui/icons/Favorite'
+import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
 import { BiCog } from 'react-icons/bi'
 import { useDrop } from 'react-dnd'
 import SubMenu from './SubMenu'
-import { canChangeTracks, OverflowTooltip } from '../common'
+import { canChangeTracks, OverflowTooltip, useRefreshOnEvents } from '../common'
 import { DraggableTypes } from '../consts'
+import { setSidebarPlaylistsOnlyFavourites } from '../actions'
 import config from '../config'
 
 const PlaylistMenuItemLink = ({ pls, sidebarIsOpen }) => {
@@ -53,6 +58,19 @@ const PlaylistMenuItemLink = ({ pls, sidebarIsOpen }) => {
 
 const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const history = useHistory()
+  const dispatch = useDispatch()
+  const translate = useTranslate()
+  const onlyFavourites = useSelector(
+    (state) => state.settings.sidebarPlaylistsOnlyFavourites,
+  )
+  const [refreshCount, setRefreshCount] = useState(0)
+
+  // A changed payload signature makes useQueryWithStore refetch on SSE events
+  const onRefresh = useCallback(async () => {
+    setRefreshCount((count) => count + 1)
+  }, [])
+  useRefreshOnEvents({ events: ['playlist'], onRefresh })
+
   const { data, loaded } = useQueryWithStore({
     type: 'getList',
     resource: 'playlist',
@@ -62,6 +80,8 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
         perPage: config.maxSidebarPlaylists,
       },
       sort: { field: 'name' },
+      ...(onlyFavourites && { filter: { starred: true } }),
+      refresh: refreshCount,
     },
   })
 
@@ -98,6 +118,10 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
     [history],
   )
 
+  const handleToggleFavourites = useCallback(() => {
+    dispatch(setSidebarPlaylistsOnlyFavourites(!onlyFavourites))
+  }, [dispatch, onlyFavourites])
+
   return (
     <>
       <SubMenu
@@ -109,6 +133,18 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
         dense={dense}
         actionIcon={<BiCog />}
         onAction={onPlaylistConfig}
+        onSecondaryAction={
+          config.enableFavourites ? handleToggleFavourites : undefined
+        }
+        secondaryActionIcon={
+          onlyFavourites ? (
+            <FavoriteIcon fontSize={'small'} />
+          ) : (
+            <FavoriteBorderIcon fontSize={'small'} />
+          )
+        }
+        secondaryActionTitle={translate('menu.onlyFavourites')}
+        secondaryActionActive={onlyFavourites}
       >
         {myPlaylists.map(renderPlaylistMenuItemLink)}
       </SubMenu>

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react'
+import React, { useCallback, useMemo, useState } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import {
   MenuItemLink,
@@ -63,15 +63,18 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   const onlyFavourites = useSelector(
     (state) => state.settings.sidebarPlaylistsOnlyFavourites,
   )
+  const playlistData = useSelector(
+    (state) => state.admin.resources.playlist?.data,
+  )
   // Fingerprint of local star state; changes only when a playlist is (un)starred,
   // so a local toggle refetches the sidebar without the SSE echo the actor never gets
-  const starFingerprint = useSelector((state) => {
-    const data = state.admin.resources.playlist?.data || {}
+  const starFingerprint = useMemo(() => {
+    const data = playlistData || {}
     return Object.keys(data)
       .filter((id) => data[id]?.starred)
       .sort()
       .join(',')
-  })
+  }, [playlistData])
   const [refreshCount, setRefreshCount] = useState(0)
 
   const onRefresh = useCallback(async () => {
@@ -89,9 +92,8 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
         perPage: config.maxSidebarPlaylists,
       },
       sort: { field: 'name' },
-      ...(onlyFavourites && { filter: { starred: true } }),
+      ...(onlyFavourites && { filter: { starred: true }, starFingerprint }),
       refresh: refreshCount,
-      starFingerprint,
     },
   })
 

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -77,9 +77,11 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
   }, [playlistData])
   const [refreshCount, setRefreshCount] = useState(0)
 
+  // Only the favourites-only view depends on star state changing elsewhere;
+  // when showing all playlists a star event from another client changes nothing
   const onRefresh = useCallback(async () => {
-    setRefreshCount((count) => count + 1)
-  }, [])
+    if (onlyFavourites) setRefreshCount((count) => count + 1)
+  }, [onlyFavourites])
   useRefreshOnEvents({ events: ['playlist'], onRefresh })
 
   // A changed payload signature makes useQueryWithStore refetch
@@ -92,8 +94,11 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
         perPage: config.maxSidebarPlaylists,
       },
       sort: { field: 'name' },
-      ...(onlyFavourites && { filter: { starred: true }, starFingerprint }),
-      refresh: refreshCount,
+      ...(onlyFavourites && {
+        filter: { starred: true },
+        starFingerprint,
+        refresh: refreshCount,
+      }),
     },
   })
 

--- a/ui/src/layout/PlaylistsSubMenu.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.jsx
@@ -13,7 +13,7 @@ import { Typography } from '@material-ui/core'
 import QueueMusicOutlinedIcon from '@material-ui/icons/QueueMusicOutlined'
 import FavoriteIcon from '@material-ui/icons/Favorite'
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder'
-import { BiCog } from 'react-icons/bi'
+import { BiListUl } from 'react-icons/bi'
 import { useDrop } from 'react-dnd'
 import SubMenu from './SubMenu'
 import { canChangeTracks, OverflowTooltip, useRefreshOnEvents } from '../common'
@@ -141,7 +141,7 @@ const PlaylistsSubMenu = ({ state, setState, sidebarIsOpen, dense }) => {
         name={'menu.playlists'}
         icon={<QueueMusicIcon />}
         dense={dense}
-        actionIcon={<BiCog />}
+        actionIcon={<BiListUl />}
         onAction={onPlaylistConfig}
         onSecondaryAction={
           config.enableFavourites ? handleToggleFavourites : undefined

--- a/ui/src/layout/PlaylistsSubMenu.test.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.test.jsx
@@ -128,8 +128,8 @@ describe('<PlaylistsSubMenu />', () => {
     expect(lastQuery().payload.filter).toEqual({ starred: true })
   })
 
-  it('refetches when a playlist refresh event arrives', async () => {
-    const store = renderMenu()
+  it('refetches on a playlist SSE event when favourites-only is on', async () => {
+    const store = renderMenu({ sidebarPlaylistsOnlyFavourites: true })
     const before = lastQuery().payload.refresh
     // useRefreshOnEvents compares Date.now() timestamps; make sure it advances
     await act(() => new Promise((resolve) => setTimeout(resolve, 5)))
@@ -139,6 +139,20 @@ describe('<PlaylistsSubMenu />', () => {
       )
     })
     expect(lastQuery().payload.refresh).toBe(before + 1)
+  })
+
+  it('does not change the query signature on an SSE event when favourites-only is off', async () => {
+    const store = renderMenu()
+    const before = JSON.stringify(lastQuery().payload)
+    await act(() => new Promise((resolve) => setTimeout(resolve, 5)))
+    act(() => {
+      store.dispatch(
+        processEvent(EVENT_REFRESH_RESOURCE, { playlist: ['pl-1'] }),
+      )
+    })
+    // Signature unchanged → useQueryWithStore dedupes, no wasted refetch
+    expect(lastQuery().payload.refresh).toBeUndefined()
+    expect(JSON.stringify(lastQuery().payload)).toBe(before)
   })
 
   it('refetches when a playlist is starred locally (no SSE echo)', () => {

--- a/ui/src/layout/PlaylistsSubMenu.test.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.test.jsx
@@ -45,13 +45,28 @@ const playlists = {
   'pl-2': { id: 'pl-2', name: 'Theirs', ownerId: 'user-2' },
 }
 
-const renderMenu = (preloadedSettings = {}) => {
+const SET_PLAYLIST_DATA = 'TEST/SET_PLAYLIST_DATA'
+const adminReducer = (state = { resources: {} }, action) =>
+  action.type === SET_PLAYLIST_DATA
+    ? { resources: { playlist: { data: action.data } } }
+    : state
+
+const renderMenu = (preloadedSettings = {}, preloadedPlaylistData) => {
   const store = createStore(
     combineReducers({
       settings: settingsReducer,
       activity: activityReducer,
+      admin: adminReducer,
     }),
-    { settings: preloadedSettings, activity: {} },
+    {
+      settings: preloadedSettings,
+      activity: {},
+      admin: {
+        resources: preloadedPlaylistData
+          ? { playlist: { data: preloadedPlaylistData } }
+          : {},
+      },
+    },
   )
   const theme = createTheme()
   render(
@@ -124,5 +139,23 @@ describe('<PlaylistsSubMenu />', () => {
       )
     })
     expect(lastQuery().payload.refresh).toBe(before + 1)
+  })
+
+  it('refetches when a playlist is starred locally (no SSE echo)', () => {
+    const store = renderMenu(
+      { sidebarPlaylistsOnlyFavourites: true },
+      { 'pl-1': { id: 'pl-1', name: 'Mine', ownerId: 'user-1' } },
+    )
+    const before = lastQuery().payload.starFingerprint
+    act(() => {
+      store.dispatch({
+        type: SET_PLAYLIST_DATA,
+        data: {
+          'pl-1': { id: 'pl-1', name: 'Mine', ownerId: 'user-1', starred: true },
+        },
+      })
+    })
+    expect(lastQuery().payload.starFingerprint).not.toBe(before)
+    expect(lastQuery().payload.starFingerprint).toContain('pl-1')
   })
 })

--- a/ui/src/layout/PlaylistsSubMenu.test.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.test.jsx
@@ -151,7 +151,12 @@ describe('<PlaylistsSubMenu />', () => {
       store.dispatch({
         type: SET_PLAYLIST_DATA,
         data: {
-          'pl-1': { id: 'pl-1', name: 'Mine', ownerId: 'user-1', starred: true },
+          'pl-1': {
+            id: 'pl-1',
+            name: 'Mine',
+            ownerId: 'user-1',
+            starred: true,
+          },
         },
       })
     })

--- a/ui/src/layout/PlaylistsSubMenu.test.jsx
+++ b/ui/src/layout/PlaylistsSubMenu.test.jsx
@@ -1,0 +1,128 @@
+import React from 'react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { Provider } from 'react-redux'
+import { createStore, combineReducers } from 'redux'
+import { ThemeProvider, createTheme } from '@material-ui/core/styles'
+import { settingsReducer, activityReducer } from '../reducers'
+import { processEvent, EVENT_REFRESH_RESOURCE } from '../actions'
+import PlaylistsSubMenu from './PlaylistsSubMenu'
+
+const mockUseQueryWithStore = vi.fn()
+
+vi.mock('../config', () => ({
+  // losslessFormats is read at module-load time by common/QualityInfo.jsx,
+  // pulled in transitively via the '../common' barrel file
+  default: {
+    enableFavourites: true,
+    maxSidebarPlaylists: 100,
+    losslessFormats: '',
+  },
+}))
+
+vi.mock('react-dnd', () => ({
+  useDrop: () => [{}, () => {}],
+}))
+
+vi.mock('react-router-dom', () => ({
+  useHistory: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('react-admin', async (importOriginal) => {
+  const actual = await importOriginal()
+  return {
+    ...actual,
+    useTranslate: () => (x) => x,
+    useDataProvider: () => ({ addToPlaylist: vi.fn() }),
+    useNotify: () => vi.fn(),
+    useQueryWithStore: (query) => mockUseQueryWithStore(query),
+    MenuItemLink: ({ primaryText }) => <div>{primaryText}</div>,
+  }
+})
+
+const playlists = {
+  'pl-1': { id: 'pl-1', name: 'Mine', ownerId: 'user-1' },
+  'pl-2': { id: 'pl-2', name: 'Theirs', ownerId: 'user-2' },
+}
+
+const renderMenu = (preloadedSettings = {}) => {
+  const store = createStore(
+    combineReducers({
+      settings: settingsReducer,
+      activity: activityReducer,
+    }),
+    { settings: preloadedSettings, activity: {} },
+  )
+  const theme = createTheme()
+  render(
+    <Provider store={store}>
+      <ThemeProvider theme={theme}>
+        <PlaylistsSubMenu
+          state={{ menuPlaylists: true, menuSharedPlaylists: true }}
+          setState={vi.fn()}
+          sidebarIsOpen={true}
+          dense={false}
+        />
+      </ThemeProvider>
+    </Provider>,
+  )
+  return store
+}
+
+const lastQuery = () =>
+  mockUseQueryWithStore.mock.calls[
+    mockUseQueryWithStore.mock.calls.length - 1
+  ][0]
+
+describe('<PlaylistsSubMenu />', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    localStorage.setItem('userId', 'user-1')
+    mockUseQueryWithStore.mockReturnValue({ data: playlists, loaded: true })
+    // SubMenu uses MUI's useMediaQuery, which needs window.matchMedia in jsdom
+    window.matchMedia = (query) => ({
+      matches: false,
+      media: query,
+      addListener: () => {},
+      removeListener: () => {},
+    })
+    // OverflowTooltip (via MenuItemLink) needs ResizeObserver, unavailable in jsdom
+    window.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  })
+
+  it('queries without a starred filter by default', () => {
+    renderMenu()
+    expect(lastQuery().payload.filter).toBeUndefined()
+    expect(screen.getByText('Mine')).not.toBeNull()
+    expect(screen.getByText('Theirs')).not.toBeNull()
+  })
+
+  it('adds the starred filter when favourites-only is enabled', () => {
+    renderMenu({ sidebarPlaylistsOnlyFavourites: true })
+    expect(lastQuery().payload.filter).toEqual({ starred: true })
+  })
+
+  it('toggles the setting when the heart action is clicked', () => {
+    const store = renderMenu()
+    fireEvent.click(screen.getByTitle('menu.onlyFavourites'))
+    expect(store.getState().settings.sidebarPlaylistsOnlyFavourites).toBe(true)
+    expect(lastQuery().payload.filter).toEqual({ starred: true })
+  })
+
+  it('refetches when a playlist refresh event arrives', async () => {
+    const store = renderMenu()
+    const before = lastQuery().payload.refresh
+    // useRefreshOnEvents compares Date.now() timestamps; make sure it advances
+    await act(() => new Promise((resolve) => setTimeout(resolve, 5)))
+    act(() => {
+      store.dispatch(
+        processEvent(EVENT_REFRESH_RESOURCE, { playlist: ['pl-1'] }),
+      )
+    })
+    expect(lastQuery().payload.refresh).toBe(before + 1)
+  })
+})

--- a/ui/src/layout/SubMenu.jsx
+++ b/ui/src/layout/SubMenu.jsx
@@ -104,6 +104,7 @@ const SubMenu = ({
           <IconButton
             size={'small'}
             title={secondaryActionTitle}
+            aria-label={secondaryActionTitle}
             className={
               isDesktop && !secondaryActionActive ? classes.actionIcon : null
             }

--- a/ui/src/layout/SubMenu.jsx
+++ b/ui/src/layout/SubMenu.jsx
@@ -33,6 +33,9 @@ const useStyles = makeStyles(
     menuHeader: {
       width: '100%',
     },
+    headerText: {
+      flexGrow: 1,
+    },
     headerWrapper: {
       display: 'flex',
       '&:hover $actionIcon': {
@@ -90,7 +93,11 @@ const SubMenu = ({
         <ListItemIcon className={classes.icon}>
           {isOpen ? <ExpandMore /> : icon}
         </ListItemIcon>
-        <Typography variant="inherit" color="textSecondary">
+        <Typography
+          variant="inherit"
+          color="textSecondary"
+          className={classes.headerText}
+        >
           {translate(name)}
         </Typography>
         {onSecondaryAction && sidebarIsOpen && (

--- a/ui/src/layout/SubMenu.jsx
+++ b/ui/src/layout/SubMenu.jsx
@@ -55,6 +55,10 @@ const SubMenu = ({
   dense,
   onAction,
   actionIcon,
+  onSecondaryAction,
+  secondaryActionIcon,
+  secondaryActionTitle,
+  secondaryActionActive,
 }) => {
   const translate = useTranslate()
   const classes = useStyles()
@@ -68,6 +72,11 @@ const SubMenu = ({
     if (isSmall) {
       dispatch(setSidebarVisibility(false))
     }
+  }
+
+  const handleSecondaryClick = (e) => {
+    e.stopPropagation()
+    onSecondaryAction(e)
   }
 
   const header = (
@@ -84,6 +93,18 @@ const SubMenu = ({
         <Typography variant="inherit" color="textSecondary">
           {translate(name)}
         </Typography>
+        {onSecondaryAction && sidebarIsOpen && (
+          <IconButton
+            size={'small'}
+            title={secondaryActionTitle}
+            className={
+              isDesktop && !secondaryActionActive ? classes.actionIcon : null
+            }
+            onClick={handleSecondaryClick}
+          >
+            {secondaryActionIcon}
+          </IconButton>
+        )}
         {onAction && sidebarIsOpen && (
           <IconButton
             size={'small'}

--- a/ui/src/playlist/PlaylistDetails.jsx
+++ b/ui/src/playlist/PlaylistDetails.jsx
@@ -13,6 +13,7 @@ import {
   CollapsibleComment,
   DurationField,
   ImageUploadOverlay,
+  LoveButton,
   SizeField,
   isWritable,
   OverflowTooltip,
@@ -81,6 +82,15 @@ const useStyles = makeStyles(
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       wordBreak: 'break-word',
+      minWidth: 0,
+    },
+    titleRow: {
+      display: 'flex',
+      alignItems: 'center',
+    },
+    loveButton: {
+      marginLeft: theme.spacing(0.5),
+      flexShrink: 0,
     },
     stats: {
       marginTop: '1em',
@@ -139,14 +149,24 @@ const PlaylistDetails = (props) => {
         </div>
         <div className={classes.details}>
           <CardContent className={classes.content}>
-            <OverflowTooltip title={record.name || ''}>
-              <Typography
-                variant={isDesktop ? 'h5' : 'h6'}
-                className={classes.title}
-              >
-                {record.name || translate('ra.page.loading')}
-              </Typography>
-            </OverflowTooltip>
+            <div className={classes.titleRow}>
+              <OverflowTooltip title={record.name || ''}>
+                <Typography
+                  variant={isDesktop ? 'h5' : 'h6'}
+                  className={classes.title}
+                >
+                  {record.name || translate('ra.page.loading')}
+                </Typography>
+              </OverflowTooltip>
+              <LoveButton
+                className={classes.loveButton}
+                record={record}
+                resource={'playlist'}
+                size={isDesktop ? 'default' : 'small'}
+                aria-label="love"
+                color="primary"
+              />
+            </div>
             <Typography component="p" className={classes.stats}>
               {record.songCount ? (
                 <span>

--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -149,10 +149,12 @@ const PlaylistListBulkActions = (props) => {
   )
 }
 
-const PlaylistLove = ({ record }) => (
-  <LoveButton record={record} resource={'playlist'} />
+// Datagrid reads `source`/`sortable`/`label` off this element for the column
+// header; only record/resource are forwarded so they never leak onto the button.
+export const PlaylistLove = ({ record, className }) => (
+  <LoveButton record={record} resource={'playlist'} className={className} />
 )
-PlaylistLove.defaultProps = { source: 'starred' }
+PlaylistLove.defaultProps = { source: 'starred', sortable: false }
 
 const PlaylistList = (props) => {
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
@@ -174,7 +176,7 @@ const PlaylistList = (props) => {
       sync: !isXsmall && (
         <ToggleAutoImport source="sync" sortByOrder={'DESC'} />
       ),
-      starred: config.enableFavourites && <PlaylistLove sortable={false} />,
+      starred: config.enableFavourites && <PlaylistLove />,
     }),
     [isDesktop, isXsmall],
   )

--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -195,8 +195,8 @@ const PlaylistList = (props) => {
       <Datagrid rowClick="show" isRowSelectable={(r) => isWritable(r?.ownerId)}>
         <CoverArtAvatar source="id" variant="square" />
         <TextField source="name" />
-        {config.enableFavourites && <PlaylistLove sortable={false} />}
         {columns}
+        {config.enableFavourites && <PlaylistLove sortable={false} />}
         <Writable>
           <EditButton />
         </Writable>

--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -4,6 +4,7 @@ import {
   DateField,
   EditButton,
   Filter,
+  NullableBooleanInput,
   NumberField,
   ReferenceInput,
   SearchInput,
@@ -22,11 +23,14 @@ import {
   CoverArtAvatar,
   DurationField,
   List,
+  LoveButton,
   Writable,
   isWritable,
   useSelectedFields,
   useResourceRefresh,
 } from '../common'
+import FavoriteIcon from '@material-ui/icons/Favorite'
+import config from '../config'
 import PlaylistListActions from './PlaylistListActions'
 import ChangePublicStatusButton from './ChangePublicStatusButton'
 
@@ -52,6 +56,12 @@ const PlaylistFilter = (props) => {
         >
           <SelectInput optionText="name" />
         </ReferenceInput>
+      )}
+      {config.enableFavourites && (
+        <NullableBooleanInput
+          source="starred"
+          label={<FavoriteIcon fontSize={'small'} />}
+        />
       )}
     </Filter>
   )
@@ -139,6 +149,10 @@ const PlaylistListBulkActions = (props) => {
   )
 }
 
+const PlaylistLove = ({ record }) => (
+  <LoveButton record={record} resource={'playlist'} />
+)
+
 const PlaylistList = (props) => {
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
   const isDesktop = useMediaQuery((theme) => theme.breakpoints.up('md'))
@@ -181,6 +195,7 @@ const PlaylistList = (props) => {
       <Datagrid rowClick="show" isRowSelectable={(r) => isWritable(r?.ownerId)}>
         <CoverArtAvatar source="id" variant="square" />
         <TextField source="name" />
+        {config.enableFavourites && <PlaylistLove sortable={false} />}
         {columns}
         <Writable>
           <EditButton />

--- a/ui/src/playlist/PlaylistList.jsx
+++ b/ui/src/playlist/PlaylistList.jsx
@@ -152,6 +152,7 @@ const PlaylistListBulkActions = (props) => {
 const PlaylistLove = ({ record }) => (
   <LoveButton record={record} resource={'playlist'} />
 )
+PlaylistLove.defaultProps = { source: 'starred' }
 
 const PlaylistList = (props) => {
   const isXsmall = useMediaQuery((theme) => theme.breakpoints.down('xs'))
@@ -173,6 +174,7 @@ const PlaylistList = (props) => {
       sync: !isXsmall && (
         <ToggleAutoImport source="sync" sortByOrder={'DESC'} />
       ),
+      starred: config.enableFavourites && <PlaylistLove sortable={false} />,
     }),
     [isDesktop, isXsmall],
   )
@@ -196,7 +198,6 @@ const PlaylistList = (props) => {
         <CoverArtAvatar source="id" variant="square" />
         <TextField source="name" />
         {columns}
-        {config.enableFavourites && <PlaylistLove sortable={false} />}
         <Writable>
           <EditButton />
         </Writable>

--- a/ui/src/playlist/PlaylistList.test.jsx
+++ b/ui/src/playlist/PlaylistList.test.jsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { PlaylistLove } from './PlaylistList'
+
+vi.mock('../config', () => ({
+  default: { enableFavourites: true },
+}))
+
+vi.mock('../common', () => ({
+  LoveButton: ({ record, resource }) => (
+    <button data-testid="love" data-resource={resource}>
+      {record?.starred ? 'starred' : 'not-starred'}
+    </button>
+  ),
+}))
+
+describe('<PlaylistLove />', () => {
+  it('renders a LoveButton bound to the playlist resource', () => {
+    render(<PlaylistLove record={{ id: 'pl-1', starred: true }} />)
+    const btn = screen.getByTestId('love')
+    expect(btn.getAttribute('data-resource')).toBe('playlist')
+    expect(btn.textContent).toBe('starred')
+  })
+
+  it('exposes datagrid header props so the column renders unsorted', () => {
+    // The Datagrid reads these off the element; the wrapper body must not
+    // forward them to the button (which would leak onto the DOM).
+    expect(PlaylistLove.defaultProps).toEqual({
+      source: 'starred',
+      sortable: false,
+    })
+  })
+})

--- a/ui/src/reducers/settingsReducer.js
+++ b/ui/src/reducers/settingsReducer.js
@@ -1,6 +1,7 @@
 import {
   SET_NOTIFICATIONS_STATE,
   SET_OMITTED_FIELDS,
+  SET_SIDEBAR_PLAYLISTS_FAVOURITES,
   SET_TOGGLEABLE_FIELDS,
 } from '../actions'
 
@@ -8,6 +9,7 @@ const initialState = {
   notifications: false,
   toggleableFields: {},
   omittedFields: {},
+  sidebarPlaylistsOnlyFavourites: false,
 }
 
 export const settingsReducer = (previousState = initialState, payload) => {
@@ -33,6 +35,11 @@ export const settingsReducer = (previousState = initialState, payload) => {
           ...previousState.omittedFields,
           ...data,
         },
+      }
+    case SET_SIDEBAR_PLAYLISTS_FAVOURITES:
+      return {
+        ...previousState,
+        sidebarPlaylistsOnlyFavourites: data,
       }
     default:
       return previousState

--- a/ui/src/reducers/settingsReducer.test.js
+++ b/ui/src/reducers/settingsReducer.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest'
+import { settingsReducer } from './settingsReducer'
+import {
+  SET_SIDEBAR_PLAYLISTS_FAVOURITES,
+  setSidebarPlaylistsOnlyFavourites,
+} from '../actions'
+
+describe('settingsReducer', () => {
+  it('defaults sidebarPlaylistsOnlyFavourites to false', () => {
+    const state = settingsReducer(undefined, { type: 'UNKNOWN' })
+    expect(state.sidebarPlaylistsOnlyFavourites).toBe(false)
+  })
+
+  it('enables the flag via the action creator', () => {
+    const state = settingsReducer(
+      undefined,
+      setSidebarPlaylistsOnlyFavourites(true),
+    )
+    expect(state.sidebarPlaylistsOnlyFavourites).toBe(true)
+  })
+
+  it('disables the flag and preserves other settings', () => {
+    const initial = settingsReducer(undefined, { type: 'UNKNOWN' })
+    const on = settingsReducer(initial, {
+      type: SET_SIDEBAR_PLAYLISTS_FAVOURITES,
+      data: true,
+    })
+    const off = settingsReducer(on, {
+      type: SET_SIDEBAR_PLAYLISTS_FAVOURITES,
+      data: false,
+    })
+    expect(off.sidebarPlaylistsOnlyFavourites).toBe(false)
+    expect(off.notifications).toEqual(initial.notifications)
+    expect(off.toggleableFields).toEqual(initial.toggleableFields)
+  })
+})


### PR DESCRIPTION
### Description

Surfaces the per-user playlist starred/favourites support added on the backend by #5749 in the web UI:

- **Mark playlists as favourites**: a heart (`LoveButton`) column in the playlist list and a heart next to the title on the playlist details header, mirroring how albums expose it. Starring is per-user, so it also works on shared/public playlists the user doesn't own.
- **Favourites filter**: a heart-labeled yes/no filter in the playlist list, same as the album list.
- **Sidebar favourites-only toggle**: a heart action on the "Playlists" sidebar submenu header (next to the existing gear) that filters both the "Playlists" and "Shared Playlists" submenus to starred playlists only. The state is kept in the redux `settings` slice (persisted to localStorage) and the filtering happens server-side (`?starred=true`), so it stays correct beyond the `MaxSidebarPlaylists` cap. The toggle icon stays visible while active (instead of hover-fading) so it's clear the list is filtered.
- **Live updates**: the sidebar now refetches its playlist query when a `RefreshResource` playlist event arrives over SSE, so star/unstar from another tab or a Subsonic client updates sidebar membership immediately. As a side benefit, the sidebar also picks up playlist creates/renames/deletes live, which it previously missed.

The only backend change is registering the `starred` REST filter on the playlist repository (one line — the annotation join and reads already existed from #5749). To support the sidebar toggle, `SubMenu` gained optional secondary-action props (`onSecondaryAction`, `secondaryActionIcon`, `secondaryActionTitle`, `secondaryActionActive`).

Everything is gated by `EnableFavourites`, consistent with the rest of the favourites UI.

### Related Issues

Related to #5749

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Screenshots


https://github.com/user-attachments/assets/bd979adf-9f82-492c-b85c-51959f059d13



### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start the server and log in to the web UI.
2. Playlists list: click the heart next to a playlist name — it fills without opening the playlist; open the filter menu and use the heart filter to narrow the list to favourites (works with yes/no/all).
3. Open a playlist: the heart next to the title reflects and toggles the same state.
4. Sidebar: hover the "Playlists" submenu header and click the heart action — both playlist submenus now show only favourites; the heart stays visible while active. Reload the page: the toggle state persists.
5. With the toggle on, unstar a playlist from the list view (or from a Subsonic client): it drops out of the sidebar without a reload.
6. Star a playlist you don't own (shared/public) — it works, and the star is per-user (other users are unaffected).
7. Set `EnableFavourites = false` and confirm all hearts, the filter, and the sidebar toggle disappear.

### Screenshots / Demos (if applicable)

### Additional Notes

The `starred` filter follows the same `annotationBoolFilter` pattern used by the album/artist/song repositories, and `CountAll` already handles the annotation join, so `X-Total-Count` matches the filtered rows.
