### PR TITLE
feat(plugins): surface the valid agent names in logs and the Plugins UI

### DIFF
--- a/core/agents/agents.go
+++ b/core/agents/agents.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"context"
 	"errors"
+	"maps"
 	"slices"
 	"strings"
 	"sync"
@@ -126,10 +127,17 @@ func (a *Agents) getEnabledAgentNames() []enabledAgent {
 		} else if isPlugin {
 			validAgents = append(validAgents, enabledAgent{name: name, isPlugin: true})
 		} else {
-			log.Debug("Unknown agent ignored", "name", name)
+			log.Debug("Unknown agent ignored", "name", name, "available", availableAgentNames(availablePlugins))
 		}
 	}
 	return validAgents
+}
+
+// availableAgentNames returns every name accepted by the Agents config option.
+func availableAgentNames(plugins []string) []string {
+	names := append(slices.Collect(maps.Keys(Map)), plugins...)
+	slices.Sort(names)
+	return names
 }
 
 func (a *Agents) getAgent(ea enabledAgent) Interface {

--- a/core/agents/agents_test.go
+++ b/core/agents/agents_test.go
@@ -3,6 +3,7 @@ package agents
 import (
 	"context"
 	"errors"
+	"slices"
 	"time"
 
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -89,6 +90,22 @@ var _ = Describe("Agents", func() {
 			// local agent is always appended to the end of the agents list
 			Expect(ags).To(HaveExactElements("empty", "fake", "local"))
 			Expect(ags).ToNot(ContainElement("disabled"))
+		})
+
+		Describe("availableAgentNames", func() {
+			It("combines built-in agents with the given plugins", func() {
+				names := availableAgentNames([]string{"apple-music"})
+				Expect(names).To(ContainElements("apple-music", LocalAgentName, "fake", "empty"))
+			})
+
+			It("returns the names sorted", func() {
+				names := availableAgentNames([]string{"zz-plugin", "aa-plugin"})
+				Expect(slices.IsSorted(names)).To(BeTrue())
+			})
+
+			It("works when there are no plugins", func() {
+				Expect(availableAgentNames(nil)).To(ContainElement(LocalAgentName))
+			})
 		})
 
 		Describe("GetArtistMBID", func() {

--- a/resources/i18n/pt-br.json
+++ b/resources/i18n/pt-br.json
@@ -394,6 +394,7 @@
         "invalidJson": "A configuração deve ser um JSON válido"
       },
       "messages": {
+        "idHelp": "O ID do plugin, derivado do nome do arquivo. Use-o ao referenciar este plugin em opções de configuração, como Agents.",
         "configHelp": "Configure o plugin usando pares chave-valor. Deixe vazio se o plugin não precisa de configuração.",
         "clickPermissions": "Clique em uma permissão para ver detalhes",
         "noConfig": "Nenhuma configuração definida",

--- a/ui/src/i18n/en.json
+++ b/ui/src/i18n/en.json
@@ -397,6 +397,7 @@
         "invalidJson": "Configuration must be valid JSON"
       },
       "messages": {
+        "idHelp": "The plugin ID, derived from its file name. Use it when referencing this plugin in configuration options, such as Agents.",
         "configHelp": "Configure the plugin using key-value pairs. Leave empty if the plugin requires no configuration.",
         "configValidationError": "Configuration validation failed:",
         "schemaRenderError": "Unable to render configuration form. The plugin's schema may be invalid.",

--- a/ui/src/plugin/InfoCard.jsx
+++ b/ui/src/plugin/InfoCard.jsx
@@ -123,6 +123,13 @@ export const InfoCard = ({ record, manifest, classes, translate, isSmall }) => (
           isSmall={isSmall}
         >
           {record.id}
+          <Typography
+            variant="caption"
+            color="textSecondary"
+            className={classes.fieldHelp}
+          >
+            {translate('resources.plugin.messages.idHelp')}
+          </Typography>
         </InfoRow>
 
         {manifest?.name && (
@@ -201,7 +208,7 @@ export const InfoCard = ({ record, manifest, classes, translate, isSmall }) => (
               <Typography
                 variant="caption"
                 color="textSecondary"
-                style={{ marginTop: 4, display: 'block' }}
+                className={classes.fieldHelp}
               >
                 {translate('resources.plugin.messages.clickPermissions')}
               </Typography>

--- a/ui/src/plugin/InfoCard.test.jsx
+++ b/ui/src/plugin/InfoCard.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+
+vi.mock('../common', () => ({
+  DateField: ({ source }) => <span data-testid={`date-${source}`} />,
+}))
+
+const { InfoCard } = await import('./InfoCard')
+
+const record = {
+  id: 'apple-music',
+  path: '/data/plugins/apple-music.ndp',
+  updatedAt: '2026-01-01T00:00:00Z',
+  createdAt: '2026-01-01T00:00:00Z',
+}
+
+const renderCard = () =>
+  render(
+    <InfoCard
+      record={record}
+      manifest={{ name: 'Apple Music Metadata Agent' }}
+      classes={{}}
+      translate={(key) => key}
+      isSmall={false}
+    />,
+  )
+
+describe('InfoCard', () => {
+  it('shows the plugin ID', () => {
+    renderCard()
+    expect(screen.getByText('apple-music')).toBeInTheDocument()
+  })
+
+  it('explains that the ID is the name used in config options', () => {
+    renderCard()
+    expect(
+      screen.getByText('resources.plugin.messages.idHelp'),
+    ).toBeInTheDocument()
+  })
+})

--- a/ui/src/plugin/styles.js
+++ b/ui/src/plugin/styles.js
@@ -45,6 +45,10 @@ export const usePluginShowStyles = makeStyles(
       fontSize: '0.85rem',
       wordBreak: 'break-all',
     },
+    fieldHelp: {
+      marginTop: theme.spacing(0.5),
+      display: 'block',
+    },
     permissionsContainer: {
       display: 'flex',
       flexWrap: 'wrap',


### PR DESCRIPTION
### Description

A plugin's agent name comes from its `.ndp` **file name**, not from the `name` field in its manifest. That is easy to trip over: renaming the downloaded package silently breaks the `Agents` config option, and nothing in the server points it out. The Plugins UI already displays the plugin ID, but never says what it is for, and the mismatch is reported by a bare `Unknown agent ignored name=...` line that gives no clue what a valid name would look like.

This PR closes that gap from both ends. The plugin detail page gains a short caption under the ID explaining that it is derived from the file name and is the value configuration options such as `Agents` expect. And the log line now lists every name the `Agents` option accepts — the registered built-in agents plus the loaded plugins — so the invalid name and the valid ones appear side by side.

No behavior changes: the same agents are enabled or ignored as before, this only makes the existing outcome explainable.

### Related Issues

Related to navidrome/apple-music-plugin#14

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

**UI**

1. Go to **Settings → Plugins** and open any plugin.
2. Under **Plugin Information**, the **ID** row should now carry a caption explaining that the ID comes from the file name and is the name to use in configuration options such as `Agents`.

**Log line**

1. Install any plugin, then set `Agents` to a name that does not exist, e.g. `ND_AGENTS=apple-music,deezer,lastfm` while the package file is named `Apple Music Plugin.ndp`.
2. Start the server with `ND_LOGLEVEL=debug` and request artist info for any artist.
3. The log should carry `msg="Unknown agent ignored" available="[...]" name=apple-music`, with `available` listing the real plugin ID alongside the built-in agent names.
4. Rename the file to `apple-music.ndp`, restart, and confirm the message disappears and the plugin is used.

### Screenshots / Demos

The `apple-music` plugin installed under its original file name. The new caption sits under the ID, directly above the manifest `Name` it is so easily confused with.

![Plugin Information card showing the ID caption](https://gist.githubusercontent.com/deluan/a137aebccb0ea6c81d87f2fb935ce471/raw/09d7d72a24e02a414034e2281dd1dbe2f3d5d7c2/pr-5910-plugin-id-help.png)

### Additional Notes

An earlier version of this PR raised that log line from Debug to Warn, so it would show at the default log level. That turned out to cost far more than it was worth. `getEnabledAgentNames()` runs on every agent call, so a Warn there floods the log and needed a cache; the cache in turn was wrong during startup, since the server and the plugin manager start in parallel and a call in the first seconds would warn that a correctly configured plugin is unknown. Fixing that needed a new `PluginsLoaded()` method on the plugin manager and on the `PluginLoader` interface. That is a cache, a mutex, and a cross-package lifecycle flag in exchange for one log level — so this PR drops it and keeps the message at Debug. The UI caption is the part that actually reaches the person hitting this.

The UI caption is intentionally generic rather than saying "this plugin is a metadata agent, add it to `Agents`". Capabilities are detected from the WASM exports at load time and are not persisted on the `plugin` table, so a capability-aware hint would need a migration plus changes to the sync path. That felt out of proportion for this.
