### PR TITLE
fix(jellyfin): split Artists/ArtistItems per track artist

### DIFF
--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/utils/slice"
 )
 
 // Jellyfin wire times are ticks: 100ns units, i.e. 10,000 per millisecond.
@@ -139,7 +140,6 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 		Album:             mf.Album,
 		AlbumId:           EncodeID(mf.AlbumID),
 		AlbumArtist:       mf.AlbumArtist,
-		Artists:           []string{mf.Artist},
 		RunTimeTicks:      TicksFromSeconds(mf.Duration),
 		DateCreated:       jellyfinDate(&mf.CreatedAt),
 		Container:         mf.Suffix,
@@ -153,11 +153,18 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 	if fields.Has("SortName") {
 		item.SortName = cmp.Or(mf.SortTitle, mf.OrderTitle, mf.Title)
 	}
-	// Finamp's Now Playing screen reads ArtistItems for the displayed artist (falling back to "Unknown
-	// Artist" if absent), even though Artists carries the same name. ArtistItems is the track artist;
-	// AlbumArtists the album artist.
-	if mf.ArtistID != "" {
-		item.ArtistItems = []NameGuidPair{{Name: mf.Artist, Id: EncodeID(mf.ArtistID)}}
+	// Real Jellyfin splits Artists/ArtistItems per track artist (AlbumArtists stays a single credit).
+	// Participants holds the per-artist list; fall back to the flattened display fields when absent.
+	if artists := mf.Participants[model.RoleArtist]; len(artists) > 0 {
+		item.Artists = slice.Map(artists, func(p model.Participant) string { return p.Name })
+		item.ArtistItems = slice.Map(artists, func(p model.Participant) NameGuidPair {
+			return NameGuidPair{Name: p.Name, Id: EncodeID(p.ID)}
+		})
+	} else {
+		item.Artists = []string{mf.Artist}
+		if mf.ArtistID != "" {
+			item.ArtistItems = []NameGuidPair{{Name: mf.Artist, Id: EncodeID(mf.ArtistID)}}
+		}
 	}
 	if mf.AlbumArtistID != "" {
 		item.AlbumArtists = []NameGuidPair{{Name: mf.AlbumArtist, Id: EncodeID(mf.AlbumArtistID)}}

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -161,7 +161,9 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 			return NameGuidPair{Name: p.Name, Id: EncodeID(p.ID)}
 		})
 	} else {
-		item.Artists = []string{mf.Artist}
+		if mf.Artist != "" {
+			item.Artists = []string{mf.Artist}
+		}
 		if mf.ArtistID != "" {
 			item.ArtistItems = []NameGuidPair{{Name: mf.Artist, Id: EncodeID(mf.ArtistID)}}
 		}

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -96,6 +96,10 @@ var _ = Describe("mappers", func() {
 		Expect(SongToBaseItem(model.MediaFile{ID: "s1", Title: "Song", Artist: "X"}, nil).ArtistItems).To(BeNil())
 	})
 
+	It("omits Artists when the track has no artist name or participants", func() {
+		Expect(SongToBaseItem(model.MediaFile{ID: "s1", Title: "Song"}, nil).Artists).To(BeNil())
+	})
+
 	It("splits Artists and ArtistItems per track artist from Participants", func() {
 		mf := model.MediaFile{
 			ID: "s1", Title: "Oooh",

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -96,6 +96,28 @@ var _ = Describe("mappers", func() {
 		Expect(SongToBaseItem(model.MediaFile{ID: "s1", Title: "Song", Artist: "X"}, nil).ArtistItems).To(BeNil())
 	})
 
+	It("splits Artists and ArtistItems per track artist from Participants", func() {
+		mf := model.MediaFile{
+			ID: "s1", Title: "Oooh",
+			Artist: "De La Soul feat. Redman", ArtistID: "ar-delasoul",
+			AlbumArtist: "De La Soul", AlbumArtistID: "ar-delasoul",
+		}
+		mf.Participants = model.Participants{
+			model.RoleArtist: model.ParticipantList{
+				{Artist: model.Artist{ID: "ar-delasoul", Name: "De La Soul"}},
+				{Artist: model.Artist{ID: "ar-redman", Name: "Redman"}},
+			},
+		}
+		item := SongToBaseItem(mf, nil)
+		Expect(item.Artists).To(Equal([]string{"De La Soul", "Redman"}))
+		Expect(item.ArtistItems).To(Equal([]NameGuidPair{
+			{Name: "De La Soul", Id: EncodeID("ar-delasoul")},
+			{Name: "Redman", Id: EncodeID("ar-redman")},
+		}))
+		// AlbumArtists stays single, matching real Jellyfin.
+		Expect(item.AlbumArtists).To(Equal([]NameGuidPair{{Name: "De La Soul", Id: EncodeID("ar-delasoul")}}))
+	})
+
 	It("builds a MediaSourceInfo from a media file", func() {
 		mf := model.MediaFile{ID: "s1", Size: 5242880, Suffix: "mp3", BitRate: 320, Duration: 100}
 		src := MediaSourceFromMediaFile(mf)


### PR DESCRIPTION
### Description

The Jellyfin API built a track's `Artists` and `ArtistItems` from the flattened
display artist (`mf.Artist` / `mf.ArtistID`), so a multi-artist track collapsed
to a single entry: every artist name was merged into one string and every artist
id but the first was dropped. For example, "Oooh" by *De La Soul feat. Redman*
returned `ArtistItems: [{"De La Soul feat. Redman", <De La Soul's id>}]` — Redman
missing entirely — even though the same track's OpenSubsonic response correctly
splits it into two artists. Real Jellyfin splits `Artists`/`ArtistItems` one entry
per track artist.

This change builds both from `Participants[model.RoleArtist]`, which is already
loaded on the search and browse paths, falling back to the flattened display
fields when participants aren't hydrated (e.g. the similar/instant-mix path).
`AlbumArtists` stays a single credit, matching real Jellyfin.

### Related Issues

Related to #5806 (first tracked bug: "Navidrome does not split `ArtistItems`")

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Enable the Jellyfin API (`ND_JELLYFIN_ENABLED=true`) and scan a library that
   contains a multi-artist track — e.g. one tagged `ARTIST=Artist A feat. Artist B`
   (the ` feat. ` / ` / ` separators split by default).
2. Authenticate and query the item:
   `GET /jellyfin/users/{userId}/items?IncludeItemTypes=Audio&Recursive=true&SearchTerm=<title>`
3. **Expected:** `ArtistItems` has one entry per track artist, each with its own
   id, and `Artists` lists each name separately. `AlbumArtists` remains a single
   entry. Compare with the same track's OpenSubsonic `search3` `artists[]` — they
   should now agree.

Verified live against a running server: the same track that OpenSubsonic splits
into two artists is now split identically by the Jellyfin API, with each artist
carrying its correct distinct id.

### Additional Notes

- Scope is intentionally the song mapper only. `AlbumToBaseItem` keeps a single
  album credit, matching real Jellyfin (the reporter observed JF doesn't split
  `AlbumArtists` either).
- While verifying #5806 I reproduced a separate, unrelated defect from the same
  tracking issue: field-gated fields like `MediaSources` are dropped when `Fields`
  is sent as repeated query params (`Fields=Genres&Fields=MediaSources`) instead
  of the comma form (`Fields=Genres,MediaSources`). That's bug 3 in #5806 and is
  not addressed here.
