### PR TITLE
fix(share): give visual feedback when downloading from a share

### DIFF
--- a/core/archiver.go
+++ b/core/archiver.go
@@ -21,7 +21,7 @@ import (
 type Archiver interface {
 	ZipAlbum(ctx context.Context, id string, format string, bitrate int, w io.Writer) error
 	ZipArtist(ctx context.Context, id string, format string, bitrate int, w io.Writer) error
-	ZipShare(ctx context.Context, id string, w io.Writer) error
+	ZipShare(ctx context.Context, s *model.Share, w io.Writer) error
 	ZipPlaylist(ctx context.Context, id string, format string, bitrate int, w io.Writer) error
 }
 
@@ -100,16 +100,14 @@ func (a *archiver) albumFilename(mf model.MediaFile, format string, isMultiDisc 
 	return fmt.Sprintf("%s/%s", str.SanitizeFilename(mf.Album), file)
 }
 
-func (a *archiver) ZipShare(ctx context.Context, id string, out io.Writer) error {
-	s, err := a.shares.Load(ctx, id)
-	if err != nil {
-		return err
-	}
+// ZipShare takes an already-loaded share: Share.Load records a visit, so
+// loading it again here would count every download twice.
+func (a *archiver) ZipShare(ctx context.Context, s *model.Share, out io.Writer) error {
 	if !s.Downloadable {
 		return model.ErrNotAuthorized
 	}
 	log.Debug(ctx, "Zipping share", "name", s.ID, "format", s.Format, "bitrate", s.MaxBitRate, "numTracks", len(s.Tracks))
-	return a.zipMediaFiles(ctx, id, s.ID, s.Format, s.MaxBitRate, out, s.Tracks, false)
+	return a.zipMediaFiles(ctx, s.ID, s.ID, s.Format, s.MaxBitRate, out, s.Tracks, false)
 }
 
 func (a *archiver) ZipPlaylist(ctx context.Context, id string, format string, bitrate int, out io.Writer) error {

--- a/core/archiver_test.go
+++ b/core/archiver_test.go
@@ -130,12 +130,15 @@ var _ = Describe("Archiver", func() {
 				Tracks:       mfs,
 			}
 
-			sh.On("Load", mock.Anything, "1").Return(share, nil)
 			ms.On("NewStream", mock.Anything, mock.Anything, stream.Request{Format: "mp3", BitRate: 128}).Return(io.NopCloser(strings.NewReader("test")), nil).Times(2)
 
 			out := new(bytes.Buffer)
-			err := arch.ZipShare(context.Background(), "1", out)
+			err := arch.ZipShare(context.Background(), share, out)
 			Expect(err).To(BeNil())
+
+			// Share.Load records a visit; re-loading here would double-count
+			// every download.
+			sh.AssertNotCalled(GinkgoT(), "Load", mock.Anything, mock.Anything)
 
 			zr, err := zip.NewReader(bytes.NewReader(out.Bytes()), int64(out.Len()))
 			Expect(err).To(BeNil())

--- a/server/public/handle_downloads.go
+++ b/server/public/handle_downloads.go
@@ -36,6 +36,6 @@ func (pub *Router) handleDownloads(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", name+".zip"))
 	w.Header().Set("Content-Type", "application/zip")
 
-	err = pub.archiver.ZipShare(ctx, id, w)
+	err = pub.archiver.ZipShare(ctx, s, w)
 	checkShareError(ctx, w, err, id)
 }

--- a/server/public/handle_downloads.go
+++ b/server/public/handle_downloads.go
@@ -1,18 +1,41 @@
 package public
 
 import (
+	"cmp"
+	"fmt"
 	"net/http"
+	"strings"
 
+	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/req"
+	"github.com/navidrome/navidrome/utils/str"
 )
 
 func (pub *Router) handleDownloads(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
 	id, err := req.Params(r).String(":id")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 
-	err = pub.archiver.ZipShare(r.Context(), id, w)
-	checkShareError(r.Context(), w, err, id)
+	// Load the share before streaming: once ZipShare writes its first byte the
+	// status is locked at 200, so errors could no longer be reported.
+	s, err := pub.share.Load(ctx, id)
+	if err != nil {
+		checkShareError(ctx, w, err, id)
+		return
+	}
+	if !s.Downloadable {
+		checkShareError(ctx, w, model.ErrNotAuthorized, id)
+		return
+	}
+
+	name := str.SanitizeFilename(cmp.Or(s.Description, s.ID))
+	name = strings.ReplaceAll(name, ",", "_")
+	w.Header().Set("Content-Disposition", fmt.Sprintf("attachment; filename=%q", name+".zip"))
+	w.Header().Set("Content-Type", "application/zip")
+
+	err = pub.archiver.ZipShare(ctx, id, w)
+	checkShareError(ctx, w, err, id)
 }

--- a/server/public/handle_downloads_test.go
+++ b/server/public/handle_downloads_test.go
@@ -1,0 +1,134 @@
+package public
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type mockArchiver struct {
+	called bool
+	err    error
+}
+
+func (m *mockArchiver) ZipAlbum(context.Context, string, string, int, io.Writer) error {
+	return nil
+}
+
+func (m *mockArchiver) ZipArtist(context.Context, string, string, int, io.Writer) error {
+	return nil
+}
+
+func (m *mockArchiver) ZipPlaylist(context.Context, string, string, int, io.Writer) error {
+	return nil
+}
+
+func (m *mockArchiver) ZipShare(_ context.Context, _ string, w io.Writer) error {
+	m.called = true
+	if m.err != nil {
+		return m.err
+	}
+	_, _ = w.Write([]byte("zip-contents"))
+	return nil
+}
+
+var _ = Describe("handleDownloads", func() {
+	var ds *tests.MockDataStore
+	var shareRepo *tests.MockShareRepo
+	var archiver *mockArchiver
+	var pub *Router
+
+	BeforeEach(func() {
+		ds = &tests.MockDataStore{}
+		shareRepo = &tests.MockShareRepo{}
+		ds.MockedShare = shareRepo
+		archiver = &mockArchiver{}
+		pub = &Router{ds: ds, archiver: archiver, share: core.NewShare(ds)}
+	})
+
+	shareIs := func(s *model.Share) {
+		shareRepo.ID = s.ID
+		shareRepo.Entity = s
+	}
+
+	makeRequest := func(id string) *httptest.ResponseRecorder {
+		r := httptest.NewRequest("GET", "/public/d/"+id+"?%3Aid="+id, nil)
+		w := httptest.NewRecorder()
+		pub.handleDownloads(w, r)
+		return w
+	}
+
+	It("sets a Content-Disposition filename from the share description", func() {
+		shareIs(&model.Share{ID: "abc123", Description: "My Mixtape", Downloadable: true})
+
+		w := makeRequest("abc123")
+
+		Expect(w.Code).To(Equal(http.StatusOK))
+		Expect(w.Header().Get("Content-Disposition")).To(Equal(`attachment; filename="My Mixtape.zip"`))
+		Expect(w.Header().Get("Content-Type")).To(Equal("application/zip"))
+		Expect(archiver.called).To(BeTrue())
+		Expect(w.Body.String()).To(Equal("zip-contents"))
+	})
+
+	It("falls back to the share ID when there is no description", func() {
+		shareIs(&model.Share{ID: "abc123", Downloadable: true})
+
+		w := makeRequest("abc123")
+
+		Expect(w.Header().Get("Content-Disposition")).To(Equal(`attachment; filename="abc123.zip"`))
+	})
+
+	It("sanitizes characters that are unsafe in a filename", func() {
+		shareIs(&model.Share{ID: "abc123", Description: `AC/DC: Live, 1979`, Downloadable: true})
+
+		w := makeRequest("abc123")
+
+		Expect(w.Header().Get("Content-Disposition")).To(Equal(`attachment; filename="AC_DC_ Live_ 1979.zip"`))
+	})
+
+	It("returns 403 without invoking the archiver when the share is not downloadable", func() {
+		shareIs(&model.Share{ID: "abc123", Description: "No Download", Downloadable: false})
+
+		w := makeRequest("abc123")
+
+		Expect(w.Code).To(Equal(http.StatusForbidden))
+		Expect(archiver.called).To(BeFalse())
+		Expect(w.Header().Get("Content-Disposition")).To(BeEmpty())
+	})
+
+	It("returns 404 when the share does not exist", func() {
+		shareIs(&model.Share{ID: "other", Downloadable: true})
+
+		w := makeRequest("missing")
+
+		Expect(w.Code).To(Equal(http.StatusNotFound))
+		Expect(archiver.called).To(BeFalse())
+	})
+
+	It("returns 410 when the share has expired", func() {
+		shareIs(&model.Share{ID: "abc123", Downloadable: true, ExpiresAt: new(time.Now().Add(-time.Hour))})
+
+		w := makeRequest("abc123")
+
+		Expect(w.Code).To(Equal(http.StatusGone))
+		Expect(archiver.called).To(BeFalse())
+	})
+
+	It("returns 500 when the share lookup fails", func() {
+		shareRepo.Error = errors.New("db error")
+
+		w := makeRequest("abc123")
+
+		Expect(w.Code).To(Equal(http.StatusInternalServerError))
+		Expect(archiver.called).To(BeFalse())
+	})
+})

--- a/server/public/handle_downloads_test.go
+++ b/server/public/handle_downloads_test.go
@@ -32,7 +32,7 @@ func (m *mockArchiver) ZipPlaylist(context.Context, string, string, int, io.Writ
 	return nil
 }
 
-func (m *mockArchiver) ZipShare(_ context.Context, _ string, w io.Writer) error {
+func (m *mockArchiver) ZipShare(_ context.Context, _ *model.Share, w io.Writer) error {
 	m.called = true
 	if m.err != nil {
 		return m.err

--- a/server/subsonic/e2e/e2e_suite_test.go
+++ b/server/subsonic/e2e/e2e_suite_test.go
@@ -330,7 +330,7 @@ func (n noopArchiver) ZipArtist(context.Context, string, string, int, io.Writer)
 	return model.ErrNotFound
 }
 
-func (n noopArchiver) ZipShare(context.Context, string, io.Writer) error {
+func (n noopArchiver) ZipShare(context.Context, *model.Share, io.Writer) error {
 	return model.ErrNotFound
 }
 

--- a/ui/src/share/SharePlayer.jsx
+++ b/ui/src/share/SharePlayer.jsx
@@ -1,14 +1,23 @@
 import ReactJkMusicPlayer from 'navidrome-music-player'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import config, { shareInfo } from '../config'
 import { shareCoverUrl, shareDownloadUrl, shareStreamUrl } from '../utils'
 
 import { makeStyles } from '@material-ui/core/styles'
+
+// How long the download button stays inert after a click. The browser needs a
+// moment to show its own download UI; until then the page looks unresponsive.
+const DOWNLOAD_FEEDBACK_MS = 5000
 
 const useStyle = makeStyles({
   player: {
     '& .group .next-audio': {
       pointerEvents: (props) => props.single && 'none',
       opacity: (props) => props.single && 0.65,
+    },
+    '& .group.audio-download': {
+      pointerEvents: (props) => props.downloading && 'none',
+      opacity: (props) => props.downloading && 0.65,
     },
     '@media (min-width: 768px)': {
       '& .react-jinke-music-player-mobile > div': {
@@ -23,7 +32,14 @@ const useStyle = makeStyles({
 })
 
 const SharePlayer = () => {
-  const classes = useStyle({ single: shareInfo?.tracks.length === 1 })
+  const [downloading, setDownloading] = useState(false)
+  const timer = useRef(null)
+  const classes = useStyle({
+    single: shareInfo?.tracks.length === 1,
+    downloading,
+  })
+
+  useEffect(() => () => clearTimeout(timer.current), [])
 
   const list = shareInfo?.tracks.map((s) => {
     return {
@@ -36,14 +52,21 @@ const SharePlayer = () => {
   })
   // An anchor, not a navigation: the service worker's NavigationRoute would
   // intercept the streamed archive and fail it.
-  const customDownloader = () => {
+  const customDownloader = useCallback(() => {
     const link = document.createElement('a')
     link.href = shareDownloadUrl(shareInfo?.id)
     link.download = ''
     document.body.appendChild(link)
     link.click()
     document.body.removeChild(link)
-  }
+
+    setDownloading(true)
+    clearTimeout(timer.current)
+    timer.current = setTimeout(
+      () => setDownloading(false),
+      DOWNLOAD_FEEDBACK_MS,
+    )
+  }, [])
   const options = {
     audioLists: list,
     mode: 'full',

--- a/ui/src/share/SharePlayer.jsx
+++ b/ui/src/share/SharePlayer.jsx
@@ -7,7 +7,7 @@ import { makeStyles } from '@material-ui/core/styles'
 
 // How long the download button stays inert after a click. The browser needs a
 // moment to show its own download UI; until then the page looks unresponsive.
-const DOWNLOAD_FEEDBACK_MS = 5000
+export const DOWNLOAD_FEEDBACK_MS = 5000
 
 const useStyle = makeStyles({
   player: {

--- a/ui/src/share/SharePlayer.jsx
+++ b/ui/src/share/SharePlayer.jsx
@@ -34,10 +34,15 @@ const SharePlayer = () => {
       duration: s.duration,
     }
   })
-  const onBeforeAudioDownload = () => {
-    return Promise.resolve({
-      src: shareDownloadUrl(shareInfo?.id),
-    })
+  // An anchor, not a navigation: the service worker's NavigationRoute would
+  // intercept the streamed archive and fail it.
+  const customDownloader = () => {
+    const link = document.createElement('a')
+    link.href = shareDownloadUrl(shareInfo?.id)
+    link.download = ''
+    document.body.appendChild(link)
+    link.click()
+    document.body.removeChild(link)
   }
   const options = {
     audioLists: list,
@@ -59,7 +64,7 @@ const SharePlayer = () => {
     <ReactJkMusicPlayer
       {...options}
       className={classes.player}
-      onBeforeAudioDownload={onBeforeAudioDownload}
+      customDownloader={customDownloader}
     />
   )
 }

--- a/ui/src/share/SharePlayer.test.jsx
+++ b/ui/src/share/SharePlayer.test.jsx
@@ -1,0 +1,138 @@
+import { render, act } from '@testing-library/react'
+import SharePlayer from './SharePlayer'
+
+let playerProps
+
+vi.mock('navidrome-music-player', () => ({
+  default: (props) => {
+    playerProps = props
+    return <div data-testid="player" />
+  },
+}))
+
+vi.mock('../config', () => ({
+  default: { enableDownloads: true },
+  shareInfo: {
+    id: 'share-1',
+    downloadable: true,
+    tracks: [{ id: 't1', title: 'One', artist: 'A', duration: 100 }],
+  },
+}))
+
+vi.mock('../utils', () => ({
+  shareDownloadUrl: (id) => `/share/d/${id}`,
+  shareStreamUrl: (id) => `/share/s/${id}`,
+  shareCoverUrl: (id) => `/share/img/${id}`,
+}))
+
+describe('SharePlayer', () => {
+  let clickSpy
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    playerProps = null
+    // Downloading for real would navigate the jsdom window.
+    clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, 'click')
+      .mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it('downloads via an anchor so the service worker does not intercept it', () => {
+    render(<SharePlayer />)
+
+    let anchor
+    clickSpy.mockImplementation(function () {
+      anchor = { href: this.href, download: this.download }
+    })
+
+    act(() => {
+      playerProps.customDownloader()
+    })
+
+    expect(clickSpy).toHaveBeenCalledTimes(1)
+    expect(anchor.href).toContain('/share/d/share-1')
+    // Empty, so the server's Content-Disposition filename wins.
+    expect(anchor.download).toBe('')
+  })
+
+  it('removes the anchor from the document after clicking', () => {
+    render(<SharePlayer />)
+
+    act(() => {
+      playerProps.customDownloader()
+    })
+
+    expect(document.querySelectorAll('a[download]')).toHaveLength(0)
+  })
+
+  // The inert styling itself is driven by JSS function values, which jsdom does
+  // not evaluate; it is verified in a browser. What is checked here is the
+  // state machine feeding it -- that the component re-renders on download and
+  // again when the window closes.
+  it('re-renders when the feedback window opens and closes', () => {
+    render(<SharePlayer />)
+    const renders = []
+    const track = () => renders.push(playerProps)
+
+    track()
+    act(() => {
+      playerProps.customDownloader()
+    })
+    track()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    track()
+
+    expect(renders[1]).not.toBe(renders[0])
+    expect(renders[2]).not.toBe(renders[1])
+  })
+
+  it('restarts the feedback window on a repeat download', () => {
+    render(<SharePlayer />)
+
+    act(() => {
+      playerProps.customDownloader()
+    })
+    act(() => {
+      vi.advanceTimersByTime(1500)
+    })
+    act(() => {
+      playerProps.customDownloader()
+    })
+
+    // Would have elapsed had the first timer not been replaced.
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    const midway = playerProps
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    expect(playerProps).not.toBe(midway)
+  })
+
+  it('does not update state after unmount', () => {
+    const { unmount } = render(<SharePlayer />)
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    act(() => {
+      playerProps.customDownloader()
+    })
+    unmount()
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/share/SharePlayer.test.jsx
+++ b/ui/src/share/SharePlayer.test.jsx
@@ -1,5 +1,5 @@
 import { render, act } from '@testing-library/react'
-import SharePlayer from './SharePlayer'
+import SharePlayer, { DOWNLOAD_FEEDBACK_MS } from './SharePlayer'
 
 let playerProps
 let renderCount
@@ -100,17 +100,19 @@ describe('SharePlayer', () => {
     act(() => {
       playerProps.customDownloader()
     })
+    const elapsedBeforeRepeat = Math.floor(DOWNLOAD_FEEDBACK_MS / 2)
     act(() => {
-      vi.advanceTimersByTime(1500)
+      vi.advanceTimersByTime(elapsedBeforeRepeat)
     })
     act(() => {
       playerProps.customDownloader()
     })
 
-    // The first timer would have fired here had it not been replaced.
+    // Past the first timer's deadline, which it would have fired at had the
+    // repeat download not replaced it.
     const beforeOriginalDeadline = renderCount
     act(() => {
-      vi.advanceTimersByTime(1001)
+      vi.advanceTimersByTime(DOWNLOAD_FEEDBACK_MS - elapsedBeforeRepeat + 1)
     })
     expect(renderCount).toBe(beforeOriginalDeadline)
 
@@ -129,7 +131,7 @@ describe('SharePlayer', () => {
     })
     unmount()
     act(() => {
-      vi.advanceTimersByTime(2000)
+      vi.runAllTimers()
     })
 
     expect(errorSpy).not.toHaveBeenCalled()

--- a/ui/src/share/SharePlayer.test.jsx
+++ b/ui/src/share/SharePlayer.test.jsx
@@ -2,10 +2,12 @@ import { render, act } from '@testing-library/react'
 import SharePlayer from './SharePlayer'
 
 let playerProps
+let renderCount
 
 vi.mock('navidrome-music-player', () => ({
   default: (props) => {
     playerProps = props
+    renderCount++
     return <div data-testid="player" />
   },
 }))
@@ -31,6 +33,7 @@ describe('SharePlayer', () => {
   beforeEach(() => {
     vi.useFakeTimers()
     playerProps = null
+    renderCount = 0
     // Downloading for real would navigate the jsdom window.
     clickSpy = vi
       .spyOn(HTMLAnchorElement.prototype, 'click')
@@ -77,22 +80,18 @@ describe('SharePlayer', () => {
   // again when the window closes.
   it('re-renders when the feedback window opens and closes', () => {
     render(<SharePlayer />)
-    const renders = []
-    const track = () => renders.push(playerProps)
 
-    track()
+    const beforeDownload = renderCount
     act(() => {
       playerProps.customDownloader()
     })
-    track()
+    expect(renderCount).toBeGreaterThan(beforeDownload)
 
+    const beforeExpiry = renderCount
     act(() => {
-      vi.advanceTimersByTime(2000)
+      vi.runAllTimers()
     })
-    track()
-
-    expect(renders[1]).not.toBe(renders[0])
-    expect(renders[2]).not.toBe(renders[1])
+    expect(renderCount).toBeGreaterThan(beforeExpiry)
   })
 
   it('restarts the feedback window on a repeat download', () => {
@@ -108,17 +107,17 @@ describe('SharePlayer', () => {
       playerProps.customDownloader()
     })
 
-    // Would have elapsed had the first timer not been replaced.
+    // The first timer would have fired here had it not been replaced.
+    const beforeOriginalDeadline = renderCount
     act(() => {
-      vi.advanceTimersByTime(1000)
+      vi.advanceTimersByTime(1001)
     })
-    const midway = playerProps
+    expect(renderCount).toBe(beforeOriginalDeadline)
 
     act(() => {
-      vi.advanceTimersByTime(1000)
+      vi.runAllTimers()
     })
-
-    expect(playerProps).not.toBe(midway)
+    expect(renderCount).toBeGreaterThan(beforeOriginalDeadline)
   })
 
   it('does not update state after unmount', () => {


### PR DESCRIPTION
### Description

Downloading from a public share page gave no visual feedback: no reaction in the player, and no browser download shelf until the transfer finished. `SharePlayer` returned a `src` from `onBeforeAudioDownload`, so the player fell through to `downloadjs`, which XHRs the whole ZIP into memory before saving. That also risks failing on large shares on mobile, and the silent window invites repeat clicks that each spawn another server-side zip.

**Frontend.** Use the player's `customDownloader` prop to trigger a synthetic anchor, so the browser does the download and shows its own progress. An anchor rather than `window.location.href`: the share page's service worker handles all navigations, intercepts the streamed ZIP and serves the offline fallback (HTTP 503 in Chrome). The download button also dims and ignores clicks for a few seconds (`DOWNLOAD_FEEDBACK_MS`), so the page itself reacts to the click.

**Backend.** `handleDownloads` now loads the share before streaming, to set `Content-Disposition` (share description, falling back to its ID, sanitized) and `Content-Type`. This also fixes error reporting: `ZipShare` previously wrote to the `ResponseWriter` before `checkShareError` ran, locking the status at 200, so expired, missing and non-downloadable shares all returned 200. They now return 410, 404 and 403.

Because that preflight load would otherwise double-count visits (`Share.Load` increments `VisitCount`, and `ZipShare` loaded the share again internally), `ZipShare` now takes the already-loaded share rather than its id.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Start a server with `ND_ENABLESHARING=true ND_ENABLEDOWNLOADS=true`.
2. Share tracks with **Downloadable** checked, using a description with unsafe filename characters, e.g. `AC/DC: Live, 1979`.
3. Open the share URL, start playback, click download.

Expected: the browser's download UI appears promptly; the file saves as `AC_DC_ Live_ 1979.zip`; the button dims for ~5s and ignores clicks; playback continues and the page does not navigate away. A share with no description falls back to its ID. Worth trying a large share, where the old in-memory buffering hurt most.

The share's visit count should advance by exactly one per download (visible in the Shares list).

Error cases, which previously all returned 200:
```
curl -o /dev/null -w '%{http_code}\n' http://localhost:4533/share/d/<non-downloadable>   # 403
curl -o /dev/null -w '%{http_code}\n' http://localhost:4533/share/d/doesnotexist         # 404
curl -o /dev/null -w '%{http_code}\n' http://localhost:4533/share/d/<expired>            # 410
```

### Additional Notes

- **The service worker interaction is the subtle part.** The `window.location.href` form passed every Go test while returning 503 to real users. Changes to how the download is triggered should be re-checked in a browser, not just unit tests.
- **The dimming is browser-verified, not jsdom-covered.** JSS function values aren't evaluated in jsdom, so that rule is never emitted and a CSS assertion would pass for the wrong reason. Tests cover the state machine; the visual effect was measured in Chrome via `getComputedStyle`. A real coverage gap, worth an eye during review.
- No true progress percentage: `ZipShare` streams without a `Content-Length`, so the browser shows bytes transferred rather than a percentage.
- The pre-flight `Downloadable` check duplicates one inside `ZipShare`, deliberately — the inner one now runs too late to affect the status.
- No new configuration options, and no changes to the player fork.
