### PR TITLE
feat(jellyfin): expose album-level ReplayGain

### DIFF
--- a/db/migrations/20260719005427_add_album_replaygain.go
+++ b/db/migrations/20260719005427_add_album_replaygain.go
@@ -12,13 +12,28 @@ func init() {
 }
 
 func upAddAlbumReplaygain(ctx context.Context, tx *sql.Tx) error {
+	// Backfill the most-frequent non-null value per album, matching MediaFiles.ToAlbum. A plain
+	// max() would pick a minority outlier, and GetTouchedAlbums never re-derives an unchanged album,
+	// so a wrong value would persist. The CTEs group media_file once instead of scanning it per album.
 	_, err := tx.ExecContext(ctx, `
 ALTER TABLE album ADD COLUMN rg_album_gain real;
 ALTER TABLE album ADD COLUMN rg_album_peak real;
 
+WITH gain_mode AS (
+	SELECT album_id, rg_album_gain AS val,
+		row_number() OVER (PARTITION BY album_id ORDER BY count(*) DESC, rg_album_gain) AS rn
+	FROM media_file WHERE rg_album_gain IS NOT NULL
+	GROUP BY album_id, rg_album_gain
+),
+peak_mode AS (
+	SELECT album_id, rg_album_peak AS val,
+		row_number() OVER (PARTITION BY album_id ORDER BY count(*) DESC, rg_album_peak) AS rn
+	FROM media_file WHERE rg_album_peak IS NOT NULL
+	GROUP BY album_id, rg_album_peak
+)
 UPDATE album SET
-	rg_album_gain = (SELECT max(rg_album_gain) FROM media_file WHERE media_file.album_id = album.id),
-	rg_album_peak = (SELECT max(rg_album_peak) FROM media_file WHERE media_file.album_id = album.id);
+	rg_album_gain = (SELECT val FROM gain_mode WHERE gain_mode.album_id = album.id AND gain_mode.rn = 1),
+	rg_album_peak = (SELECT val FROM peak_mode WHERE peak_mode.album_id = album.id AND peak_mode.rn = 1);
 	`)
 	return err
 }

--- a/db/migrations/20260719005427_add_album_replaygain.go
+++ b/db/migrations/20260719005427_add_album_replaygain.go
@@ -1,0 +1,29 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/pressly/goose/v3"
+)
+
+func init() {
+	goose.AddMigrationContext(upAddAlbumReplaygain, downAddAlbumReplaygain)
+}
+
+func upAddAlbumReplaygain(ctx context.Context, tx *sql.Tx) error {
+	_, err := tx.ExecContext(ctx, `
+ALTER TABLE album ADD COLUMN rg_album_gain real;
+ALTER TABLE album ADD COLUMN rg_album_peak real;
+
+UPDATE album SET
+	rg_album_gain = (SELECT max(rg_album_gain) FROM media_file WHERE media_file.album_id = album.id),
+	rg_album_peak = (SELECT max(rg_album_peak) FROM media_file WHERE media_file.album_id = album.id);
+	`)
+	return err
+}
+
+func downAddAlbumReplaygain(ctx context.Context, tx *sql.Tx) error {
+	// This code is executed when the migration is rolled back.
+	return nil
+}

