### PR TITLE
feat(config): warn about unrecognized options in the config file

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -2,14 +2,18 @@ package conf
 
 import (
 	"cmp"
+	"encoding"
 	"encoding/json"
 	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
+	"reflect"
+	"regexp"
 	"runtime"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
@@ -21,6 +25,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/scheduler"
 	"github.com/navidrome/navidrome/utils/run"
+	"github.com/navidrome/navidrome/utils/slice"
 	"github.com/spf13/viper"
 )
 
@@ -340,12 +345,11 @@ func Load(noConfigDump bool) {
 	remapEnvVarKeysFromConfig()
 
 	// Map deprecated options to their new names for backwards compatibility
-	mapDeprecatedOption("ReverseProxyWhitelist", "ExtAuth.TrustedSources")
-	mapDeprecatedOption("ReverseProxyUserHeader", "ExtAuth.UserHeader")
-	mapDeprecatedOption("HTTPSecurityHeaders.CustomFrameOptionsValue", "HTTPHeaders.FrameOptions")
-	mapDeprecatedOption("CoverJpegQuality", "CoverArtQuality")
-	mapDeprecatedOption("SimilarSongsMatchThreshold", "Matcher.FuzzyThreshold")
-	mapDeprecatedOption("EnableTranscodingCancellation", "Transcoding.EnableCancellation")
+	for _, o := range deprecatedOptions {
+		if o.replacement != "" {
+			mapDeprecatedOption(o.name, o.replacement)
+		}
+	}
 
 	err := viper.Unmarshal(&Server, viper.DecodeHook(
 		mapstructure.ComposeDecodeHookFunc(
@@ -402,6 +406,13 @@ func Load(noConfigDump bool) {
 	log.SetLogLevels(Server.DevLogLevels)
 	log.SetLogSourceLine(Server.DevLogSourceLine)
 	log.SetRedacting(Server.EnableLogRedacting)
+
+	// Log deprecated, removed and unknown options
+	for _, o := range deprecatedOptions {
+		logDeprecatedOptions(o.name, o.replacement)
+	}
+	logRemovedOptions(removedOptions...)
+	logUnknownOptions()
 
 	err = run.Sequentially(
 		validateScanSchedule,
@@ -461,21 +472,6 @@ func Load(noConfigDump bool) {
 	// Parse Deezer.Language into Languages slice (comma-separated, with fallback to DefaultInfoLanguage)
 	Server.Deezer.Languages = parseLanguages(Server.Deezer.Language)
 
-	// Deprecated options
-	logDeprecatedOptions("Scanner.GenreSeparators", "")
-	logDeprecatedOptions("Scanner.GroupAlbumReleases", "")
-	logDeprecatedOptions("DevEnableBufferedScrobble", "") // Deprecated: Buffered scrobbling is now always enabled and this option is ignored
-	logDeprecatedOptions("SearchFullString", "Search.FullString")
-	logDeprecatedOptions("ReverseProxyWhitelist", "ExtAuth.TrustedSources")
-	logDeprecatedOptions("ReverseProxyUserHeader", "ExtAuth.UserHeader")
-	logDeprecatedOptions("HTTPSecurityHeaders.CustomFrameOptionsValue", "HTTPHeaders.FrameOptions")
-	logDeprecatedOptions("CoverJpegQuality", "CoverArtQuality")
-	logDeprecatedOptions("SimilarSongsMatchThreshold", "Matcher.FuzzyThreshold")
-	logDeprecatedOptions("EnableTranscodingCancellation", "Transcoding.EnableCancellation")
-
-	// Removed options
-	logRemovedOptions("Spotify.ID", "Spotify.Secret")
-
 	// Validate other options
 	if Server.UICoverArtSize < 200 || Server.UICoverArtSize > 1200 {
 		newValue := max(200, min(1200, Server.UICoverArtSize))
@@ -488,6 +484,23 @@ func Load(noConfigDump bool) {
 		hook()
 	}
 }
+
+// deprecatedOptions still work, but will be removed in a future release. An empty
+// replacement means the option is now ignored.
+var deprecatedOptions = []struct{ name, replacement string }{
+	{"Scanner.GenreSeparators", ""},
+	{"Scanner.GroupAlbumReleases", ""},
+	{"DevEnableBufferedScrobble", ""},
+	{"SearchFullString", "Search.FullString"},
+	{"ReverseProxyWhitelist", "ExtAuth.TrustedSources"},
+	{"ReverseProxyUserHeader", "ExtAuth.UserHeader"},
+	{"HTTPSecurityHeaders.CustomFrameOptionsValue", "HTTPHeaders.FrameOptions"},
+	{"CoverJpegQuality", "CoverArtQuality"},
+	{"SimilarSongsMatchThreshold", "Matcher.FuzzyThreshold"},
+	{"EnableTranscodingCancellation", "Transcoding.EnableCancellation"},
+}
+
+var removedOptions = []string{"Spotify.ID", "Spotify.Secret"}
 
 func logDeprecatedOptions(oldName, newName string) {
 	envVar := "ND_" + strings.ToUpper(strings.ReplaceAll(oldName, ".", "_"))
@@ -532,24 +545,27 @@ func remapEnvVarKeysFromConfig() {
 			continue
 		}
 		stripped := strings.TrimPrefix(key, "nd_")
-		canonicalKey := strings.ReplaceAll(stripped, "_", ".")
+		canonicalKey := ndKeyToCanonical(key)
 		displayNDKey := "ND_" + strings.ToUpper(stripped)
-		displayCanonical := toPascalCase(canonicalKey)
+		canonicalName := canonicalOptionName(canonicalKey)
 
 		if viper.InConfig(canonicalKey) {
 			logFatal(fmt.Sprintf(
 				"Config file contains both '%s' and '%s'. Remove the ND_-prefixed version. "+
 					"The 'ND_' prefix is only needed for environment variables, not config file keys.",
-				displayNDKey, displayCanonical,
+				displayNDKey, cmp.Or(canonicalName, toPascalCase(canonicalKey)),
 			))
 			return
 		}
 
 		viper.Set(canonicalKey, viper.Get(key))
-		_, _ = fmt.Fprintf(os.Stderr, "WARNING: Config key '%s' uses environment variable naming. Use '%s' instead. "+
-			"The 'ND_' prefix is only needed for environment variables.\n",
-			displayNDKey, displayCanonical,
-		)
+		// Unknown keys get no advice here, logUnknownOptions reports them instead
+		if canonicalName != "" {
+			_, _ = fmt.Fprintf(os.Stderr, "WARNING: Config key '%s' uses environment variable naming. Use '%s' instead. "+
+				"The 'ND_' prefix is only needed for environment variables.\n",
+				displayNDKey, canonicalName,
+			)
+		}
 	}
 }
 
@@ -560,6 +576,143 @@ func mapDeprecatedOption(legacyName, newName string) {
 		viper.Set(newName, viper.Get(legacyName))
 	}
 }
+
+func logUnknownOptions() {
+	for _, key := range unknownConfigKeys() {
+		msg := fmt.Sprintf("Option '%s' is not recognized and will be ignored", key)
+		if matches := suggestOptions(key); len(matches) > 0 {
+			msg += fmt.Sprintf(". Did you mean '%s'?", strings.Join(matches, "' or '"))
+		}
+		log.Warn(msg)
+	}
+}
+
+// suggestOptions returns the known options sharing the last segment with key,
+// catching options written outside their section.
+func suggestOptions(key string) []string {
+	key = strings.ToLower(key)
+	leaf := leafKey(key)
+	canonical, _ := configKeys()
+	var matches []string
+	for known, name := range canonical {
+		if known != key && leafKey(known) == leaf {
+			matches = append(matches, name)
+		}
+	}
+	slices.Sort(matches)
+	return matches
+}
+
+func leafKey(key string) string {
+	return key[strings.LastIndex(key, ".")+1:]
+}
+
+// unknownConfigKeys returns config file keys that don't match any known option, so
+// typos and options written outside their section don't fail silently.
+func unknownConfigKeys() []string {
+	// INI files keep the original [default] section alongside the merged one
+	skipDefault := strings.EqualFold(filepath.Ext(viper.ConfigFileUsed()), ".ini")
+
+	var unknown []string
+	for _, key := range viper.AllKeys() {
+		if !viper.InConfig(key) || canonicalOptionName(key) != "" {
+			continue
+		}
+		if skipDefault && strings.HasPrefix(key, "default.") {
+			continue
+		}
+		// Only ND_-prefixed keys that remapEnvVarKeysFromConfig could resolve are valid
+		if strings.HasPrefix(key, "nd_") && canonicalOptionName(ndKeyToCanonical(key)) != "" {
+			continue
+		}
+		unknown = append(unknown, key)
+	}
+	slices.Sort(unknown)
+	return asWrittenInConfigFile(unknown)
+}
+
+func ndKeyToCanonical(key string) string {
+	return strings.ReplaceAll(strings.TrimPrefix(key, "nd_"), "_", ".")
+}
+
+// canonicalOptionName returns the documented spelling of a known option key, or ""
+// if it matches no option. Subkeys of free-form maps have no fixed spelling.
+func canonicalOptionName(key string) string {
+	keys, prefixes := configKeys()
+	if name, ok := keys[key]; ok {
+		return name
+	}
+	if slices.ContainsFunc(prefixes, func(p string) bool { return strings.HasPrefix(key, p) }) {
+		return toPascalCase(key)
+	}
+	return ""
+}
+
+// asWrittenInConfigFile restores the casing the keys have in the config file, as
+// viper lowercases every key it loads.
+func asWrittenInConfigFile(keys []string) []string {
+	if len(keys) == 0 {
+		return nil
+	}
+	data, err := os.ReadFile(viper.ConfigFileUsed())
+	if err != nil {
+		return keys
+	}
+	casing := map[string]string{}
+	for _, match := range configFileKeyRx.FindAllStringSubmatch(string(data), -1) {
+		for segment := range strings.SplitSeq(match[1], ".") {
+			lower := strings.ToLower(segment)
+			casing[lower] = cmp.Or(casing[lower], segment)
+		}
+	}
+	return slice.Map(keys, func(key string) string {
+		segments := strings.Split(key, ".")
+		for i, s := range segments {
+			segments[i] = cmp.Or(casing[s], s)
+		}
+		return strings.Join(segments, ".")
+	})
+}
+
+// Matches keys and section headers in all supported config formats.
+var configFileKeyRx = regexp.MustCompile(`(?m)^\s*\[?\s*"?([\w.]+)"?\s*[]=:]`)
+
+// configKeys maps every accepted option name, lowercased, to its canonical spelling,
+// plus the prefixes of free-form map options (Tags, DevLogLevels).
+var configKeys = sync.OnceValues(func() (map[string]string, []string) {
+	keys := map[string]string{}
+	var prefixes []string
+
+	var collect func(t reflect.Type, prefix string)
+	collect = func(t reflect.Type, prefix string) {
+		for field := range t.Fields() {
+			if !field.IsExported() {
+				continue
+			}
+			name := prefix + field.Name
+			if field.Type.Kind() == reflect.Struct && !reflect.PointerTo(field.Type).Implements(textUnmarshalerType) {
+				collect(field.Type, name+".")
+				continue
+			}
+			lower := strings.ToLower(name)
+			keys[lower] = name
+			if field.Type.Kind() == reflect.Map {
+				prefixes = append(prefixes, lower+".")
+			}
+		}
+	}
+	collect(reflect.TypeFor[configOptions](), "")
+
+	for _, o := range deprecatedOptions {
+		keys[strings.ToLower(o.name)] = o.name
+	}
+	for _, o := range removedOptions {
+		keys[strings.ToLower(o)] = o
+	}
+	return keys, prefixes
+})
+
+var textUnmarshalerType = reflect.TypeFor[encoding.TextUnmarshaler]()
 
 // parseIniFileConfiguration is used to parse the config file when it is in INI format. For INI files, it
 // would require a nested structure, so instead we unmarshal it to a map and then merge the nested [default]

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -579,9 +579,11 @@ func mapDeprecatedOption(legacyName, newName string) {
 }
 
 // explicitlySet reports whether the user provided the option, ignoring defaults,
-// which viper.IsSet counts as set.
+// which viper.IsSet counts as set. The ND_ spelling is also accepted in the config
+// file, and remapEnvVarKeysFromConfig has already moved it out of InConfig's reach.
 func explicitlySet(name string) bool {
-	return viper.InConfig(name) || os.Getenv(envVarName(name)) != ""
+	envVar := envVarName(name)
+	return viper.InConfig(name) || os.Getenv(envVar) != "" || viper.InConfig(strings.ToLower(envVar))
 }
 
 func envVarName(option string) string {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -30,7 +30,7 @@ import (
 )
 
 type configOptions struct {
-	ConfigFile                      string
+	ConfigFile                      string `conf:"-"`
 	Address                         string
 	Port                            int
 	UnixSocketPerm                  string
@@ -206,7 +206,7 @@ type lastfmOptions struct {
 	ScrobbleFirstArtistOnly bool
 
 	// Computed values
-	Languages []string // Computed from Language, split by comma
+	Languages []string `conf:"-"` // Computed from Language, split by comma
 }
 
 type deezerOptions struct {
@@ -214,7 +214,7 @@ type deezerOptions struct {
 	Language string
 
 	// Computed values
-	Languages []string // Computed from Language, split by comma
+	Languages []string `conf:"-"` // Computed from Language, split by comma
 }
 
 type listenBrainzOptions struct {
@@ -503,8 +503,8 @@ var deprecatedOptions = []struct{ name, replacement string }{
 var removedOptions = []string{"Spotify.ID", "Spotify.Secret"}
 
 func logDeprecatedOptions(oldName, newName string) {
-	envVar := "ND_" + strings.ToUpper(strings.ReplaceAll(oldName, ".", "_"))
-	newEnvVar := "ND_" + strings.ToUpper(strings.ReplaceAll(newName, ".", "_"))
+	envVar := envVarName(oldName)
+	newEnvVar := envVarName(newName)
 	logWarning := func(oldName, newName string) {
 		if newName != "" {
 			log.Warn(fmt.Sprintf("Option '%s' is deprecated and will be ignored in a future release. Please use the new '%s'", oldName, newName))
@@ -524,7 +524,7 @@ func logDeprecatedOptions(oldName, newName string) {
 // not available anymore
 func logRemovedOptions(options ...string) {
 	for _, option := range options {
-		envVar := "ND_" + strings.ToUpper(strings.ReplaceAll(option, ".", "_"))
+		envVar := envVarName(option)
 		logWarning := func(option string) {
 			log.Warn(fmt.Sprintf("Option '%s' is not available anymore and will be ignored. Please remove it from your config", option))
 		}
@@ -572,9 +572,23 @@ func remapEnvVarKeysFromConfig() {
 // mapDeprecatedOption is used to provide backwards compatibility for deprecated options. It should be called after
 // the config has been read by viper, but before unmarshalling it into the Config struct.
 func mapDeprecatedOption(legacyName, newName string) {
-	if viper.IsSet(legacyName) {
+	// viper.Set outranks the config file, so an explicit replacement must win over the legacy value
+	if viper.IsSet(legacyName) && !explicitlySet(newName) {
 		viper.Set(newName, viper.Get(legacyName))
 	}
+}
+
+// explicitlySet reports whether the user provided the option, ignoring defaults,
+// which viper.IsSet counts as set.
+func explicitlySet(name string) bool {
+	return viper.InConfig(name) || os.Getenv(envVarName(name)) != ""
+}
+
+func envVarName(option string) string {
+	if option == "" {
+		return ""
+	}
+	return "ND_" + strings.ToUpper(strings.ReplaceAll(option, ".", "_"))
 }
 
 func logUnknownOptions() {
@@ -595,7 +609,8 @@ func suggestOptions(key string) []string {
 	canonical, _ := configKeys()
 	var matches []string
 	for known, name := range canonical {
-		if known != key && leafKey(known) == leaf {
+		// Removed options are known only so they get their own warning, never suggest them
+		if known != key && leafKey(known) == leaf && !slices.Contains(removedOptions, name) {
 			matches = append(matches, name)
 		}
 	}
@@ -686,7 +701,8 @@ var configKeys = sync.OnceValues(func() (map[string]string, []string) {
 	var collect func(t reflect.Type, prefix string)
 	collect = func(t reflect.Type, prefix string) {
 		for field := range t.Fields() {
-			if !field.IsExported() {
+			// `conf:"-"` marks values computed during Load, not settable in the config
+			if !field.IsExported() || field.Tag.Get("conf") == "-" {
 				continue
 			}
 			name := prefix + field.Name

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -1,12 +1,14 @@
 package conf_test
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/log"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/spf13/viper"
@@ -257,6 +259,22 @@ var _ = Describe("Configuration", func() {
 
 			Expect(conf.Server.Search.FullString).To(BeTrue())
 			Expect(conf.UnknownConfigKeys()).To(BeEmpty())
+		})
+
+		It("warns about each unrecognized option at startup", func() {
+			var logBuf bytes.Buffer
+			log.SetOutput(&logBuf)
+			DeferCleanup(func() { log.SetOutput(GinkgoWriter) })
+
+			conf.InitConfig(filepath.Join("testdata", "cfg_warning_output.toml"), false)
+			conf.Load(true)
+
+			Expect(logBuf.String()).To(ContainSubstring(
+				"Option 'ArtistSplitExceptions' is not recognized and will be ignored. " +
+					"Did you mean 'Scanner.ArtistSplitExceptions'?"))
+			Expect(logBuf.String()).To(ContainSubstring(
+				"Option 'EnableDownlods' is not recognized and will be ignored"))
+			Expect(logBuf.String()).ToNot(ContainSubstring("ArtistJoiner"))
 		})
 
 		Context("with runtime-computed and removed options in the config", func() {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -258,6 +258,25 @@ var _ = Describe("Configuration", func() {
 			Expect(conf.Server.Search.FullString).To(BeTrue())
 			Expect(conf.UnknownConfigKeys()).To(BeEmpty())
 		})
+
+		Context("with runtime-computed and removed options in the config", func() {
+			BeforeEach(func() {
+				conf.InitConfig(filepath.Join("testdata", "cfg_runtime_fields.toml"), false)
+				conf.Load(true)
+			})
+
+			It("reports values computed during Load, which the config cannot set", func() {
+				Expect(conf.UnknownConfigKeys()).To(ContainElements("ConfigFile", "LastFM.Languages"))
+			})
+
+			It("never suggests a removed option", func() {
+				Expect(conf.SuggestOptions("id")).To(BeEmpty())
+			})
+
+			It("keeps an explicit replacement over the deprecated value", func() {
+				Expect(conf.Server.Search.FullString).To(BeFalse())
+			})
+		})
 	})
 
 	Describe("logFatal", func() {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -178,6 +178,88 @@ var _ = Describe("Configuration", func() {
 		})
 	})
 
+	Describe("unknownConfigKeys", func() {
+		BeforeEach(func() {
+			viper.Reset()
+			conf.SetViperDefaults()
+			viper.SetDefault("datafolder", GinkgoT().TempDir())
+			viper.SetDefault("loglevel", "error")
+			conf.ResetConf()
+		})
+
+		It("reports misplaced and misspelled options, as spelled in the config file", func() {
+			conf.InitConfig(filepath.Join("testdata", "cfg_unknown_keys.toml"), false)
+			conf.Load(true)
+
+			Expect(conf.UnknownConfigKeys()).To(ConsistOf(
+				"ArtistSplitExceptions", "EnableDownlods", "Whatever.Foo",
+			))
+		})
+
+		DescribeTable("recovers the original casing in all supported formats",
+			func(file string) {
+				conf.InitConfig(filepath.Join("testdata", file), false)
+				conf.Load(true)
+
+				Expect(conf.UnknownConfigKeys()).To(ConsistOf("NotAnOption"))
+			},
+			Entry("TOML", "cfg_unknown_casing.toml"),
+			Entry("YAML", "cfg_unknown_casing.yaml"),
+			Entry("JSON", "cfg_unknown_casing.json"),
+			Entry("INI", "cfg_unknown_casing.ini"),
+		)
+
+		It("does not report valid, deprecated or free-form keys", func() {
+			conf.InitConfig(filepath.Join("testdata", "cfg.toml"), false)
+			conf.Load(true)
+
+			Expect(conf.UnknownConfigKeys()).To(BeEmpty())
+		})
+
+		It("does not report the [default] section of INI files", func() {
+			conf.InitConfig(filepath.Join("testdata", "cfg.ini"), false)
+			conf.Load(true)
+
+			Expect(conf.UnknownConfigKeys()).To(BeEmpty())
+		})
+
+		DescribeTable("SuggestOptions",
+			func(key string, expected []string) {
+				Expect(conf.SuggestOptions(key)).To(Equal(expected))
+			},
+			Entry("suggests the section of a misplaced option", "artistsplitexceptions",
+				[]string{"Scanner.ArtistSplitExceptions"}),
+			Entry("suggests the section of a misplaced nested option", "backup.fuzzythreshold",
+				[]string{"Matcher.FuzzyThreshold"}),
+			Entry("suggests every section defining the option", "schedule",
+				[]string{"Backup.Schedule", "Scanner.Schedule"}),
+			Entry("suggests nothing for a typo", "enabledownlods", nil),
+		)
+
+		It("does not report ND_-prefixed keys, as they are remapped", func() {
+			conf.InitConfig(filepath.Join("testdata", "cfg_nd_keys.toml"), false)
+			conf.Load(true)
+
+			Expect(conf.UnknownConfigKeys()).To(BeEmpty())
+		})
+
+		It("reports ND_-prefixed keys that remap to no known option", func() {
+			conf.InitConfig(filepath.Join("testdata", "cfg_nd_bogus.toml"), false)
+			conf.Load(true)
+
+			Expect(conf.UnknownConfigKeys()).To(ConsistOf("ND_TOTALLY_BOGUS_OPTION"))
+			Expect(conf.Server.Scanner.Schedule).To(Equal("@every 1h"))
+		})
+
+		It("migrates every deprecated option that has a replacement", func() {
+			conf.InitConfig(filepath.Join("testdata", "cfg_deprecated_search.toml"), false)
+			conf.Load(true)
+
+			Expect(conf.Server.Search.FullString).To(BeTrue())
+			Expect(conf.UnknownConfigKeys()).To(BeEmpty())
+		})
+	})
+
 	Describe("logFatal", func() {
 		var invalidPath string
 		BeforeEach(func() {

--- a/conf/export_test.go
+++ b/conf/export_test.go
@@ -32,3 +32,7 @@ func SetLogFatal(f func(...any)) func() {
 	logFatal = f
 	return func() { logFatal = old }
 }
+
+var UnknownConfigKeys = unknownConfigKeys
+
+var SuggestOptions = suggestOptions

--- a/conf/testdata/cfg_deprecated_search.toml
+++ b/conf/testdata/cfg_deprecated_search.toml
@@ -1,0 +1,2 @@
+MusicFolder = "/toml/music"
+SearchFullString = true

--- a/conf/testdata/cfg_nd_bogus.toml
+++ b/conf/testdata/cfg_nd_bogus.toml
@@ -1,0 +1,3 @@
+MusicFolder = "/toml/music"
+ND_TOTALLY_BOGUS_OPTION = true
+ND_SCANNER_SCHEDULE = "@every 1h"

--- a/conf/testdata/cfg_runtime_fields.toml
+++ b/conf/testdata/cfg_runtime_fields.toml
@@ -1,0 +1,10 @@
+MusicFolder = "/toml/music"
+SearchFullString = true
+ConfigFile = "/somewhere/else"
+ID = "oops"
+
+[Search]
+FullString = false
+
+[LastFM]
+Languages = ["pt"]

--- a/conf/testdata/cfg_unknown_casing.ini
+++ b/conf/testdata/cfg_unknown_casing.ini
@@ -1,0 +1,3 @@
+[default]
+MusicFolder = /ini/music
+NotAnOption = true

--- a/conf/testdata/cfg_unknown_casing.json
+++ b/conf/testdata/cfg_unknown_casing.json
@@ -1,0 +1,4 @@
+{
+  "MusicFolder": "/json/music",
+  "NotAnOption": true
+}

--- a/conf/testdata/cfg_unknown_casing.toml
+++ b/conf/testdata/cfg_unknown_casing.toml
@@ -1,0 +1,2 @@
+MusicFolder = "/toml/music"
+NotAnOption = true

--- a/conf/testdata/cfg_unknown_casing.yaml
+++ b/conf/testdata/cfg_unknown_casing.yaml
@@ -1,0 +1,2 @@
+MusicFolder: /yaml/music
+NotAnOption: true

--- a/conf/testdata/cfg_unknown_keys.toml
+++ b/conf/testdata/cfg_unknown_keys.toml
@@ -1,0 +1,18 @@
+MusicFolder = "/toml/music"
+
+# Valid option, but written at the root level instead of under Scanner
+ArtistSplitExceptions = ["AC/DC", "Tyler, the creator"]
+
+# Misspelled option
+EnableDownlods = true
+
+# Unknown section
+[Whatever]
+Foo = "bar"
+
+# Valid options, must not be reported
+[Scanner]
+ArtistJoiner = " • "
+
+[Tags.custom]
+aliases = ["toml", "test"]

--- a/conf/testdata/cfg_warning_output.toml
+++ b/conf/testdata/cfg_warning_output.toml
@@ -1,0 +1,7 @@
+MusicFolder = "/toml/music"
+LogLevel = "warn"
+ArtistSplitExceptions = ["AC/DC"]
+EnableDownlods = true
+
+[Scanner]
+ArtistJoiner = " • "


### PR DESCRIPTION
### Description

Navidrome silently discards config file keys it doesn't recognize, so a typo or an option written outside its section looks like it was applied. This adds a startup warning listing every unrecognized key, with a "did you mean" suggestion when the option exists under a different section.

This came out of debugging #5869, where the user set `ArtistSplitExceptions` at the root level instead of under `Scanner`. With no feedback, it looked like `ArtistSplitExceptions` was broken for `AlbumArtist` specifically. Their config had two more silently-ignored keys that nobody had noticed. With this change it now logs:

```
Option 'ArtistSplitExceptions' is not recognized and will be ignored. Did you mean 'Scanner.ArtistSplitExceptions'?
Option 'ND_SCANNER_WATCHERENABLED' is not recognized and will be ignored
Option 'ScanSchedule' is not recognized and will be ignored
```

The set of known names is derived by reflection over `configOptions`, so it can't drift from the struct. I deliberately did not use the keys registered in `setViperDefaults()`: 10 valid options (`Jellyfin.ExposedPublicUsers`, `BaseHost`/`BasePath`/`BaseScheme`, `DbPath`, and others) have no `SetDefault` call and rely on Go zero values, so they would have been reported as unknown. Structs implementing `TextUnmarshaler` (`Dir`) are treated as leaves, and `map` options (`Tags`, `DevLogLevels`) register a prefix so their free-form subkeys pass.

Keys are reported as spelled in the config file. Viper lowercases every key it loads and offers no way to recover the original, so the file is re-read and scanned with one regex covering all four supported formats. This only happens when there is at least one unknown key, so the normal startup path is unaffected.

Suggestions match on the last segment and return every match rather than guessing, so a root-level `Schedule` reports both `Backup.Schedule` and `Scanner.Schedule`. There is no fuzzy/edit-distance matching: a wrong suggestion is worse than none, so a genuine typo like `EnableDownlods` gets the warning without a suggestion.

The change warns rather than fails, so upgrades don't break on a stray key.

Two pre-existing gaps that this work surfaced are fixed here as well, since both are the same class of "silently wrong config feedback":

- `remapEnvVarKeysFromConfig` accepted any `ND_`-prefixed key and built the suggested canonical name by string substitution, without checking it existed. `ND_SCANNER_WATCHERENABLED` (not an option) produced "use `Scanner.Watcherenabled` instead" (also not an option). It now resolves through the known-key set, advises only names that exist using their documented spelling, and leaves anything else to the new unrecognized-option warning.

- The deprecated option list drove only the warnings, while the value migration kept a second hardcoded list of `mapDeprecatedOption` calls. The two had drifted: `SearchFullString` warned about `Search.FullString` but never migrated to it, so anyone still using the old name silently got the default. Both now come from the single `deprecatedOptions` slice.

### Related Issues

Related to #5869

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Create a config file with a misplaced option, a typo, and an unknown section:

```toml
MusicFolder = "/your/music"
ArtistSplitExceptions = ["AC/DC", "Tyler, the creator"]
EnableDownlods = true

[Whatever]
Foo = "bar"
```

2. Start Navidrome with `--configfile` pointing at it. Expect three warnings at startup, with `ArtistSplitExceptions` suggesting `Scanner.ArtistSplitExceptions` and the other two having no suggestion.

3. Move the option under `[Scanner]` and restart. Expect the warning to be gone and the option to take effect.

4. Verify no false positives against a real config: a file using free-form `Tags.<name>.*` keys, a deprecated option such as `ReverseProxyUserHeader`, and an INI file with its `[default]` section should all produce no unrecognized-option warnings.

5. Verify the casing is echoed back as written, in each supported format (`.toml`, `.yaml`, `.json`, `.ini`).

6. For the `ND_` fix: put `ND_TOTALLY_BOGUS_OPTION = true` and `ND_SCANNER_SCHEDULE = "@every 1h"` in the config file. The first should be reported as unrecognized with no suggested replacement; the second should still be remapped, with the advice naming `Scanner.Schedule`.

7. For the deprecated-option fix: set `SearchFullString = true` and confirm `Search.FullString` is now actually enabled.

### Additional Notes

The unrecognized-key check runs after the logging setup in `Load()`, so the warnings honor `LogLevel`, land in `LogFile`, and get systemd journal formatting. This is why they are not at the very top of `Load()` next to `remapEnvVarKeysFromConfig`, which runs before logging is configured and writes to stderr directly. They do run before the schedule/path/size validations, so a config with both a typo and a fatal error reports the typo before exiting.

Env var typos are still not caught. Viper's `AutomaticEnv` doesn't enumerate the environment, so an unknown `ND_*` env var is invisible to this check. Only config *file* keys are validated.

Free-form map subkeys are accepted wholesale, so a typo inside `Tags.artist.spleet` is not caught. Validating those would need a separate schema for `TagConf`, which felt like more machinery than the problem warrants.

One behavior change worth calling out for the release notes: instances that set the deprecated `SearchFullString` will now actually get full-string search, where before the option was silently ignored. That is the documented intent of the deprecation, but it is a real change for anyone who has been running with the old key.
