### PR TITLE
fix(scanner): accept absolute paths in selective scan --target

### DIFF
--- a/model/scanner.go
+++ b/model/scanner.go
@@ -12,7 +12,7 @@ import (
 // NOTE: This struct is used as a map key, so it should only contain comparable types.
 type ScanTarget struct {
 	LibraryID  int
-	FolderPath string // Relative path within the library, or "" for entire library
+	FolderPath string // Path within the library (relative or absolute), or "" for entire library
 }
 
 func (st ScanTarget) String() string {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -59,7 +59,13 @@ func libraryRelativePath(libPath, folderPath string) string {
 	if !filepath.IsAbs(folderPath) {
 		return folderPath
 	}
-	rel, err := filepath.Rel(libPath, folderPath)
+	// The library root may be relative (e.g. the default "./music"); it must be made absolute
+	// to match against an absolute target, and it resolves against the same cwd as the scanner's fs.
+	absLib, err := filepath.Abs(libPath)
+	if err != nil {
+		return folderPath
+	}
+	rel, err := filepath.Rel(absLib, folderPath)
 	if err != nil || !filepath.IsLocal(rel) {
 		return folderPath
 	}

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -63,7 +63,8 @@ func libraryRelativePath(libPath, folderPath string) string {
 	if err != nil || !filepath.IsLocal(rel) {
 		return folderPath
 	}
-	return rel
+	// The scanner's fs.FS is an io/fs, which always uses forward slashes.
+	return filepath.ToSlash(rel)
 }
 
 func (s *scannerImpl) scanFolders(ctx context.Context, fullScan bool, targets []model.ScanTarget, progress chan<- *ProgressInfo) {

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -6,7 +6,6 @@ import (
 	"maps"
 	"path/filepath"
 	"slices"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -61,7 +60,7 @@ func libraryRelativePath(libPath, folderPath string) string {
 		return folderPath
 	}
 	rel, err := filepath.Rel(libPath, folderPath)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err != nil || !filepath.IsLocal(rel) {
 		return folderPath
 	}
 	return rel
@@ -93,10 +92,9 @@ func (s *scannerImpl) scanFolders(ctx context.Context, fullScan bool, targets []
 		// Selective scan: filter libraries and build targets map
 		state.targets = make(map[int][]string)
 
-		libPaths := make(map[int]string, len(allLibs))
-		for _, lib := range allLibs {
-			libPaths[lib.ID] = lib.Path
-		}
+		libPaths := slice.ToMap(allLibs, func(lib model.Library) (int, string) {
+			return lib.ID, lib.Path
+		})
 
 		for _, target := range targets {
 			folderPath := libraryRelativePath(libPaths[target.LibraryID], target.FolderPath)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"path/filepath"
 	"slices"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -51,6 +53,20 @@ func (s *scanState) sendError(err error) {
 	s.sendProgress(&ProgressInfo{Error: err.Error()})
 }
 
+// libraryRelativePath rebases an absolute scan target path onto the library root, since the
+// scanner's fs.FS only accepts paths relative to it. Relative paths, and absolute paths outside
+// the library root, are returned unchanged.
+func libraryRelativePath(libPath, folderPath string) string {
+	if !filepath.IsAbs(folderPath) {
+		return folderPath
+	}
+	rel, err := filepath.Rel(libPath, folderPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return folderPath
+	}
+	return rel
+}
+
 func (s *scannerImpl) scanFolders(ctx context.Context, fullScan bool, targets []model.ScanTarget, progress chan<- *ProgressInfo) {
 	startTime := time.Now()
 
@@ -77,8 +93,13 @@ func (s *scannerImpl) scanFolders(ctx context.Context, fullScan bool, targets []
 		// Selective scan: filter libraries and build targets map
 		state.targets = make(map[int][]string)
 
+		libPaths := make(map[int]string, len(allLibs))
+		for _, lib := range allLibs {
+			libPaths[lib.ID] = lib.Path
+		}
+
 		for _, target := range targets {
-			folderPath := target.FolderPath
+			folderPath := libraryRelativePath(libPaths[target.LibraryID], target.FolderPath)
 			if folderPath == "" {
 				folderPath = "."
 			}

--- a/scanner/scanner_internal_test.go
+++ b/scanner/scanner_internal_test.go
@@ -4,6 +4,7 @@ package scanner
 import (
 	"context"
 	"errors"
+	"os"
 	"path/filepath"
 	"sync/atomic"
 
@@ -20,6 +21,12 @@ var _ = Describe("libraryRelativePath", func() {
 
 	It("returns a relative path unchanged", func() {
 		Expect(libraryRelativePath(libRoot, "_Collection")).To(Equal("_Collection"))
+	})
+
+	It("rebases an absolute target when the library root is relative", func() {
+		cwd, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(libraryRelativePath(filepath.Join("music", "library"), filepath.Join(cwd, "music", "library", "rock"))).To(Equal("rock"))
 	})
 
 	It("rebases an absolute path that equals the library root to '.'", func() {

--- a/scanner/scanner_internal_test.go
+++ b/scanner/scanner_internal_test.go
@@ -4,6 +4,7 @@ package scanner
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"sync/atomic"
 
 	ppl "github.com/google/go-pipeline/pkg/pipeline"
@@ -12,28 +13,33 @@ import (
 )
 
 var _ = Describe("libraryRelativePath", func() {
+	// Paths are built with filepath so the "absolute" cases stay absolute on every OS
+	// (a Unix-style "/foo" is not absolute on Windows).
+	libRoot, _ := filepath.Abs(filepath.Join("jukebox", "collection"))
+	outside, _ := filepath.Abs(filepath.Join("somewhere", "else"))
+
 	It("returns a relative path unchanged", func() {
-		Expect(libraryRelativePath("/jukebox/collection", "_Collection")).To(Equal("_Collection"))
+		Expect(libraryRelativePath(libRoot, "_Collection")).To(Equal("_Collection"))
 	})
 
 	It("rebases an absolute path that equals the library root to '.'", func() {
-		Expect(libraryRelativePath("/jukebox/collection", "/jukebox/collection")).To(Equal("."))
+		Expect(libraryRelativePath(libRoot, libRoot)).To(Equal("."))
 	})
 
 	It("rebases an absolute path under the library root", func() {
-		Expect(libraryRelativePath("/jukebox/collection", "/jukebox/collection/_Collection")).To(Equal("_Collection"))
+		Expect(libraryRelativePath(libRoot, filepath.Join(libRoot, "_Collection"))).To(Equal("_Collection"))
 	})
 
 	It("handles a trailing slash on the library path", func() {
-		Expect(libraryRelativePath("/jukebox/collection/", "/jukebox/collection/_Collection")).To(Equal("_Collection"))
+		Expect(libraryRelativePath(libRoot+string(filepath.Separator), filepath.Join(libRoot, "_Collection"))).To(Equal("_Collection"))
 	})
 
 	It("leaves an absolute path outside the library root unchanged", func() {
-		Expect(libraryRelativePath("/jukebox/collection", "/somewhere/else")).To(Equal("/somewhere/else"))
+		Expect(libraryRelativePath(libRoot, outside)).To(Equal(outside))
 	})
 
 	It("returns an empty path unchanged", func() {
-		Expect(libraryRelativePath("/jukebox/collection", "")).To(Equal(""))
+		Expect(libraryRelativePath(libRoot, "")).To(Equal(""))
 	})
 })
 

--- a/scanner/scanner_internal_test.go
+++ b/scanner/scanner_internal_test.go
@@ -11,6 +11,32 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("libraryRelativePath", func() {
+	It("returns a relative path unchanged", func() {
+		Expect(libraryRelativePath("/jukebox/collection", "_Collection")).To(Equal("_Collection"))
+	})
+
+	It("rebases an absolute path that equals the library root to '.'", func() {
+		Expect(libraryRelativePath("/jukebox/collection", "/jukebox/collection")).To(Equal("."))
+	})
+
+	It("rebases an absolute path under the library root", func() {
+		Expect(libraryRelativePath("/jukebox/collection", "/jukebox/collection/_Collection")).To(Equal("_Collection"))
+	})
+
+	It("handles a trailing slash on the library path", func() {
+		Expect(libraryRelativePath("/jukebox/collection/", "/jukebox/collection/_Collection")).To(Equal("_Collection"))
+	})
+
+	It("leaves an absolute path outside the library root unchanged", func() {
+		Expect(libraryRelativePath("/jukebox/collection", "/somewhere/else")).To(Equal("/somewhere/else"))
+	})
+
+	It("returns an empty path unchanged", func() {
+		Expect(libraryRelativePath("/jukebox/collection", "")).To(Equal(""))
+	})
+})
+
 type mockPhase struct {
 	num           int
 	produceFunc   func() ppl.Producer[int]


### PR DESCRIPTION
### Description

The selective scan `--target` flag documents `folderPath` as relative to the library root, but the scanner's `fs.FS` is already rooted there and rejects any leading `/`. A user passing an absolute path (e.g. `--target "2:/jukebox/collection"`) got an opaque `open /jukebox/collection: invalid argument` and nothing was scanned, while a plain full scan of the same library worked fine.

This adds a small `libraryRelativePath` helper that rebases an absolute target onto its library root before scanning. Relative paths, and absolute paths that fall outside the library root, are passed through unchanged. The normalization lives in `scannerImpl.scanFolders`, the single choke point every caller (CLI, native API, watcher, and the external subprocess scanner) funnels through, and it's the only place with both the raw targets and the library paths available.

### Related Issues

Fixes #5943

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Configure a library, e.g. library `1` pointing at `/music`, with a subfolder `/music/rock`.
2. Run a selective scan using an **absolute** path: `navidrome scan --full --target "1:/music/rock"`.
3. Expected: the `rock` folder is scanned and its tracks imported. Before this change the same command logged `Scanner: Target folder does not exist.` with `error="... invalid argument"` and imported nothing.
4. Edge cases to verify:
   - Absolute path equal to the library root (`1:/music`) scans the whole library.
   - Relative paths (`1:rock`) still work as before.
   - An absolute path outside the library root is left unchanged and simply reports the folder as missing.
