### PR TITLE
feat(jellyfin): filter items by year and record label

### DIFF
--- a/model/album.go
+++ b/model/album.go
@@ -142,7 +142,7 @@ type AlbumRepository interface {
 	Get(id string) (*Album, error)
 	GetAll(...QueryOptions) (Albums, error)
 	GetCursor(...QueryOptions) (AlbumCursor, error)
-	GetYears() ([]int, error)
+	GetYears(libraryIDs ...int) ([]int, error)
 
 	// The following methods are used exclusively by the scanner:
 	Touch(ids ...string) error

--- a/model/album.go
+++ b/model/album.go
@@ -142,6 +142,7 @@ type AlbumRepository interface {
 	Get(id string) (*Album, error)
 	GetAll(...QueryOptions) (Albums, error)
 	GetCursor(...QueryOptions) (AlbumCursor, error)
+	GetYears() ([]int, error)
 
 	// The following methods are used exclusively by the scanner:
 	Touch(ids ...string) error

--- a/model/tag.go
+++ b/model/tag.go
@@ -153,6 +153,7 @@ func (t Tags) Add(name TagName, v string) {
 type TagRepository interface {
 	Add(libraryID int, tags ...Tag) error
 	UpdateCounts() error
+	GetAll(name TagName, options ...QueryOptions) (TagList, error)
 }
 
 type TagName string

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"maps"
@@ -254,6 +255,18 @@ func (r *albumRepository) GetCursor(options ...model.QueryOptions) (model.AlbumC
 		return nil, err
 	}
 	return wrapAlbumCursor(cursor), nil
+}
+
+func (r *albumRepository) GetYears() ([]int, error) {
+	sq := r.applyLibraryFilter(
+		Select("distinct max_year").From("album").Where(Gt{"max_year": 0}).OrderBy("max_year"),
+	)
+	years := []int{}
+	err := r.queryAllSlice(sq, &years)
+	if err != nil && !errors.Is(err, model.ErrNotFound) {
+		return nil, err
+	}
+	return years, nil
 }
 
 func (r *albumRepository) CopyAttributes(fromID, toID string, columns ...string) error {

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -257,11 +257,12 @@ func (r *albumRepository) GetCursor(options ...model.QueryOptions) (model.AlbumC
 	return wrapAlbumCursor(cursor), nil
 }
 
-func (r *albumRepository) GetYears() ([]int, error) {
-	sq := r.applyLibraryFilter(
-		Select("distinct max_year").From("album").
-			Where(And{Gt{"max_year": 0}, Eq{"missing": false}}).OrderBy("max_year"),
-	)
+func (r *albumRepository) GetYears(libraryIDs ...int) ([]int, error) {
+	cond := And{Gt{"max_year": 0}, Eq{"missing": false}}
+	if len(libraryIDs) > 0 {
+		cond = append(cond, Eq{"library_id": libraryIDs})
+	}
+	sq := r.applyLibraryFilter(Select("distinct max_year").From("album").Where(cond).OrderBy("max_year"))
 	years := []int{}
 	err := r.queryAllSlice(sq, &years)
 	if err != nil && !errors.Is(err, model.ErrNotFound) {

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -259,7 +259,8 @@ func (r *albumRepository) GetCursor(options ...model.QueryOptions) (model.AlbumC
 
 func (r *albumRepository) GetYears() ([]int, error) {
 	sq := r.applyLibraryFilter(
-		Select("distinct max_year").From("album").Where(Gt{"max_year": 0}).OrderBy("max_year"),
+		Select("distinct max_year").From("album").
+			Where(And{Gt{"max_year": 0}, Eq{"missing": false}}).OrderBy("max_year"),
 	)
 	years := []int{}
 	err := r.queryAllSlice(sq, &years)

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -888,6 +888,16 @@ var _ = Describe("AlbumRepository", func() {
 			Expect(count).To(Equal(1), "year 2005 should appear exactly once despite two albums having it")
 		})
 
+		It("scopes years to the given libraries", func() {
+			all, err := albumRepo.GetYears()
+			Expect(err).ToNot(HaveOccurred())
+			// A library with no albums yields no years.
+			scoped, err := albumRepo.GetYears(99999)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(scoped).To(BeEmpty())
+			Expect(all).ToNot(BeEmpty())
+		})
+
 		It("excludes years that belong only to missing albums", func() {
 			gone := &model.Album{LibraryID: 1, ID: "missing-year-1", Name: "Gone", MaxYear: 1911, Missing: true}
 			Expect(albumRepo.Put(gone)).To(Succeed())

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -3,6 +3,7 @@ package persistence
 import (
 	"errors"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/Masterminds/squirrel"
@@ -848,6 +849,19 @@ var _ = Describe("AlbumRepository", func() {
 			// Clean up
 			_, _ = artistRepo.executeSQL(squirrel.Delete("artist").Where(squirrel.Eq{"id": artist.ID}))
 			_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": album.ID}))
+		})
+	})
+
+	Describe("GetYears", func() {
+		It("returns distinct album years ascending, excluding zero", func() {
+			years, err := albumRepo.GetYears()
+			Expect(err).ToNot(HaveOccurred())
+			// Sorted ascending, no duplicates, no zero-year entries.
+			Expect(sort.IsSorted(sort.IntSlice(years))).To(BeTrue())
+			Expect(years).ToNot(ContainElement(0))
+			for i := 1; i < len(years); i++ {
+				Expect(years[i]).To(BeNumerically(">", years[i-1])) // strictly increasing = distinct
+			}
 		})
 	})
 

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -887,6 +887,18 @@ var _ = Describe("AlbumRepository", func() {
 			}
 			Expect(count).To(Equal(1), "year 2005 should appear exactly once despite two albums having it")
 		})
+
+		It("excludes years that belong only to missing albums", func() {
+			gone := &model.Album{LibraryID: 1, ID: "missing-year-1", Name: "Gone", MaxYear: 1911, Missing: true}
+			Expect(albumRepo.Put(gone)).To(Succeed())
+			DeferCleanup(func() {
+				_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": "missing-year-1"}))
+			})
+
+			years, err := albumRepo.GetYears()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(years).ToNot(ContainElement(1911))
+		})
 	})
 
 	Describe("wrapAlbumCursor", func() {

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -863,6 +863,30 @@ var _ = Describe("AlbumRepository", func() {
 				Expect(years[i]).To(BeNumerically(">", years[i-1])) // strictly increasing = distinct
 			}
 		})
+
+		It("deduplicates repeated years", func() {
+			// Regression test: verify that DISTINCT is applied in the SQL.
+			// Insert two albums with the same non-zero max_year (2005).
+			album1 := &model.Album{LibraryID: 1, ID: "dedup-test-1", Name: "Album 1", MaxYear: 2005}
+			album2 := &model.Album{LibraryID: 1, ID: "dedup-test-2", Name: "Album 2", MaxYear: 2005}
+			Expect(albumRepo.Put(album1)).To(Succeed())
+			Expect(albumRepo.Put(album2)).To(Succeed())
+			DeferCleanup(func() {
+				_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": []string{"dedup-test-1", "dedup-test-2"}}))
+			})
+
+			years, err := albumRepo.GetYears()
+			Expect(err).ToNot(HaveOccurred())
+
+			// Count occurrences of 2005 in the result
+			count := 0
+			for _, y := range years {
+				if y == 2005 {
+					count++
+				}
+			}
+			Expect(count).To(Equal(1), "year 2005 should appear exactly once despite two albums having it")
+		})
 	})
 
 	Describe("wrapAlbumCursor", func() {

--- a/persistence/tag_repository.go
+++ b/persistence/tag_repository.go
@@ -75,7 +75,7 @@ DO UPDATE SET %[1]s_count = excluded.%[1]s_count;
 }
 
 func (r *tagRepository) GetAll(name model.TagName, options ...model.QueryOptions) (model.TagList, error) {
-	sq := r.newSelect(options...).Columns("tag.id", "tag.tag_value").Where(Eq{"tag.tag_name": name})
+	sq := r.newSelect(options...).Where(Eq{"tag.tag_name": name})
 	res := model.TagList{}
 	err := r.queryAll(sq, &res)
 	return res, err

--- a/persistence/tag_repository.go
+++ b/persistence/tag_repository.go
@@ -74,13 +74,20 @@ DO UPDATE SET %[1]s_count = excluded.%[1]s_count;
 	return nil
 }
 
+func (r *tagRepository) GetAll(name model.TagName, options ...model.QueryOptions) (model.TagList, error) {
+	sq := r.newSelect(options...).Columns("tag.id", "tag.tag_value").Where(Eq{"tag.tag_name": name})
+	res := model.TagList{}
+	err := r.queryAll(sq, &res)
+	return res, err
+}
+
 func (r *tagRepository) purgeUnused() error {
-	del := Delete(r.tableName).Where(`	
+	del := Delete(r.tableName).Where(`
 	id not in (select jt.value
 	from album left join json_tree(album.tags, '$') as jt
 	where atom is not null
 	  and key = 'id'
-	UNION 
+	UNION
 	select jt.value
 	from media_file left join json_tree(media_file.tags, '$') as jt
 	where atom is not null

--- a/server/filter/filters.go
+++ b/server/filter/filters.go
@@ -214,10 +214,17 @@ func ArtistsByGenreID(genreIds []string) Sqlizer {
 	)
 }
 
-// genreTagFilter builds an EXISTS over the genre entries in the tags JSON, matching each entry
-// against cond (its name via Like, or its tag id via Eq/IN). Shared by the name- and id-based lookups.
-func genreTagFilter(cond Sqlizer) Sqlizer {
-	return persistence.Exists(`json_tree(tags, "$.genre")`, And{NotEq{"atom": nil}, cond})
+// tagIDFilter builds an EXISTS over the given tag role's entries in the tags JSON, matching each
+// entry against cond (its name via Like, or its tag id via Eq/IN).
+func tagIDFilter(tagName string, cond Sqlizer) Sqlizer {
+	return persistence.Exists(`json_tree(tags, "$.`+tagName+`")`, And{NotEq{"atom": nil}, cond})
+}
+
+func genreTagFilter(cond Sqlizer) Sqlizer { return tagIDFilter("genre", cond) }
+
+// ByStudioID matches items (albums or songs) whose record-label tag id is in ids.
+func ByStudioID(ids []string) Sqlizer {
+	return tagIDFilter("recordlabel", Eq{"value": ids})
 }
 
 func filterByGenre(genre string) Sqlizer {

--- a/server/filter/filters.go
+++ b/server/filter/filters.go
@@ -194,6 +194,16 @@ func ByAlbumID(albumIds []string) Sqlizer {
 	return Eq{"album_id": albumIds}
 }
 
+// AlbumsByYears matches albums whose production year (max_year) is in years.
+func AlbumsByYears(years []int) Sqlizer {
+	return Eq{"max_year": years}
+}
+
+// SongsByYears matches media files whose year is in years.
+func SongsByYears(years []int) Sqlizer {
+	return Eq{"year": years}
+}
+
 // ArtistsByGenreID matches artists credited as album artist on an album with any of the given
 // genre tag ids. Non-correlated semi-join: the correlated EXISTS form rescans albums per artist row.
 func ArtistsByGenreID(genreIds []string) Sqlizer {

--- a/server/jellyfin/api.go
+++ b/server/jellyfin/api.go
@@ -146,6 +146,7 @@ func (api *Router) routes() http.Handler {
 		r.Get("/items/{itemId}/instantmix", api.getInstantMix)
 		r.Get("/genres", api.getGenres)
 		r.Get("/musicgenres", api.getGenres)
+		r.Get("/studios", api.getStudios)
 		r.Get("/items/filters", api.getQueryFiltersLegacy)
 
 		r.Post("/playlists", api.createPlaylist)

--- a/server/jellyfin/api.go
+++ b/server/jellyfin/api.go
@@ -146,6 +146,7 @@ func (api *Router) routes() http.Handler {
 		r.Get("/items/{itemId}/instantmix", api.getInstantMix)
 		r.Get("/genres", api.getGenres)
 		r.Get("/musicgenres", api.getGenres)
+		r.Get("/items/filters", api.getQueryFiltersLegacy)
 
 		r.Post("/playlists", api.createPlaylist)
 		r.Get("/playlists/{playlistId}", api.getPlaylist)

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -3,6 +3,7 @@ package jellyfin
 import (
 	"net/http"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
 	"github.com/navidrome/navidrome/utils/req"
@@ -62,11 +63,16 @@ func (api *Router) getGenres(w http.ResponseWriter, r *http.Request) {
 }
 
 // getStudios handles GET /Studios, exposing record labels (Jellyfin's audio "studio" source) as
-// Studio items. Global, like genres.
+// Studio items, scoped to ParentId's library when accessible.
 func (api *Router) getStudios(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	p := req.Params(r)
-	labels, err := api.ds.Tag(ctx).GetAll(model.TagRecordLabel, model.QueryOptions{Sort: "tag_value"})
+	scope, _ := resolveLibraryScope(ctx, dto.DecodeID(p.StringOr("parentid", "")))
+	opts := model.QueryOptions{Sort: "tag_value"}
+	if len(scope) > 0 {
+		opts.Filters = squirrel.Eq{"library_tag.library_id": scope}
+	}
+	labels, err := api.ds.Tag(ctx).GetAll(model.TagRecordLabel, opts)
 	if err != nil {
 		api.internalError(w, r, err)
 		return
@@ -76,16 +82,21 @@ func (api *Router) getStudios(w http.ResponseWriter, r *http.Request) {
 	api.ok(w, r, result(paginate(items, offset, max), len(items), offset))
 }
 
-// getQueryFiltersLegacy handles GET /Items/Filters. Genres reuse the global genre list; Years are
-// distinct album years. Tags/OfficialRatings have no music source, so they are always empty.
+// getQueryFiltersLegacy handles GET /Items/Filters. Genres and Years are scoped to ParentId's
+// library when accessible. Tags/OfficialRatings have no music source, so they are always empty.
 func (api *Router) getQueryFiltersLegacy(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	genres, err := api.ds.Genre(ctx).GetAll(model.QueryOptions{Sort: "name"})
+	scope, _ := resolveLibraryScope(ctx, dto.DecodeID(req.Params(r).StringOr("parentid", "")))
+	genreOpts := model.QueryOptions{Sort: "name"}
+	if len(scope) > 0 {
+		genreOpts.Filters = squirrel.Eq{"library_tag.library_id": scope}
+	}
+	genres, err := api.ds.Genre(ctx).GetAll(genreOpts)
 	if err != nil {
 		api.internalError(w, r, err)
 		return
 	}
-	years, err := api.ds.Album(ctx).GetYears()
+	years, err := api.ds.Album(ctx).GetYears(scope...)
 	if err != nil {
 		api.internalError(w, r, err)
 		return

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -6,6 +6,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
 	"github.com/navidrome/navidrome/utils/req"
+	"github.com/navidrome/navidrome/utils/slice"
 )
 
 // getArtists handles GET /Artists (performing artists, Finamp's "Artists" tab); getAlbumArtists
@@ -58,4 +59,26 @@ func (api *Router) getGenres(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	api.ok(w, r, res)
+}
+
+// getQueryFiltersLegacy handles GET /Items/Filters. Genres reuse the global genre list; Years are
+// distinct album years. Tags/OfficialRatings have no music source, so they are always empty.
+func (api *Router) getQueryFiltersLegacy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	genres, err := api.ds.Genre(ctx).GetAll(model.QueryOptions{Sort: "name"})
+	if err != nil {
+		api.internalError(w, r, err)
+		return
+	}
+	years, err := api.ds.Album(ctx).GetYears()
+	if err != nil {
+		api.internalError(w, r, err)
+		return
+	}
+	api.ok(w, r, dto.QueryFiltersLegacy{
+		Genres:          slice.Map(genres, func(g model.Genre) string { return g.Name }),
+		Tags:            []string{},
+		OfficialRatings: []string{},
+		Years:           years,
+	})
 }

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -61,6 +61,21 @@ func (api *Router) getGenres(w http.ResponseWriter, r *http.Request) {
 	api.ok(w, r, res)
 }
 
+// getStudios handles GET /Studios, exposing record labels (Jellyfin's audio "studio" source) as
+// Studio items. Global, like genres.
+func (api *Router) getStudios(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	p := req.Params(r)
+	labels, err := api.ds.Tag(ctx).GetAll(model.TagRecordLabel, model.QueryOptions{Sort: "tag_value"})
+	if err != nil {
+		api.internalError(w, r, err)
+		return
+	}
+	items := slice.Map(labels, dto.StudioToBaseItem)
+	offset, max := p.IntOr("startindex", 0), p.IntOr("limit", 0)
+	api.ok(w, r, result(paginate(items, offset, max), len(items), offset))
+}
+
 // getQueryFiltersLegacy handles GET /Items/Filters. Genres reuse the global genre list; Years are
 // distinct album years. Tags/OfficialRatings have no music source, so they are always empty.
 func (api *Router) getQueryFiltersLegacy(w http.ResponseWriter, r *http.Request) {

--- a/server/jellyfin/browsing.go
+++ b/server/jellyfin/browsing.go
@@ -3,7 +3,6 @@ package jellyfin
 import (
 	"net/http"
 
-	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
 	"github.com/navidrome/navidrome/utils/req"
@@ -29,7 +28,7 @@ func (api *Router) listArtistsByRole(w http.ResponseWriter, r *http.Request, rol
 	opts := model.QueryOptions{Offset: p.IntOr("startindex", 0), Max: p.IntOr("limit", 0)}
 	applySort(&opts, "MusicArtist", p.StringOr("sortby", ""), p.StringOr("sortorder", ""))
 
-	scopeIDs, _ := resolveLibraryScope(ctx, dto.DecodeID(p.StringOr("parentid", "")))
+	scopeIDs, _ := parentIDScope(ctx, r)
 	// Only the fields listArtists reads; /Artists has no favorites filter, so favOnly stays false.
 	// Finamp's artist tab sends GenreIds when a genre filter is active.
 	q := itemsQuery{
@@ -67,11 +66,8 @@ func (api *Router) getGenres(w http.ResponseWriter, r *http.Request) {
 func (api *Router) getStudios(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	p := req.Params(r)
-	scope, _ := resolveLibraryScope(ctx, dto.DecodeID(p.StringOr("parentid", "")))
-	opts := model.QueryOptions{Sort: "tag_value"}
-	if len(scope) > 0 {
-		opts.Filters = squirrel.Eq{"library_tag.library_id": scope}
-	}
+	scope, _ := parentIDScope(ctx, r)
+	opts := model.QueryOptions{Sort: "tag_value", Filters: libraryScopeFilter(scope)}
 	labels, err := api.ds.Tag(ctx).GetAll(model.TagRecordLabel, opts)
 	if err != nil {
 		api.internalError(w, r, err)
@@ -86,11 +82,8 @@ func (api *Router) getStudios(w http.ResponseWriter, r *http.Request) {
 // library when accessible. Tags/OfficialRatings have no music source, so they are always empty.
 func (api *Router) getQueryFiltersLegacy(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
-	scope, _ := resolveLibraryScope(ctx, dto.DecodeID(req.Params(r).StringOr("parentid", "")))
-	genreOpts := model.QueryOptions{Sort: "name"}
-	if len(scope) > 0 {
-		genreOpts.Filters = squirrel.Eq{"library_tag.library_id": scope}
-	}
+	scope, _ := parentIDScope(ctx, r)
+	genreOpts := model.QueryOptions{Sort: "name", Filters: libraryScopeFilter(scope)}
 	genres, err := api.ds.Genre(ctx).GetAll(genreOpts)
 	if err != nil {
 		api.internalError(w, r, err)

--- a/server/jellyfin/browsing_test.go
+++ b/server/jellyfin/browsing_test.go
@@ -175,4 +175,52 @@ var _ = Describe("Browsing", func() {
 			Expect(w.Code).To(Equal(http.StatusOK))
 		})
 	})
+
+	Describe("getStudios", func() {
+		It("scopes results to the user's accessible libraries", func() {
+			tagRepo := ds.Tag(context.Background()).(*tests.MockTagRepo)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Studios", nil).WithContext(ctxUser(model.Libraries{{ID: 1}, {ID: 2}}))
+			invoke(api.getStudios, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			sql, args, err := tagRepo.Options.Filters.ToSql()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sql).To(ContainSubstring("library_tag.library_id"))
+			Expect(args).To(ContainElements(1, 2))
+		})
+
+		// An empty scope (admin, or a non-admin with no explicit library grants) must be treated
+		// as unrestricted, matching accessibleLibraryIDs' documented contract, not as "match nothing".
+		It("does not restrict results for an admin user", func() {
+			tagRepo := ds.Tag(context.Background()).(*tests.MockTagRepo)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Studios", nil).WithContext(ctxAdmin())
+			invoke(api.getStudios, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(tagRepo.Options.Filters).To(BeNil())
+		})
+	})
+
+	Describe("getQueryFiltersLegacy", func() {
+		It("scopes genres to the user's accessible libraries", func() {
+			genreRepo := ds.Genre(context.Background()).(*tests.MockedGenreRepo)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items/Filters", nil).WithContext(ctxUser(model.Libraries{{ID: 1}, {ID: 2}}))
+			invoke(api.getQueryFiltersLegacy, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			sql, args, err := genreRepo.Options.Filters.ToSql()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sql).To(ContainSubstring("library_tag.library_id"))
+			Expect(args).To(ContainElements(1, 2))
+		})
+
+		It("does not restrict genres for an admin user", func() {
+			genreRepo := ds.Genre(context.Background()).(*tests.MockedGenreRepo)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items/Filters", nil).WithContext(ctxAdmin())
+			invoke(api.getQueryFiltersLegacy, w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			Expect(genreRepo.Options.Filters).To(BeNil())
+		})
+	})
 })

--- a/server/jellyfin/dto/dto.go
+++ b/server/jellyfin/dto/dto.go
@@ -71,6 +71,7 @@ type BaseItemDto struct {
 	ArtistItems            []NameGuidPair    `json:"ArtistItems,omitempty"`
 	Genres                 []string          `json:"Genres,omitempty"`
 	GenreItems             []NameGuidPair    `json:"GenreItems,omitempty"`
+	Studios                []NameGuidPair    `json:"Studios,omitempty"`
 	NormalizationGain      *float64          `json:"NormalizationGain,omitempty"`
 	AlbumNormalizationGain *float64          `json:"AlbumNormalizationGain,omitempty"`
 	ChildCount             *int              `json:"ChildCount,omitempty"`

--- a/server/jellyfin/dto/dto.go
+++ b/server/jellyfin/dto/dto.go
@@ -288,3 +288,12 @@ type LyricLineCue struct {
 	Start       int64  `json:"Start"`
 	End         *int64 `json:"End,omitempty"`
 }
+
+// QueryFiltersLegacy is the response for GET /Items/Filters. All four lists are always present;
+// clients (jellyfin-web) render each unconditionally.
+type QueryFiltersLegacy struct {
+	Genres          []string `json:"Genres"`
+	Tags            []string `json:"Tags"`
+	OfficialRatings []string `json:"OfficialRatings"`
+	Years           []int    `json:"Years"`
+}

--- a/server/jellyfin/dto/filters_test.go
+++ b/server/jellyfin/dto/filters_test.go
@@ -1,0 +1,22 @@
+package dto
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("QueryFiltersLegacy", func() {
+	It("marshals all four keys, empty ones as [] not null", func() {
+		b, err := json.Marshal(QueryFiltersLegacy{
+			Genres: []string{"Rock"}, Tags: []string{}, OfficialRatings: []string{}, Years: []int{1999},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		j := string(b)
+		Expect(j).To(ContainSubstring(`"Genres":["Rock"]`))
+		Expect(j).To(ContainSubstring(`"Tags":[]`))
+		Expect(j).To(ContainSubstring(`"OfficialRatings":[]`))
+		Expect(j).To(ContainSubstring(`"Years":[1999]`))
+	})
+})

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -200,7 +200,7 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 	return item
 }
 
-func AlbumToBaseItem(al model.Album) BaseItemDto {
+func AlbumToBaseItem(al model.Album, fields Fields) BaseItemDto {
 	item := BaseItemDto{
 		Name:              al.Name,
 		Id:                EncodeID(al.ID),
@@ -230,6 +230,14 @@ func AlbumToBaseItem(al model.Album) BaseItemDto {
 		for _, g := range al.Genres {
 			item.Genres = append(item.Genres, g.Name)
 			item.GenreItems = append(item.GenreItems, NameGuidPair{Id: EncodeID(g.ID), Name: g.Name})
+		}
+	}
+	// Jellyfin leaves Studios empty for music; we expose record labels here to match our /Studios
+	// list and StudioIds= filter, so a client can display and click through to filter by label.
+	if fields.Has("Studios") {
+		for _, label := range al.Tags.Values(model.TagRecordLabel) {
+			id := EncodeID(model.NewTag(model.TagRecordLabel, label).ID)
+			item.Studios = append(item.Studios, NameGuidPair{Name: label, Id: id})
 		}
 	}
 	return item

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -261,6 +261,15 @@ func GenreToBaseItem(g model.Genre) BaseItemDto {
 	}
 }
 
+func StudioToBaseItem(t model.Tag) BaseItemDto {
+	return BaseItemDto{
+		Name:              t.TagValue,
+		Id:                EncodeID(t.ID),
+		Type:              "Studio",
+		BackdropImageTags: []string{},
+	}
+}
+
 // PlaylistToBaseItem maps a playlist to a Playlist BaseItemDto.
 func PlaylistToBaseItem(p model.Playlist) BaseItemDto {
 	// Finamp caches covers keyed by blurHash, so the tag (and blurhash) must change with the cover.

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -278,6 +278,13 @@ var _ = Describe("mappers", func() {
 		Expect(item.Name).To(Equal("Rock"))
 	})
 
+	It("maps a tag to a Studio BaseItemDto", func() {
+		item := StudioToBaseItem(model.Tag{ID: "t1", TagValue: "Blue Note"})
+		Expect(item.Type).To(Equal("Studio"))
+		Expect(item.Name).To(Equal("Blue Note"))
+		Expect(item.Id).To(Equal(EncodeID("t1")))
+	})
+
 	Describe("premiereDate", func() {
 		// Finamp re-sorts "Latest Releases" client-side by PremiereDate; absent values sort arbitrarily.
 		It("serializes a full date", func() {

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -244,7 +244,7 @@ var _ = Describe("mappers", func() {
 
 	It("maps an album to a MusicAlbum folder item", func() {
 		al := model.Album{ID: "alb-1", Name: "Alb", AlbumArtist: "AA", AlbumArtistID: "art-1", MaxYear: 1999, SongCount: 10, Genres: []model.Genre{{ID: "1", Name: "genre 1"}, {ID: "2", Name: "genre 2"}}}
-		item := AlbumToBaseItem(al)
+		item := AlbumToBaseItem(al, nil)
 		Expect(item.Type).To(Equal("MusicAlbum"))
 		Expect(item.IsFolder).To(BeTrue())
 		Expect(item.Id).To(Equal(EncodeID("alb-1")))
@@ -258,6 +258,19 @@ var _ = Describe("mappers", func() {
 		Expect(item.ImageBlurHashes["Primary"][item.ImageTags["Primary"]]).To(HaveLen(6))
 		Expect(item.Genres).To(Equal([]string{"genre 1", "genre 2"}))
 		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: EncodeID("1"), Name: "genre 1"}, {Id: EncodeID("2"), Name: "genre 2"}}))
+	})
+
+	It("populates album Studios from record-label tags only when Fields=Studios", func() {
+		al := model.Album{ID: "alb-2", Name: "Alb2"}
+		al.Tags = model.Tags{model.TagRecordLabel: []string{"Columbia", "Legacy"}}
+
+		Expect(AlbumToBaseItem(al, nil).Studios).To(BeEmpty())
+
+		item := AlbumToBaseItem(al, ParseFields("Studios"))
+		Expect(item.Studios).To(Equal([]NameGuidPair{
+			{Name: "Columbia", Id: EncodeID(model.NewTag(model.TagRecordLabel, "Columbia").ID)},
+			{Name: "Legacy", Id: EncodeID(model.NewTag(model.TagRecordLabel, "Legacy").ID)},
+		}))
 	})
 
 	It("maps an artist to a MusicArtist folder item", func() {
@@ -313,9 +326,9 @@ var _ = Describe("mappers", func() {
 		})
 
 		It("is set on albums from their date, falling back to MaxYear", func() {
-			Expect(*AlbumToBaseItem(model.Album{ID: "a1", Date: "2013-09-06"}).PremiereDate).To(Equal("2013-09-06T00:00:00Z"))
-			Expect(*AlbumToBaseItem(model.Album{ID: "a2", MaxYear: 2013}).PremiereDate).To(Equal("2013-01-01T00:00:00Z"))
-			Expect(AlbumToBaseItem(model.Album{ID: "a3"}).PremiereDate).To(BeNil())
+			Expect(*AlbumToBaseItem(model.Album{ID: "a1", Date: "2013-09-06"}, nil).PremiereDate).To(Equal("2013-09-06T00:00:00Z"))
+			Expect(*AlbumToBaseItem(model.Album{ID: "a2", MaxYear: 2013}, nil).PremiereDate).To(Equal("2013-01-01T00:00:00Z"))
+			Expect(AlbumToBaseItem(model.Album{ID: "a3"}, nil).PremiereDate).To(BeNil())
 		})
 	})
 

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -229,6 +229,22 @@ var _ = Describe("Browsing", func() {
 		})
 	})
 
+	Describe("studio filtering (StudioIds=)", func() {
+		It("filters items by StudioIds=", func() {
+			studios := queryResult(get("/Studios"))
+			var columbiaID string
+			for _, it := range studios.Items {
+				if it.Name == "Columbia" {
+					columbiaID = it.Id
+				}
+			}
+			Expect(columbiaID).ToNot(BeEmpty())
+
+			albums := queryResult(get("/Items?IncludeItemTypes=MusicAlbum&Recursive=true&StudioIds=" + columbiaID))
+			Expect(names(albums.Items)).To(ConsistOf("Kind of Blue"))
+		})
+	})
+
 	// Finamp's genre screen sends ParentId=<libraryId> (scoping) plus GenreIds=<genreId>.
 	Describe("genre filtering (GenreIds)", func() {
 		lib1 := enc("1")

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"net/http"
+	"sort"
 	"time"
 
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
@@ -481,6 +482,22 @@ var _ = Describe("Browsing", func() {
 			q := queryResult(get("/Genres?StartIndex=1&Limit=1"))
 			Expect(q.Items).To(HaveLen(1))
 			Expect(q.TotalRecordCount).To(Equal(3))
+		})
+	})
+
+	Describe("GET /Items/Filters", func() {
+		It("returns legacy query filters with genres, years, and empty tags/ratings", func() {
+			var filters dto.QueryFiltersLegacy
+			parseInto(get("/Items/Filters?IncludeItemTypes=Audio&Recursive=true"), &filters)
+			Expect(filters.Genres).To(ContainElements("Rock", "Jazz"))
+			Expect(filters.Years).To(ContainElements(1959, 1965, 1969, 1971))
+			// Verify ascending sort by checking it equals itself sorted.
+			sorted := make([]int, len(filters.Years))
+			copy(sorted, filters.Years)
+			sort.Ints(sorted)
+			Expect(filters.Years).To(Equal(sorted))
+			Expect(filters.Tags).To(BeEmpty())
+			Expect(filters.OfficialRatings).To(BeEmpty())
 		})
 	})
 })

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -243,6 +243,14 @@ var _ = Describe("Browsing", func() {
 			albums := queryResult(get("/Items?IncludeItemTypes=MusicAlbum&Recursive=true&StudioIds=" + columbiaID))
 			Expect(names(albums.Items)).To(ConsistOf("Kind of Blue"))
 		})
+
+		It("returns filter lists scoped to a ParentId library", func() {
+			var filters dto.QueryFiltersLegacy
+			parseInto(get("/Items/Filters?ParentId="+enc("1")+"&IncludeItemTypes=Audio&Recursive=true"), &filters)
+			Expect(filters.Years).To(ContainElements(1959, 1965))
+			studios := queryResult(get("/Studios?ParentId=" + enc("1")))
+			Expect(names(studios.Items)).To(ContainElement("Columbia"))
+		})
 	})
 
 	// Finamp's genre screen sends ParentId=<libraryId> (scoping) plus GenreIds=<genreId>.

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -483,6 +483,16 @@ var _ = Describe("Browsing", func() {
 			Expect(q.Items).To(HaveLen(1))
 			Expect(q.TotalRecordCount).To(Equal(3))
 		})
+
+		It("returns record labels as Studio items", func() {
+			q := queryResult(get("/Studios"))
+			names := make([]string, 0, len(q.Items))
+			for _, it := range q.Items {
+				Expect(it.Type).To(Equal("Studio"))
+				names = append(names, it.Name)
+			}
+			Expect(names).To(ContainElement("Columbia"))
+		})
 	})
 
 	Describe("GET /Items/Filters", func() {

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -214,11 +214,7 @@ var _ = Describe("Browsing", func() {
 	Describe("year filtering (Years=)", func() {
 		It("filters items by Years=", func() {
 			albums := queryResult(get("/Items?IncludeItemTypes=MusicAlbum&Recursive=true&Years=1959"))
-			names := make([]string, 0)
-			for _, it := range albums.Items {
-				names = append(names, it.Name)
-			}
-			Expect(names).To(ConsistOf("Kind of Blue"))
+			Expect(names(albums.Items)).To(ConsistOf("Kind of Blue"))
 
 			songs := queryResult(get("/Items?IncludeItemTypes=Audio&Recursive=true&Years=1959"))
 			for _, it := range songs.Items {

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -211,6 +211,24 @@ var _ = Describe("Browsing", func() {
 		})
 	})
 
+	Describe("year filtering (Years=)", func() {
+		It("filters items by Years=", func() {
+			albums := queryResult(get("/Items?IncludeItemTypes=MusicAlbum&Recursive=true&Years=1959"))
+			names := make([]string, 0)
+			for _, it := range albums.Items {
+				names = append(names, it.Name)
+			}
+			Expect(names).To(ConsistOf("Kind of Blue"))
+
+			songs := queryResult(get("/Items?IncludeItemTypes=Audio&Recursive=true&Years=1959"))
+			for _, it := range songs.Items {
+				Expect(it.ProductionYear).ToNot(BeNil())
+				Expect(*it.ProductionYear).To(Equal(1959))
+			}
+			Expect(songs.Items).ToNot(BeEmpty())
+		})
+	})
+
 	// Finamp's genre screen sends ParentId=<libraryId> (scoping) plus GenreIds=<genreId>.
 	Describe("genre filtering (GenreIds)", func() {
 		lib1 := enc("1")

--- a/server/jellyfin/e2e/e2e_suite_test.go
+++ b/server/jellyfin/e2e/e2e_suite_test.go
@@ -111,7 +111,7 @@ func buildTestFS() storagetest.FakeFS {
 	abbeyRoad := template(_t{"albumartist": "The Beatles", "artist": "The Beatles", "album": "Abbey Road", "year": 1969, "genre": "Rock"})
 	help := template(_t{"albumartist": "The Beatles", "artist": "The Beatles", "album": "Help!", "year": 1965, "genre": "Rock"})
 	ledZepIV := template(_t{"albumartist": "Led Zeppelin", "artist": "Led Zeppelin", "album": "IV", "year": 1971, "genre": "Rock"})
-	kindOfBlue := template(_t{"albumartist": "Miles Davis", "artist": "Miles Davis", "album": "Kind of Blue", "year": 1959, "genre": "Jazz"})
+	kindOfBlue := template(_t{"albumartist": "Miles Davis", "artist": "Miles Davis", "album": "Kind of Blue", "year": 1959, "genre": "Jazz", "label": "Columbia"})
 	singles := template(_t{"albumartist": "Solo Artist", "artist": "Solo Artist", "album": "Singles", "year": 2020, "genre": "Pop"})
 
 	return harness.CreateFS(fstest.MapFS{

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -223,6 +223,7 @@ type itemsQuery struct {
 	genreIds         []string
 	albumIds         []string
 	years            []int
+	studioIds        []string
 }
 
 // parseItemsQuery also resolves the entity types (inferring them from the parent when
@@ -246,8 +247,9 @@ func (api *Router) parseItemsQuery(ctx context.Context, r *http.Request) itemsQu
 		// Finamp's genre screen sends ParentId=<libraryId> for scoping plus GenreIds for the genre.
 		genreIds: decodedQueryIDs(r, "genreids"),
 		// Feishin fetches an album's tracks with AlbumIds instead of ParentId.
-		albumIds: decodedQueryIDs(r, "albumids"),
-		years:    parseYears(r),
+		albumIds:  decodedQueryIDs(r, "albumids"),
+		years:     parseYears(r),
+		studioIds: decodedQueryIDs(r, "studioids"),
 	}
 	// An artist's page filters by artist, not ParentId: Finamp sends ParentId=<libraryId> for scoping
 	// plus AlbumArtistIds/ArtistIds/contributingArtistIds for the artist.
@@ -512,6 +514,9 @@ func (api *Router) listAlbums(ctx context.Context, opts model.QueryOptions, q it
 	if len(q.years) > 0 {
 		filters = append(filters, filter.AlbumsByYears(q.years))
 	}
+	if len(q.studioIds) > 0 {
+		filters = append(filters, filter.ByStudioID(q.studioIds))
+	}
 	if q.favOnly {
 		filters = append(filters, filter.ByStarred().Filters)
 	}
@@ -555,6 +560,9 @@ func (api *Router) listSongs(ctx context.Context, opts model.QueryOptions, q ite
 	}
 	if len(q.years) > 0 {
 		filters = append(filters, filter.SongsByYears(q.years))
+	}
+	if len(q.studioIds) > 0 {
+		filters = append(filters, filter.ByStudioID(q.studioIds))
 	}
 	if q.favOnly {
 		filters = append(filters, filter.ByStarred().Filters)

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -496,6 +496,7 @@ func searchPage[S ~[]E, E any](opts model.QueryOptions, search func(model.QueryO
 }
 
 func (api *Router) listAlbums(ctx context.Context, opts model.QueryOptions, q itemsQuery) (itemsResult, error) {
+	toItem := func(al model.Album) dto.BaseItemDto { return dto.AlbumToBaseItem(al, q.fields) }
 	repo := api.ds.Album(ctx)
 	filters := squirrel.And{}
 	// For albums, ParentId (browse an artist) and AlbumArtistIds/ArtistIds both mean "this artist's
@@ -530,12 +531,12 @@ func (api *Router) listAlbums(ctx context.Context, opts model.QueryOptions, q it
 		if err != nil {
 			return itemsResult{}, err
 		}
-		return materialized(result(slice.Map(albums, dto.AlbumToBaseItem), total, opts.Offset)), nil
+		return materialized(result(slice.Map(albums, toItem), total, opts.Offset)), nil
 	}
 	total, _ := repo.CountAll(model.QueryOptions{Filters: opts.Filters})
 	open := streamCursor(func() (func(func(model.Album, error) bool), error) {
 		return repo.GetCursor(opts)
-	}, dto.AlbumToBaseItem)
+	}, toItem)
 	return streamed(open, int(total), opts.Offset), nil
 }
 
@@ -692,7 +693,7 @@ func (api *Router) resolveItemByID(ctx context.Context, id string, fields dto.Fi
 		if !u.HasLibraryAccess(al.LibraryID) {
 			return dto.BaseItemDto{}, false
 		}
-		return dto.AlbumToBaseItem(*al), true
+		return dto.AlbumToBaseItem(*al, fields), true
 	}
 	if ar, err := api.ds.Artist(ctx).Get(id); err == nil {
 		// TODO: an artist spans multiple libraries (library_artist), so there's no single
@@ -781,13 +782,15 @@ func (api *Router) deleteItem(w http.ResponseWriter, r *http.Request) {
 // /Items/Latest, and why it writes directly instead of going through api.ok.
 func (api *Router) getLatest(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	p := req.Params(r)
+	fields := dto.ParseFields(p.Strings("fields")...)
 	opts := filter.AlbumsByNewest()
-	opts.Max = req.Params(r).IntOr("limit", 20)
+	opts.Max = p.IntOr("limit", 20)
 	opts = filter.ApplyLibraryFilter(opts, accessibleLibraryIDs(ctx))
 	repo := api.ds.Album(ctx)
 	open := streamCursor(func() (func(func(model.Album, error) bool), error) {
 		return repo.GetCursor(opts)
-	}, dto.AlbumToBaseItem)
+	}, func(al model.Album) dto.BaseItemDto { return dto.AlbumToBaseItem(al, fields) })
 	api.writeItemsArray(w, r, streamed(open, 0, 0))
 }
 

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -222,6 +222,7 @@ type itemsQuery struct {
 	contributingOnly bool
 	genreIds         []string
 	albumIds         []string
+	years            []int
 }
 
 // parseItemsQuery also resolves the entity types (inferring them from the parent when
@@ -246,6 +247,7 @@ func (api *Router) parseItemsQuery(ctx context.Context, r *http.Request) itemsQu
 		genreIds: decodedQueryIDs(r, "genreids"),
 		// Feishin fetches an album's tracks with AlbumIds instead of ParentId.
 		albumIds: decodedQueryIDs(r, "albumids"),
+		years:    parseYears(r),
 	}
 	// An artist's page filters by artist, not ParentId: Finamp sends ParentId=<libraryId> for scoping
 	// plus AlbumArtistIds/ArtistIds/contributingArtistIds for the artist.
@@ -414,6 +416,17 @@ func decodedQueryIDs(r *http.Request, key string) []string {
 	return slice.Map(queryIDs(r, key), dto.DecodeID)
 }
 
+// parseYears reads Years= as a discrete list, accepting comma-separated and repeated params.
+func parseYears(r *http.Request) []int {
+	var years []int
+	for _, v := range queryIDs(r, "years") {
+		if y, err := strconv.Atoi(v); err == nil && y > 0 {
+			years = append(years, y)
+		}
+	}
+	return years
+}
+
 // parseTypes returns the recognized entries in IncludeItemTypes in order, defaulting to
 // {"MusicAlbum"} when none are recognized (so ParentId=<artistId> browses that artist's albums).
 func parseTypes(types string) []string {
@@ -496,6 +509,9 @@ func (api *Router) listAlbums(ctx context.Context, opts model.QueryOptions, q it
 	if len(q.genreIds) > 0 {
 		filters = append(filters, filter.ByGenreID(q.genreIds))
 	}
+	if len(q.years) > 0 {
+		filters = append(filters, filter.AlbumsByYears(q.years))
+	}
 	if q.favOnly {
 		filters = append(filters, filter.ByStarred().Filters)
 	}
@@ -536,6 +552,9 @@ func (api *Router) listSongs(ctx context.Context, opts model.QueryOptions, q ite
 	}
 	if len(q.genreIds) > 0 {
 		filters = append(filters, filter.ByGenreID(q.genreIds))
+	}
+	if len(q.years) > 0 {
+		filters = append(filters, filter.SongsByYears(q.years))
 	}
 	if q.favOnly {
 		filters = append(filters, filter.ByStarred().Filters)

--- a/server/jellyfin/library.go
+++ b/server/jellyfin/library.go
@@ -2,11 +2,14 @@ package jellyfin
 
 import (
 	"context"
+	"net/http"
 	"strconv"
 
+	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
+	"github.com/navidrome/navidrome/utils/req"
 )
 
 // accessibleLibraryIDs returns the ids of the libraries the current user can access. An empty
@@ -28,6 +31,20 @@ func resolveLibraryScope(ctx context.Context, parentId string) (scopeIDs []int, 
 		}
 	}
 	return accessibleLibraryIDs(ctx), false
+}
+
+// parentIDScope resolves the request's ParentId param to a library scope (see resolveLibraryScope).
+func parentIDScope(ctx context.Context, r *http.Request) (scopeIDs []int, isLibraryParent bool) {
+	return resolveLibraryScope(ctx, dto.DecodeID(req.Params(r).StringOr("parentid", "")))
+}
+
+// libraryScopeFilter restricts a tag query to the given library scope. Empty scope means
+// unrestricted (see accessibleLibraryIDs), so it returns nil rather than an impossible IN ().
+func libraryScopeFilter(scope []int) squirrel.Sqlizer {
+	if len(scope) == 0 {
+		return nil
+	}
+	return squirrel.Eq{"library_tag.library_id": scope}
 }
 
 // libraryView builds the CollectionFolder BaseItemDto representing a library as a top-level node.

--- a/server/jellyfin/similar.go
+++ b/server/jellyfin/similar.go
@@ -177,7 +177,7 @@ func (api *Router) similarAlbums(ctx context.Context, id string, limit int) dto.
 		}
 		seen[s.AlbumID] = true
 		if al, err := api.ds.Album(ctx).Get(s.AlbumID); err == nil && u.HasLibraryAccess(al.LibraryID) {
-			items = append(items, dto.AlbumToBaseItem(*al))
+			items = append(items, dto.AlbumToBaseItem(*al, nil))
 			if len(items) >= limit {
 				break
 			}

--- a/tests/mock_album_repo.go
+++ b/tests/mock_album_repo.go
@@ -209,4 +209,11 @@ func (m *MockAlbumRepo) SetStar(starred bool, itemIDs ...string) error {
 	return nil
 }
 
+func (m *MockAlbumRepo) GetYears() ([]int, error) {
+	if m.Err {
+		return nil, errors.New("error")
+	}
+	return nil, nil
+}
+
 var _ model.AlbumRepository = (*MockAlbumRepo)(nil)

--- a/tests/mock_album_repo.go
+++ b/tests/mock_album_repo.go
@@ -213,7 +213,7 @@ func (m *MockAlbumRepo) GetYears() ([]int, error) {
 	if m.Err {
 		return nil, errors.New("error")
 	}
-	return nil, nil
+	return []int{}, nil
 }
 
 var _ model.AlbumRepository = (*MockAlbumRepo)(nil)

--- a/tests/mock_album_repo.go
+++ b/tests/mock_album_repo.go
@@ -209,7 +209,7 @@ func (m *MockAlbumRepo) SetStar(starred bool, itemIDs ...string) error {
 	return nil
 }
 
-func (m *MockAlbumRepo) GetYears() ([]int, error) {
+func (m *MockAlbumRepo) GetYears(libraryIDs ...int) ([]int, error) {
 	if m.Err {
 		return nil, errors.New("error")
 	}

--- a/tests/mock_data_store.go
+++ b/tests/mock_data_store.go
@@ -65,7 +65,7 @@ func (db *MockDataStore) Tag(ctx context.Context) model.TagRepository {
 	if db.RealDS != nil {
 		return db.RealDS.Tag(ctx)
 	}
-	db.MockedTag = struct{ model.TagRepository }{}
+	db.MockedTag = &MockTagRepo{}
 	return db.MockedTag
 }
 

--- a/tests/mock_genre_repo.go
+++ b/tests/mock_genre_repo.go
@@ -5,8 +5,9 @@ import (
 )
 
 type MockedGenreRepo struct {
-	Error error
-	Data  map[string]model.Genre
+	Error   error
+	Data    map[string]model.Genre
+	Options model.QueryOptions
 }
 
 func (r *MockedGenreRepo) init() {
@@ -15,7 +16,10 @@ func (r *MockedGenreRepo) init() {
 	}
 }
 
-func (r *MockedGenreRepo) GetAll(...model.QueryOptions) (model.Genres, error) {
+func (r *MockedGenreRepo) GetAll(options ...model.QueryOptions) (model.Genres, error) {
+	if len(options) > 0 {
+		r.Options = options[0]
+	}
 	if r.Error != nil {
 		return nil, r.Error
 	}

--- a/tests/mock_tag_repo.go
+++ b/tests/mock_tag_repo.go
@@ -1,0 +1,24 @@
+package tests
+
+import (
+	"github.com/navidrome/navidrome/model"
+)
+
+// MockTagRepo records the QueryOptions passed to GetAll, mirroring MockArtistRepo, so tests can
+// assert on which filters a caller attached (e.g. a library scope).
+type MockTagRepo struct {
+	model.TagRepository
+	Data    model.TagList
+	Options model.QueryOptions
+	Err     error
+}
+
+func (r *MockTagRepo) GetAll(_ model.TagName, options ...model.QueryOptions) (model.TagList, error) {
+	if len(options) > 0 {
+		r.Options = options[0]
+	}
+	if r.Err != nil {
+		return nil, r.Err
+	}
+	return r.Data, nil
+}


### PR DESCRIPTION
### Description

Makes the Jellyfin filter experience work end-to-end: the filter endpoints load and populate, the values they return actually filter `/Items`, and albums expose their record labels so clients can display and click through them. Built in two phases on this branch.

**1. Filter endpoints** (so client filter UIs load instead of 404ing):

- **`GET /Items/Filters`** (legacy `QueryFiltersLegacy`): returns real `Genres` and `Years` (distinct `album.max_year`, ascending), with `Tags` and `OfficialRatings` always present and `[]` when empty, matching real Jellyfin.
- **`GET /Studios`**: returns record labels (from the `recordlabel` tag) as `Type:"Studio"` items in the standard `QueryResult` envelope, mirroring how real Jellyfin sources audio studios (the `label`/`publisher`/`organization` tags our `recordlabel` is aliased from).

**2. Functional filtering** (so the returned values actually narrow results):

- **`Years=`** → `ProductionYear IN (years)`: `album.max_year IN` for MusicAlbum, `media_file.year IN` for Audio. Discrete list (accepts comma-separated and repeated forms), not a range, matching Jellyfin (Jellify expands its range slider to a full list before sending).
- **`StudioIds=`** → items crediting any of the given record-label tag ids, via a tag semi-join generalized from the existing genre filter.
- **`ParentId` scoping**: `/Items/Filters` and `/Studios` decode `ParentId` via the existing `resolveLibraryScope` and restrict the years / genres / studios lists to that library, so listed values always match filterable items. No `ParentId` (or an admin, whose accessible-library set is empty) means all accessible libraries, so single-library servers are unchanged.
- **Album `Studios`**: `AlbumToBaseItem` exposes record labels as `Studios` (`NameGuidPair[]`), gated behind `Fields=Studios` per Jellyfin's `ItemFields` convention. The studio ids reuse the record-label tag identity, so they round-trip with `/Studios` and `StudioIds=` (list → filter → display). Feishin consumes this as the album's record label.

Behavior was verified against real Jellyfin, jellyfin-web, Feishin, Jellify, and Finamp source throughout. Only the legacy `/Items/Filters` is used by clients (Feishin reads `Tags`, Jellify reads `Years`, jellyfin-web renders all four); none use `Filters2`, so it is intentionally not implemented. Feishin's filter panel needs both `/Items/Filters` and `/Studios` (its `getTagList` awaits both), so both ship together. `Tags` stays empty because Jellyfin does not derive audio tags from file metadata (only NFO/manual), so there is no parity source.

`Years` uses `album.max_year` because that is what `AlbumToBaseItem` already emits as `ProductionYear`, so the picker values match the items. No existing DTO field mappings are changed; `Studios` is a new, additive field.

### Related Issues

Related to #5807 (completes the `/items/filters` + `/studios` item, and adds the functional `Years=`/`StudioIds=` filtering and album `Studios` those UIs need).

### Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Enable the Jellyfin API (`ND_JELLYFIN_ENABLED=true`) and scan a library with albums across different years and `label`/`recordlabel` tags.
2. `GET /jellyfin/items/filters?IncludeItemTypes=Audio&Recursive=true` → `Genres` and `Years` populated (years ascending, distinct), `Tags: []`, `OfficialRatings: []`.
3. `GET /jellyfin/studios` → record labels as `Type:"Studio"` items; note an id.
4. `GET /jellyfin/items?IncludeItemTypes=MusicAlbum&Recursive=true&Years=<year>` → only that year's album(s); same with `IncludeItemTypes=Audio`; comma (`Years=1969,1971`) and repeated (`Years=1969&Years=1971`) forms both work.
5. `GET /jellyfin/items?IncludeItemTypes=MusicAlbum&Recursive=true&StudioIds=<id>` → only albums crediting that label.
6. `GET /jellyfin/items/filters?ParentId=<encoded library id>` and `GET /jellyfin/studios?ParentId=<encoded library id>` → only that library's values.
7. `GET /jellyfin/items?IncludeItemTypes=MusicAlbum&Fields=Studios` → each album carries `Studios` (record labels); the same ids fed back as `StudioIds=` return that album. Without `Fields=Studios`, `Studios` is omitted.

Verified live end-to-end against a copy of a real ~96k-track / 6.9k-album / 1.5k-label library: all filters narrow correctly (including combined `Years=`+`StudioIds=`), no-match years return empty, non-numeric/zero years are dropped, and the `Studios` ids round-trip through `/Studios` and `StudioIds=`. The year query is index-served via `album_max_year` (7 ms cold, sub-ms warm; no new index needed).

### Additional Notes

- **Empty library scope = unrestricted.** For admins (whose accessible-library set is empty by convention), the genre/studio lists and years fall back to the full library, matching Navidrome's documented `accessibleLibraryIDs` contract. For music, genre/studio lists were already global before this PR, so this is not a regression.
- **`Studios` is a Navidrome extension for music.** Real Jellyfin leaves `Studios` empty for `Audio`/`MusicAlbum` (it is a Movie/Series concept), but since we already surface record labels via `/Studios` and `StudioIds=`, exposing them on the album item completes the round-trip.
- **Audio year picker is album-based.** For `IncludeItemTypes=Audio` the years list comes from `album.max_year`; every value is a real track year (so nothing in the picker returns an empty result), but non-maximum track years on multi-year albums are omitted. This is a deliberate, index-served trade-off.
- **Known follow-up:** `library_tag` associations are insert/upsert-only and not reconciled per library on scan, so a genre or label removed from one library-of-many can linger in that library's picker until it disappears everywhere. Pre-existing and shared with genres; a scan-time reconciliation is the proper fix.
- **Out of scope:** `Filters2`, real `Tags` support (a `Tags` field on item DTOs + a `Tags=` filter), `OfficialRatings`, and populating `GenreItems`/`Studios` on the flattened-genre fallback path in `SongToBaseItem`.
