### PR TITLE
fix(jellyfin): honor repeated Fields query params

### DIFF
--- a/server/jellyfin/dto/fields.go
+++ b/server/jellyfin/dto/fields.go
@@ -7,12 +7,15 @@ import "strings"
 // omits those unless the client asks for them.
 type Fields map[string]struct{}
 
-// ParseFields splits the comma-separated Fields param into a lowercased set.
-func ParseFields(csv string) Fields {
+// ParseFields builds a lowercased set from the Fields param. It accepts each value comma-separated
+// (Fields=a,b) and across repeated params (Fields=a&Fields=b), both of which real Jellyfin honors.
+func ParseFields(values ...string) Fields {
 	f := Fields{}
-	for name := range strings.SplitSeq(csv, ",") {
-		if name = strings.TrimSpace(strings.ToLower(name)); name != "" {
-			f[name] = struct{}{}
+	for _, csv := range values {
+		for name := range strings.SplitSeq(csv, ",") {
+			if name = strings.TrimSpace(strings.ToLower(name)); name != "" {
+				f[name] = struct{}{}
+			}
 		}
 	}
 	return f

--- a/server/jellyfin/dto/fields_test.go
+++ b/server/jellyfin/dto/fields_test.go
@@ -1,0 +1,26 @@
+package dto
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ParseFields", func() {
+	It("parses a single comma-separated value", func() {
+		f := ParseFields("Genres,MediaSources")
+		Expect(f.Has("Genres")).To(BeTrue())
+		Expect(f.Has("MediaSources")).To(BeTrue())
+	})
+
+	It("parses fields spread across repeated params", func() {
+		f := ParseFields("Genres", "MediaSources", "SortName")
+		Expect(f.Has("Genres")).To(BeTrue())
+		Expect(f.Has("MediaSources")).To(BeTrue())
+		Expect(f.Has("SortName")).To(BeTrue())
+	})
+
+	It("returns an empty set for no values", func() {
+		Expect(ParseFields()).To(BeEmpty())
+		Expect(ParseFields("")).To(BeEmpty())
+	})
+})

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -62,6 +62,16 @@ var _ = Describe("Browsing", func() {
 			}
 		})
 
+		// Clients (Finamp, Feishin) send Fields as repeated params rather than one comma-separated
+		// value; real Jellyfin accepts both, so a later Fields=MediaSources must still take effect.
+		It("honors MediaSources when Fields is sent as repeated params", func() {
+			q := queryResult(get("/Items?IncludeItemTypes=Audio&Recursive=true&Fields=Genres&Fields=MediaSources"))
+			Expect(q.Items).ToNot(BeEmpty())
+			for _, it := range q.Items {
+				Expect(it.MediaSources).To(HaveLen(1))
+			}
+		})
+
 		It("lists all album artists", func() {
 			q := queryResult(get("/Items?IncludeItemTypes=MusicArtist&Recursive=true"))
 			Expect(q.TotalRecordCount).To(Equal(4))

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -224,13 +224,20 @@ type itemsQuery struct {
 	albumIds         []string
 }
 
+// parseFields reads the Fields param, accepting both repeated params (Fields=a&Fields=b) and a
+// comma-separated value (Fields=a,b), matching real Jellyfin. StringOr would keep only one value.
+func parseFields(p *req.Values) dto.Fields {
+	values, _ := p.Strings("fields")
+	return dto.ParseFields(values...)
+}
+
 // parseItemsQuery also resolves the entity types (inferring them from the parent when
 // IncludeItemTypes is absent) and the library scope. Query keys are read lowercase because
 // normalizeQueryKeys folded them (Jellyfin binds case-insensitively).
 func (api *Router) parseItemsQuery(ctx context.Context, r *http.Request) itemsQuery {
 	p := req.Params(r)
 	q := itemsQuery{
-		fields:    dto.ParseFields(p.StringOr("fields", "")),
+		fields:    parseFields(p),
 		ids:       decodedQueryIDs(r, "ids"),
 		rawTypes:  p.StringOr("includeitemtypes", ""),
 		search:    searchTerm(p),
@@ -730,7 +737,7 @@ func (api *Router) itemsByIDs(ctx context.Context, ids []string, fields dto.Fiel
 
 func (api *Router) getItem(w http.ResponseWriter, r *http.Request) {
 	id := api.resolveItemID(r.Context(), dto.DecodeID(chi.URLParam(r, "itemId")))
-	fields := dto.ParseFields(req.Params(r).StringOr("fields", ""))
+	fields := parseFields(req.Params(r))
 	if item, ok := api.resolveItemByID(r.Context(), id, fields); ok {
 		api.ok(w, r, item)
 		return

--- a/server/jellyfin/playlists.go
+++ b/server/jellyfin/playlists.go
@@ -191,7 +191,7 @@ func (api *Router) getPlaylistItems(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	p := req.Params(r)
-	fields := dto.ParseFields(p.StringOr("fields", ""))
+	fields := parseFields(p)
 	res, err := api.playlistTrackPage(repo, fields, p.IntOr("startindex", 0), p.IntOr("limit", 0))
 	if err != nil {
 		api.internalError(w, r, err)


### PR DESCRIPTION
### Description

Jellyfin clients can send list-style query params two ways — repeated
(`Fields=Genres&Fields=MediaSources`) or comma-separated (`Fields=Genres,MediaSources`) —
and real Jellyfin accepts both. Navidrome read the `Fields` param with `StringOr`,
which keeps only a single value, so the repeated form (used by Finamp and Feishin)
lost every value but the first. Field-gated data like `MediaSources` was then
omitted from `Audio` items even when the client requested it; the comma form
happened to work only because `ParseFields` splits on commas.

This makes `ParseFields` variadic and adds a small `parseFields` helper that reads
every repeated value via `req.Values.Strings`, applied to the three call sites
(item list, single-item `getItem`, and playlist items). No behavior change for the
comma form, and the "omit unless requested" gating is preserved.

### Related Issues

Related to #5806 (bug: "MediaSources not exposed for item responses that are of type Audio")

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Enable the Jellyfin API (`ND_JELLYFIN_ENABLED=true`) and scan any library.
2. Query an Audio item with `Fields` as **repeated** params:
   `GET /jellyfin/users/{userId}/items?IncludeItemTypes=Audio&Recursive=true&Fields=Genres&Fields=MediaSources`
3. **Expected:** each item includes `MediaSources`. Previously it was omitted.
4. Verify the comma form still works (`Fields=Genres,MediaSources`) and that a
   request without `MediaSources` in `Fields` still omits it.

Verified live: repeated and comma forms both yield `MediaSources`; order within
the repeated list doesn't matter; a request that omits it still gets no
`MediaSources`; and a second field-gated field (`SortName`) in a later repeated
param is honored too. Confirmed on both the item-list and single-item endpoints.

### Additional Notes

- Scoped to `Fields` deliberately. Sibling params (`IncludeItemTypes`, `SortBy`,
  `Filters`) are also read via `StringOr` and split on comma downstream, so they
  share the same latent shape — but there's no evidence clients send those as
  repeated params (they're conventionally comma-separated), so per YAGNI they're
  left as-is. If a second such bug appears, the consolidation point would be
  `normalizeQueryKeys` (which already rewrites the query) rather than another
  per-param helper.
