### PR TITLE
feat(jellyfin): expose NormalizationGain from ReplayGain tags

### DIFF
--- a/server/jellyfin/dto/dto.go
+++ b/server/jellyfin/dto/dto.go
@@ -61,20 +61,22 @@ type BaseItemDto struct {
 	PremiereDate *string `json:"PremiereDate,omitempty"`
 	// DateCreated is the ISO 8601 date the item was added to the library; clients show it as
 	// "Date Added" and sort "Recently Added" by it.
-	DateCreated          string            `json:"DateCreated,omitempty"`
-	Album                string            `json:"Album,omitempty"`
-	AlbumId              string            `json:"AlbumId,omitempty"`
-	AlbumArtist          string            `json:"AlbumArtist,omitempty"`
-	AlbumArtists         []NameGuidPair    `json:"AlbumArtists,omitempty"`
-	AlbumPrimaryImageTag string            `json:"AlbumPrimaryImageTag,omitempty"`
-	Artists              []string          `json:"Artists,omitempty"`
-	ArtistItems          []NameGuidPair    `json:"ArtistItems,omitempty"`
-	Genres               []string          `json:"Genres,omitempty"`
-	GenreItems           []NameGuidPair    `json:"GenreItems,omitempty"`
-	ChildCount           *int              `json:"ChildCount,omitempty"`
-	SongCount            *int              `json:"SongCount,omitempty"`
-	AlbumCount           *int              `json:"AlbumCount,omitempty"`
-	ImageTags            map[string]string `json:"ImageTags,omitempty"`
+	DateCreated            string            `json:"DateCreated,omitempty"`
+	Album                  string            `json:"Album,omitempty"`
+	AlbumId                string            `json:"AlbumId,omitempty"`
+	AlbumArtist            string            `json:"AlbumArtist,omitempty"`
+	AlbumArtists           []NameGuidPair    `json:"AlbumArtists,omitempty"`
+	AlbumPrimaryImageTag   string            `json:"AlbumPrimaryImageTag,omitempty"`
+	Artists                []string          `json:"Artists,omitempty"`
+	ArtistItems            []NameGuidPair    `json:"ArtistItems,omitempty"`
+	Genres                 []string          `json:"Genres,omitempty"`
+	GenreItems             []NameGuidPair    `json:"GenreItems,omitempty"`
+	NormalizationGain      *float64          `json:"NormalizationGain,omitempty"`
+	AlbumNormalizationGain *float64          `json:"AlbumNormalizationGain,omitempty"`
+	ChildCount             *int              `json:"ChildCount,omitempty"`
+	SongCount              *int              `json:"SongCount,omitempty"`
+	AlbumCount             *int              `json:"AlbumCount,omitempty"`
+	ImageTags              map[string]string `json:"ImageTags,omitempty"`
 	// ImageBlurHashes is keyed by image type (e.g. "Primary") then image tag. Finamp uses it as a
 	// de-dup key for image downloads (and a placeholder); absent, it warns the server isn't
 	// calculating blurhashes.

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -171,6 +171,9 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 	if mf.AlbumArtistID != "" {
 		item.AlbumArtists = []NameGuidPair{{Name: mf.AlbumArtist, Id: EncodeID(mf.AlbumArtistID)}}
 	}
+	// dB to apply at the RG2 −18 LUFS reference — same convention real Jellyfin uses, no conversion.
+	item.NormalizationGain = mf.RGTrackGain
+	item.AlbumNormalizationGain = mf.RGAlbumGain
 	if mf.Year > 0 {
 		item.ProductionYear = new(mf.Year)
 	}

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -171,7 +171,7 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 	if mf.AlbumArtistID != "" {
 		item.AlbumArtists = []NameGuidPair{{Name: mf.AlbumArtist, Id: EncodeID(mf.AlbumArtistID)}}
 	}
-	// dB to apply at the RG2 −18 LUFS reference — same convention real Jellyfin uses, no conversion.
+	// dB to apply at the RG2 -18 LUFS reference, same convention real Jellyfin uses; no conversion.
 	item.NormalizationGain = mf.RGTrackGain
 	item.AlbumNormalizationGain = mf.RGAlbumGain
 	if mf.Year > 0 {

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -125,6 +125,30 @@ var _ = Describe("mappers", func() {
 		Expect(item.AlbumArtists).To(Equal([]NameGuidPair{{Name: "De La Soul", Id: EncodeID("ar-delasoul")}}))
 	})
 
+	It("sets NormalizationGain and AlbumNormalizationGain from ReplayGain values", func() {
+		mf := model.MediaFile{ID: "s1", Title: "Song",
+			RGTrackGain: new(-3.5), RGAlbumGain: new(-4.25)}
+		item := SongToBaseItem(mf, nil)
+		Expect(*item.NormalizationGain).To(Equal(-3.5))
+		Expect(*item.AlbumNormalizationGain).To(Equal(-4.25))
+	})
+
+	It("serializes normalization gains with Jellyfin's exact key casing", func() {
+		mf := model.MediaFile{ID: "s1", Title: "Song",
+			RGTrackGain: new(-3.5), RGAlbumGain: new(-4.25)}
+		b, err := json.Marshal(SongToBaseItem(mf, nil))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(b)).To(ContainSubstring(`"NormalizationGain":-3.5`))
+		Expect(string(b)).To(ContainSubstring(`"AlbumNormalizationGain":-4.25`))
+	})
+
+	It("omits normalization gains when the file has no ReplayGain tags", func() {
+		b, err := json.Marshal(SongToBaseItem(model.MediaFile{ID: "s1", Title: "Song"}, nil))
+		Expect(err).ToNot(HaveOccurred())
+		// Substring check covers both keys (AlbumNormalizationGain contains NormalizationGain).
+		Expect(string(b)).ToNot(ContainSubstring("NormalizationGain"))
+	})
+
 	It("builds a MediaSourceInfo from a media file", func() {
 		mf := model.MediaFile{ID: "s1", Size: 5242880, Suffix: "mp3", BitRate: 320, Duration: 100}
 		src := MediaSourceFromMediaFile(mf)

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -125,14 +125,6 @@ var _ = Describe("mappers", func() {
 		Expect(item.AlbumArtists).To(Equal([]NameGuidPair{{Name: "De La Soul", Id: EncodeID("ar-delasoul")}}))
 	})
 
-	It("sets NormalizationGain and AlbumNormalizationGain from ReplayGain values", func() {
-		mf := model.MediaFile{ID: "s1", Title: "Song",
-			RGTrackGain: new(-3.5), RGAlbumGain: new(-4.25)}
-		item := SongToBaseItem(mf, nil)
-		Expect(*item.NormalizationGain).To(Equal(-3.5))
-		Expect(*item.AlbumNormalizationGain).To(Equal(-4.25))
-	})
-
 	It("serializes normalization gains with Jellyfin's exact key casing", func() {
 		mf := model.MediaFile{ID: "s1", Title: "Song",
 			RGTrackGain: new(-3.5), RGAlbumGain: new(-4.25)}

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -415,6 +415,22 @@ var _ = Describe("Browsing", func() {
 			Expect(item.AlbumArtists[0].Name).To(Equal("Miles Davis"))
 		})
 
+		It("exposes NormalizationGain and AlbumNormalizationGain from ReplayGain tags", func() {
+			var item dto.BaseItemDto
+			parseInto(get("/Items/"+enc(songID("Stairway To Heaven"))), &item)
+			Expect(item.NormalizationGain).ToNot(BeNil())
+			Expect(*item.NormalizationGain).To(BeNumerically("~", -3.5, 0.001))
+			Expect(item.AlbumNormalizationGain).ToNot(BeNil())
+			Expect(*item.AlbumNormalizationGain).To(BeNumerically("~", -4.25, 0.001))
+		})
+
+		It("omits normalization gains for files without ReplayGain tags", func() {
+			var item dto.BaseItemDto
+			parseInto(get("/Items/"+enc(songID("So What"))), &item)
+			Expect(item.NormalizationGain).To(BeNil())
+			Expect(item.AlbumNormalizationGain).To(BeNil())
+		})
+
 		It("resolves an artist", func() {
 			var item dto.BaseItemDto
 			parseInto(get("/Items/"+enc(artistID("Miles Davis"))), &item)

--- a/server/jellyfin/e2e/e2e_suite_test.go
+++ b/server/jellyfin/e2e/e2e_suite_test.go
@@ -121,7 +121,9 @@ func buildTestFS() storagetest.FakeFS {
 		"Rock/The Beatles/Abbey Road/02 - Come Together.mp3": abbeyRoad(track(2, "Come Together")),
 		"Rock/The Beatles/Help!/01 - Help.mp3":               help(track(1, "Help!")),
 		"Rock/Led Zeppelin/IV/01 - Stairway To Heaven.mp3": ledZepIV(track(1, "Stairway To Heaven", _t{
-			"lyrics:eng": "[00:01.00]There's a lady who's sure\n[00:05.50]All that glitters is gold",
+			"lyrics:eng":            "[00:01.00]There's a lady who's sure\n[00:05.50]All that glitters is gold",
+			"replaygain_track_gain": "-3.50 dB",
+			"replaygain_album_gain": "-4.25 dB",
 		})),
 		"Jazz/Miles Davis/Kind of Blue/01 - So What.mp3":    kindOfBlue(track(1, "So What")),
 		"Pop/Solo Artist/Singles/01 - Standalone Track.mp3": singles(track(1, "Standalone Track")),


### PR DESCRIPTION
### Description

Adds `NormalizationGain` and `AlbumNormalizationGain` to Audio items on the
Jellyfin API, so clients like Feishin can volume-normalize playback.

The values come straight from the ReplayGain data the scanner already extracts
(`REPLAYGAIN_*` tags, with `R128_*` converted to the same reference level) — no
new analysis, no persistence changes. This is the same unit and reference real
Jellyfin uses: dB of gain to apply at −18 LUFS ("same as ReplayGain 2.0", per
Jellyfin's own source, which stores a `REPLAYGAIN_TRACK_GAIN` tag verbatim into
`NormalizationGain`). Verified against jellyfin, jellyfin-web, and Feishin
sources:

- Both fields live on `BaseItemDto`, PascalCase, omitted when null.
- Real Jellyfin emits them unconditionally (there is no `ItemFields` entry), so
  no `Fields=` gating here either.
- Feishin reads both fields from song DTOs and applies `10^(dB/20)` in its web
  player.

Implementation is two optional pointer fields on the DTO plus a direct
assignment in `SongToBaseItem`, covering every path that serves songs (lists,
search, single item, playlists, similar/instant-mix).

### Related Issues

Related to #5807 (first item: `NormalizationGain` / `AlbumNormalizationGain`)

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Enable the Jellyfin API (`ND_JELLYFIN_ENABLED=true`) and scan a library
   containing files with `REPLAYGAIN_TRACK_GAIN`/`REPLAYGAIN_ALBUM_GAIN` tags.
2. Query `GET /jellyfin/users/{userId}/items?IncludeItemTypes=Audio&Recursive=true`.
3. **Expected:** tagged items carry `"NormalizationGain"` and
   `"AlbumNormalizationGain"` with the tag values in dB; untagged items omit
   both keys entirely (not `0`).
4. The single-item endpoint (`/Items/{id}`) returns the same values.

Verified live against a running server: −6.2/−5.1 on a tagged file through both
the list and single-item paths, keys absent on an untagged file.

### Additional Notes

- Album (`MusicAlbum`) items intentionally do not carry `NormalizationGain`
  (real JF puts the album's own gain there): `model.Album` has no gain column,
  and Feishin reads gain from song DTOs, so the aggregation cost buys nothing
  today. Can be revisited if a client needs it.
- No ffmpeg/LUFS analysis for untagged files (real JF has an opt-in scheduled
  task for this) — files without ReplayGain tags simply omit the fields,
  consistent with how the Subsonic `replayGain` object behaves.
