### PR TITLE
fix(deezer): pick most-popular artist among same-name matches

### DIFF
--- a/adapters/deezer/deezer.go
+++ b/adapters/deezer/deezer.go
@@ -95,13 +95,20 @@ func (s *deezerAgent) searchArtist(ctx context.Context, name string) (*Artist, e
 		}
 	}
 
-	// If the first one has the same name, that's the one
-	if !strings.EqualFold(artists[0].Name, name) {
-		log.Trace(ctx, "Top artist do not match", "searched_name", name, "found_name", artists[0].Name)
+	// Deezer's RANKING order isn't reliable for homonyms, so among exact-name
+	// matches pick the most popular one by fan count.
+	var best *Artist
+	for i := range artists {
+		if strings.EqualFold(artists[i].Name, name) && (best == nil || artists[i].NbFan > best.NbFan) {
+			best = &artists[i]
+		}
+	}
+	if best == nil {
+		log.Trace(ctx, "No artist matched the searched name", "searched_name", name, "found_name", artists[0].Name)
 		return nil, agents.ErrNotFound
 	}
-	log.Trace(ctx, "Found artist", "name", artists[0].Name, "id", artists[0].ID, "link", artists[0].Link)
-	return &artists[0], err
+	log.Trace(ctx, "Found artist", "name", best.Name, "id", best.ID, "link", best.Link)
+	return best, nil
 }
 
 func (s *deezerAgent) GetSimilarArtists(ctx context.Context, _, name, _ string, limit int) ([]agents.Artist, error) {

--- a/adapters/deezer/deezer.go
+++ b/adapters/deezer/deezer.go
@@ -1,10 +1,12 @@
 package deezer
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 
 	"github.com/navidrome/navidrome/conf"
@@ -95,20 +97,32 @@ func (s *deezerAgent) searchArtist(ctx context.Context, name string) (*Artist, e
 		}
 	}
 
