### PR TITLE
fix(streaming): surface why a transcode decision failed

### DIFF
--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -167,13 +167,13 @@ func (e *ffmpeg) ProbeAudioStream(ctx context.Context, filePath string) (*AudioP
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, &ProbeError{Path: filePath, Reason: probeErrorReason(err), err: err}
+		return nil, &ProbeError{Path: filePath, Reason: probeClientReason(err, filePath), err: err}
 	}
 	return parseProbeOutput(output)
 }
 
-// ProbeError reports an ffprobe failure, keeping the file path separate from the
-// reason so callers can log the full detail but expose a path-free message.
+// ProbeError reports an ffprobe failure. Reason is a path-free message safe to
+// expose to clients; the wrapped cause carries the full detail for logging.
 type ProbeError struct {
 	Path   string
 	Reason string
@@ -181,17 +181,18 @@ type ProbeError struct {
 }
 
 func (e *ProbeError) Error() string {
-	return fmt.Sprintf("probe failed on %q: %s", e.Path, e.Reason)
+	if e.err == nil {
+		return fmt.Sprintf("probe failed on %q: %s", e.Path, e.Reason)
+	}
+	return fmt.Sprintf("probe failed on %q: %s", e.Path, probeDetail(e.err))
 }
 
 // Unwrap exposes the underlying cause so callers can test it with errors.Is
 // (e.g. fs.ErrNotExist to detect a missing file).
 func (e *ProbeError) Unwrap() error { return e.err }
 
-// SafeReason returns the failure reason with the file path removed.
-func (e *ProbeError) SafeReason() string {
-	return strings.TrimSpace(strings.ReplaceAll(e.Reason, e.Path, "the file"))
-}
+// SafeReason returns the path-free reason, safe to send to clients.
+func (e *ProbeError) SafeReason() string { return e.Reason }
 
 // fileAccessReason maps a stat failure to a clear, path-free reason, so a moved
 // or unreadable file reads as "file not found" rather than a raw ffprobe message.
@@ -206,13 +207,24 @@ func fileAccessReason(err error) string {
 	}
 }
 
-// probeErrorReason prefers ffprobe's stderr (populated on ExitError) over the
-// bare "exit status N", so the real diagnostic reaches logs and clients.
-func probeErrorReason(err error) string {
+// probeDetail returns the full diagnostic for logging (may contain paths):
+// ffprobe's stderr when present, otherwise the raw error text.
+func probeDetail(err error) string {
 	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && len(exitErr.Stderr) > 0 {
 		return strings.TrimSpace(string(exitErr.Stderr))
 	}
 	return err.Error()
+}
+
+// probeClientReason returns a path-free reason for an ffprobe execution failure:
+// ffprobe's stderr with the file path stripped, or a generic reason when ffprobe
+// couldn't run at all (its launch error may embed the binary path).
+func probeClientReason(err error, path string) string {
+	exitErr, ok := errors.AsType[*exec.ExitError](err)
+	if !ok || len(exitErr.Stderr) == 0 {
+		return "could not read file"
+	}
+	return strings.TrimSpace(strings.ReplaceAll(string(exitErr.Stderr), path, "the file"))
 }
 
 type probeOutput struct {

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -160,14 +160,14 @@ func (e *ffmpeg) ProbeAudioStream(ctx context.Context, filePath string) (*AudioP
 		return nil, err
 	}
 	if err := fileExists(filePath); err != nil {
-		return nil, &ProbeError{Path: filePath, Reason: fileAccessReason(err)}
+		return nil, &ProbeError{Path: filePath, Reason: fileAccessReason(err), err: err}
 	}
 	args := createFFmpegCommand(probeAudioStreamCmd, filePath, 0, 0)
 	log.Trace(ctx, "Executing ffprobe command", "args", args)
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, &ProbeError{Path: filePath, Reason: probeErrorReason(err)}
+		return nil, &ProbeError{Path: filePath, Reason: probeErrorReason(err), err: err}
 	}
 	return parseProbeOutput(output)
 }
