### PR TITLE
fix(cache): write the completion marker before closing the cache writer

### DIFF
--- a/core/artwork/artwork_test.go
+++ b/core/artwork/artwork_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Artwork", func() {
 			func(ctx context.Context, arg cache.Item) (io.Reader, error) {
 				return arg.(artworkReader).Reader(ctx)
 			})
-		Eventually(func() bool { return imgCache.Available(ctx) }).Should(BeTrue())
+		Eventually(func() bool { return imgCache.Available(ctx) }, 10*time.Second).Should(BeTrue())
 		svc = NewArtwork(ds, imgCache, store, ffm)
 	})
 

--- a/core/artwork/worker.go
+++ b/core/artwork/worker.go
@@ -167,19 +167,15 @@ func (w *Worker) drain(ctx context.Context, concurrency int, kinds ...string) (i
 	var refreshMu sync.Mutex
 	var refresh []model.ArtworkQueueItem
 	for _, item := range items {
-		// Checked first: with a free slot AND a cancelled ctx both cases of the blocking
-		// select are ready and it picks randomly, which would dispatch after cancellation.
-		select {
-		case <-ctx.Done():
-			wg.Wait()
-			return len(items), nil
-		default:
-		}
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():
+		}
+		// Checked outside the select: with a free slot AND a cancelled ctx both cases
+		// are ready and select picks randomly, which could dispatch after cancellation.
+		if ctx.Err() != nil {
 			wg.Wait()
-			return len(items), nil
+			return len(items), nil //nolint:nilerr // a cancelled drain is a clean stop, not an error
 		}
 		wg.Go(func() {
 			defer func() { <-sem }()

--- a/core/artwork/worker.go
+++ b/core/artwork/worker.go
@@ -167,6 +167,14 @@ func (w *Worker) drain(ctx context.Context, concurrency int, kinds ...string) (i
 	var refreshMu sync.Mutex
 	var refresh []model.ArtworkQueueItem
 	for _, item := range items {
+		// Checked first: with a free slot AND a cancelled ctx both cases of the blocking
+		// select are ready and it picks randomly, which would dispatch after cancellation.
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return len(items), nil
+		default:
+		}
 		select {
 		case sem <- struct{}{}:
 		case <-ctx.Done():

--- a/core/artwork/worker.go
+++ b/core/artwork/worker.go
@@ -171,8 +171,7 @@ func (w *Worker) drain(ctx context.Context, concurrency int, kinds ...string) (i
 		case sem <- struct{}{}:
 		case <-ctx.Done():
 		}
-		// Checked outside the select: with a free slot AND a cancelled ctx both cases
-		// are ready and select picks randomly, which could dispatch after cancellation.
+		// select picks randomly when both cases are ready, so re-check to never dispatch after cancellation.
 		if ctx.Err() != nil {
 			wg.Wait()
 			return len(items), nil //nolint:nilerr // a cancelled drain is a clean stop, not an error

--- a/core/artwork/worker_test.go
+++ b/core/artwork/worker_test.go
@@ -706,13 +706,17 @@ var _ = Describe("Worker", func() {
 
 	Describe("batching", func() {
 		It("leaves undispatched items queued when cancelled mid-batch", func() {
+			// Every album must resolve (to absent), so ANY dispatched item deletes its row
+			// and the assertion below can see it — regardless of dequeue order.
+			albums := model.Albums{}
 			for i := range 8 {
 				id := fmt.Sprintf("alc%d", i)
-				ds.MockedAlbum.(*tests.MockAlbumRepo).SetData(model.Albums{{ID: id, Name: "Album"}})
+				albums = append(albums, model.Album{ID: id, Name: "Album"})
 				Expect(queueRepo.Enqueue(model.ArtworkQueueItem{
 					ItemKind: "al", ItemID: id, Priority: model.ArtworkPriorityScan,
 				})).To(Succeed())
 			}
+			ds.MockedAlbum.(*tests.MockAlbumRepo).SetData(albums)
 			cancelledCtx, cancel := context.WithCancel(ctx)
 			cancel()
 

--- a/core/artwork/worker_test.go
+++ b/core/artwork/worker_test.go
@@ -707,8 +707,7 @@ var _ = Describe("Worker", func() {
 
 	Describe("batching", func() {
 		It("leaves undispatched items queued when cancelled mid-batch", func() {
-			// Every album must resolve (to absent), so ANY dispatched item deletes its row
-			// and the assertion below can see it — regardless of dequeue order.
+			// Every album must resolve, so any dispatched item deletes its row regardless of dequeue order.
 			albums := model.Albums{}
 			for i := range 8 {
 				id := fmt.Sprintf("alc%d", i)

--- a/core/artwork/worker_test.go
+++ b/core/artwork/worker_test.go
@@ -151,7 +151,8 @@ var _ = Describe("Worker", func() {
 			func(ctx context.Context, arg cache.Item) (io.Reader, error) {
 				return arg.(artworkReader).Reader(ctx)
 			})}
-		Eventually(func() bool { return imgCache.Available(ctx) }).Should(BeTrue())
+		// Init walks the cache dir on a goroutine; loaded CI runners can take >1s.
+		Eventually(func() bool { return imgCache.Available(ctx) }, 10*time.Second).Should(BeTrue())
 		w = NewWorker(ds, store, ag, ffm, broker, imgCache)
 	})
 

--- a/scanner/watcher_test.go
+++ b/scanner/watcher_test.go
@@ -26,8 +26,7 @@ var _ = Describe("Watcher", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
-		// Must dwarf the 20ms Consistently windows below: the debouncing spec fails if a
-		// loaded runner delays a timer reset past this wait (seen at 50ms on Windows CI).
+		// Must dwarf the 20ms Consistently windows below, or a loaded runner's delayed timer reset flakes the debouncing spec.
 		conf.Server.Scanner.WatcherWait = 200 * time.Millisecond
 
 		ctx, cancel = context.WithCancel(GinkgoT().Context())

--- a/scanner/watcher_test.go
+++ b/scanner/watcher_test.go
@@ -26,7 +26,9 @@ var _ = Describe("Watcher", func() {
 
 	BeforeEach(func() {
 		DeferCleanup(configtest.SetupConfig())
-		conf.Server.Scanner.WatcherWait = 50 * time.Millisecond // Short wait for tests
+		// Must dwarf the 20ms Consistently windows below: the debouncing spec fails if a
+		// loaded runner delays a timer reset past this wait (seen at 50ms on Windows CI).
+		conf.Server.Scanner.WatcherWait = 200 * time.Millisecond
 
 		ctx, cancel = context.WithCancel(GinkgoT().Context())
 		DeferCleanup(cancel)
@@ -91,7 +93,7 @@ var _ = Describe("Watcher", func() {
 					return nil
 				}
 				return calls[0].Targets
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(HaveLen(2))
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveLen(2))
 
 			// Verify targets
 			calls := mockScanner.GetScanFoldersCalls()
@@ -111,7 +113,7 @@ var _ = Describe("Watcher", func() {
 			// Wait for watcher to process and trigger scan
 			Eventually(func() int {
 				return mockScanner.GetScanFoldersCallCount()
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(Equal(1))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(1))
 
 			// Verify the target
 			calls := mockScanner.GetScanFoldersCalls()
@@ -129,7 +131,7 @@ var _ = Describe("Watcher", func() {
 			// Wait for watcher to process and trigger scan
 			Eventually(func() int {
 				return mockScanner.GetScanFoldersCallCount()
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(Equal(1))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(1))
 
 			// Verify only one target despite multiple file/folder changes
 			calls := mockScanner.GetScanFoldersCalls()
@@ -170,7 +172,7 @@ var _ = Describe("Watcher", func() {
 			// Now wait for the debounce timer to expire and trigger scan
 			Eventually(func() int {
 				return mockScanner.GetScanFoldersCallCount()
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(Equal(1))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(1))
 		})
 
 		It("triggers scan after quiet period", func() {
@@ -183,7 +185,7 @@ var _ = Describe("Watcher", func() {
 			// Wait for quiet period
 			Eventually(func() int {
 				return mockScanner.GetScanFoldersCallCount()
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(Equal(1))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(1))
 		})
 	})
 
@@ -205,7 +207,7 @@ var _ = Describe("Watcher", func() {
 			// Wait for scan
 			Eventually(func() int {
 				return mockScanner.GetScanFoldersCallCount()
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(Equal(1))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(1))
 
 			// Should scan the library root
 			calls := mockScanner.GetScanFoldersCalls()
@@ -222,7 +224,7 @@ var _ = Describe("Watcher", func() {
 			// Wait for scan
 			Eventually(func() int {
 				return mockScanner.GetScanFoldersCallCount()
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(Equal(1))
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(1))
 
 			// Should have only one target
 			calls := mockScanner.GetScanFoldersCalls()
@@ -266,7 +268,7 @@ var _ = Describe("Watcher", func() {
 					return nil
 				}
 				return calls[0].Targets
-			}, 500*time.Millisecond, 10*time.Millisecond).Should(HaveLen(2))
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveLen(2))
 
 			// Verify library IDs are different
 			calls := mockScanner.GetScanFoldersCalls()

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -242,8 +242,7 @@ func getFinalCachedSize(r fscache.ReadAtCloser) int64 {
 	return -1
 }
 
-// copyAndClose marks the entry complete before closing w: readers only see EOF at
-// Close, so EOF must already imply all of the entry's on-disk writes are finished.
+// copyAndClose marks the entry complete before closing w, so EOF implies the entry is settled on disk.
 func (fc *fileCache) copyAndClose(ctx context.Context, key string, w io.WriteCloser, r io.Reader) error {
 	_, err := io.Copy(w, r)
 	if err != nil {

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -183,12 +183,11 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 			return nil, err
 		}
 		go func() {
-			if err := copyAndClose(w, reader); err != nil {
+			if err := fc.copyAndClose(ctx, key, w, reader); err != nil {
 				log.Debug(ctx, "Error storing file in cache", "cache", fc.name, "key", key, err)
 				_ = fc.invalidate(ctx, key)
 			} else {
 				log.Trace(ctx, "File successfully stored in cache", "cache", fc.name, "key", key)
-				fc.markComplete(ctx, key)
 			}
 		}()
 	}
@@ -243,7 +242,9 @@ func getFinalCachedSize(r fscache.ReadAtCloser) int64 {
 	return -1
 }
 
-func copyAndClose(w io.WriteCloser, r io.Reader) error {
+// copyAndClose marks the entry complete before closing w: readers only see EOF at
+// Close, so EOF must already imply all of the entry's on-disk writes are finished.
+func (fc *fileCache) copyAndClose(ctx context.Context, key string, w io.WriteCloser, r io.Reader) error {
 	_, err := io.Copy(w, r)
 	if err != nil {
 		err = fmt.Errorf("copying data to cache: %w", err)
@@ -253,7 +254,9 @@ func copyAndClose(w io.WriteCloser, r io.Reader) error {
 			err = multierror.Append(err, fmt.Errorf("closing source stream: %w", cErr))
 		}
 	}
-
+	if err == nil {
+		fc.markComplete(ctx, key)
+	}
 	if cErr := w.Close(); cErr != nil {
 		err = multierror.Append(err, fmt.Errorf("closing cache writer: %w", cErr))
 	}

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -115,8 +115,7 @@ var _ = Describe("File Caches", func() {
 			_, _ = io.ReadAll(s)
 			_ = s.Close()
 
-			// EOF must imply the entry is settled on disk: callers treat end-of-stream as
-			// "no more cache writes are coming" (e.g. test temp-dir cleanups on Windows).
+			// EOF must imply the entry is settled on disk (Windows temp-dir cleanups rely on it).
 			dataPath := fcSpreadFS(fc).KeyMapper((&testArg{"markme"}).Key())
 			_, statErr := os.Stat(dataPath + ".complete")
 			Expect(statErr).ToNot(HaveOccurred())

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -114,11 +114,11 @@ var _ = Describe("File Caches", func() {
 			_, _ = io.ReadAll(s)
 			_ = s.Close()
 
+			// EOF must imply the entry is settled on disk: callers treat end-of-stream as
+			// "no more cache writes are coming" (e.g. test temp-dir cleanups on Windows).
 			dataPath := fcSpreadFS(fc).KeyMapper((&testArg{"markme"}).Key())
-			Eventually(func() bool {
-				_, statErr := os.Stat(dataPath + ".complete")
-				return statErr == nil
-			}).Should(BeTrue())
+			_, statErr := os.Stat(dataPath + ".complete")
+			Expect(statErr).ToNot(HaveOccurred())
 		})
 
 		It("serves a concurrent reader from an in-progress write and marks complete once", func() {

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -18,7 +19,7 @@ import (
 // Call NewFileCache and wait for it to be ready
 func callNewFileCache(name, cacheSize, cacheFolder string, maxItems int, getReader ReadFunc) *fileCache {
 	fc := NewFileCache(name, cacheSize, cacheFolder, maxItems, getReader).(*fileCache)
-	Eventually(func() bool { return fc.ready.Load() }).Should(BeTrue())
+	Eventually(func() bool { return fc.ready.Load() }, 10*time.Second).Should(BeTrue())
 	return fc
 }
 


### PR DESCRIPTION
### Description

Fixes two `Test Go code (Windows)` flakes that surfaced with the artwork pipeline (#5847). Both were found by stress-running the Windows test job 10x in parallel on a scratch branch; the first was also seen in run [31333810377](https://github.com/navidrome/navidrome/actions/runs/31333810377).

**1. `FileCache` completion marker raced test cleanup (`unlinkat ...: The directory is not empty`).** On a cache miss, the background writer goroutine closed the cache writer and only then created the `.complete` marker file. Readers of an in-progress write see EOF at the moment of that close (`djherbis/stream` releases the OS file handle and then broadcasts EOF), so a caller that fully drained the stream had no guarantee the cache was done touching disk. The artwork precache spec ends right at EOF, and Ginkgo's `TempDir()` cleanup raced the marker creation. The fix writes the marker after a clean copy but **before** the writer is closed, so reader-EOF now implies every on-disk write for the entry is finished. Error semantics are unchanged: a failed copy never marks, and a failed writer close still invalidates the entry, removing both marker and data file. The existing marker test now asserts the marker exists immediately at EOF (previously `Eventually`) — on the old code it reproduces the race on macOS in 2 of 3 runs.

**2. `Worker.drain` could dispatch items after its context was cancelled.** With a free semaphore slot and an already-cancelled context, both cases of the blocking `select` are ready and Go picks one at random — so a cancelled drain could still dispatch queue items (stress jobs lost row `alc7` in 4 of 10 runs). The semaphore select now carries no exit logic; a `ctx.Err()` check right after it is the single exit path, so even a select that randomly picks the free slot while cancelled cannot dispatch. The race was invisible on Linux/macOS only by accident: the spec seeded the album repo with one album at a time (each `SetData` overwriting the last), so only the last row resolved to absent and got deleted when dispatched, and nanosecond-distinct enqueue timestamps kept that row last out of the mock dequeue. Windows' coarse clock ties the timestamps and randomizes the dequeue order, exposing the race. The spec now seeds all eight albums, which reproduces the race locally on first run against the old code.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. On master, `go run github.com/onsi/ginkgo/v2/ginkgo -repeat=10 ./utils/cache` with this branch's `file_caches_test.go` fails within a few repeats; `-repeat=10 --focus "leaves undispatched items queued" ./core/artwork` with this branch's `worker_test.go` fails on the first repeats.
2. On this branch, both commands pass all repeats, and `go test -race ./utils/cache/ ./core/artwork/ ./core/stream/` passes.
3. Full suite: `make test` (74 packages pass).
4. Verified on CI by running an exact copy of the `go-windows` job 10x in parallel on a scratch branch, iterating until clean: [round 1](https://github.com/navidrome/navidrome/actions/runs/31348858330) 6/10 (marker fix held; exposed the drain cancellation race), [round 2](https://github.com/navidrome/navidrome/actions/runs/31349387049) 9/10 (drain fix held; exposed a too-tight cache-init wait and the known latent `persistence` GC crash), [round 3](https://github.com/navidrome/navidrome/actions/runs/31349844720) 9/10 (exposed the pre-existing watcher-debounce flake), [round 4](https://github.com/navidrome/navidrome/actions/runs/31350227908) **10/10 green** with all fixes, [round 5](https://github.com/navidrome/navidrome/actions/runs/31415793932) **10/10 green** re-validating the simplified single-exit cancellation check.

### Additional Notes

Crash-recovery semantics of the completion marker are preserved: `io.Copy` has fully written the data before the marker appears, so an entry adopted on restart (see `spreadFS.Reload`) is still guaranteed complete. The latent `persistence` "found pointer to free object" GC crash occasionally seen on Windows is unrelated and not addressed here.


