### PR TITLE
Keep trying artist art sources when folder lookup fails

### DIFF
--- a/core/artwork/reader_artist.go
+++ b/core/artwork/reader_artist.go
@@ -61,7 +61,13 @@ func newArtistArtworkReader(ctx context.Context, artwork *artwork, artID model.A
 	}
 	artistFolder, artistFolderLastUpdate, err := loadArtistFolder(ctx, artwork.ds, als, albumPaths)
 	if err != nil {
-		return nil, err
+		// The artist folder is only one of the possible art sources, so a failure to
+		// resolve it must not discard the remaining ones (uploaded image, image-folder,
+		// external). Carry on without it and let the priority chain fall through.
+		log.Warn(ctx, "Could not load artist folder, trying remaining art sources", "artist", ar.Name,
+			"id", artID.ID, err)
+		artistFolder = ""
+		artistFolderLastUpdate = time.Time{}
 	}
 	var lib libraryView
 	if len(als) > 0 {

--- a/core/artwork/reader_artist_test.go
+++ b/core/artwork/reader_artist_test.go
@@ -125,6 +125,19 @@ var _ = Describe("artistArtworkReader", func() {
 				Expect(upd).To(BeZero())
 			})
 		})
+
+		When("the folder is not in the database", func() {
+			It("returns no folder without an error, so other art sources are still tried", func() {
+				paths = []string{
+					filepath.FromSlash("/music/artist/album1"),
+				}
+				repo.result = []model.Folder{}
+				folder, upd, err := loadArtistFolder(ctx, fds, albums, paths)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(folder).To(BeEmpty())
+				Expect(upd).To(BeZero())
+			})
+		})
 	})
 
 	var _ = Describe("fromArtistFolder", func() {


### PR DESCRIPTION
Addresses the second half of #5823.

**What I could confirm about the report**

The first request in that issue — resolving the artist folder for a single-album artist — already works on `master`. `loadArtistFolder` climbs to the parent when there is only one distinct album root:

```go
roots := slices.Compact(slices.Sorted(slices.Values(paths)))
folderPath := commonDir(roots)
if len(roots) < 2 {
    folderPath = filepath.Dir(folderPath)
}
```

and `reader_artist_test.go` covers it ("artist has only one album" → "returns the parent folder"). The reporter was on 0.63.2, so that part looks fixed since.

**What is still wrong**

The issue also notes that failing local resolution doesn't fall through to the rest of `ArtistArtPriority`. That part is real: `newArtistArtworkReader` aborted the whole reader when `loadArtistFolder` returned an error, so a folder-lookup failure discarded every other source — the uploaded image, `image-folder`, and `external` — and the UI fell back to the placeholder.

The artist folder is only one candidate source, so this now logs and continues with an empty folder, letting the priority chain proceed.

Note this affects the DB-error path specifically. When the folder simply isn't in the database (`len(folders) == 0`, the "Could not find folder for artist" warning in the report) `loadArtistFolder` already returns a nil error, and the chain continues — I added a test pinning that behaviour so it can't silently regress into an error return.

**Verification**
- `go test ./core/artwork/` passes, including the new case