### PR TITLE
fix(plugins): reject plugin IDs that are unusable as directory names

### DIFF
--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -271,6 +271,10 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 		return fmt.Errorf("manager is stopped")
 	}
 
+	if !validPluginID(p.ID) {
+		return fmt.Errorf("invalid plugin ID %q", p.ID)
+	}
+
 	// Track this operation
 	m.loadWg.Add(1)
 	defer m.loadWg.Done()

--- a/plugins/manager_loader_test.go
+++ b/plugins/manager_loader_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -24,6 +25,18 @@ var _ = Describe("buildExtismManifest", func() {
 
 	It("carries the hosts the plugin is allowed to reach", func() {
 		Expect(buildExtismManifest(pkg, nil).AllowedHosts).To(Equal([]string{"example.com"}))
+	})
+})
+
+var _ = Describe("loadPluginWithConfig", func() {
+	// Discovery already rejects these, but a row predating that check, or one
+	// left behind by a failed sync, must not reach the mount setup
+	It("refuses a plugin whose ID is not usable as a directory name", func() {
+		m := &Manager{plugins: make(map[string]*plugin)}
+
+		err := m.loadPluginWithConfig(&model.Plugin{ID: "..", Path: "/does/not/matter.ndp"})
+
+		Expect(err).To(MatchError(ContainSubstring("invalid plugin ID")))
 	})
 })
 

--- a/plugins/manager_sync.go
+++ b/plugins/manager_sync.go
@@ -152,7 +152,11 @@ func (m *Manager) syncPlugins(ctx context.Context, folder string) error {
 			log.Trace(ctx, "Skipping non-plugin entry", "name", entry.Name(), "isDir", entry.IsDir())
 			continue
 		}
-		name := strings.TrimSuffix(entry.Name(), PackageExtension)
+		name, ok := pluginIDFromPath(entry.Name())
+		if !ok {
+			log.Warn(ctx, "Skipping plugin with unusable name", "name", entry.Name())
+			continue
+		}
 		filesOnDisk[name] = filepath.Join(folder, entry.Name())
 	}
 	log.Debug(ctx, "Plugin sync: scanned folder", "folder", folder, "entriesTotal", len(entries), "pluginsFound", len(filesOnDisk))