--- a/model/album.go
+++ b/model/album.go
@@ -49,6 +49,8 @@ type Album struct {
 	MbzReleaseGroupID    string   `structs:"mbz_release_group_id" json:"mbzReleaseGroupId,omitempty"`
 	FolderIDs            []string `structs:"folder_ids" json:"-" hash:"set"` // All folders that contain media_files for this album
 	ExplicitStatus       string   `structs:"explicit_status" json:"explicitStatus"`
+	RGAlbumGain          *float64 `structs:"rg_album_gain" json:"rgAlbumGain"`
+	RGAlbumPeak          *float64 `structs:"rg_album_peak" json:"rgAlbumPeak"`
 
 	// External metadata fields
 	Description           string     `structs:"description" json:"description,omitempty" hash:"ignore"`

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -314,6 +314,8 @@ func (mfs MediaFiles) ToAlbum() Album {
 	originalYears := make([]int, 0, len(mfs))
 	originalDates := make([]string, 0, len(mfs))
 	releaseDates := make([]string, 0, len(mfs))
+	rgAlbumGains := make([]*float64, 0, len(mfs))
+	rgAlbumPeaks := make([]*float64, 0, len(mfs))
 	tags := make(TagList, 0, len(mfs[0].Tags)*len(mfs))
 
 	a.Missing = true
@@ -344,6 +346,8 @@ func (mfs MediaFiles) ToAlbum() Album {
 		originalYears = append(originalYears, m.OriginalYear)
 		originalDates = append(originalDates, m.OriginalDate)
 		releaseDates = append(releaseDates, m.ReleaseDate)
+		rgAlbumGains = append(rgAlbumGains, m.RGAlbumGain)
+		rgAlbumPeaks = append(rgAlbumPeaks, m.RGAlbumPeak)
 		comments = append(comments, m.Comment)
 		mbzAlbumIds = append(mbzAlbumIds, m.MbzAlbumID)
 		mbzReleaseGroupIds = append(mbzReleaseGroupIds, m.MbzReleaseGroupID)
@@ -378,6 +382,8 @@ func (mfs MediaFiles) ToAlbum() Album {
 	a.Comment, _ = allOrNothing(comments)
 	a.MbzAlbumID = slice.MostFrequent(mbzAlbumIds)
 	a.MbzReleaseGroupID = slice.MostFrequent(mbzReleaseGroupIds)
+	a.RGAlbumGain = mostFrequentPtr(rgAlbumGains)
+	a.RGAlbumPeak = mostFrequentPtr(rgAlbumPeaks)
 	fixAlbumArtist(&a)
 
 	return a
@@ -405,6 +411,26 @@ func minMax(items []int) (int, int) {
 		}
 	}
 	return mn, mx
+}
+
+// mostFrequentPtr returns a pointer to the most common non-nil value, or nil if
+// none. It counts by dereferenced value so a genuine 0.0 is a real candidate
+// (slice.MostFrequent skips the zero value and compares pointers by identity).
+func mostFrequentPtr(items []*float64) *float64 {
+	counts := map[float64]int{}
+	var best *float64
+	var bestCount int
+	for _, it := range items {
+		if it == nil {
+			continue
+		}
+		counts[*it]++
+		if counts[*it] > bestCount {
+			bestCount = counts[*it]
+			best = it
+		}
+	}
+	return best
 }
 
 func newer(t1, t2 time.Time) time.Time {

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -418,7 +418,7 @@ func minMax(items []int) (int, int) {
 // (slice.MostFrequent skips the zero value and compares pointers by identity).
 func mostFrequentPtr(items []*float64) *float64 {
 	var counts map[float64]int
-	var best *float64
+	var best float64
 	var bestCount int
 	for _, it := range items {
 		if it == nil {
@@ -430,10 +430,13 @@ func mostFrequentPtr(items []*float64) *float64 {
 		counts[*it]++
 		if counts[*it] > bestCount {
 			bestCount = counts[*it]
-			best = it
+			best = *it
 		}
 	}
-	return best
+	if bestCount == 0 {
+		return nil
+	}
+	return &best
 }
 
 func newer(t1, t2 time.Time) time.Time {

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -417,12 +417,15 @@ func minMax(items []int) (int, int) {
 // none. It counts by dereferenced value so a genuine 0.0 is a real candidate
 // (slice.MostFrequent skips the zero value and compares pointers by identity).
 func mostFrequentPtr(items []*float64) *float64 {
-	counts := map[float64]int{}
+	var counts map[float64]int
 	var best *float64
 	var bestCount int
 	for _, it := range items {
 		if it == nil {
 			continue
+		}
+		if counts == nil {
+			counts = map[float64]int{}
 		}
 		counts[*it]++
 		if counts[*it] > bestCount {

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -268,6 +268,35 @@ var _ = Describe("MediaFiles", func() {
 					})
 				})
 			})
+			Context("ReplayGain", func() {
+				It("picks the most frequent non-nil album gain and peak", func() {
+					mfs := MediaFiles{
+						{Path: "a", RGAlbumGain: new(-8.0), RGAlbumPeak: new(0.9)},
+						{Path: "b", RGAlbumGain: new(-8.0), RGAlbumPeak: new(0.9)},
+						{Path: "c", RGAlbumGain: new(-5.0), RGAlbumPeak: new(1.0)},
+					}
+					album := mfs.ToAlbum()
+					Expect(album.RGAlbumGain).ToNot(BeNil())
+					Expect(*album.RGAlbumGain).To(Equal(-8.0))
+					Expect(album.RGAlbumPeak).ToNot(BeNil())
+					Expect(*album.RGAlbumPeak).To(Equal(0.9))
+				})
+				It("keeps a genuine 0.0 gain instead of dropping it", func() {
+					mfs := MediaFiles{
+						{Path: "a", RGAlbumGain: new(0.0)},
+						{Path: "b", RGAlbumGain: new(0.0)},
+					}
+					album := mfs.ToAlbum()
+					Expect(album.RGAlbumGain).ToNot(BeNil())
+					Expect(*album.RGAlbumGain).To(Equal(0.0))
+				})
+				It("leaves gain and peak nil when no track has a value", func() {
+					mfs := MediaFiles{{Path: "a"}, {Path: "b"}}
+					album := mfs.ToAlbum()
+					Expect(album.RGAlbumGain).To(BeNil())
+					Expect(album.RGAlbumPeak).To(BeNil())
+				})
+			})
 			Context("Participants", func() {
 				var album Album
 				BeforeEach(func() {

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -31,6 +31,10 @@ type dbAlbum struct {
 	Participants string `structs:"-" json:"-"`
 	Tags         string `structs:"-" json:"-"`
 	FolderIDs    string `structs:"-" json:"-"`
+	// dbx maps columns to fields by name; RGAlbumGain doesn't convert to
+	// rg_album_gain, so shim fields carry the read and PostScan copies them over.
+	RgAlbumGain *float64 `structs:"-" json:"-"`
+	RgAlbumPeak *float64 `structs:"-" json:"-"`
 }
 
 func (a *dbAlbum) PostScan() error {
@@ -58,6 +62,8 @@ func (a *dbAlbum) PostScan() error {
 		}
 		a.Album.FolderIDs = ids
 	}
+	a.Album.RGAlbumGain = a.RgAlbumGain
+	a.Album.RGAlbumPeak = a.RgAlbumPeak
 	return nil
 }
 

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -892,6 +892,11 @@ var _ = Describe("AlbumRepository", func() {
 	})
 
 	Describe("ReplayGain", func() {
+		BeforeEach(func() {
+			DeferCleanup(func() {
+				_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": []string{"rg-1", "rg-2"}}))
+			})
+		})
 		It("round-trips album ReplayGain gain and peak", func() {
 			Expect(albumRepo.Put(&model.Album{
 				ID: "rg-1", Name: "rg", LibraryID: 1,

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -890,6 +890,28 @@ var _ = Describe("AlbumRepository", func() {
 			Expect(albums[0].ID).To(Equal("a1"))
 		})
 	})
+
+	Describe("ReplayGain", func() {
+		It("round-trips album ReplayGain gain and peak", func() {
+			Expect(albumRepo.Put(&model.Album{
+				ID: "rg-1", Name: "rg", LibraryID: 1,
+				RGAlbumGain: new(-7.5), RGAlbumPeak: new(0.98),
+			})).To(Succeed())
+			got, err := albumRepo.Get("rg-1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.RGAlbumGain).ToNot(BeNil())
+			Expect(*got.RGAlbumGain).To(Equal(-7.5))
+			Expect(got.RGAlbumPeak).ToNot(BeNil())
+			Expect(*got.RGAlbumPeak).To(Equal(0.98))
+		})
+		It("reads nil when ReplayGain is unset", func() {
+			Expect(albumRepo.Put(&model.Album{ID: "rg-2", Name: "rg2", LibraryID: 1})).To(Succeed())
+			got, err := albumRepo.Get("rg-2")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.RGAlbumGain).To(BeNil())
+			Expect(got.RGAlbumPeak).To(BeNil())
+		})
+	})
 })
 
 func _p(id, name string, sortName ...string) model.Participant {

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -232,6 +232,9 @@ func AlbumToBaseItem(al model.Album) BaseItemDto {
 			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: EncodeID(g.ID), Name: g.Name})
 		}
 	}
+	// The album's own ReplayGain gain (dB at the RG2 -18 LUFS reference) — same
+	// convention as tracks; clients read it off the album item as NormalizationGain.
+	item.NormalizationGain = al.RGAlbumGain
 	return item
 }
 

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -260,6 +260,21 @@ var _ = Describe("mappers", func() {
 		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: EncodeID("1"), Name: "genre 1"}, {Id: EncodeID("2"), Name: "genre 2"}}))
 	})
 
+	It("sets NormalizationGain on the album from its ReplayGain", func() {
+		al := model.Album{ID: "al1", Name: "Album", RGAlbumGain: new(-6.0)}
+		b, err := json.Marshal(AlbumToBaseItem(al))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(b)).To(ContainSubstring(`"NormalizationGain":-6`))
+		// Real Jellyfin never sets AlbumNormalizationGain on an album item.
+		Expect(string(b)).ToNot(ContainSubstring("AlbumNormalizationGain"))
+	})
+
+	It("omits NormalizationGain when the album has no ReplayGain", func() {
+		b, err := json.Marshal(AlbumToBaseItem(model.Album{ID: "al1", Name: "Album"}))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(b)).ToNot(ContainSubstring("NormalizationGain"))
+	})
+
 	It("maps an artist to a MusicArtist folder item", func() {
 		ar := model.Artist{ID: "art-1", Name: "AA", AlbumCount: 2, SongCount: 20}
 		item := ArtistToBaseItem(ar)


### PR DESCRIPTION
### Description

Adds album-level ReplayGain to Navidrome.

**What:** `model.Album` gains two nullable fields, `RGAlbumGain` and `RGAlbumPeak`, populated during scanning by aggregating the per-track ReplayGain values already carried on each `MediaFile`. The values are persisted, exposed automatically on the Native API, and mapped onto the Jellyfin album DTO's `NormalizationGain` field.

**Why:** Track-level and per-song `AlbumNormalizationGain` shipped in #5815, but the album itself carried no ReplayGain. Clients (e.g. jellyfin-web) fetch the album item and read its own `NormalizationGain` to drive album-mode volume normalization; without it, album-gain normalization can't be served without walking every track.

**How:**
- **Aggregation (`MediaFiles.ToAlbum`)** — picks the most-frequent non-nil album gain/peak across the album's tracks (a small local helper rather than `slice.MostFrequent`, which skips the zero value and compares pointers by identity, so a genuine `0.0` dB would be dropped).
- **Persistence** — nullable `real` columns `rg_album_gain` / `rg_album_peak`, read back via a `dbAlbum` shim mirroring the existing `dbMediaFile` pattern (dbx can't map `RGAlbumGain` → `rg_album_gain` by name).
- **Migration** — adds the columns and backfills existing albums from `media_file` (no full rescan needed, since the per-track data is already in the DB).
- **Jellyfin (`AlbumToBaseItem`)** — sets `NormalizationGain` **only** (never `AlbumNormalizationGain` on an album), matching real Jellyfin's `DtoService` and how jellyfin-web consumes it.

Nullability is deliberate end-to-end: an album with no ReplayGain reads back `nil` and is omitted from the API responses rather than emitted as `0`.

### Related Issues

Follow-up to #5815 (which added track/song `NormalizationGain`).

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Point Navidrome at a library whose tracks carry ReplayGain album tags (`replaygain_album_gain` / `replaygain_album_peak`, or R128 album gain) and run a scan.
2. **Native API** — `GET /api/album/{id}` returns `rgAlbumGain` and `rgAlbumPeak`; an album without ReplayGain returns them as `null`.
3. **Jellyfin API** (requires `Jellyfin.Enabled = true`) — `GET /jellyfin/Users/{userId}/Items?IncludeItemTypes=MusicAlbum` returns `NormalizationGain` on albums that have ReplayGain, and omits it (along with `AlbumNormalizationGain`, which is never set on an album) when they don't.
4. **Upgrade path** — on an existing database, the migration backfills album gain/peak from the already-scanned `media_file` rows, so albums expose the values without a re-scan.

### Additional Notes

- The migration backfills the most-frequent album gain/peak per album (matching `MediaFiles.ToAlbum`), computed via grouped CTEs so `media_file` is scanned once rather than per album. `max()` was avoided because it would pick a minority outlier when track tags disagree, and `GetTouchedAlbums` never re-derives an unchanged album, so a wrong value would persist.
- No UI changes and no Subsonic/OpenSubsonic changes in this PR.

