### PR TITLE
fix(artwork): serve images whose format has no registered decoder

### DIFF
--- a/core/artwork/e2e/acquire_serve_test.go
+++ b/core/artwork/e2e/acquire_serve_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
@@ -115,6 +116,25 @@ var _ = Describe("Acquisition → serve loop", func() {
 		folderRepo.result = []model.Folder{{Path: albumFolderPath, ImageFiles: []string{"cover.jpg"}}}
 		albumRepo.SetData(model.Albums{{ID: albumID, Name: "Album", FolderIDs: []string{"f1"}, LibraryID: 0}})
 	}
+
+	It("acquires and serves a cover whose format has no registered decoder (#5950)", func() {
+		libDir := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(libDir, "an-album"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(libDir, "an-album", "cover.jxl"), jxlFixture, 0600)).To(Succeed())
+
+		conf.Server.CoverArtPriority = "cover.*"
+		libRepo.SetData(model.Libraries{{ID: 0, Path: libDir}})
+		folderRepo.result = []model.Folder{{Path: "an-album", ImageFiles: []string{"cover.jxl"}}}
+		albumRepo.SetData(model.Albums{{ID: "al1", Name: "Album", FolderIDs: []string{"f1"}, LibraryID: 0}})
+
+		bump("al", "al1")
+		runWorkerUntil(ctx, worker, itemFound(model.KindAlbumArtwork, "al1"))
+
+		img, err := svc.Get(ctx, model.MustParseArtworkID("al-al1"), 0, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(img.Placeholder).To(BeFalse())
+		Expect(readAll(img)).To(Equal(jxlFixture))
+	})
 
 	It("acquires album folder art and serves the exact bytes under its hash", func() {
 		seedFolderAlbum("al1")
@@ -317,6 +337,9 @@ func mustGet(img *artwork.Image, err error) *artwork.Image {
 }
 
 // Raw bytes on purpose: encoding a GIF here would register image/gif in the test binary, masking
+// jxlFixture is a JPEG XL bare codestream header: a real image format, with no stdlib decoder.
+var jxlFixture = []byte{0xff, 0x0a, 0x00, 0x10, 0x00}
+
 // the production import the spec above guards.
 var gifFixture = []byte{
 	0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x04, 0x00, 0x04, 0x00, 0x80, 0x00,

--- a/core/artwork/processor.go
+++ b/core/artwork/processor.go
@@ -130,9 +130,9 @@ func (p *processor) acquire(ctx context.Context, item model.ArtworkQueueItem) (o
 	case err == nil, errors.Is(err, model.ErrNotFound):
 		decodeStart := time.Now()
 		art, err = decodeArtwork(ctx, hash, data)
-		// A local file was picked by matching an image extension, so bytes we cannot decode are
-		// most likely a codec we lack. An external response carries no such guarantee.
-		if errors.Is(err, image.ErrFormat) && isLocalSource(res.source) {
+		// Extension-matched local bytes we cannot decode are most likely a codec we lack; an
+		// external body carries no such guarantee, and empty bytes are no image at all.
+		if errors.Is(err, image.ErrFormat) && len(data) > 0 && isLocalSource(res.source) {
 			log.Debug(ctx, "Artwork: No decoder for this image format, storing it without placeholders",
 				"kind", item.ItemKind, "id", item.ItemID, "source", res.source, "bytes", len(data))
 			art, err = undecodedArtwork(hash), nil

--- a/core/artwork/processor.go
+++ b/core/artwork/processor.go
@@ -123,12 +123,20 @@ func (p *processor) acquire(ctx context.Context, item model.ArtworkQueueItem) (o
 
 	art, err := repo.GetImage(hash)
 	switch {
-	case err == nil:
+	case err == nil && art.Width > 0:
 		log.Debug(ctx, "Artwork: Reusing a known image, skipping decode", "kind", item.ItemKind,
 			"id", item.ItemID, "hash", hash)
-	case errors.Is(err, model.ErrNotFound):
+	// A row with no dimensions was stored when no decoder matched; retry in case one exists now.
+	case err == nil, errors.Is(err, model.ErrNotFound):
 		decodeStart := time.Now()
 		art, err = decodeArtwork(ctx, hash, data)
+		// A local file was picked by matching an image extension, so bytes we cannot decode are
+		// most likely a codec we lack. An external response carries no such guarantee.
+		if errors.Is(err, image.ErrFormat) && isLocalSource(res.source) {
+			log.Debug(ctx, "Artwork: No decoder for this image format, storing it without placeholders",
+				"kind", item.ItemKind, "id", item.ItemID, "source", res.source, "bytes", len(data))
+			art, err = undecodedArtwork(hash), nil
+		}
 		if err != nil {
 			log.Warn(ctx, "Artwork: Failed to decode resolved image", "kind", item.ItemKind, "id", item.ItemID, err)
 			return outcomeFailed, nil
@@ -234,6 +242,12 @@ func decodeCapped(data []byte) (image.Image, string, error) {
 	return img, format, nil
 }
 
+// undecodedArtwork is the row for bytes no decoder matched: servable, but with no dimensions
+// and none of the placeholders a decode would have produced.
+func undecodedArtwork(hash string) *model.Artwork {
+	return &model.Artwork{Hash: hash, Mime: mimeForFormat("")}
+}
+
 // decodeArtwork builds a new Artwork row from raw bytes: dimensions, mime and the two
 // placeholder hashes, both encoded from one shared downscaled thumbnail.
 func decodeArtwork(ctx context.Context, hash string, data []byte) (*model.Artwork, error) {
@@ -286,6 +300,11 @@ func makeThumbnail(img image.Image, maxSize int) image.Image {
 // content-addressed store must not duplicate them.
 func isFileBacked(source string) bool {
 	return source == "folder" || source == "upload"
+}
+
+// isLocalSource reports whether the bytes came off disk rather than off the network.
+func isLocalSource(source string) bool {
+	return isFileBacked(source) || source == "embedded"
 }
 
 // placeBytes reports the item's backing-file provenance and writes the bytes into the store

--- a/core/artwork/processor_test.go
+++ b/core/artwork/processor_test.go
@@ -283,6 +283,21 @@ var _ = Describe("processor.acquire", func() {
 		Expect(art.BlurHash).To(BeEmpty())
 	})
 
+	It("empty local file: fails without writing state", func() {
+		libRoot := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(libRoot, "album"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(libRoot, "album", "cover.jpg"), nil, 0600)).To(Succeed())
+		libRepo.SetData(model.Libraries{{ID: 0, Path: testFileLibPath(libRoot)}})
+		ds.MockedAlbum.(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "alE", Name: "Album", FolderIDs: []string{"f1"}}})
+		folderRepo.result = []model.Folder{{Path: "album", ImageFiles: []string{"cover.jpg"}}}
+
+		out, _ := proc.acquire(ctx, model.ArtworkQueueItem{ItemKind: "al", ItemID: "alE"})
+		Expect(out).To(Equal(outcomeFailed))
+
+		_, err := artRepo.GetItemArtwork(model.KindAlbumArtwork, "alE", model.ImageTypePrimary)
+		Expect(err).To(MatchError(model.ErrNotFound))
+	})
+
 	// An agent answering 200 with a non-image body must keep retrying, not pin garbage as a cover.
 	It("undecodable external body: fails without writing state", func() {
 		conf.Server.CoverArtPriority = "external"

--- a/core/artwork/processor_test.go
+++ b/core/artwork/processor_test.go
@@ -1,6 +1,7 @@
 package artwork
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -23,6 +24,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// jxlCodestream is a JPEG XL bare codestream header: a real image format, with no stdlib decoder.
+var jxlCodestream = []byte{0xff, 0x0a, 0x00, 0x10, 0x00}
 
 // DecodeConfig reads only the header, so the pixel data can be omitted entirely.
 func pngHeaderWithDims(w, h uint32) []byte {
@@ -259,6 +263,44 @@ var _ = Describe("processor.acquire", func() {
 		Expect(ia.Source).To(Equal("folder"))
 	})
 
+	It("undecodable local file: acquires it anyway, with no placeholder metadata", func() {
+		libRoot := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(libRoot, "album"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(libRoot, "album", "cover.jpg"), jxlCodestream, 0600)).To(Succeed())
+		libRepo.SetData(model.Libraries{{ID: 0, Path: testFileLibPath(libRoot)}})
+		ds.MockedAlbum.(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "alU", Name: "Album", FolderIDs: []string{"f1"}}})
+		folderRepo.result = []model.Folder{{Path: "album", ImageFiles: []string{"cover.jpg"}}}
+
+		out, _ := proc.acquire(ctx, model.ArtworkQueueItem{ItemKind: "al", ItemID: "alU"})
+		Expect(out).To(Equal(outcomeFound))
+
+		ia, err := artRepo.GetItemArtwork(model.KindAlbumArtwork, "alU", model.ImageTypePrimary)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ia.Source).To(Equal("folder"))
+		art, err := artRepo.GetImage(ia.Hash)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(art.Width).To(BeZero())
+		Expect(art.BlurHash).To(BeEmpty())
+	})
+
+	// An agent answering 200 with a non-image body must keep retrying, not pin garbage as a cover.
+	It("undecodable external body: fails without writing state", func() {
+		conf.Server.CoverArtPriority = "external"
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("<html>rate limited</html>"))
+		}))
+		DeferCleanup(srv.Close)
+
+		ds.MockedAlbum.(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "alX", Name: "Album"}})
+		imageAgents(&fakeImageAgent{name: "deezerFake", imgs: []agents.ExternalImage{{URL: srv.URL, Size: 500}}})
+
+		out, _ := proc.acquire(ctx, model.ArtworkQueueItem{ItemKind: "al", ItemID: "alX"})
+		Expect(out).To(Equal(outcomeFailed))
+
+		_, err := artRepo.GetItemArtwork(model.KindAlbumArtwork, "alX", model.ImageTypePrimary)
+		Expect(err).To(MatchError(model.ErrNotFound))
+	})
+
 	It("found-external: persists source as external:<agentName> and stores the fetched bytes", func() {
 		conf.Server.CoverArtPriority = "external"
 		imgBytes, err := os.ReadFile(filepath.Join(repoRoot, "tests/fixtures/artist/an-album/cover.jpg"))
@@ -374,7 +416,8 @@ var _ = Describe("processor.acquire", func() {
 		conf.Server.DataFolder = conf.NewDir(tmpDir)
 		Expect(os.MkdirAll(filepath.Join(tmpDir, "artwork", "radio"), 0755)).To(Succeed())
 		imgPath := filepath.Join(tmpDir, "artwork", "radio", "ra1_test.jpg")
-		Expect(os.WriteFile(imgPath, []byte("not actually an image"), 0600)).To(Succeed())
+		// Truncated PNG: a known format, so this is a real decode failure, not a missing decoder.
+		Expect(os.WriteFile(imgPath, pngHeaderWithDims(100, 100), 0600)).To(Succeed())
 
 		radioRepo := tests.CreateMockedRadioRepo()
 		radioRepo.Data = map[string]*model.Radio{"ra1": {ID: "ra1", Name: "Radio", UploadedImage: "ra1_test.jpg"}}
@@ -426,6 +469,54 @@ var _ = Describe("processor.acquire", func() {
 		_, err := decodeArtwork(ctx, "bomb", data)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("dimensions"))
+	})
+
+	It("unknown format: reports ErrFormat so the caller can decide", func() {
+		_, err := decodeArtwork(ctx, "jxl", jxlCodestream)
+		Expect(err).To(MatchError(image.ErrFormat))
+	})
+
+	It("undecodedArtwork: carries the hash and mime, and nothing a decode would add", func() {
+		art := undecodedArtwork("jxl")
+		Expect(art.Hash).To(Equal("jxl"))
+		Expect(art.Mime).To(Equal("application/octet-stream"))
+		Expect(art.Width).To(BeZero())
+		Expect(art.Height).To(BeZero())
+		Expect(art.BlurHash).To(BeEmpty())
+		Expect(art.ThumbHash).To(BeEmpty())
+		Expect(art.DominantColor).To(BeEmpty())
+	})
+
+	It("corrupt image of a known format: still fails", func() {
+		data := pngHeaderWithDims(100, 100) // header declares a decodable size, body is missing
+		_, err := decodeArtwork(ctx, "truncated", data)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("decode image"))
+	})
+
+	// Without this a metadata-less row would be reused forever, so a decoder added later
+	// could never upgrade it.
+	It("metadata-less row: re-decodes on reuse instead of skipping", func() {
+		libRoot := GinkgoT().TempDir()
+		imgBytes, err := os.ReadFile(filepath.Join(repoRoot, "tests/fixtures/artist/an-album/cover.jpg"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.MkdirAll(filepath.Join(libRoot, "album"), 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(libRoot, "album", "cover.jpg"), imgBytes, 0600)).To(Succeed())
+		libRepo.SetData(model.Libraries{{ID: 0, Path: testFileLibPath(libRoot)}})
+		ds.MockedAlbum.(*tests.MockAlbumRepo).SetData(model.Albums{{ID: "alM", Name: "Album", FolderIDs: []string{"f1"}}})
+		folderRepo.result = []model.Folder{{Path: "album", ImageFiles: []string{"cover.jpg"}}}
+
+		hash, err := hashImage(bytes.NewReader(imgBytes))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(artRepo.PutImage(&model.Artwork{Hash: hash, Mime: "application/octet-stream"})).To(Succeed())
+
+		out, _ := proc.acquire(ctx, model.ArtworkQueueItem{ItemKind: "al", ItemID: "alM"})
+		Expect(out).To(Equal(outcomeFound))
+
+		upgraded, err := artRepo.GetImage(hash)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(upgraded.Width).To(BeNumerically(">", 0))
+		Expect(upgraded.BlurHash).ToNot(BeEmpty())
 	})
 
 	It("store write failure: fails without writing state", func() {

--- a/resources/mime_types.yaml
+++ b/resources/mime_types.yaml
@@ -37,6 +37,9 @@ types:
   .webp: image/webp
   .png: image/png
   .bmp: image/bmp
+  .jxl: image/jxl
+  .heic: image/heic
+  .heif: image/heif
 
 # List of audio formats that are considered lossless
 lossless:


### PR DESCRIPTION
### Description

The new artwork pipeline derives dimensions, mime, dominant color, blurhash and thumbhash at resolution time, which made a successful decode a precondition for recording artwork at all. A cover in a format Go has no registered decoder for (JPEG XL, HEIC, and AVIF/BMP/TIFF on builds without those decoders) therefore failed acquisition, retried until the 12h budget ran out, and then settled as absent, serving a placeholder from that point on. The old pipeline only decoded in order to resize, and fell back to the original bytes when that failed, so these covers used to work.

This restores that graceful degradation at the layer where decoding now lives. `image.ErrFormat` is treated as "no decoder matched", not "bad image": for a local source the acquisition still records an `artwork` row carrying just the hash and mime, leaving dimensions and placeholders empty, and the bytes stay servable. `image.ErrFormat` is specifically distinguished from the other two failure modes in `decodeCapped`, so a corrupt image of a known format and an over-cap declared size both still fail exactly as before, and the decompression bomb guard is untouched.

The fallback is gated to local sources (`folder`, `upload`, `embedded`). Those files were selected by matching an image extension, so bytes we cannot decode are most likely a codec we lack. An external agent response carries no such guarantee — `fromURL` checks only the HTTP status — so an agent answering 200 with an HTML error page or JSON body still fails and retries rather than pinning a non-image body as a permanent cover.

Two supporting changes. Reusing a stored image now re-decodes when the row carries no dimensions, so a row recorded while a decoder was missing can still be upgraded if a decoder is added later; without this, `GetImage` hitting would short-circuit the decode forever. And `jxl`, `heic` and `heif` are registered in `mime_types.yaml`: image detection resolves the extension through the host MIME table, and the Alpine release image ships no `/etc/mime.types`, so those covers were never recorded in `folder.ImageFiles` in Docker and never reached the pipeline at all. That second one is a pre-existing gap rather than a regression — v0.63.1 behaves identically — but without it the fix is unreachable for Docker users, which is most of them.

No `artworkEpoch` bump: the absent rows this bug produced are exactly what the existing stale-absent recheck already re-enqueues (`hash = '' AND attempted_at < cutoff`), so affected installs self-heal within a day. Bumping the epoch would instead force every install to re-resolve its entire library on upgrade, including re-downloading every artist image from external agents.

### Related Issues

Fixes #5950

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Create an album folder whose only cover is in a format the stdlib cannot decode, and point a server at it:

```bash
cjxl some-image.png "/tmp/lib/Artist/Album/cover.jxl"
cp some-track.mp3 "/tmp/lib/Artist/Album/"
ND_MUSICFOLDER=/tmp/lib ND_DATAFOLDER=/tmp/nd-data ./navidrome
```

After the scan, request the cover through the Subsonic API:

```bash
curl -s -o got.bin "http://localhost:4533/rest/getCoverArt?id=al-<albumID>&u=admin&p=<pass>&v=1.16.1&c=test"
cmp got.bin "/tmp/lib/Artist/Album/cover.jxl"   # identical
```

Expected on this branch: HTTP 200 with the original bytes, no `Failed to decode resolved image` in the log, an `item_artwork` row with a non-empty hash and `source=folder`, an `artwork` row with `mime=application/octet-stream`, `0x0` dimensions and an empty blurhash, and an empty `artwork_queue`.

On master the same setup logs the decode failure, writes no `item_artwork` row, and leaves the item in `artwork_queue` with a climbing `attempts`; it serves the cover only through the provisional read-through, and once the 12h retry budget is exhausted it records absent and serves the placeholder permanently.

Worth checking too:

- A truncated or corrupt PNG/JPEG must still fail and must not write state (covered by `decode failure on found bytes` in `processor_test.go`).
- An external agent returning a non-image body must still fail rather than store it (covered by `undecodable external body`).
- `.jxl` detection inside the release image, where there is no `/etc/mime.types`.

### Additional Notes

Sized requests for these covers return the full-size original rather than a thumbnail, because `resizeStaticImage` cannot decode them either and `resizedItem.Reader` falls back to the original bytes. Verified live with a 1000x1000 JXL against a 1000x1000 JPEG control: the JPEG returns 300x300 and 600x600 as expected, the JXL returns the full 1000x1000 original at every size, and the image cache ends up holding one identical full-size copy per size key. This matches v0.63.1 behaviour exactly and is the inherent price of keeping bytes servable without understanding them, so it is not a regression — but it does mean album grids ship full-size covers for these formats, and those cache entries charge the cache budget as if they were thumbnails.

The natural follow-up is to route the stdlib decode failure to ffmpeg, which is already installed in the release image, already shelled out to for animated GIFs in `resizeImageData`, and whose `libjxl` decoder handles JPEG XL. That needs its own timeout and failure handling, so I kept it out of this fix. The per-size cache duplication is worth addressing at the same time.

Adding a JPEG XL decoder dependency was considered and rejected. `gen2brain/jpegxl` does decode all eight JXL variants I tested, including blurhash generation, but it is another WASM/purego dependency with binary-size and 32-bit-ARM risk for a format almost no client renders. Users who want it can add the import themselves and bump `artworkEpoch` locally.
