### PR TITLE
build: upgrade Alpine base image to 3.21

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM ghcr.io/crazy-max/osxcross:14.5-debian AS osxcros
 
 ########################################################################################################################
 ### Build xx (original image: tonistiigi/xx)
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/alpine:3.20 AS xx-build
+FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/alpine:3.21 AS xx-build
 
 # v1.9.0
 ENV XX_VERSION=a5592eab7a57895e8d385394ff12241bc65ecd50
@@ -154,7 +154,7 @@ COPY --from=build /out /
 
 ########################################################################################################################
 ### Build Final Image
-FROM public.ecr.aws/docker/library/alpine:3.20 AS final
+FROM public.ecr.aws/docker/library/alpine:3.21 AS final
 LABEL maintainer="deluan@navidrome.org"
 LABEL org.opencontainers.image.source="https://github.com/navidrome/navidrome"
 


### PR DESCRIPTION
### Description

Bumps the Alpine base image from `3.20` to `3.21` in the `Dockerfile`. The version is updated in both stages that use it:

- **`xx-build`** — the cross-compilation toolchain builder stage.
- **`final`** — the runtime image the released binary ships in.

This keeps both the build toolchain and the runtime on a current, supported Alpine release (3.20 is past end of active support), picking up the newer package set and security fixes that come with it. No application code or build logic changes — it's a base-image version bump only.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Build / base-image dependency update

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

_No new tests: this is a base-image version bump with no code changes; correctness is verified by the Docker build and existing CI._

### How to Test

1. Build the Docker image:
   ```bash
   docker build -t navidrome-alpine321 .
   ```
2. Confirm the final image is running Alpine 3.21:
   ```bash
   docker run --rm --entrypoint cat navidrome-alpine321 /etc/alpine-release
   # expect: 3.21.x
   ```
3. Start the container and verify Navidrome boots and serves the web UI as usual.

### Additional Notes

Minor base-image bump within the same major line (3.x); no breaking changes expected. The runtime image stays Alpine-based, consistent with the project's image conventions.
