### PR TITLE
perf(persistence): make album list pages index-served

### DIFF
--- a/db/migrations/20260810171732_add_album_library_id_index.sql
+++ b/db/migrations/20260810171732_add_album_library_id_index.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- id leads so library_id cannot drive a seek: the index covers library-filtered counts without
+-- tempting the planner to sort a whole library instead of walking a sort-satisfying index.
+create index if not exists album_id_library_id
+	on album(id, library_id);
+
+drop index if exists album_order_album_name;
+create index album_order_album_name
+	on album(order_album_name, order_album_artist_name, id);
+
+-- +goose Down
+drop index if exists album_id_library_id;
+
+drop index if exists album_order_album_name;
+create index album_order_album_name
+	on album(order_album_name);

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
@@ -109,7 +110,7 @@ func NewAlbumRepository(ctx context.Context, db dbx.Builder) model.AlbumReposito
 	r.tableName = "album"
 	r.registerModel(&model.Album{}, albumFilters())
 	r.setSortMappings(map[string]string{
-		"name":         "order_album_name, order_album_artist_name",
+		"name":         "order_album_name, order_album_artist_name, album.id",
 		"artist":       "compilation, order_album_artist_name, order_album_name",
 		"album_artist": "compilation, order_album_artist_name, order_album_name",
 		// TODO Rename this to just year (or date)
@@ -239,7 +240,14 @@ func (r *albumRepository) Get(id string) (*model.Album, error) {
 	return &res[0], nil
 }
 
+// Above this page size the id round-trip stops paying for itself and the IN list gets unwieldy.
+const maxRandomPageIDs = 1000
+
 func (r *albumRepository) GetAll(options ...model.QueryOptions) (model.Albums, error) {
+	if len(options) > 0 && options[0].Sort == "random" &&
+		options[0].Max > 0 && options[0].Max <= maxRandomPageIDs {
+		return r.getRandomPage(options[0])
+	}
 	sq := r.selectAlbum(options...)
 	var res dbAlbums
 	err := r.queryAll(sq, &res)
@@ -248,6 +256,28 @@ func (r *albumRepository) GetAll(options ...model.QueryOptions) (model.Albums, e
 	}
 	albums := res.toModels()
 	r.hydrateArtwork(albums)
+	return albums, nil
+}
+
+// No index can serve a random sort, so the sort pass visits every matching row. Resolving ids
+// first keeps that pass on a covering index instead of dragging full rows and joins through it.
+func (r *albumRepository) getRandomPage(options model.QueryOptions) (model.Albums, error) {
+	ids, err := r.GetAllIDs(options)
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		return model.Albums{}, nil
+	}
+	albums, err := r.GetAll(model.QueryOptions{Filters: Eq{"album.id": ids}})
+	if err != nil {
+		return nil, err
+	}
+	pos := make(map[string]int, len(ids))
+	for i, albumID := range ids {
+		pos[albumID] = i
+	}
+	slices.SortFunc(albums, func(a, b model.Album) int { return cmp.Compare(pos[a.ID], pos[b.ID]) })
 	return albums, nil
 }
 

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -109,6 +109,84 @@ var _ = Describe("AlbumRepository", func() {
 			Expect(GetAll()).To(Equal(testAlbums))
 		})
 
+		// The REST layer sends library_id as a string. SQLite only coerces it to the column's
+		// integer affinity while the term stays a plain column reference, so a filter built on an
+		// expression instead would silently match nothing (#5929).
+		DescribeTable("library_id filter from the REST layer",
+			func(sort string) {
+				res, err := albumRepo.ReadAll(rest.QueryOptions{
+					Sort: sort, Max: 10, Filters: map[string]any{"library_id": "1"},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(res.(model.Albums)).ToNot(BeEmpty())
+			},
+			Entry("name sort", "name"),
+			Entry("random sort", "random"),
+			Entry("no sort", ""),
+		)
+
+		Context("random sort", func() {
+			It("returns the page in the same order the id query produced", func() {
+				opts := model.QueryOptions{Sort: "random", Max: 4, Seed: "a-seed"}
+				ids, err := albumRepo.GetAllIDs(opts)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ids).To(HaveLen(4))
+
+				albums, err := GetAll(opts)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(slice.Map(albums, func(a model.Album) string { return a.ID })).To(Equal(ids))
+			})
+
+			It("keeps paging on one shuffle for a given seed", func() {
+				ids := func(albums model.Albums) []string {
+					return slice.Map(albums, func(a model.Album) string { return a.ID })
+				}
+				firstTwoPages, err := GetAll(model.QueryOptions{Sort: "random", Max: 3, Seed: "s"})
+				Expect(err).ToNot(HaveOccurred())
+				secondPage, err := GetAll(model.QueryOptions{Sort: "random", Max: 3, Offset: 3, Seed: "s"})
+				Expect(err).ToNot(HaveOccurred())
+				whole, err := GetAll(model.QueryOptions{Sort: "random", Max: 6, Seed: "s"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(append(ids(firstTwoPages), ids(secondPage)...)).To(Equal(ids(whole)))
+			})
+
+			// Without an explicit seed, only Offset == 0 reseeds, so scrolling never repeats an album.
+			It("does not repeat albums across pages of one scroll", func() {
+				page1, err := GetAll(model.QueryOptions{Sort: "random", Max: 3})
+				Expect(err).ToNot(HaveOccurred())
+				page2, err := GetAll(model.QueryOptions{Sort: "random", Max: 3, Offset: 3})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(page1).To(HaveLen(3))
+				Expect(page2).To(HaveLen(3))
+				for _, a := range page2 {
+					Expect(page1).ToNot(ContainElement(a))
+				}
+			})
+
+			It("returns every record when no limit is given", func() {
+				albums, err := GetAll(model.QueryOptions{Sort: "random"})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(albums).To(ConsistOf(testAlbums))
+			})
+
+			It("applies filters", func() {
+				albums, err := GetAll(model.QueryOptions{
+					Sort: "random", Max: 10, Filters: squirrel.Eq{"album.name": albumSgtPeppers.Name},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(albums).To(HaveLen(1))
+				Expect(albums[0].ID).To(Equal(albumSgtPeppers.ID))
+			})
+
+			It("hydrates the same fields as a non-random page", func() {
+				albums, err := GetAll(model.QueryOptions{
+					Sort: "random", Max: 1, Filters: squirrel.Eq{"album.id": albumSgtPeppers.ID},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(albums).To(Equal(model.Albums{albumSgtPeppers}))
+			})
+		})
+
 		It("returns all records sorted", func() {
 			Expect(GetAll(model.QueryOptions{Sort: "name"})).To(Equal(model.Albums{
 				albumAbbeyRoad,

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -511,13 +511,26 @@ func (r sqlRepository) classifyOwnedWriteMiss(id string) error {
 	return rest.ErrNotFound
 }
 
+var joinRegex = regexp.MustCompile(`\bJOIN\b`)
+
+// countExpression returns count(*) for join-free queries; joins can fan out rows per id and
+// need the much more expensive count(distinct id) (temp b-tree over the whole result set).
+func (r sqlRepository) countExpression(query SelectBuilder) string {
+	sql, _, err := query.Columns("1").ToSql()
+	if err != nil || joinRegex.MatchString(sql) {
+		return "count(distinct " + r.tableName + ".id) as count"
+	}
+	return "count(*) as count"
+}
+
 func (r sqlRepository) count(countQuery SelectBuilder, options ...model.QueryOptions) (int64, error) {
 	countQuery = countQuery.
-		RemoveColumns().Columns("count(distinct " + r.tableName + ".id) as count").
+		RemoveColumns().
 		RemoveOffset().RemoveLimit().
 		OrderBy(r.tableName + ".id"). // To remove any ORDER BY clause that could slow down the query
 		From(r.tableName)
 	countQuery = r.applyFilters(countQuery, options...)
+	countQuery = countQuery.Columns(r.countExpression(countQuery))
 	var res struct{ Count int64 }
 	err := r.queryOne(countQuery, &res)
 	return res.Count, err

--- a/persistence/sql_base_repository_test.go
+++ b/persistence/sql_base_repository_test.go
@@ -18,6 +18,22 @@ var _ = Describe("sqlRepository", func() {
 		r.tableName = "table"
 	})
 
+	Describe("countExpression", func() {
+		It("uses a plain count when the query has no joins", func() {
+			sq := squirrel.Select().From("table").Where(squirrel.Eq{"library_id": []int{1, 4}})
+			Expect(r.countExpression(sq)).To(Equal("count(*) as count"))
+		})
+		It("uses a distinct count when the query has a join", func() {
+			sq := squirrel.Select().From("table").
+				LeftJoin("annotation on annotation.item_id = table.id")
+			Expect(r.countExpression(sq)).To(Equal("count(distinct table.id) as count"))
+		})
+		It("is not fooled by parametrized values containing the word join", func() {
+			sq := squirrel.Select().From("table").Where(squirrel.Eq{"name": "the join band"})
+			Expect(r.countExpression(sq)).To(Equal("count(*) as count"))
+		})
+	})
+
 	Describe("applyOptions", func() {
 		var sq squirrel.SelectBuilder
 		BeforeEach(func() {


### PR DESCRIPTION
### Description

Follow-up to discussion #5929. On a 110k-album, two-library instance the reporter measured `/api/album?_sort=name` at 3.84s and `_sort=random` at 8.66s. Both requests did work proportional to the whole library rather than to the 36-album page they returned.

There were two independent causes:

**The count.** Every native API list request also runs a count for the `X-Total-Count` header. `album` had no index covering `library_id`, so that count scanned the entire table on every request, pulling each row's JSON blobs through the page cache. On top of that, `count(distinct id)` builds a temp b-tree over the full result set even when the query has no join that could duplicate rows.

**The random sort.** No index can serve a random sort, so SQLite evaluated `SEEDEDRAND` for every matching row and pushed each one — with its `library` and `annotation` joins and the full `album.*` projection — through a sorter that kept only 36 rows.

The change is three parts:

1. **`album(id, library_id)` index, and `count(*)` for join-free counts.** Library-filtered counts become a covering index scan. The shared `count()` helper now uses `count(*)` when the rendered query has no join, keeping `count(distinct id)` wherever a join could fan out rows (artist counts through `library_artist`, annotation-filtered queries, shares, tags). Even on an index, `count(DISTINCT)` builds a temp b-tree over the whole result set.

2. **`id` leads that index on purpose, please keep the column order.** The intuitive shape is `(library_id, id)`, or the wider `(library_id, order_album_name, ...)`. Both are worse here: `library_id` leading lets the planner drive *sorted list* queries off the index, and since SQLite cannot merge several `IN` ranges in sorted order it then sorts the entire result set. Fresh `ANALYZE` statistics do not change that choice. With `id` leading, `library_id` cannot drive a seek, so the index still covers the count but never tempts the planner away from the sort index. Measurements in the index shape section below.

3. **Random pages resolve their ids first.** The sort pass then runs on that covering index with no joins, and only the 36 rows of the page are materialized. Pages larger than 1000 keep the single-query path. The seeded shuffle is unchanged — the id query carries the caller's options, so `SEEDEDRAND`, explicit seeds, and the reseed-only-at-`Offset == 0` rule all still apply; the page is reordered in Go afterwards to preserve it.

Also: the album name sort is now a total order (`album.id` appended) and `album_order_album_name` is widened to `(order_album_name, order_album_artist_name, id)` to serve it. Without a tiebreaker, equal album names made page order plan-dependent, which can skip or duplicate rows across paginated requests.

### Related Issues

Related to #5929

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Performance

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Benchmarked with `testing.B` + benchstat through the real repository code paths, on a QNAP NAS (Intel Celeron N5105, 4 cores @ 2.0GHz), against a synthetic 110k-album / 856k-track / 41.5k-artist DB (6.6GB). 6 runs per side, fresh DB copy per revision.

| benchmark | master | this PR | change |
|---|--:|--:|--:|
| album count, two libraries (the #5929 count) | 222.8ms | 8.96ms | **-96.0%** |
| song count, two libraries | 1240.7ms | 76.4ms | **-93.8%** |
| deep page (offset 50k), name sort | 132.7ms | 34.1ms | **-74.3%** |
| first page, random sort | 476.4ms | 259.0ms | **-45.6%** |
| first page, name sort | 2.63ms | 2.43ms | -7.4% |
| starred count | 180µs | 192µs | +6.4% |
| **geomean** | **44.96ms** | **11.88ms** | **-73.6%** |

<sub>benchstat n=6, p≤0.041 on every row.</sub>

One album-grid request's database work drops from ~225ms to ~11ms sorted by name, and from ~699ms to ~268ms sorted randomly.

**Why `id` leads the index.** A `library_id` prefixed index is the intuitive shape, and it is what was proposed in the discussion. It is better for a single library. But on its own, without the UNION ALL rewrite that goes with it there, it regresses the multi library page that was actually reported: SQLite cannot merge several `IN` ranges in sorted order, so it falls back to sorting the whole result set. Same machine, a separate benchmark over a four-library variant of that DB (55k / 54k / 1.1k / a 20-album one whose names all sort last). The last two columns run the *same binary*, so the index is the only variable:

| query | master | this PR | `library_id` prefixed, no UNION ALL |
|---|--:|--:|--:|
| count, two libraries holding 99% of albums | 219ms | 9.5ms | 8.5ms |
| count, one library holding 1% | 52.6ms | 7.3ms | 0.16ms |
| **first page, two libraries holding 99%** | 2.7ms | **2.6ms** | 37.1ms |
| first page, one library holding 49% | 2.8ms | 2.5ms | 2.7ms |
| first page, a 20 album library sorting last | 61.2ms | 59.6ms | 2.7ms |
| first page, random, two libraries holding 99% | 486ms | 262ms | 397ms |

Two gaps this PR does not close, both visible above: counting a library holding a small share of the collection, and paging a small library whose albums sort late in the alphabet. Note the master column on those rows, they are unimproved rather than regressed. Closing them needs the `library_id` prefixed indexes *plus* a UNION ALL rewrite turning `IN (a,b)` into per-library queries, which is a much larger change and is not attempted here.

End-to-end against a real server, the two reported requests (`/api/album?_end=36&_order=ASC&_sort=name|random&_start=0&library_id=1&library_id=4`) return 36 albums with `X-Total-Count: 110412` in 13ms (name) and 77ms (random) warm. Consecutive random pages return 36 albums each with zero overlap.

To verify manually: open the album grid with more than one library selected and compare timings for `_sort=name` and `_sort=random`. `EXPLAIN QUERY PLAN` for the count should show `SCAN album USING COVERING INDEX album_id_library_id`, and the name-sorted page `SCAN album USING INDEX album_order_album_name` with no `USE TEMP B-TREE FOR ORDER BY`.

### Additional Notes

- The starred count costs ~12µs more: `count()` renders the query once to detect joins. Annotation-filtered counts keep their `count(distinct)` correctness.
- The first page barely moves, and that is expected: it was never the bottleneck. Essentially all of the `sort=name` win is the count.
- The random sort's **allocations are unchanged** (~1.0M per page, ~27MB). The win is all I/O: `SEEDEDRAND` is still evaluated once per matching row, and each of those is a Go function call from SQLite. Removing that floor needs a stored, indexable ordering, which is a different change and not attempted here. It is also the noisiest benchmark here, swinging ±29% run to run.
- The migration relies on `db.Init`'s existing post-migration `ANALYZE` for planner statistics on the new indexes; verified on a fresh 6.6GB copy that both get correct `sqlite_stat1` rows from that path alone. It creates one index on `album` and rebuilds another, about a second on the test DB.
