### PR TITLE
feat(jellyfin): send a synthetic placeholder blurhash for unresolved artwork

### DIFF
--- a/core/artwork/blurhash/blurhash.go
+++ b/core/artwork/blurhash/blurhash.go
@@ -39,22 +39,25 @@ func Encode(img image.Image) (string, error) {
 // bounds, and a source far larger than the counts: too few samples overshoot the AC terms.
 func encodeAt(img image.Image, xComp, yComp int) string {
 	src := pixelsOf(downscale(img))
-	w, h := src.w, src.h
+	return encodePixels(src, xComp, yComp, cosBasis(xComp, src.w), cosBasis(yComp, src.h))
+}
 
-	cosX := make([][]float64, xComp)
-	for i := range cosX {
-		cosX[i] = make([]float64, w)
-		for x := range cosX[i] {
-			cosX[i][x] = math.Cos(math.Pi * float64(i) * float64(x) / float64(w))
+// cosBasis is the cosine basis for comp components sampled across n pixels. It depends only
+// on its arguments, so a caller with a fixed shape can build it once and reuse it.
+func cosBasis(comp, n int) [][]float64 {
+	basis := make([][]float64, comp)
+	for i := range basis {
+		basis[i] = make([]float64, n)
+		for x := range basis[i] {
+			basis[i][x] = math.Cos(math.Pi * float64(i) * float64(x) / float64(n))
 		}
 	}
-	cosY := make([][]float64, yComp)
-	for j := range cosY {
-		cosY[j] = make([]float64, h)
-		for y := range cosY[j] {
-			cosY[j][y] = math.Cos(math.Pi * float64(j) * float64(y) / float64(h))
-		}
-	}
+	return basis
+}
+
+// encodePixels is the encoder proper; cosX and cosY must match src's dimensions.
+func encodePixels(src pixels, xComp, yComp int, cosX, cosY [][]float64) string {
+	w, h := src.w, src.h
 
 	lin := srgbToLinearTable()
 	factors := make([][3]float64, xComp*yComp)

--- a/core/artwork/blurhash/blurhash.go
+++ b/core/artwork/blurhash/blurhash.go
@@ -35,7 +35,7 @@ func Encode(img image.Image) (string, error) {
 	return encodeAt(img, xComp, yComp), nil
 }
 
-// encodeAt encodes img at the given component counts (each 1..9). Callers guarantee non-empty bounds.
+// encodeAt encodes img at the given component counts (each 2..9). Callers guarantee non-empty bounds.
 func encodeAt(img image.Image, xComp, yComp int) string {
 	src := pixelsOf(downscale(img))
 	w, h := src.w, src.h

--- a/core/artwork/blurhash/blurhash.go
+++ b/core/artwork/blurhash/blurhash.go
@@ -35,7 +35,8 @@ func Encode(img image.Image) (string, error) {
 	return encodeAt(img, xComp, yComp), nil
 }
 
-// encodeAt encodes img at the given component counts (each 2..9). Callers guarantee non-empty bounds.
+// encodeAt encodes img at the given component counts (each 2..9). Callers guarantee non-empty
+// bounds, and a source far larger than the counts: too few samples overshoot the AC terms.
 func encodeAt(img image.Image, xComp, yComp int) string {
 	src := pixelsOf(downscale(img))
 	w, h := src.w, src.h

--- a/core/artwork/blurhash/blurhash.go
+++ b/core/artwork/blurhash/blurhash.go
@@ -32,6 +32,11 @@ func Encode(img image.Image) (string, error) {
 	}
 	// Pre-downscale: its rounding can flip a component count, and the hash is a client cache key.
 	xComp, yComp := components(img.Bounds().Dx(), img.Bounds().Dy())
+	return encodeAt(img, xComp, yComp), nil
+}
+
+// encodeAt encodes img at the given component counts (each 1..9). Callers guarantee non-empty bounds.
+func encodeAt(img image.Image, xComp, yComp int) string {
 	src := pixelsOf(downscale(img))
 	w, h := src.w, src.h
 
@@ -86,7 +91,7 @@ func Encode(img image.Image) (string, error) {
 	var sb strings.Builder
 	sb.WriteString(encode83((xComp-1)+(yComp-1)*9, 1))
 
-	// Derived counts are at least 1x9, so there is always at least one AC factor.
+	// Every caller passes at least 2 components, so there is always at least one AC factor.
 	ac := factors[1:]
 	actualMax := 0.0
 	for _, f := range ac {
@@ -101,7 +106,7 @@ func Encode(img image.Image) (string, error) {
 	for _, f := range ac {
 		sb.WriteString(encode83(quantAC(f[0], maxVal)*19*19+quantAC(f[1], maxVal)*19+quantAC(f[2], maxVal), 2))
 	}
-	return sb.String(), nil
+	return sb.String()
 }
 
 // pixels is direct Pix access for the pixel loop, avoiding a per-pixel allocation via image.At.

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -8,8 +8,7 @@ import (
 	"github.com/zeebo/xxh3"
 )
 
-// synthComponents is deliberately below the ~4x4 Encode derives, so a synthetic value is
-// always shorter than a real one and the two can never collide.
+// A real hash never has 3x3 components: components() always targets ~16 tiles.
 const synthComponents = 3
 
 // Synthetic returns a blurhash unique to seed, for artwork whose real hash does not exist

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -2,7 +2,6 @@ package blurhash
 
 import (
 	"image"
-	"image/color"
 	"math"
 	"strconv"
 
@@ -12,13 +11,17 @@ import (
 // A real hash never has 3x3 components: components() always targets ~16 tiles.
 const synthComponents = 3
 
+// Encoding a source no bigger than the component grid overshoots the AC coefficients,
+// clamping the corners to black; the encoder assumes many samples per component.
+const synthSourceSize = 8
+
 // Synthetic returns a blurhash unique to seed, for artwork whose real hash does not exist
 // yet. baseColor ("#rrggbb") sets the hue family; "" derives it from the seed.
 func Synthetic(seed, baseColor string) string {
 	hue, sat, light := baseTone(baseColor, xxh3.HashStringSeed(seed, 0))
 
-	img := image.NewNRGBA(image.Rect(0, 0, synthComponents, synthComponents))
-	for i := range synthComponents * synthComponents {
+	var grid [synthComponents * synthComponents][3]float64
+	for i := range grid {
 		// Each cell hashes the seed separately, so one tint shared by many items still
 		// yields one value per item.
 		bits := xxh3.HashStringSeed(seed, uint64(i)+1)
@@ -26,9 +29,39 @@ func Synthetic(seed, baseColor string) string {
 		ds := (byteFrac(bits, 8) - 0.5) * 0.16
 		dl := (byteFrac(bits, 16) - 0.5) * 0.30
 		r, g, b := hslToRGB(hue+dh, clamp01(sat+ds), clamp01(light+dl))
-		img.SetNRGBA(i%synthComponents, i/synthComponents, color.NRGBA{R: r, G: g, B: b, A: 255})
+		grid[i] = [3]float64{float64(r), float64(g), float64(b)}
 	}
-	return encodeAt(img, synthComponents, synthComponents)
+	return encodeAt(upscale(&grid), synthComponents, synthComponents)
+}
+
+// upscale renders the cell grid bilinearly at synthSourceSize. Hand-rolled because
+// x/image's scaler allocates per call, and this runs once per mapped item.
+func upscale(grid *[synthComponents * synthComponents][3]float64) *image.NRGBA {
+	const n, size = synthComponents, synthSourceSize
+	img := image.NewNRGBA(image.Rect(0, 0, size, size))
+	for y := range size {
+		fy := (float64(y)+0.5)*n/size - 0.5
+		y0, wy := cellWeight(fy)
+		for x := range size {
+			fx := (float64(x)+0.5)*n/size - 0.5
+			x0, wx := cellWeight(fx)
+			p := img.Pix[y*img.Stride+x*4:]
+			for c := range 3 {
+				top := grid[y0*n+x0][c]*(1-wx) + grid[y0*n+x0+1][c]*wx
+				bot := grid[(y0+1)*n+x0][c]*(1-wx) + grid[(y0+1)*n+x0+1][c]*wx
+				p[c] = uint8(top*(1-wy) + bot*wy + 0.5)
+			}
+			p[3] = 255
+		}
+	}
+	return img
+}
+
+// cellWeight splits a grid coordinate into its lower cell and the fraction toward the next.
+func cellWeight(f float64) (int, float64) {
+	f = min(max(f, 0), synthComponents-1-1e-9)
+	i := int(f)
+	return i, f - float64(i)
 }
 
 func byteFrac(bits uint64, shift int) float64 {

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"image/color"
 	"math"
+	"strconv"
 
 	"github.com/zeebo/xxh3"
 )
@@ -31,9 +32,49 @@ func Synthetic(seed, baseColor string) string {
 	return encodeAt(img, n, n)
 }
 
-// baseTone is the hue, saturation and lightness the cells orbit.
+// baseTone clamps saturation and lightness away from the extremes, so a placeholder
+// never reads as neon or as solid black.
 func baseTone(baseColor string, hueBits uint64) (hue, sat, light float64) {
+	if r, g, b, ok := parseHex(baseColor); ok {
+		h, s, l := rgbToHSL(r, g, b)
+		return h, min(max(s, 0.10), 0.35), min(max(l, 0.15), 0.75)
+	}
 	return float64(hueBits&0x1FF) / 512 * 360, 0.22, 0.40
+}
+
+func parseHex(s string) (r, g, b uint8, ok bool) {
+	if len(s) != 7 || s[0] != '#' {
+		return 0, 0, 0, false
+	}
+	v, err := strconv.ParseUint(s[1:], 16, 32)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	return uint8(v >> 16), uint8(v >> 8), uint8(v), true
+}
+
+func rgbToHSL(r, g, b uint8) (h, s, l float64) {
+	rf, gf, bf := float64(r)/255, float64(g)/255, float64(b)/255
+	mx, mn := max(rf, gf, bf), min(rf, gf, bf)
+	l = (mx + mn) / 2
+	if mx == mn {
+		return 0, 0, l
+	}
+	d := mx - mn
+	s = d / (1 - math.Abs(2*l-1))
+	switch mx {
+	case rf:
+		h = math.Mod((gf-bf)/d, 6)
+	case gf:
+		h = (bf-rf)/d + 2
+	default:
+		h = (rf-gf)/d + 4
+	}
+	h *= 60
+	if h < 0 {
+		h += 360
+	}
+	return h, s, l
 }
 
 func hslToRGB(h, s, l float64) (uint8, uint8, uint8) {

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -17,19 +17,22 @@ const synthComponents = 3
 func Synthetic(seed, baseColor string) string {
 	hue, sat, light := baseTone(baseColor, xxh3.HashStringSeed(seed, 0))
 
-	const n = synthComponents
-	img := image.NewNRGBA(image.Rect(0, 0, n, n))
-	for i := range n * n {
+	img := image.NewNRGBA(image.Rect(0, 0, synthComponents, synthComponents))
+	for i := range synthComponents * synthComponents {
 		// Each cell hashes the seed separately, so one tint shared by many items still
 		// yields one value per item.
 		bits := xxh3.HashStringSeed(seed, uint64(i)+1)
-		dh := (float64(bits&0xFF)/255 - 0.5) * 60
-		ds := (float64(bits>>8&0x3F)/63 - 0.5) * 0.16
-		dl := (float64(bits>>14&0x3F)/63 - 0.5) * 0.30
+		dh := (byteFrac(bits, 0) - 0.5) * 60
+		ds := (byteFrac(bits, 8) - 0.5) * 0.16
+		dl := (byteFrac(bits, 16) - 0.5) * 0.30
 		r, g, b := hslToRGB(hue+dh, clamp01(sat+ds), clamp01(light+dl))
-		img.SetNRGBA(i%n, i/n, color.NRGBA{R: r, G: g, B: b, A: 255})
+		img.SetNRGBA(i%synthComponents, i/synthComponents, color.NRGBA{R: r, G: g, B: b, A: 255})
 	}
-	return encodeAt(img, n, n)
+	return encodeAt(img, synthComponents, synthComponents)
+}
+
+func byteFrac(bits uint64, shift int) float64 {
+	return float64(bits>>shift&0xFF) / 255
 }
 
 // baseTone clamps saturation and lightness away from the extremes, so a placeholder

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -34,8 +34,15 @@ func Synthetic(seed, baseColor string) string {
 		r, g, b := hslToRGB(hue+dh, clamp01(sat+ds), clamp01(light+dl))
 		grid[i] = [3]float64{float64(r), float64(g), float64(b)}
 	}
-	return encodeAt(upscale(&grid), synthComponents, synthComponents)
+	// The shape is fixed, so the cosine basis is reused instead of rebuilt per call.
+	basis := synthBasis()
+	return encodePixels(pixelsOf(upscale(&grid)), synthComponents, synthComponents, basis, basis)
 }
+
+// synthBasis is the cosine basis for the fixed synthetic shape. Square, so one serves both axes.
+var synthBasis = sync.OnceValue(func() [][]float64 {
+	return cosBasis(synthComponents, synthSourceSize)
+})
 
 // upscale renders the cell grid bilinearly at synthSourceSize. Hand-rolled because
 // x/image's scaler allocates per call, and this runs once per mapped item.

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -15,12 +15,14 @@ const synthComponents = 3
 // clamping the corners to black; the encoder assumes many samples per component.
 const synthSourceSize = 8
 
+type colorGrid = [synthComponents * synthComponents][3]float64
+
 // Synthetic returns a blurhash unique to seed, for artwork whose real hash does not exist
 // yet. baseColor ("#rrggbb") sets the hue family; "" derives it from the seed.
 func Synthetic(seed, baseColor string) string {
 	hue, sat, light := baseTone(baseColor, xxh3.HashStringSeed(seed, 0))
 
-	var grid [synthComponents * synthComponents][3]float64
+	var grid colorGrid
 	for i := range grid {
 		// Each cell hashes the seed separately, so one tint shared by many items still
 		// yields one value per item.
@@ -36,7 +38,7 @@ func Synthetic(seed, baseColor string) string {
 
 // upscale renders the cell grid bilinearly at synthSourceSize. Hand-rolled because
 // x/image's scaler allocates per call, and this runs once per mapped item.
-func upscale(grid *[synthComponents * synthComponents][3]float64) *image.NRGBA {
+func upscale(grid *colorGrid) *image.NRGBA {
 	const n, size = synthComponents, synthSourceSize
 	img := image.NewNRGBA(image.Rect(0, 0, size, size))
 	for y := range size {
@@ -58,9 +60,10 @@ func upscale(grid *[synthComponents * synthComponents][3]float64) *image.NRGBA {
 }
 
 // cellWeight splits a grid coordinate into its lower cell and the fraction toward the next.
+// Edge pixels fall outside the cell centres, so both ends clamp rather than extrapolate.
 func cellWeight(f float64) (int, float64) {
-	f = min(max(f, 0), synthComponents-1-1e-9)
-	i := int(f)
+	f = min(max(f, 0), synthComponents-1)
+	i := min(int(f), synthComponents-2)
 	return i, f - float64(i)
 }
 

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -4,6 +4,7 @@ import (
 	"image"
 	"math"
 	"strconv"
+	"sync"
 
 	"github.com/zeebo/xxh3"
 )
@@ -40,18 +41,26 @@ func Synthetic(seed, baseColor string) string {
 // x/image's scaler allocates per call, and this runs once per mapped item.
 func upscale(grid *colorGrid) *image.NRGBA {
 	const n, size = synthComponents, synthSourceSize
+	axis := axisWeights()
+
+	// Separable: each grid row is stretched horizontally once, then rows blend vertically.
+	// Doing it per pixel instead would repeat every horizontal lerp `size` times.
+	var rows [n][size][3]float64
+	for r := range n {
+		for x, a := range axis {
+			for c := range 3 {
+				rows[r][x][c] = grid[r*n+a.cell][c]*(1-a.frac) + grid[r*n+a.cell+1][c]*a.frac
+			}
+		}
+	}
+
 	img := image.NewNRGBA(image.Rect(0, 0, size, size))
-	for y := range size {
-		fy := (float64(y)+0.5)*n/size - 0.5
-		y0, wy := cellWeight(fy)
+	for y, a := range axis {
+		top, bot := &rows[a.cell], &rows[a.cell+1]
 		for x := range size {
-			fx := (float64(x)+0.5)*n/size - 0.5
-			x0, wx := cellWeight(fx)
 			p := img.Pix[y*img.Stride+x*4:]
 			for c := range 3 {
-				top := grid[y0*n+x0][c]*(1-wx) + grid[y0*n+x0+1][c]*wx
-				bot := grid[(y0+1)*n+x0][c]*(1-wx) + grid[(y0+1)*n+x0+1][c]*wx
-				p[c] = uint8(top*(1-wy) + bot*wy + 0.5)
+				p[c] = uint8(top[x][c]*(1-a.frac) + bot[x][c]*a.frac + 0.5)
 			}
 			p[3] = 255
 		}
@@ -59,13 +68,24 @@ func upscale(grid *colorGrid) *image.NRGBA {
 	return img
 }
 
-// cellWeight splits a grid coordinate into its lower cell and the fraction toward the next.
-// Edge pixels fall outside the cell centres, so both ends clamp rather than extrapolate.
-func cellWeight(f float64) (int, float64) {
-	f = min(max(f, 0), synthComponents-1)
-	i := min(int(f), synthComponents-2)
-	return i, f - float64(i)
-}
+// axisWeights maps each source pixel to its lower cell and the fraction toward the next.
+// Both axes are square and constant-sized, so one table serves both and outlives the call.
+var axisWeights = sync.OnceValue(func() *[synthSourceSize]struct {
+	cell int
+	frac float64
+} {
+	var t [synthSourceSize]struct {
+		cell int
+		frac float64
+	}
+	for i := range t {
+		// Edge pixels fall outside the cell centres, so both ends clamp rather than extrapolate.
+		f := min(max((float64(i)+0.5)*synthComponents/synthSourceSize-0.5, 0), synthComponents-1)
+		t[i].cell = min(int(f), synthComponents-2)
+		t[i].frac = f - float64(t[i].cell)
+	}
+	return &t
+})
 
 func byteFrac(bits uint64, shift int) float64 {
 	return float64(bits>>shift&0xFF) / 255

--- a/core/artwork/blurhash/synthetic.go
+++ b/core/artwork/blurhash/synthetic.go
@@ -1,0 +1,66 @@
+package blurhash
+
+import (
+	"image"
+	"image/color"
+	"math"
+
+	"github.com/zeebo/xxh3"
+)
+
+// synthComponents is deliberately below the ~4x4 Encode derives, so a synthetic value is
+// always shorter than a real one and the two can never collide.
+const synthComponents = 3
+
+// Synthetic returns a blurhash unique to seed, for artwork whose real hash does not exist
+// yet. baseColor ("#rrggbb") sets the hue family; "" derives it from the seed.
+func Synthetic(seed, baseColor string) string {
+	hue, sat, light := baseTone(baseColor, xxh3.HashStringSeed(seed, 0))
+
+	const n = synthComponents
+	img := image.NewNRGBA(image.Rect(0, 0, n, n))
+	for i := range n * n {
+		// Each cell hashes the seed separately, so one tint shared by many items still
+		// yields one value per item.
+		bits := xxh3.HashStringSeed(seed, uint64(i)+1)
+		dh := (float64(bits&0xFF)/255 - 0.5) * 60
+		ds := (float64(bits>>8&0x3F)/63 - 0.5) * 0.16
+		dl := (float64(bits>>14&0x3F)/63 - 0.5) * 0.30
+		r, g, b := hslToRGB(hue+dh, clamp01(sat+ds), clamp01(light+dl))
+		img.SetNRGBA(i%n, i/n, color.NRGBA{R: r, G: g, B: b, A: 255})
+	}
+	return encodeAt(img, n, n)
+}
+
+// baseTone is the hue, saturation and lightness the cells orbit.
+func baseTone(baseColor string, hueBits uint64) (hue, sat, light float64) {
+	return float64(hueBits&0x1FF) / 512 * 360, 0.22, 0.40
+}
+
+func hslToRGB(h, s, l float64) (uint8, uint8, uint8) {
+	h = math.Mod(math.Mod(h, 360)+360, 360)
+	c := (1 - math.Abs(2*l-1)) * s
+	hp := h / 60
+	x := c * (1 - math.Abs(math.Mod(hp, 2)-1))
+	var r, g, b float64
+	switch int(hp) {
+	case 0:
+		r, g, b = c, x, 0
+	case 1:
+		r, g, b = x, c, 0
+	case 2:
+		r, g, b = 0, c, x
+	case 3:
+		r, g, b = 0, x, c
+	case 4:
+		r, g, b = x, 0, c
+	default:
+		r, g, b = c, 0, x
+	}
+	m := l - c/2
+	return to8(r + m), to8(g + m), to8(b + m)
+}
+
+func clamp01(v float64) float64 { return min(max(v, 0), 1) }
+
+func to8(v float64) uint8 { return uint8(math.Round(clamp01(v) * 255)) }

--- a/core/artwork/blurhash/synthetic_test.go
+++ b/core/artwork/blurhash/synthetic_test.go
@@ -52,8 +52,6 @@ var _ = Describe("Synthetic", func() {
 		Expect(min(r, g, b)).To(BeNumerically(">", 10), "lightness is capped above black")
 	})
 
-	// The Finamp maintainers' condition for accepting a fabricated value is that it is
-	// unique; this is the assertion that holds us to it.
 	It("keeps 1,000,000 seeds effectively distinct", func() {
 		const count = 1_000_000
 		seen := make(map[uint64]struct{}, count)

--- a/core/artwork/blurhash/synthetic_test.go
+++ b/core/artwork/blurhash/synthetic_test.go
@@ -43,9 +43,13 @@ var _ = Describe("Synthetic", func() {
 		Expect(blurhash.Synthetic("alb-1", "")).ToNot(Equal(blurhash.Synthetic("alb-2", "")))
 	})
 
+	dcOf := func(hash string) (int, int, int) {
+		dc := decode83(hash[2:6])
+		return dc >> 16 & 0xFF, dc >> 8 & 0xFF, dc & 0xFF
+	}
+
 	It("decodes to a muted DC colour", func() {
-		dc := decode83(blurhash.Synthetic("alb-1", "")[2:6])
-		r, g, b := dc>>16&0xFF, dc>>8&0xFF, dc&0xFF
+		r, g, b := dcOf(blurhash.Synthetic("alb-1", ""))
 		spread := max(r, g, b) - min(r, g, b)
 		Expect(spread).To(BeNumerically("<", 120), "saturation is capped, so no channel should run away")
 		Expect(max(r, g, b)).To(BeNumerically("<", 240), "lightness is capped below white")
@@ -60,11 +64,6 @@ var _ = Describe("Synthetic", func() {
 		}
 		Expect(len(seen)).To(BeNumerically(">=", 999_900))
 	})
-
-	dcOf := func(hash string) (int, int, int) {
-		dc := decode83(hash[2:6])
-		return dc >> 16 & 0xFF, dc >> 8 & 0xFF, dc & 0xFF
-	}
 
 	It("leans the DC towards a red tint", func() {
 		r, g, b := dcOf(blurhash.Synthetic("alb-1", "#c04040"))

--- a/core/artwork/blurhash/synthetic_test.go
+++ b/core/artwork/blurhash/synthetic_test.go
@@ -62,4 +62,47 @@ var _ = Describe("Synthetic", func() {
 		}
 		Expect(len(seen)).To(BeNumerically(">=", 999_900))
 	})
+
+	dcOf := func(hash string) (int, int, int) {
+		dc := decode83(hash[2:6])
+		return dc >> 16 & 0xFF, dc >> 8 & 0xFF, dc & 0xFF
+	}
+
+	It("leans the DC towards a red tint", func() {
+		r, g, b := dcOf(blurhash.Synthetic("alb-1", "#c04040"))
+		Expect(r).To(BeNumerically(">", g))
+		Expect(r).To(BeNumerically(">", b))
+	})
+
+	It("leans the DC towards a blue tint", func() {
+		r, g, b := dcOf(blurhash.Synthetic("alb-1", "#4040c0"))
+		Expect(b).To(BeNumerically(">", r))
+		Expect(b).To(BeNumerically(">", g))
+	})
+
+	It("changes the value when only the tint changes", func() {
+		Expect(blurhash.Synthetic("alb-1", "#c04040")).ToNot(Equal(blurhash.Synthetic("alb-1", "#4040c0")))
+	})
+
+	It("falls back to the seed hue for an unparseable tint", func() {
+		Expect(blurhash.Synthetic("alb-1", "not-a-colour")).To(Equal(blurhash.Synthetic("alb-1", "")))
+	})
+
+	It("tracks a dark tint's lightness", func() {
+		dark, _, _ := dcOf(blurhash.Synthetic("alb-1", "#101820"))
+		light, _, _ := dcOf(blurhash.Synthetic("alb-1", "#e8f0f8"))
+		Expect(dark).To(BeNumerically("<", light))
+	})
+
+	// One album's colour is shared by all its tracks, so the seed alone has to carry
+	// uniqueness. A collision here would make Finamp skip a track's image request, and
+	// that request is what extracts its embedded art.
+	It("keeps 1,000,000 seeds distinct under a single fixed tint", func() {
+		const count = 1_000_000
+		seen := make(map[uint64]struct{}, count)
+		for i := range count {
+			seen[xxh3.HashString(blurhash.Synthetic(fmt.Sprintf("track-%d", i), "#3a5f7d"))] = struct{}{}
+		}
+		Expect(len(seen)).To(BeNumerically(">=", 999_900))
+	})
 })

--- a/core/artwork/blurhash/synthetic_test.go
+++ b/core/artwork/blurhash/synthetic_test.go
@@ -22,11 +22,17 @@ var _ = Describe("Synthetic", func() {
 		}
 	})
 
-	It("cannot collide with a real blurhash, which is far longer", func() {
-		// `real` is a Go builtin; do not name the variable that.
-		encoded, err := blurhash.Encode(gradientImage(64, 64))
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(encoded)).To(BeNumerically(">", 22))
+	It("keeps its prefix exclusive to real encodes, across aspect ratios", func() {
+		Expect(blurhash.Synthetic("alb-1", "")).To(HavePrefix("K"))
+
+		ratios := []struct{ w, h int }{
+			{10, 200}, {200, 10}, {1, 50}, {50, 1}, {64, 64}, {100, 300}, {300, 100},
+		}
+		for _, r := range ratios {
+			encoded, err := blurhash.Encode(gradientImage(r.w, r.h))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(encoded).ToNot(HavePrefix("K"), "real encode at %dx%d produced the synthetic prefix", r.w, r.h)
+		}
 	})
 
 	It("is deterministic for one seed", func() {

--- a/core/artwork/blurhash/synthetic_test.go
+++ b/core/artwork/blurhash/synthetic_test.go
@@ -1,0 +1,59 @@
+package blurhash_test
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/navidrome/navidrome/core/artwork/blurhash"
+	"github.com/zeebo/xxh3"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Synthetic", func() {
+	It("returns a well-formed 3x3 blurhash", func() {
+		h := blurhash.Synthetic("alb-1", "")
+		// 3x3 encodes as (3-1)+(3-1)*9 = 20, which is base83 'K'; length is 1+1+4+8*2.
+		Expect(h).To(HaveLen(22))
+		Expect(h).To(HavePrefix("K"))
+		for _, c := range h {
+			Expect(strings.ContainsRune(alphabet, c)).To(BeTrue(), "unexpected char %q", c)
+		}
+	})
+
+	It("cannot collide with a real blurhash, which is far longer", func() {
+		// `real` is a Go builtin; do not name the variable that.
+		encoded, err := blurhash.Encode(gradientImage(64, 64))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(len(encoded)).To(BeNumerically(">", 22))
+	})
+
+	It("is deterministic for one seed", func() {
+		Expect(blurhash.Synthetic("alb-1", "")).To(Equal(blurhash.Synthetic("alb-1", "")))
+	})
+
+	It("differs across seeds", func() {
+		Expect(blurhash.Synthetic("alb-1", "")).ToNot(Equal(blurhash.Synthetic("alb-2", "")))
+	})
+
+	It("decodes to a muted DC colour", func() {
+		dc := decode83(blurhash.Synthetic("alb-1", "")[2:6])
+		r, g, b := dc>>16&0xFF, dc>>8&0xFF, dc&0xFF
+		spread := max(r, g, b) - min(r, g, b)
+		Expect(spread).To(BeNumerically("<", 120), "saturation is capped, so no channel should run away")
+		Expect(max(r, g, b)).To(BeNumerically("<", 240), "lightness is capped below white")
+		Expect(min(r, g, b)).To(BeNumerically(">", 10), "lightness is capped above black")
+	})
+
+	// The Finamp maintainers' condition for accepting a fabricated value is that it is
+	// unique; this is the assertion that holds us to it.
+	It("keeps 1,000,000 seeds effectively distinct", func() {
+		const count = 1_000_000
+		seen := make(map[uint64]struct{}, count)
+		for i := range count {
+			seen[xxh3.HashString(blurhash.Synthetic(fmt.Sprintf("item-%d", i), ""))] = struct{}{}
+		}
+		Expect(len(seen)).To(BeNumerically(">=", 999_900))
+	})
+})

--- a/core/artwork/blurhash/synthetic_test.go
+++ b/core/artwork/blurhash/synthetic_test.go
@@ -94,9 +94,7 @@ var _ = Describe("Synthetic", func() {
 		Expect(dark).To(BeNumerically("<", light))
 	})
 
-	// One album's colour is shared by all its tracks, so the seed alone has to carry
-	// uniqueness. A collision here would make Finamp skip a track's image request, and
-	// that request is what extracts its embedded art.
+	// A shared tint must not become a shared value: the seed alone carries uniqueness.
 	It("keeps 1,000,000 seeds distinct under a single fixed tint", func() {
 		const count = 1_000_000
 		seen := make(map[uint64]struct{}, count)

--- a/server/jellyfin/README.md
+++ b/server/jellyfin/README.md
@@ -180,6 +180,14 @@ warmer uses — so user-scoped items like private playlists still resolve their 
 falling back to the placeholder. Album, artist, media-file and playlist ids are all resolved to
 their Navidrome `ArtworkID`.
 
+Blurhash placeholders follow the same principle. A real blurhash is computed once in
+`core/artwork` from the decoded image and stored per artwork row; the mappers read it whenever it
+exists. While artwork is still unresolved, `dto/mappers.go` instead emits a synthetic 3x3 blurhash
+(`core/artwork/blurhash.Synthetic`), seeded on the image tag so it's effectively unique per image
+and can never collide with a real hash's leading byte, giving clients a valid cache key while art
+loads. A track awaiting embedded-art extraction has its synthetic hash tinted from the parent
+album's dominant colour. Known-absent artwork emits no tag and no blurhash at all.
+
 ## Finamp saved-queue id truncation
 
 Real Jellyfin item ids are GUIDs — 128-bit values, always 32 hex characters. Finamp relies on that
@@ -330,16 +338,6 @@ make test PKG=./server/jellyfin/...
   Access control for artists is enforced by scoping the `Artists`/`Items?IncludeItemTypes=MusicArtist`
   *list* to the user's libraries, plus the persistence layer's own defense-in-depth; a client
   that already has an artist id from elsewhere is not re-checked against library membership.
-- **Blurhashes are synthetic, not computed from the artwork (follow-up).** `ImageBlurHashes` is
-  populated by `dto/blurhash.go`, which derives a well-formed **1-component (solid color)**
-  blurhash by hashing the item id — it never looks at the actual image. Real Jellyfin computes a
-  multi-component blurhash from the cover's pixels (downscaled to 128×128) once at scan time and
-  stores it per image, so its placeholder approximates the art. Ours satisfies the protocol
-  (Finamp gets a valid value to use as a de-dup key and a placeholder, no missing-blurhash
-  warning) but renders as a flat color while art loads. A proper implementation would compute the
-  real blurhash in the `core/artwork` pipeline (where the image is already decoded), cache it
-  keyed like the artwork, and have the mappers read it — keeping the synthetic value as a fallback
-  for art that hasn't been rendered yet.
 - **The WebSocket only keep-alives; it pushes no events (follow-up).** `GET socket` sends a
   `ForceKeepAlive` and answers `KeepAlive` pings so real-time clients (Finamp) settle into a
   working session instead of 404-loop-reconnecting, but it never pushes anything. A follow-up

--- a/server/jellyfin/README.md
+++ b/server/jellyfin/README.md
@@ -180,7 +180,7 @@ warmer uses — so user-scoped items like private playlists still resolve their 
 falling back to the placeholder. Album, artist, media-file and playlist ids are all resolved to
 their Navidrome `ArtworkID`.
 
-Blurhash placeholders follow the same principle. A real blurhash is computed once in
+Blurhashes come in three tiers. A real blurhash is computed once in
 `core/artwork` from the decoded image and stored per artwork row; the mappers read it whenever it
 exists. While artwork is still unresolved, `dto/mappers.go` instead emits a synthetic 3x3 blurhash
 (`core/artwork/blurhash.Synthetic`), seeded on the image tag so it's effectively unique per image

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -213,6 +213,8 @@ func SongToBaseItem(mf model.MediaFile, fields Fields) BaseItemDto {
 		// Nothing enqueues media files: advertising the id is what makes a client ask, and that
 		// request is what extracts the embedded art and queues the track.
 		item.ImageTags = map[string]string{"Primary": mf.ID}
+		hash := blurhash.Synthetic(mf.ID, mf.AlbumImage.DominantColor)
+		item.ImageBlurHashes = map[string]map[string]string{"Primary": {mf.ID: hash}}
 	} else if mf.AlbumID != "" {
 		if tag, blurs, ratio := primaryImage(mf.AlbumImage, mf.AlbumID, fields); tag != "" {
 			item.AlbumPrimaryImageTag = tag

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/core/artwork/blurhash"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/slice"
 )
@@ -227,15 +228,15 @@ func embeddedArtPending(mf model.MediaFile) bool {
 		mf.ImageHash == "" && !mf.ItemImage.ImageAbsent
 }
 
-// primaryImage never fakes a blurhash: clients key their cover cache on the value, which would
-// pin a stale cover forever.
+// primaryImage synthesizes a blurhash when none was computed yet: clients key their cover
+// cache on the value, so it must be unique per image, never shared or reused.
 func primaryImage(img model.ItemImage, fallback string, fields Fields) (tag string, blurs map[string]map[string]string, ratio *float64) {
 	if img.ImageAbsent {
 		return "", nil, nil
 	}
 	tag = cmp.Or(img.ImageHash, fallback)
-	if img.BlurHash != "" {
-		blurs = map[string]map[string]string{"Primary": {tag: img.BlurHash}}
+	if tag != "" {
+		blurs = map[string]map[string]string{"Primary": {tag: cmp.Or(img.BlurHash, blurhash.Synthetic(tag, ""))}}
 	}
 	if fields.Has("PrimaryImageAspectRatio") {
 		ratio = img.AspectRatio()

--- a/server/jellyfin/dto/mappers.go
+++ b/server/jellyfin/dto/mappers.go
@@ -236,7 +236,11 @@ func primaryImage(img model.ItemImage, fallback string, fields Fields) (tag stri
 	}
 	tag = cmp.Or(img.ImageHash, fallback)
 	if tag != "" {
-		blurs = map[string]map[string]string{"Primary": {tag: cmp.Or(img.BlurHash, blurhash.Synthetic(tag, ""))}}
+		hash := img.BlurHash
+		if hash == "" {
+			hash = blurhash.Synthetic(tag, "")
+		}
+		blurs = map[string]map[string]string{"Primary": {tag: hash}}
 	}
 	if fields.Has("PrimaryImageAspectRatio") {
 		ratio = img.AspectRatio()

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/core/artwork/blurhash"
 	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,7 +38,7 @@ var _ = Describe("mappers", func() {
 		Expect(item.UserData.Key).To(Equal(EncodeID("song-1")))
 		Expect(item.UserData.ItemId).To(Equal(EncodeID("song-1")))
 		Expect(item.AlbumPrimaryImageTag).To(Equal("alb-1"))
-		Expect(item.ImageBlurHashes).To(BeNil())
+		Expect(item.ImageBlurHashes["Primary"]).To(HaveKeyWithValue("alb-1", blurhash.Synthetic("alb-1", "")))
 		Expect(item.Genres).To(Equal([]string{"genre 1", "genre 2"}))
 		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: EncodeID("1"), Name: "genre 1"}, {Id: EncodeID("2"), Name: "genre 2"}}))
 	})
@@ -298,7 +299,7 @@ var _ = Describe("mappers", func() {
 		Expect(*item.ProductionYear).To(Equal(1999))
 		Expect(*item.ChildCount).To(Equal(10))
 		Expect(item.ImageTags).To(HaveKeyWithValue("Primary", "alb-1"))
-		Expect(item.ImageBlurHashes).To(BeNil())
+		Expect(item.ImageBlurHashes["Primary"]).To(HaveKeyWithValue("alb-1", blurhash.Synthetic("alb-1", "")))
 		Expect(item.Genres).To(Equal([]string{"genre 1", "genre 2"}))
 		Expect(item.GenreItems).To(Equal([]NameGuidPair{{Id: EncodeID("1"), Name: "genre 1"}, {Id: EncodeID("2"), Name: "genre 2"}}))
 	})
@@ -472,7 +473,7 @@ var _ = Describe("mappers", func() {
 		Expect(item.UserData.PlayCount).To(Equal(2))
 		Expect(*item.UserData.Rating).To(Equal(8.0))
 		Expect(item.ImageTags).To(HaveKeyWithValue("Primary", "pl-1"))
-		Expect(item.ImageBlurHashes).To(BeNil())
+		Expect(item.ImageBlurHashes["Primary"]).To(HaveKeyWithValue("pl-1", blurhash.Synthetic("pl-1", "")))
 	})
 
 	It("changes the playlist image tag when the cover content changes", func() {
@@ -555,13 +556,14 @@ var _ = Describe("mappers", func() {
 			Expect(item.ImageBlurHashes["Primary"]).To(HaveKeyWithValue("0123456789abcdef", "LEHV6nWB2yk8"))
 		})
 
-		It("omits the blurhash entirely when none was computed", func() {
+		It("synthesizes a blurhash when none was computed", func() {
 			al := model.Album{ID: "alb-2", Name: "Album"}
 			al.ImageHash = "0123456789abcdef"
 
 			item := AlbumToBaseItem(al, nil)
 			Expect(item.ImageTags).To(HaveKeyWithValue("Primary", "0123456789abcdef"))
-			Expect(item.ImageBlurHashes).To(BeNil(), "a synthesized blurhash pins stale covers in Finamp")
+			Expect(item.ImageBlurHashes["Primary"]).To(
+				HaveKeyWithValue("0123456789abcdef", blurhash.Synthetic("0123456789abcdef", "")))
 		})
 
 		It("omits tags for known-absent artwork", func() {
@@ -573,10 +575,19 @@ var _ = Describe("mappers", func() {
 			Expect(item.ImageBlurHashes).To(BeNil())
 		})
 
+		It("keeps known-absent artwork free of any synthesized value", func() {
+			al := model.Album{ID: "alb-5", Name: "Album"}
+			al.ImageAbsent = true
+
+			item := AlbumToBaseItem(al, nil)
+			Expect(item.ImageBlurHashes).To(BeNil(),
+				"there is no image to key a cache on, and nothing will ever re-key it")
+		})
+
 		It("falls back to the entity id while artwork is still unresolved", func() {
 			item := AlbumToBaseItem(model.Album{ID: "alb-4", Name: "Album"}, nil)
 			Expect(item.ImageTags).To(HaveKeyWithValue("Primary", "alb-4"))
-			Expect(item.ImageBlurHashes).To(BeNil())
+			Expect(item.ImageBlurHashes["Primary"]).To(HaveKeyWithValue("alb-4", blurhash.Synthetic("alb-4", "")))
 		})
 
 		It("versions an artist's tag by content hash", func() {
@@ -601,13 +612,14 @@ var _ = Describe("mappers", func() {
 			Expect(item.ImageBlurHashes["Primary"]).To(HaveKeyWithValue("0123456789abcdef", "LEHV6nWB2yk8"))
 		})
 
-		It("never synthesizes a song blurhash when the album has none", func() {
+		It("synthesizes a song's album blurhash when the album has none", func() {
 			mf := model.MediaFile{ID: "song-2", Title: "Song", AlbumID: "alb-2"}
 			mf.AlbumImage.ImageHash = "0123456789abcdef"
 
 			item := SongToBaseItem(mf, nil)
 			Expect(item.AlbumPrimaryImageTag).To(Equal("0123456789abcdef"))
-			Expect(item.ImageBlurHashes).To(BeNil())
+			Expect(item.ImageBlurHashes["Primary"]).To(
+				HaveKeyWithValue("0123456789abcdef", blurhash.Synthetic("0123456789abcdef", "")))
 		})
 
 		It("omits a song's album tag when the album art is known absent", func() {

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -508,11 +508,35 @@ var _ = Describe("mappers", func() {
 		It("advertises the track id so the client triggers the read-through", func() {
 			mf := model.MediaFile{ID: "mf-1", AlbumID: "alb-1", HasCoverArt: true}
 			mf.AlbumImage.ImageHash = "0123456789abcdef"
+			mf.AlbumImage.DominantColor = "#3a5f7d"
 
 			item := SongToBaseItem(mf, nil)
 			Expect(item.ImageTags).To(HaveKeyWithValue("Primary", "mf-1"))
-			Expect(item.ImageBlurHashes).To(BeNil(), "no resolved image means no blurhash to send")
+			Expect(item.ImageBlurHashes["Primary"]).To(
+				HaveKeyWithValue("mf-1", blurhash.Synthetic("mf-1", "#3a5f7d")))
 			Expect(item.AlbumPrimaryImageTag).To(BeEmpty())
+		})
+
+		// The client's image request is what extracts the embedded art. Reusing the album's
+		// value would let Finamp answer from cache and never send it.
+		It("gives the track a value distinct from its album's", func() {
+			mf := model.MediaFile{ID: "mf-3", AlbumID: "alb-1", HasCoverArt: true}
+			mf.AlbumImage.ImageHash = "0123456789abcdef"
+			mf.AlbumImage.BlurHash = "LEHV6nWB2yk8"
+			mf.AlbumImage.DominantColor = "#3a5f7d"
+
+			track := SongToBaseItem(mf, nil).ImageBlurHashes["Primary"]["mf-3"]
+			album := AlbumToBaseItem(model.Album{ID: "alb-1", ItemImage: mf.AlbumImage}, nil).
+				ImageBlurHashes["Primary"]["0123456789abcdef"]
+			Expect(track).ToNot(BeEmpty())
+			Expect(track).ToNot(Equal(album))
+		})
+
+		It("still emits a value when the album has no dominant colour", func() {
+			mf := model.MediaFile{ID: "mf-4", AlbumID: "alb-1", HasCoverArt: true}
+
+			item := SongToBaseItem(mf, nil)
+			Expect(item.ImageBlurHashes["Primary"]).To(HaveKeyWithValue("mf-4", blurhash.Synthetic("mf-4", "")))
 		})
 
 		It("falls back to the album when the track has no art of its own", func() {

--- a/server/jellyfin/dto/mappers_test.go
+++ b/server/jellyfin/dto/mappers_test.go
@@ -518,7 +518,7 @@ var _ = Describe("mappers", func() {
 		})
 
 		// The client's image request is what extracts the embedded art. Reusing the album's
-		// value would let Finamp answer from cache and never send it.
+		// value would let it answer from cache and never send it.
 		It("gives the track a value distinct from its album's", func() {
 			mf := model.MediaFile{ID: "mf-3", AlbumID: "alb-1", HasCoverArt: true}
 			mf.AlbumImage.ImageHash = "0123456789abcdef"


### PR DESCRIPTION
### Description

Jellyfin clients show a blurred placeholder while a cover loads. Navidrome only sent one if the artwork pipeline had already computed a real blurhash for that image, and left `ImageBlurHashes` out otherwise — so anything not yet resolved rendered as an empty box.

This adds a synthetic placeholder for that gap. There are three cases now:

| Artwork state | What we send |
| --- | --- |
| Resolved | The real blurhash, computed once in `core/artwork` and stored per artwork row |
| Pending | A synthetic 3x3 blurhash from the new `blurhash.Synthetic(seed, baseColor)` |
| Known-absent | Nothing at all — no tag, no blurhash |

Known-absent stays empty on purpose. The image endpoint answers through `GetOrPlaceholder`, so if we advertised a tag for an item with no art, every one of them would download the same generic placeholder, cache it under its own key, and pin it for a year with nothing to ever replace it.

Fabricating a value is only safe if it is unique per image, because Finamp keys its cover cache, its 365-day pin and its download de-duplication on the blurhash value. That is why an earlier fallback was removed from this codebase (`817baa5c1`, `dafcdf438`), and the Finamp maintainers have since said they would rather have a fabricated blurhash than none as long as that holds. Two things make it hold:

**The seed is the image tag.** That tag is the content hash once artwork resolves, and the item id before that. So when a cover is replaced, the tag changes and the synthetic value changes with it, and the client re-keys. Seeding on the item id instead would leave the value unchanged across a cover swap, which is exactly how you pin a stale image.

**A synthetic value can never equal a real one**, because the first character encodes the grid as `(xComp-1)+(yComp-1)*9`. A 3x3 grid is `K`, and `components()` can't produce 3x3 — it holds `xf*yf` at 16, and two factors both in `[2,3)` can't multiply to 16. Worth noting the guarantee is the shape byte and not the length: a very wide or tall image gives 1x9, which is also 22 characters.

The grid is 3x3 rather than something smaller because the palette is deliberately muted. At around 22% saturation the RGB spread is only about 45 of 255, so a four-cell grid collapses too many hue steps onto the same 8-bit colour to stay collision-free at library scale. Nine cells and eight AC components have room to spare.

Those nine colours are rendered bilinearly into an 8x8 image before encoding, rather than handed to the encoder as a 3x3. Blurhash normalises its coefficients on the assumption that there are many samples per component, so a source the same size as the grid overshoots the AC terms and clamps the corners to black. The interpolation is hand-rolled because `x/image`'s scaler allocates 528 times per call against 14 for this, and this runs once per mapped item.

Tracks waiting on embedded-art extraction get one extra touch: their placeholder is tinted with the parent album's `DominantColor`, so it looks roughly like the cover that is about to appear. The value is still seeded on the track id, though, and that matters. Nothing enqueues media files, so advertising the track id is what prompts a client to request the image, and that request is what extracts the embedded art. Reusing the album's value would let the client serve it from cache and never ask.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Run with `ND_JELLYFIN_ENABLED=true` against a library whose artwork hasn't fully resolved, then `GET /jellyfin/Items?IncludeItemTypes=MusicAlbum&Recursive=true`. You should see the stored blurhash keyed by a content-hash tag for resolved albums, a 22-character value starting with `K` keyed by the item id for pending ones, and no image fields at all for known-absent ones.

Ask for the same list twice — the synthetic values must come back byte-identical. Then `GET /jellyfin/Items/{id}/Images/Primary` for one of the pending albums to trigger the read-through and list again: that album should flip its tag from item id to content hash and its value from synthetic to real at the same time. `IncludeItemTypes=Audio` shows the tinted track case.

For uniqueness, the two collision specs in `core/artwork/blurhash` each run 1,000,000 seeds and require at least 99.99% distinct. Both currently come back with 1,000,000 of 1,000,000.

### Screenshots / Demos

Placeholders as clients render them while a cover loads:

![Synthetic blurhash placeholders](https://gist.githubusercontent.com/deluan/a137aebccb0ea6c81d87f2fb935ce471/raw/9dd236cce8dc7de761fd7a44665035a3a4ace65d/jellyfin-synthetic-blurhash-placeholders-v2.png)

A track waiting on embedded-art extraction, tinted from its album's `#c6c394` on the left, and the same track untinted on the right:

![Tinted vs untinted placeholder](https://gist.githubusercontent.com/deluan/a137aebccb0ea6c81d87f2fb935ce471/raw/78c3078479a7b254266a59d8b574d80865b2d5c9/jellyfin-synthetic-blurhash-tint-v2.png)

### Additional Notes

`primaryImage` runs once per mapped item, so a list page calls it hundreds of times. The synthetic value is therefore computed behind an explicit `if hash == ""` rather than `cmp.Or(img.BlurHash, blurhash.Synthetic(tag, ""))` — Go evaluates arguments before `cmp.Or` runs, so the shorter form would build and throw away a full encode on every call that already has a real blurhash, which is most of them.

Two things I left alone. A greyscale `DominantColor` currently tints toward desaturated red instead of grey, because the saturation clamp has a floor; lifting that floor affects the entropy budget and deserves measuring on its own. And `primaryImage` could pass a tint in the one case where it synthesizes over resolved art, since `processor.go` stores an empty `BlurHash` when encoding fails but still records a real dominant colour. Neither affects correctness.

No schema change, and items that already have a stored blurhash serialize exactly as before — only previously-empty entries start carrying a value.