@@ -177,11 +177,16 @@ func (e *ffmpeg) ProbeAudioStream(ctx context.Context, filePath string) (*AudioP
 type ProbeError struct {
 	Path   string
 	Reason string
+	err    error
 }
 
 func (e *ProbeError) Error() string {
 	return fmt.Sprintf("probe failed on %q: %s", e.Path, e.Reason)
 }
+
+// Unwrap exposes the underlying cause so callers can test it with errors.Is
+// (e.g. fs.ErrNotExist to detect a missing file).
+func (e *ProbeError) Unwrap() error { return e.err }
 
 // SafeReason returns the failure reason with the file path removed.
 func (e *ProbeError) SafeReason() string {

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -160,7 +160,8 @@ func (e *ffmpeg) ProbeAudioStream(ctx context.Context, filePath string) (*AudioP
 		return nil, err
 	}
 	if err := fileExists(filePath); err != nil {
-		return nil, &ProbeError{Path: filePath, Reason: fileAccessReason(err), err: err}
+		return nil, &ProbeError{Path: filePath, Reason: fileAccessReason(err),
+			NotFound: errors.Is(err, fs.ErrNotExist), err: err}
 	}
 	args := createFFmpegCommand(probeAudioStreamCmd, filePath, 0, 0)
 	log.Trace(ctx, "Executing ffprobe command", "args", args)
@@ -169,15 +170,23 @@ func (e *ffmpeg) ProbeAudioStream(ctx context.Context, filePath string) (*AudioP
 	if err != nil {
 		return nil, &ProbeError{Path: filePath, Reason: probeClientReason(err, filePath), err: err}
 	}
-	return parseProbeOutput(output)
+	result, err := parseProbeOutput(output)
+	if err != nil {
+		return nil, &ProbeError{Path: filePath, Reason: err.Error(), err: err}
+	}
+	return result, nil
 }
 
 // ProbeError reports an ffprobe failure. Reason is a path-free message safe to
 // expose to clients; the wrapped cause carries the full detail for logging.
+// NotFound marks the media file itself as missing — a launch failure of a
+// deleted ffprobe binary also wraps fs.ErrNotExist, so callers must not infer
+// it from the error chain.
 type ProbeError struct {
-	Path   string
-	Reason string
-	err    error
+	Path     string
+	Reason   string
+	NotFound bool
+	err      error
 }
 
 func (e *ProbeError) Error() string {

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -204,8 +204,7 @@ func fileAccessReason(err error) string {
 // probeErrorReason prefers ffprobe's stderr (populated on ExitError) over the
 // bare "exit status N", so the real diagnostic reaches logs and clients.
 func probeErrorReason(err error) string {
-	var exitErr *exec.ExitError
-	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+	if exitErr, ok := errors.AsType[*exec.ExitError](err); ok && len(exitErr.Stderr) > 0 {
 		return strings.TrimSpace(string(exitErr.Stderr))
 	}
 	return err.Error()

--- a/core/ffmpeg/ffmpeg.go
+++ b/core/ffmpeg/ffmpeg.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -67,7 +68,7 @@ var ErrAnimatedWebPUnsupported = errors.New("ffmpeg lacks libwebp_anim encoder â
 const (
 	extractImageCmd     = "ffmpeg -i %s -map 0:v -map -0:V -vcodec copy -f image2pipe -"
 	probeCmd            = "ffmpeg %s -f ffmetadata"
-	probeAudioStreamCmd = "ffprobe -v quiet -select_streams a:0 -print_format json -show_streams -show_format %s"
+	probeAudioStreamCmd = "ffprobe -v error -select_streams a:0 -print_format json -show_streams -show_format %s"
 )
 
 type ffmpeg struct{}
@@ -159,16 +160,55 @@ func (e *ffmpeg) ProbeAudioStream(ctx context.Context, filePath string) (*AudioP
 		return nil, err
 	}
 	if err := fileExists(filePath); err != nil {
-		return nil, err
+		return nil, &ProbeError{Path: filePath, Reason: fileAccessReason(err)}
 	}
 	args := createFFmpegCommand(probeAudioStreamCmd, filePath, 0, 0)
 	log.Trace(ctx, "Executing ffprobe command", "args", args)
 	cmd := exec.CommandContext(ctx, args[0], args[1:]...) // #nosec
 	output, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("running ffprobe on %q: %w", filePath, err)
+		return nil, &ProbeError{Path: filePath, Reason: probeErrorReason(err)}
 	}
 	return parseProbeOutput(output)
+}
+
+// ProbeError reports an ffprobe failure, keeping the file path separate from the
+// reason so callers can log the full detail but expose a path-free message.
+type ProbeError struct {
+	Path   string
+	Reason string
+}
+
+func (e *ProbeError) Error() string {
+	return fmt.Sprintf("probe failed on %q: %s", e.Path, e.Reason)
+}
+
+// SafeReason returns the failure reason with the file path removed.
+func (e *ProbeError) SafeReason() string {
+	return strings.TrimSpace(strings.ReplaceAll(e.Reason, e.Path, "the file"))
+}
+
+// fileAccessReason maps a stat failure to a clear, path-free reason, so a moved
+// or unreadable file reads as "file not found" rather than a raw ffprobe message.
+func fileAccessReason(err error) string {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return "file not found"
+	case errors.Is(err, fs.ErrPermission):
+		return "permission denied"
+	default:
+		return "file not accessible"
+	}
+}
+
+// probeErrorReason prefers ffprobe's stderr (populated on ExitError) over the
+// bare "exit status N", so the real diagnostic reaches logs and clients.
+func probeErrorReason(err error) string {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && len(exitErr.Stderr) > 0 {
+		return strings.TrimSpace(string(exitErr.Stderr))
+	}
+	return err.Error()
 }
 
 type probeOutput struct {

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -566,6 +566,11 @@ var _ = Describe("ffmpeg", func() {
 			Expect(e.SafeReason()).To(Equal("the file: Invalid data found when processing input"))
 			Expect(e.SafeReason()).ToNot(ContainSubstring("/music/foo.flac"))
 		})
+
+		It("unwraps to the underlying cause so errors.Is detects a missing file", func() {
+			e := &ProbeError{Path: "/music/foo.flac", Reason: "file not found", err: os.ErrNotExist}
+			Expect(errors.Is(e, os.ErrNotExist)).To(BeTrue())
+		})
 	})
 
 	Describe("fileAccessReason", func() {
@@ -591,6 +596,15 @@ var _ = Describe("ffmpeg", func() {
 				if !ff.IsAvailable() {
 					Skip("FFmpeg not available on this system")
 				}
+			})
+
+			It("ProbeAudioStream returns a not-found ProbeError for a missing file", func() {
+				_, err := ff.ProbeAudioStream(GinkgoT().Context(), "/no/such/dir/really-missing.flac")
+				Expect(err).To(HaveOccurred())
+				Expect(errors.Is(err, os.ErrNotExist)).To(BeTrue())
+				var pe *ProbeError
+				Expect(errors.As(err, &pe)).To(BeTrue())
+				Expect(pe.SafeReason()).To(Equal("file not found"))
 			})
 
 			It("should interrupt transcoding when context is cancelled", func() {

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -555,14 +555,15 @@ var _ = Describe("ffmpeg", func() {
 	})
 
 	Describe("ProbeError", func() {
-		It("keeps the file path in Error() for logging", func() {
-			e := &ProbeError{Path: "/music/foo.flac", Reason: "/music/foo.flac: Invalid data found when processing input"}
+		It("uses the underlying cause in Error() so logs keep the full detail", func() {
+			e := &ProbeError{Path: "/music/foo.flac",
+				err: errors.New("/music/foo.flac: Invalid data found when processing input")}
 			Expect(e.Error()).To(ContainSubstring("/music/foo.flac"))
 			Expect(e.Error()).To(ContainSubstring("Invalid data found when processing input"))
 		})
 
-		It("strips the file path from SafeReason()", func() {
-			e := &ProbeError{Path: "/music/foo.flac", Reason: "/music/foo.flac: Invalid data found when processing input"}
+		It("returns the path-free reason from SafeReason()", func() {
+			e := &ProbeError{Path: "/music/foo.flac", Reason: "the file: Invalid data found when processing input"}
 			Expect(e.SafeReason()).To(Equal("the file: Invalid data found when processing input"))
 			Expect(e.SafeReason()).ToNot(ContainSubstring("/music/foo.flac"))
 		})
@@ -570,6 +571,33 @@ var _ = Describe("ffmpeg", func() {
 		It("unwraps to the underlying cause so errors.Is detects a missing file", func() {
 			e := &ProbeError{Path: "/music/foo.flac", Reason: "file not found", err: os.ErrNotExist}
 			Expect(errors.Is(e, os.ErrNotExist)).To(BeTrue())
+		})
+	})
+
+	Describe("probeClientReason", func() {
+		It("strips the file path from ffprobe stderr", func() {
+			if runtime.GOOS == "windows" {
+				Skip("uses /bin/sh")
+			}
+			_, err := exec.Command("/bin/sh", "-c", "echo '/music/foo.flac: Invalid data found' >&2; exit 1").Output()
+			Expect(err).To(HaveOccurred())
+			Expect(probeClientReason(err, "/music/foo.flac")).To(Equal("the file: Invalid data found"))
+		})
+
+		It("returns a generic reason for launch failures, without leaking the binary path", func() {
+			err := errors.New("fork/exec /opt/navidrome/bin/ffprobe: no such file or directory")
+			Expect(probeClientReason(err, "/music/foo.flac")).To(Equal("could not read file"))
+		})
+	})
+
+	Describe("probeDetail", func() {
+		It("surfaces ffprobe stderr for logging", func() {
+			if runtime.GOOS == "windows" {
+				Skip("uses /bin/sh")
+			}
+			_, err := exec.Command("/bin/sh", "-c", "echo 'boom detail' >&2; exit 1").Output()
+			Expect(err).To(HaveOccurred())
+			Expect(probeDetail(err)).To(Equal("boom detail"))
 		})
 	})
 

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -633,6 +633,7 @@ var _ = Describe("ffmpeg", func() {
 				var pe *ProbeError
 				Expect(errors.As(err, &pe)).To(BeTrue())
 				Expect(pe.SafeReason()).To(Equal("file not found"))
+				Expect(pe.NotFound).To(BeTrue())
 			})
 
 			It("should interrupt transcoding when context is cancelled", func() {

--- a/core/ffmpeg/ffmpeg_test.go
+++ b/core/ffmpeg/ffmpeg_test.go
@@ -2,6 +2,7 @@ package ffmpeg
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -550,6 +551,32 @@ var _ = Describe("ffmpeg", func() {
 			result, err := parseProbeOutput(data)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.Profile).To(BeEmpty())
+		})
+	})
+
+	Describe("ProbeError", func() {
+		It("keeps the file path in Error() for logging", func() {
+			e := &ProbeError{Path: "/music/foo.flac", Reason: "/music/foo.flac: Invalid data found when processing input"}
+			Expect(e.Error()).To(ContainSubstring("/music/foo.flac"))
+			Expect(e.Error()).To(ContainSubstring("Invalid data found when processing input"))
+		})
+
+		It("strips the file path from SafeReason()", func() {
+			e := &ProbeError{Path: "/music/foo.flac", Reason: "/music/foo.flac: Invalid data found when processing input"}
+			Expect(e.SafeReason()).To(Equal("the file: Invalid data found when processing input"))
+			Expect(e.SafeReason()).ToNot(ContainSubstring("/music/foo.flac"))
+		})
+	})
+
+	Describe("fileAccessReason", func() {
+		It("reports a missing file as 'file not found', not a raw stat message", func() {
+			_, err := os.Stat("/no/such/dir/really-missing.flac")
+			Expect(err).To(HaveOccurred())
+			Expect(fileAccessReason(err)).To(Equal("file not found"))
+		})
+
+		It("falls back to a generic reason for other access errors", func() {
+			Expect(fileAccessReason(errors.New("boom"))).To(Equal("file not accessible"))
 		})
 	})
 

--- a/server/subsonic/transcode.go
+++ b/server/subsonic/transcode.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 
+	"github.com/navidrome/navidrome/core/ffmpeg"
 	"github.com/navidrome/navidrome/core/stream"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
@@ -315,7 +316,7 @@ func (api *Router) GetTranscodeDecision(w http.ResponseWriter, r *http.Request) 
 	decision, err := api.transcodeDecision.MakeDecision(ctx, mf, clientInfo, stream.TranscodeOptions{})
 	if err != nil {
 		log.Error(ctx, "Failed to make transcode decision", "mediaID", mediaID, err)
-		return nil, newError(responses.ErrorGeneric, "failed to make transcode decision")
+		return nil, newError(responses.ErrorGeneric, "failed to make transcode decision: %s", transcodeFailureReason(err))
 	}
 
 	// Only create a token when there is a valid playback path
@@ -344,6 +345,14 @@ func (api *Router) GetTranscodeDecision(w http.ResponseWriter, r *http.Request) 
 	}
 
 	return response, nil
+}
+
+// transcodeFailureReason returns a reason safe to send to clients, omitting server file paths.
+func transcodeFailureReason(err error) string {
+	if pe, ok := errors.AsType[*ffmpeg.ProbeError](err); ok {
+		return pe.SafeReason()
+	}
+	return "internal error"
 }
 
 // GetTranscodeStream handles the OpenSubsonic getTranscodeStream endpoint.

--- a/server/subsonic/transcode.go
+++ b/server/subsonic/transcode.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/fs"
 	"net/http"
 	"slices"
 	"strconv"
@@ -317,11 +316,8 @@ func (api *Router) GetTranscodeDecision(w http.ResponseWriter, r *http.Request) 
 	decision, err := api.transcodeDecision.MakeDecision(ctx, mf, clientInfo, stream.TranscodeOptions{})
 	if err != nil {
 		log.Error(ctx, "Failed to make transcode decision", "mediaID", mediaID, err)
-		code := responses.ErrorGeneric
-		if errors.Is(err, fs.ErrNotExist) {
-			code = responses.ErrorDataNotFound
-		}
-		return nil, newError(code, "failed to make transcode decision: %s", transcodeFailureReason(err))
+		code, reason := transcodeFailure(err)
+		return nil, newError(code, "failed to make transcode decision: %s", reason)
 	}
 
 	// Only create a token when there is a valid playback path
@@ -352,12 +348,17 @@ func (api *Router) GetTranscodeDecision(w http.ResponseWriter, r *http.Request) 
 	return response, nil
 }
 
-// transcodeFailureReason returns a reason safe to send to clients, omitting server file paths.
-func transcodeFailureReason(err error) string {
-	if pe, ok := errors.AsType[*ffmpeg.ProbeError](err); ok {
-		return pe.SafeReason()
+// transcodeFailure maps a decision error to a Subsonic error code and a reason
+// safe to send to clients, omitting server file paths.
+func transcodeFailure(err error) (int32, string) {
+	pe, ok := errors.AsType[*ffmpeg.ProbeError](err)
+	if !ok {
+		return responses.ErrorGeneric, "internal error"
 	}
-	return "internal error"
+	if pe.NotFound {
+		return responses.ErrorDataNotFound, pe.SafeReason()
+	}
+	return responses.ErrorGeneric, pe.SafeReason()
 }
 
 // GetTranscodeStream handles the OpenSubsonic getTranscodeStream endpoint.

--- a/server/subsonic/transcode.go
+++ b/server/subsonic/transcode.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"slices"
 	"strconv"
@@ -316,7 +317,11 @@ func (api *Router) GetTranscodeDecision(w http.ResponseWriter, r *http.Request) 
 	decision, err := api.transcodeDecision.MakeDecision(ctx, mf, clientInfo, stream.TranscodeOptions{})
 	if err != nil {
 		log.Error(ctx, "Failed to make transcode decision", "mediaID", mediaID, err)
-		return nil, newError(responses.ErrorGeneric, "failed to make transcode decision: %s", transcodeFailureReason(err))
+		code := responses.ErrorGeneric
+		if errors.Is(err, fs.ErrNotExist) {
+			code = responses.ErrorDataNotFound
+		}
+		return nil, newError(code, "failed to make transcode decision: %s", transcodeFailureReason(err))
 	}
 
 	// Only create a token when there is a valid playback path

--- a/server/subsonic/transcode_test.go
+++ b/server/subsonic/transcode_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Transcode endpoints", func() {
 		It("enriches the decision error with the reason, without leaking the file path", func() {
 			mockMFRepo.SetData(model.MediaFiles{{ID: "song-1", Suffix: "flac"}})
 			mockTD.decisionErr = fmt.Errorf("probing media file song-1: %w",
-				&ffmpeg.ProbeError{Path: "/music/secret/foo.flac", Reason: "/music/secret/foo.flac: Invalid data found when processing input"})
+				&ffmpeg.ProbeError{Path: "/music/secret/foo.flac", Reason: "the file: Invalid data found when processing input"})
 			r := newJSONPostRequest("mediaId=song-1&mediaType=song", "{}")
 			_, err := router.GetTranscodeDecision(w, r)
 			Expect(err).To(HaveOccurred())

--- a/server/subsonic/transcode_test.go
+++ b/server/subsonic/transcode_test.go
@@ -98,13 +98,28 @@ var _ = Describe("Transcode endpoints", func() {
 
 		It("returns ErrorDataNotFound when the source file is missing on disk", func() {
 			mockMFRepo.SetData(model.MediaFiles{{ID: "song-1", Suffix: "flac"}})
-			mockTD.decisionErr = fmt.Errorf("probing media file song-1: %w", fs.ErrNotExist)
+			mockTD.decisionErr = fmt.Errorf("probing media file song-1: %w",
+				&ffmpeg.ProbeError{Path: "/music/gone.flac", Reason: "file not found", NotFound: true})
+			r := newJSONPostRequest("mediaId=song-1&mediaType=song", "{}")
+			_, err := router.GetTranscodeDecision(w, r)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("file not found"))
+			var subErr subError
+			Expect(errors.As(err, &subErr)).To(BeTrue())
+			Expect(subErr.code).To(Equal(responses.ErrorDataNotFound))
+		})
+
+		It("keeps ErrorGeneric when ffprobe is missing, even though the cause wraps fs.ErrNotExist", func() {
+			mockMFRepo.SetData(model.MediaFiles{{ID: "song-1", Suffix: "flac"}})
+			pe := &ffmpeg.ProbeError{Path: "/music/song.flac", Reason: "could not read file"}
+			mockTD.decisionErr = fmt.Errorf("probing media file song-1: %w (%w)", pe, fs.ErrNotExist)
+			Expect(errors.Is(mockTD.decisionErr, fs.ErrNotExist)).To(BeTrue())
 			r := newJSONPostRequest("mediaId=song-1&mediaType=song", "{}")
 			_, err := router.GetTranscodeDecision(w, r)
 			Expect(err).To(HaveOccurred())
 			var subErr subError
 			Expect(errors.As(err, &subErr)).To(BeTrue())
-			Expect(subErr.code).To(Equal(responses.ErrorDataNotFound))
+			Expect(subErr.code).To(Equal(responses.ErrorGeneric))
 		})
 
 		It("returns error when body is empty", func() {

--- a/server/subsonic/transcode_test.go
+++ b/server/subsonic/transcode_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/navidrome/navidrome/core/ffmpeg"
 	"github.com/navidrome/navidrome/core/stream"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
@@ -75,6 +77,18 @@ var _ = Describe("Transcode endpoints", func() {
 			_, err := router.GetTranscodeDecision(w, r)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("error retrieving media file"))
+		})
+
+		It("enriches the decision error with the reason, without leaking the file path", func() {
+			mockMFRepo.SetData(model.MediaFiles{{ID: "song-1", Suffix: "flac"}})
+			mockTD.decisionErr = fmt.Errorf("probing media file song-1: %w",
+				&ffmpeg.ProbeError{Path: "/music/secret/foo.flac", Reason: "/music/secret/foo.flac: Invalid data found when processing input"})
+			r := newJSONPostRequest("mediaId=song-1&mediaType=song", "{}")
+			_, err := router.GetTranscodeDecision(w, r)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to make transcode decision"))
+			Expect(err.Error()).To(ContainSubstring("Invalid data found when processing input"))
+			Expect(err.Error()).ToNot(ContainSubstring("/music/secret"))
 		})
 
 		It("returns error when body is empty", func() {
@@ -516,6 +530,7 @@ func newJSONPostRequest(queryParams string, jsonBody string) *http.Request {
 // mockTranscodeDecision is a test double for stream.TranscodeDecider
 type mockTranscodeDecision struct {
 	decision       *stream.TranscodeDecision
+	decisionErr    error
 	token          string
 	tokenErr       error
 	resolvedReq    stream.Request
@@ -525,6 +540,9 @@ type mockTranscodeDecision struct {
 
 func (m *mockTranscodeDecision) MakeDecision(_ context.Context, _ *model.MediaFile, ci *stream.ClientInfo, _ stream.TranscodeOptions) (*stream.TranscodeDecision, error) {
 	m.capturedClient = ci
+	if m.decisionErr != nil {
+		return nil, m.decisionErr
+	}
 	if m.decision != nil {
 		return m.decision, nil
 	}

--- a/server/subsonic/transcode_test.go
+++ b/server/subsonic/transcode_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/http/httptest"
 
@@ -12,6 +13,7 @@ import (
 	"github.com/navidrome/navidrome/core/stream"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
+	"github.com/navidrome/navidrome/server/subsonic/responses"
 	"github.com/navidrome/navidrome/tests"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -89,6 +91,20 @@ var _ = Describe("Transcode endpoints", func() {
 			Expect(err.Error()).To(ContainSubstring("failed to make transcode decision"))
 			Expect(err.Error()).To(ContainSubstring("Invalid data found when processing input"))
 			Expect(err.Error()).ToNot(ContainSubstring("/music/secret"))
+			var subErr subError
+			Expect(errors.As(err, &subErr)).To(BeTrue())
+			Expect(subErr.code).To(Equal(responses.ErrorGeneric))
+		})
+
+		It("returns ErrorDataNotFound when the source file is missing on disk", func() {
+			mockMFRepo.SetData(model.MediaFiles{{ID: "song-1", Suffix: "flac"}})
+			mockTD.decisionErr = fmt.Errorf("probing media file song-1: %w", fs.ErrNotExist)
+			r := newJSONPostRequest("mediaId=song-1&mediaType=song", "{}")
+			_, err := router.GetTranscodeDecision(w, r)
+			Expect(err).To(HaveOccurred())
+			var subErr subError
+			Expect(errors.As(err, &subErr)).To(BeTrue())
+			Expect(subErr.code).To(Equal(responses.ErrorDataNotFound))
 		})
 
 		It("returns error when body is empty", func() {


### PR DESCRIPTION
### Description

When `getTranscodeDecision` (OpenSubsonic) fails because ffprobe can't read the source file, the endpoint returned a bare `failed to make transcode decision` with no reason, and the probe ran ffprobe with `-v quiet` — so even the server log bottomed out at `exit status 1`. A user whose files had been moved by an external tool (reported via Symfonium's dev) only ever saw the opaque error.

This PR surfaces *why* the decision failed, at both layers:

- **Server log** now carries the real reason. `ProbeAudioStream` returns a typed `ffmpeg.ProbeError`, and ffprobe runs with `-v error` so its stderr diagnostic is captured (via `exec.ExitError.Stderr`) instead of being swallowed. `ProbeError.Error()` formats the underlying cause, so the operator sees the full detail — including the real `stat` error for unexpected filesystem failures.
- **Client error** is enriched but path-free. `ProbeError.Reason` holds a path-free message built at construction, which the handler appends to the Subsonic error. Clients get an actionable reason without leaking the server's filesystem layout. When ffprobe can't be launched at all, the client gets a generic `could not read file` so the ffprobe binary path is never exposed.
- A **missing** file is reported distinctly as `file not found` and now returns the standard Subsonic error code **70** ("The requested data was not found") — the same code the endpoint already returns for an unknown `mediaId`, and a defined OpenSubsonic error code. Files that exist but are **corrupt** or **unreadable** keep the generic code `0`.

`ProbeError` wraps the underlying cause and implements `Unwrap`, so the handler selects the code with `errors.Is(err, fs.ErrNotExist)`.

### Samples

Captured against a live server (`DevEnableMediaFileProbe` enabled).

**Returned Subsonic error — before:**
```json
{"subsonic-response":{"status":"failed","error":{"code":0,"message":"failed to make transcode decision"}}}
```

**Returned Subsonic error — after** (path never leaked to the client):
```json
// file missing (moved / deleted after scan) — now code 70
{"subsonic-response":{"status":"failed","error":{"code":70,"message":"failed to make transcode decision: file not found"}}}

// file present but corrupt / unreadable — stays code 0
{"subsonic-response":{"status":"failed","error":{"code":0,"message":"failed to make transcode decision: the file: Invalid data found when processing input"}}}

// file present but no read permission — stays code 0
{"subsonic-response":{"status":"failed","error":{"code":0,"message":"failed to make transcode decision: the file: Permission denied"}}}
```

**Server log — before:** `error="running ffprobe on \"…\": exit status 1"`

**Server log — after** (full detail retained for the operator):
```
level=error msg="Failed to make transcode decision" mediaID=qyK…
  error="probing media file qyK…: probe failed on \"/music/Foo/Bar/03 - Track.flac\": stat /music/Foo/Bar/03 - Track.flac: no such file or directory"

level=error msg="Failed to make transcode decision" mediaID=CH3…
  error="probing media file CH3…: probe failed on \"/music/Foo/Bar/03 - Track.flac\": /music/Foo/Bar/03 - Track.flac: Invalid data found when processing input"
```

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

The probe-on-decision path runs only when `DevEnableMediaFileProbe` is enabled.

1. Start the server with `ND_DEVENABLEMEDIAFILEPROBE=true` and a small library.
2. `POST /rest/getTranscodeDecision?u=…&mediaId=<id>&mediaType=song` with body `{}` for a media file whose backing file is:
   - **valid** → `status: ok`, decision returned;
   - **deleted after scan** → error code `70`, message `failed to make transcode decision: file not found`;
   - **corrupt (garbage bytes)** → error code `0`, `failed to make transcode decision: the file: <ffprobe reason>`;
   - **unreadable (chmod 000)** → error code `0`, `failed to make transcode decision: the file: Permission denied`.
3. Confirm the server error log for each carries the **full path and underlying cause**, while the returned message never does.

### Additional Notes

- Reported via Symfonium's developer (Tolriq): https://support.symfonium.app/t/certain-flacs-wont-play/14522
- Verified end-to-end against a live server, both for the failure paths above (missing / corrupt / no-permission / unknown id) and for the success paths this touches: direct-play decision, transcode decision (128k cap on a 192k source), and streaming both resulting tokens through `getTranscodeStream` (passthrough vs. re-encoded).