--- a/plugins/manager_sync_test.go
+++ b/plugins/manager_sync_test.go
@@ -12,6 +12,46 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("syncPlugins", func() {
+	var m *Manager
+	var repo *tests.MockPluginRepo
+	var folder string
+
+	BeforeEach(func() {
+		folder = GinkgoT().TempDir()
+		repo = tests.CreateMockPluginRepo()
+		repo.SetData(model.Plugins{})
+		m = &Manager{ds: &tests.MockDataStore{MockedPlugin: repo}}
+	})
+
+	writePackage := func(name string) {
+		GinkgoHelper()
+		manifest := &Manifest{Name: "Test Plugin", Author: "Test Author", Version: "1.0.0"}
+		wasm := []byte{0x00, 0x61, 0x73, 0x6d} // Minimal wasm header
+		Expect(createTestPackage(filepath.Join(folder, name), manifest, wasm)).To(Succeed())
+	}
+
+	It("registers a plugin with a usable ID", func() {
+		writePackage("my-plugin" + PackageExtension)
+
+		Expect(m.syncPlugins(context.Background(), folder)).To(Succeed())
+
+		_, err := repo.Get("my-plugin")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("skips packages whose name yields a path-like ID", func() {
+		writePackage("." + PackageExtension)
+		writePackage(".." + PackageExtension)
+
+		Expect(m.syncPlugins(context.Background(), folder)).To(Succeed())
+
+		all, err := repo.GetAll()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(all).To(BeEmpty())
+	})
+})
+
 var _ = Describe("removePluginFromDB", func() {
 	It("discards buffered scrobbles for the removed plugin", func() {
 		ctx := context.Background()

--- a/plugins/manager_watcher.go
+++ b/plugins/manager_watcher.go
@@ -89,7 +89,11 @@ func (m *Manager) handleWatcherEvent(event notify.EventInfo) {
 		return
 	}
 
-	pluginName := strings.TrimSuffix(filepath.Base(path), PackageExtension)
+	pluginName, ok := pluginIDFromPath(path)
+	if !ok {
+		log.Warn(m.ctx, "Ignoring plugin file with unusable name", "path", path)
+		return
+	}
 
 	log.Trace(m.ctx, "Plugin file event", "plugin", pluginName, "event", event.Event(), "path", path)
 

--- a/plugins/package.go
+++ b/plugins/package.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
+	"strings"
 )
 
 const (
@@ -17,6 +19,26 @@ const (
 	// wasmFileName is the name of the WebAssembly module inside the package.
 	wasmFileName = "plugin.wasm"
 )
+
+// validPluginID reports whether id is usable. It names a directory under
+// DataFolder/plugins, so a path-like one would point at another plugin's data.
+func validPluginID(id string) bool {
+	if id == "." || id == ".." || strings.ContainsAny(id, `/\`) || !filepath.IsLocal(id) {
+		return false
+	}
+	// Windows drops trailing dots and spaces, so "foo." and "foo" would end up
+	// sharing a directory
+	return strings.TrimRight(id, ". ") == id
+}
+
+// pluginIDFromPath derives the plugin ID from a package path.
+func pluginIDFromPath(path string) (string, bool) {
+	id := strings.TrimSuffix(filepath.Base(path), PackageExtension)
+	if !validPluginID(id) {
+		return "", false
+	}
+	return id, true
+}
 
 // ndpPackage represents a loaded .ndp plugin package.
 // It contains the manifest and wasm bytes read from the archive.

--- a/plugins/package_test.go
+++ b/plugins/package_test.go
@@ -11,6 +11,36 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("pluginIDFromPath", func() {
+	DescribeTable("derives the ID from the package filename",
+		func(path, expected string) {
+			id, ok := pluginIDFromPath(path)
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal(expected))
+		},
+		Entry("plain name", "/plugins/discord-rich-presence.ndp", "discord-rich-presence"),
+		Entry("name with spaces", "/plugins/My Plugin.ndp", "My Plugin"),
+		Entry("leading dot", "/plugins/.hidden.ndp", ".hidden"),
+		Entry("dots inside", "/plugins/v1.2.3.ndp", "v1.2.3"),
+	)
+
+	// The ID becomes a directory name under DataFolder/plugins, so a path-like
+	// one would let a plugin reach another plugin's data
+	DescribeTable("rejects IDs that are unsafe as a directory name",
+		func(path string) {
+			_, ok := pluginIDFromPath(path)
+			Expect(ok).To(BeFalse())
+		},
+		Entry("empty", "/plugins/.ndp"),
+		Entry("current directory", "/plugins/..ndp"),
+		Entry("parent directory", "/plugins/...ndp"),
+		// Windows drops trailing dots and spaces, so these would share a
+		// directory with "foo"
+		Entry("trailing dot", "/plugins/foo..ndp"),
+		Entry("trailing space", "/plugins/foo .ndp"),
+	)
+})
+
 var _ = Describe("ndpPackage", func() {
 	var tmpDir string
 


### PR DESCRIPTION
### Description

A plugin's ID is derived from its package filename (`strings.TrimSuffix(entry.Name(), ".ndp")`) and then used verbatim as a directory name under `DataFolder/plugins` by the kvstore (`host_kvstore.go:57`) and taskqueue (`host_taskqueue.go:87`) services. Nothing validates it, so a package installed as `..ndp` yields the ID `.` and `...ndp` yields `..`. `filepath.Join` cleans those away, and the plugin's data directory resolves to the plugins folder itself or the data folder root — outside the per-plugin directory those services assume they own.

Rather than patch each consumer, this validates the ID where it enters the system. `pluginIDFromPath` is now the only place an ID is derived, rejecting `.`, `..`, empty names, anything containing a path separator, trailing dots or spaces, and anything `filepath.IsLocal` refuses (Windows reserved device names, drive-relative paths). The trailing dot/space case is Windows-specific: path normalization drops them, so `foo..ndp` and `foo.ndp` produce distinct IDs (`foo.` and `foo`) that resolve to the same directory and would share the same SQLite files. Discovery and the file watcher both go through it, logging a warning and skipping the file; the loader repeats the check because a sync failure is explicitly non-fatal (`manager.go:153-155`) and a stale row could otherwise still reach the host services. Any future consumer of the plugin ID inherits the guarantee.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

```bash
make test PKG=./plugins/
```

`pluginIDFromPath` has table tests for the accepted and rejected shapes; `loadPluginWithConfig` has one for a row with a path-like ID. The `syncPlugins` test writes real `.ndp` packages into a folder and asserts a normally-named one is registered while `.ndp` and `..ndp` are skipped — it needs valid packages, since invalid ones are skipped for unrelated reasons and would make it pass vacuously.

### Additional Notes

**Existing installs.** A plugin already in the DB with such an ID stops loading. On the next sync its file is skipped, the row is treated as removed from disk, and it is cleaned up — the same path as a deleted plugin.

**Platform-dependent acceptance.** `filepath.IsLocal` is platform-aware, so `CON.ndp` is accepted on Linux/macOS and rejected on Windows. That's correct — the name is only hazardous where the OS treats it as a device — but a plugin can load on one platform and be skipped on another.

**Deliberately permissive otherwise.** `My Plugin.ndp`, `v1.2.3.ndp` and `.hidden.ndp` still work; only names unsafe as a directory component are rejected, so this shouldn't break any existing plugin.
