### PR TITLE
fix(subsonic): avoid double brackets when appending subtitle or version

### DIFF
--- a/model/album.go
+++ b/model/album.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"fmt"
 	"iter"
 	"math"
 	"sync"
@@ -77,7 +76,7 @@ func (a Album) CoverArtID() ArtworkID {
 
 func (a Album) FullName() string {
 	if conf.Server.Subsonic.AppendAlbumVersion && len(a.Tags[TagAlbumVersion]) > 0 {
-		return fmt.Sprintf("%s (%s)", a.Name, a.Tags[TagAlbumVersion][0])
+		return appendSuffix(a.Name, a.Tags[TagAlbumVersion][0])
 	}
 	return a.Name
 }

--- a/model/album_test.go
+++ b/model/album_test.go
@@ -24,6 +24,8 @@ var _ = Describe("Album", func() {
 		Entry("returns just name when disabled", false, Tags{TagAlbumVersion: []string{"Remastered"}}, "Album"),
 		Entry("returns just name when tag is absent", true, Tags{}, "Album"),
 		Entry("returns just name when tag is an empty slice", true, Tags{TagAlbumVersion: []string{}}, "Album"),
+		Entry("does not double parentheses when version is already parenthesized", true, Tags{TagAlbumVersion: []string{"(Remastered)"}}, "Album (Remastered)"),
+		Entry("does not add parentheses when version is wrapped in square brackets", true, Tags{TagAlbumVersion: []string{"[Remastered]"}}, "Album [Remastered]"),
 	)
 })
 

--- a/model/mediafile.go
+++ b/model/mediafile.go
@@ -100,16 +100,26 @@ type MediaFile struct {
 
 func (mf MediaFile) FullTitle() string {
 	if conf.Server.Subsonic.AppendSubtitle && len(mf.Tags[TagSubtitle]) > 0 {
-		return fmt.Sprintf("%s (%s)", mf.Title, mf.Tags[TagSubtitle][0])
+		return appendSuffix(mf.Title, mf.Tags[TagSubtitle][0])
 	}
 	return mf.Title
 }
 
 func (mf MediaFile) FullAlbumName() string {
 	if conf.Server.Subsonic.AppendAlbumVersion && len(mf.Tags[TagAlbumVersion]) > 0 {
-		return fmt.Sprintf("%s (%s)", mf.Album, mf.Tags[TagAlbumVersion][0])
+		return appendSuffix(mf.Album, mf.Tags[TagAlbumVersion][0])
 	}
 	return mf.Album
+}
+
+var bracketPairs = map[byte]byte{'(': ')', '[': ']', '{': '}', '<': '>'}
+
+func appendSuffix(base, suffix string) string {
+	suffix = strings.TrimSpace(suffix)
+	if len(suffix) >= 2 && bracketPairs[suffix[0]] == suffix[len(suffix)-1] {
+		return base + " " + suffix
+	}
+	return base + " (" + suffix + ")"
 }
 
 func (mf MediaFile) ContentType() string {

--- a/model/mediafile_test.go
+++ b/model/mediafile_test.go
@@ -533,6 +533,13 @@ var _ = Describe("MediaFile", func() {
 		Entry("returns just title when disabled", false, Tags{TagSubtitle: []string{"Live"}}, "Song"),
 		Entry("returns just title when tag is absent", true, Tags{}, "Song"),
 		Entry("returns just title when tag is an empty slice", true, Tags{TagSubtitle: []string{}}, "Song"),
+		Entry("does not double parentheses when subtitle is already parenthesized", true, Tags{TagSubtitle: []string{"(non-explicit version)"}}, "Song (non-explicit version)"),
+		Entry("does not add parentheses when subtitle is wrapped in square brackets", true, Tags{TagSubtitle: []string{"[Live]"}}, "Song [Live]"),
+		Entry("does not add parentheses when subtitle is wrapped in curly braces", true, Tags{TagSubtitle: []string{"{Remix}"}}, "Song {Remix}"),
+		Entry("does not add parentheses when subtitle is wrapped in angle brackets", true, Tags{TagSubtitle: []string{"<Live>"}}, "Song <Live>"),
+		Entry("adds parentheses when brackets do not match", true, Tags{TagSubtitle: []string{"[Live)"}}, "Song ([Live))"),
+		Entry("trims surrounding whitespace before wrapping", true, Tags{TagSubtitle: []string{"  Live  "}}, "Song (Live)"),
+		Entry("trims whitespace around an already-bracketed subtitle", true, Tags{TagSubtitle: []string{" (Live) "}}, "Song (Live)"),
 	)
 	DescribeTable("FullAlbumName",
 		func(enabled bool, tags Tags, expected string) {
@@ -544,6 +551,8 @@ var _ = Describe("MediaFile", func() {
 		Entry("returns just album name when disabled", false, Tags{TagAlbumVersion: []string{"Deluxe Edition"}}, "Album"),
 		Entry("returns just album name when tag is absent", true, Tags{}, "Album"),
 		Entry("returns just album name when tag is an empty slice", true, Tags{TagAlbumVersion: []string{}}, "Album"),
+		Entry("does not double parentheses when version is already parenthesized", true, Tags{TagAlbumVersion: []string{"(Deluxe Edition)"}}, "Album (Deluxe Edition)"),
+		Entry("does not add parentheses when version is wrapped in square brackets", true, Tags{TagAlbumVersion: []string{"[Deluxe Edition]"}}, "Album [Deluxe Edition]"),
 	)
 	Describe("CoverArtId", func() {
 		It("returns its own id if it HasCoverArt", func() {


### PR DESCRIPTION
### Description

When `Subsonic.AppendSubtitle` or `Subsonic.AppendAlbumVersion` is enabled, the subtitle/version tag was always wrapped in parentheses before being appended, so a tag that already came bracketed got doubled — e.g. `(non-explicit version)` rendered as `The Lazy Generation ((non-explicit version))`.

Now the tag is appended as-is when it is already wrapped in a matching bracket pair — `()`, `[]`, `{}` or `<>` — with surrounding whitespace trimmed first. The shared `appendSuffix` helper is used by `MediaFile.FullTitle`, `MediaFile.FullAlbumName` and `Album.FullName`, so all consumers stay consistent.

Note: the search full-text column stores the appended title at scan time, so existing rows keep their old value until the next scan; display output is corrected immediately.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Enable `Subsonic.AppendSubtitle` (and/or `Subsonic.AppendAlbumVersion`).
2. On a track whose `subtitle` tag is already bracketed (e.g. `(non-explicit version)`), confirm the title reads `Title (non-explicit version)` — not doubled.
3. Verify a plain subtitle like `Live` still renders as `Title (Live)`, a padded ` (Live) ` as `Title (Live)`, and a mismatched `[Live)` as `Title ([Live))`.
