### PR TITLE
feat(jellyfin): expose genreitems for song/album

### DIFF
--- a/server/jellyfin/dto/dto.go
+++ b/server/jellyfin/dto/dto.go
@@ -70,6 +70,7 @@ type BaseItemDto struct {
 	Artists              []string          `json:"Artists,omitempty"`
 	ArtistItems          []NameGuidPair    `json:"ArtistItems,omitempty"`
 	Genres               []string          `json:"Genres,omitempty"`
+	GenreItems           []NameGuidPair    `json:"GenreItems,omitempty"`
 	ChildCount           *int              `json:"ChildCount,omitempty"`
 	SongCount            *int              `json:"SongCount,omitempty"`
 	AlbumCount           *int              `json:"AlbumCount,omitempty"`

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -175,6 +175,7 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 	if len(mf.Genres) > 0 {
 		for _, g := range mf.Genres {
 			item.Genres = append(item.Genres, g.Name)
+			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: g.ID, Name: g.Name})
 		}
 	} else if mf.Genre != "" {
 		item.Genres = []string{mf.Genre}
@@ -216,6 +217,7 @@ func AlbumToBaseItem(al model.Album) BaseItemDto {
 	if len(al.Genres) > 0 {
 		for _, g := range al.Genres {
 			item.Genres = append(item.Genres, g.Name)
+			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: g.ID, Name: g.Name})
 		}
 	}
 	return item

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -175,7 +175,7 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 	if len(mf.Genres) > 0 {
 		for _, g := range mf.Genres {
 			item.Genres = append(item.Genres, g.Name)
-			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: g.ID, Name: g.Name})
+			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: EncodeID(g.ID), Name: g.Name})
 		}
 	} else if mf.Genre != "" {
 		item.Genres = []string{mf.Genre}
@@ -217,7 +217,7 @@ func AlbumToBaseItem(al model.Album) BaseItemDto {
 	if len(al.Genres) > 0 {
 		for _, g := range al.Genres {
 			item.Genres = append(item.Genres, g.Name)
-			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: g.ID, Name: g.Name})
+			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: EncodeID(g.ID), Name: g.Name})
 		}
 	}
 	return item

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -15,6 +15,7 @@ var _ = Describe("mappers", func() {
 			ID: "song-1", Title: "Song", Album: "Alb", AlbumID: "alb-1",
 			Artist: "Art", AlbumArtist: "AA", TrackNumber: 3, DiscNumber: 1,
 			Year: 1999, Duration: 60, Size: 2_500_000,
+			Genres: []model.Genre{{ID: "1", Name: "genre 1"}, {ID: "2", Name: "genre 2"}},
 		}
 		mf.PlayCount = 2
 		mf.Starred = true
@@ -35,6 +36,8 @@ var _ = Describe("mappers", func() {
 		Expect(item.UserData.ItemId).To(Equal(EncodeID("song-1")))
 		Expect(item.ImageBlurHashes["Primary"]).To(HaveKey(item.AlbumPrimaryImageTag))
 		Expect(item.ImageBlurHashes["Primary"][item.AlbumPrimaryImageTag]).To(HaveLen(6))
+		Expect(item.Genres).To(Equal([]string{"genre 1", "genre 2"}))
+		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: "1", Name: "genre 1"}, {Id: "2", Name: "genre 2"}}))
 	})
 
 	Describe("Fields gating (matches real Jellyfin)", func() {
@@ -198,7 +201,7 @@ var _ = Describe("mappers", func() {
 	})
 
 	It("maps an album to a MusicAlbum folder item", func() {
-		al := model.Album{ID: "alb-1", Name: "Alb", AlbumArtist: "AA", AlbumArtistID: "art-1", MaxYear: 1999, SongCount: 10}
+		al := model.Album{ID: "alb-1", Name: "Alb", AlbumArtist: "AA", AlbumArtistID: "art-1", MaxYear: 1999, SongCount: 10, Genres: []model.Genre{{ID: "1", Name: "genre 1"}, {ID: "2", Name: "genre 2"}}}
 		item := AlbumToBaseItem(al)
 		Expect(item.Type).To(Equal("MusicAlbum"))
 		Expect(item.IsFolder).To(BeTrue())
@@ -211,6 +214,8 @@ var _ = Describe("mappers", func() {
 		Expect(*item.ChildCount).To(Equal(10))
 		Expect(item.ImageBlurHashes["Primary"]).To(HaveKey(item.ImageTags["Primary"]))
 		Expect(item.ImageBlurHashes["Primary"][item.ImageTags["Primary"]]).To(HaveLen(6))
+		Expect(item.Genres).To(Equal([]string{"genre 1", "genre 2"}))
+		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: "1", Name: "genre 1"}, {Id: "2", Name: "genre 2"}}))
 	})
 
 	It("maps an artist to a MusicArtist folder item", func() {

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -37,7 +37,7 @@ var _ = Describe("mappers", func() {
 		Expect(item.ImageBlurHashes["Primary"]).To(HaveKey(item.AlbumPrimaryImageTag))
 		Expect(item.ImageBlurHashes["Primary"][item.AlbumPrimaryImageTag]).To(HaveLen(6))
 		Expect(item.Genres).To(Equal([]string{"genre 1", "genre 2"}))
-		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: "1", Name: "genre 1"}, {Id: "2", Name: "genre 2"}}))
+		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: EncodeID("1"), Name: "genre 1"}, {Id: EncodeID("2"), Name: "genre 2"}}))
 	})
 
 	Describe("Fields gating (matches real Jellyfin)", func() {
@@ -215,7 +215,7 @@ var _ = Describe("mappers", func() {
 		Expect(item.ImageBlurHashes["Primary"]).To(HaveKey(item.ImageTags["Primary"]))
 		Expect(item.ImageBlurHashes["Primary"][item.ImageTags["Primary"]]).To(HaveLen(6))
 		Expect(item.Genres).To(Equal([]string{"genre 1", "genre 2"}))
-		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: "1", Name: "genre 1"}, {Id: "2", Name: "genre 2"}}))
+		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: EncodeID("1"), Name: "genre 1"}, {Id: EncodeID("2"), Name: "genre 2"}}))
 	})
 
 	It("maps an artist to a MusicArtist folder item", func() {


### PR DESCRIPTION
### Description
Exposes `GenreItems` in Jellyfin song/album response.

### Related Issues
Part of https://github.com/navidrome/navidrome/discussions/5807

### Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [X] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
`make test`. Or, connect to Feishin using Jellyfin API, and confirm that genres are now being populated.

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->