-	// Deezer's RANKING order isn't reliable for homonyms, so among exact-name
-	// matches pick the most popular one by fan count.
-	var best *Artist
-	for i := range artists {
-		if strings.EqualFold(artists[i].Name, name) && (best == nil || artists[i].NbFan > best.NbFan) {
-			best = &artists[i]
+	// Deezer's RANKING order isn't reliable for homonyms: rank name matches
+	// ahead of non-matches, prefer an exact-case match, then the most fans.
+	rank := func(a Artist) int {
+		switch {
+		case a.Name == name:
+			return 2
+		case strings.EqualFold(a.Name, name):
+			return 1
+		default:
+			return 0
 		}
 	}
-	if best == nil {
+	slices.SortFunc(artists, func(a, b Artist) int {
+		return cmp.Or(
+			cmp.Compare(rank(b), rank(a)),
+			cmp.Compare(b.NbFan, a.NbFan),
+			cmp.Compare(a.ID, b.ID),
+		)
+	})
+	best := artists[0]
+	if !strings.EqualFold(best.Name, name) {
 		log.Trace(ctx, "No artist matched the searched name", "searched_name", name, "found_name", artists[0].Name)
 		return nil, agents.ErrNotFound
 	}
-	log.Trace(ctx, "Found artist", "name", best.Name, "id", best.ID, "link", best.Link)
-	return best, nil
+	log.Trace(ctx, "Found artist", "name", best.Name, "id", best.ID, "link", best.Link, "nb_fan", best.NbFan)
+	return new(best), nil
 }
 
 func (s *deezerAgent) GetSimilarArtists(ctx context.Context, _, name, _ string, limit int) ([]agents.Artist, error) {

--- a/adapters/deezer/deezer_test.go
+++ b/adapters/deezer/deezer_test.go
@@ -34,6 +34,66 @@ var _ = Describe("deezerAgent", func() {
 		})
 	})
 
+	Describe("searchArtist", func() {
+		var agent *deezerAgent
+		var httpClient *fakeHttpClient
+
+		BeforeEach(func() {
+			httpClient = &fakeHttpClient{}
+			agent = &deezerAgent{
+				dataStore: &tests.MockDataStore{},
+				client:    newClient(httpClient),
+			}
+		})
+
+		It("picks the exact-name match with the most fans when several share the name", func() {
+			// Deezer RANKING order returns a low-popularity homonym first (see issue #5802)
+			httpClient.mock("https://api.deezer.com/search/artist", http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(bytes.NewBufferString(`{"data":[
+					{"id":61045802,"name":"Queen","nb_fan":75},
+					{"id":141954732,"name":"Queen","nb_fan":397},
+					{"id":135041032,"name":"Queen(Ares)","nb_fan":133},
+					{"id":183179807,"name":"Queen","nb_fan":53},
+					{"id":412,"name":"Queen","nb_fan":12744378}
+				],"total":5}`)),
+			})
+
+			artist, err := agent.searchArtist(ctx, "Queen")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(artist.ID).To(Equal(412))
+		})
+
+		It("matches the name case-insensitively", func() {
+			httpClient.mock("https://api.deezer.com/search/artist", http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(bytes.NewBufferString(`{"data":[
+					{"id":1,"name":"QUEEN","nb_fan":10},
+					{"id":2,"name":"queen","nb_fan":20}
+				],"total":2}`)),
+			})
+
+			artist, err := agent.searchArtist(ctx, "Queen")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(artist.ID).To(Equal(2))
+		})
+
+		It("returns ErrNotFound when no result matches the name exactly", func() {
+			httpClient.mock("https://api.deezer.com/search/artist", http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(bytes.NewBufferString(`{"data":[
+					{"id":1,"name":"Queens of the Stone Age","nb_fan":100}
+				],"total":1}`)),
+			})
+
+			_, err := agent.searchArtist(ctx, "Queen")
+
+			Expect(err).To(MatchError(agents.ErrNotFound))
+		})
+	})
+
 	Describe("GetArtistBiography - Language Fallback", func() {
 		var agent *deezerAgent
 		var httpClient *langAwareHttpClient


### PR DESCRIPTION
### Description

The Deezer agent resolves an artist by name via `searchArtist`, which searched with `order=RANKING` and then **unconditionally took the top-ranked result** (`artists[0]`), only checking that its name matched. Deezer's `RANKING` order is not reliable for disambiguating homonyms, so for names shared by several artists it could lock onto a low-popularity artist whose Top Tracks response is empty — leaving `getTopSongs` (and biography/similar-artists) empty.

For "Queen", live Deezer returns several exact-name matches; the top-ranked one is a homonym with an empty Top Tracks list, while the real band (Deezer ID `412`, ~12.7M fans) ranks lower.

This PR changes `searchArtist` to re-rank the results instead of blindly taking the first one. Candidates are sorted so that:

1. name matches sort ahead of non-matches (case-insensitive),
2. an exact-case match is preferred over a case-insensitive-only match,
3. then the highest fan count (`nb_fan`) wins,
4. then the artist ID breaks any remaining tie deterministically.

The best result is then accepted only if its name still matches case-insensitively, preserving the existing `ErrNotFound` behavior when no result matches. Because `GetArtistTopSongs`, `GetSimilarArtists`, `GetArtistBiography`, and `GetArtistImages` all flow through `searchArtist`, they all benefit.

### Related Issues

Fixes #5802

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

This exercises the live Deezer public API (no API key required).

1. With Deezer enabled (the default), the agent now resolves "Queen" to the real band. Verified live via the agent's public interface:
   - `GetArtistTopSongs("Queen")` → returns Bohemian Rhapsody, Under Pressure, Another One Bites The Dust, … (previously returned **0 songs**).
   - `GetSimilarArtists("Queen")` → The Rolling Stones, Bruce Springsteen, Dire Straits, Pink Floyd, David Bowie (previously **0**).
2. Regression checks: a normal single-artist name (`Daft Punk`) still resolves to its top songs; a non-existent name still returns `ErrNotFound`.
3. Unit tests: `make test PKG=./adapters/deezer`. New `searchArtist` specs cover the highest-fans-wins selection among homonyms, case-insensitive matching, the exact-case preference, and the no-exact-match → `ErrNotFound` path.

### Additional Notes

- Deezer's public API has no MusicBrainz-ID lookup, so fan count is used as the popularity signal for disambiguation rather than the MBID (which is available to the agent but unused).
- The homonym IDs/fan counts on Deezer drift over time, which is exactly why keying on `nb_fan` rather than result position is the robust fix.
