### PR TITLE
feat(insights): report the app store or hosting platform via ND_PLATFORM

### DIFF
--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"runtime/debug"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -153,6 +154,17 @@ func getFSInfo(path string) *insights.FSInfo {
 	return &info
 }
 
+// installedPackage returns the official installer format used, as written by our own packagers.
+func installedPackage() string {
+	data, _ := os.ReadFile(filepath.Join(conf.Server.DataFolder.String(), ".package"))
+	return strings.TrimSpace(string(data))
+}
+
+// hostingPlatform is env-based, not a file, as app stores can only inject env vars into our image.
+func hostingPlatform() string {
+	return strings.TrimSpace(os.Getenv("ND_PLATFORM"))
+}
+
 var staticData = sync.OnceValue(func() insights.Data {
 	// Basic info
 	data := insights.Data{
@@ -165,11 +177,8 @@ var staticData = sync.OnceValue(func() insights.Data {
 	data.OS.Containerized = consts.InContainer
 
 	// Install info
-	packageFilename := filepath.Join(conf.Server.DataFolder.String(), ".package")
-	packageFileData, err := os.ReadFile(packageFilename)
-	if err == nil {
-		data.OS.Package = string(packageFileData)
-	}
+	data.OS.Package = installedPackage()
+	data.Platform = hostingPlatform()
 
 	// OS info
 	data.OS.Type = runtime.GOOS

--- a/core/metrics/insights/data.go
+++ b/core/metrics/insights/data.go
@@ -4,7 +4,9 @@ type Data struct {
 	InsightsID string `json:"id"`
 	Version    string `json:"version"`
 	Uptime     int64  `json:"uptime"`
-	Build      struct {
+	// Platform is the app store or hosting provider this instance runs on, self-declared via ND_PLATFORM
+	Platform string `json:"platform,omitempty"`
+	Build    struct {
 		// build settings used by the Go compiler
 		Settings  map[string]string `json:"settings"`
 		GoVersion string            `json:"goVersion"`

--- a/core/metrics/insights_internal_test.go
+++ b/core/metrics/insights_internal_test.go
@@ -1,0 +1,64 @@
+package metrics
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("installedPackage", func() {
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.DataFolder = conf.NewDir(GinkgoT().TempDir())
+	})
+
+	It("returns empty when there's no .package file", func() {
+		Expect(installedPackage()).To(BeEmpty())
+	})
+
+	It("reads the .package file from the data folder", func() {
+		writePackageFile("deb")
+
+		Expect(installedPackage()).To(Equal("deb"))
+	})
+
+	It("trims surrounding whitespace, as the msi packager writes a trailing newline", func() {
+		writePackageFile("msi\n")
+
+		Expect(installedPackage()).To(Equal("msi"))
+	})
+
+	It("ignores ND_PLATFORM", func() {
+		GinkgoT().Setenv("ND_PLATFORM", "zimaos")
+
+		Expect(installedPackage()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("hostingPlatform", func() {
+	It("returns empty when ND_PLATFORM is not set", func() {
+		Expect(hostingPlatform()).To(BeEmpty())
+	})
+
+	It("reads ND_PLATFORM", func() {
+		GinkgoT().Setenv("ND_PLATFORM", "zimaos")
+
+		Expect(hostingPlatform()).To(Equal("zimaos"))
+	})
+
+	It("trims surrounding whitespace", func() {
+		GinkgoT().Setenv("ND_PLATFORM", "  pikapods\n")
+
+		Expect(hostingPlatform()).To(Equal("pikapods"))
+	})
+})
+
+func writePackageFile(content string) {
+	GinkgoHelper()
+	path := filepath.Join(conf.Server.DataFolder.String(), ".package")
+	Expect(os.WriteFile(path, []byte(content), 0600)).To(Succeed())
+}

--- a/core/metrics/insights_internal_test.go
+++ b/core/metrics/insights_internal_test.go
@@ -40,6 +40,12 @@ var _ = Describe("installedPackage", func() {
 })
 
 var _ = Describe("hostingPlatform", func() {
+	BeforeEach(func() {
+		// Setenv registers the restore, then unset so an inherited value can't leak in
+		GinkgoT().Setenv("ND_PLATFORM", "")
+		Expect(os.Unsetenv("ND_PLATFORM")).To(Succeed())
+	})
+
 	It("returns empty when ND_PLATFORM is not set", func() {
 		Expect(hostingPlatform()).To(BeEmpty())
 	})

--- a/core/metrics/metrics_suite_test.go
+++ b/core/metrics/metrics_suite_test.go
@@ -1,0 +1,17 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	tests.Init(t, false)
+	log.SetLevel(log.LevelFatal)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}


### PR DESCRIPTION
### Description

Insights can't tell where an instance is deployed — whether it came from an app store or a hosting provider like ZimaOS, PikaPods, TrueNAS or Unraid.

The existing `os.package` field looked like the place for it, but it isn't: it's written only by our own release pipeline and holds exactly three values in the wild (`deb`, `msi`, `rpm`). It answers "which installer", not "where". Overloading it would mix two unrelated dimensions into one field.

So this adds a separate top-level `platform` field, declared via a new `ND_PLATFORM` environment variable. The two are orthogonal: a PikaPods instance has no `package` but `platform: pikapods`. It's read straight from the environment instead of being a config option — app stores deploy our image unmodified and can only inject env vars, and this is a packager marker, not a user setting, so it stays out of the config surface.

Both values are now trimmed. That fixes a small existing bug: the msi packager writes the file with `echo`, so `os.package` has been arriving as `"msi\n"` and sorting separately from `"msi"`.

`platform` is `omitempty`, so instances that don't set it send exactly what they send today.

### Related Issues

<!-- none -->

### Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

Docs unchecked on purpose: `ND_PLATFORM` targets packagers, not end users, so it doesn't belong in the config reference.

### How to Test

`core/metrics` had no tests before this, so a suite is added along with coverage for both fields:

```bash
make test PKG=./core/metrics
```

End to end:

```bash
ND_ENABLEINSIGHTSCOLLECTOR=true ND_PLATFORM=zimaos ND_LOGLEVEL=trace make server
```

The logged payload should contain a top-level `"platform": "zimaos"`, and omit the field entirely when the variable is unset. A `.package` file containing `msi\n` should report `msi`.

### Additional Notes

The daily summaries on the insights server don't aggregate `platform` yet — nor `os.package`, for that matter. Surfacing either in the fleet reports is separate server-side work.

Values are free text, so `zimaos` / `ZimaOS` / `zima-os` would be distinct. Left unnormalized since we control the string handed to each vendor, but lowercasing on ingest is a one-liner if it becomes a problem.

Follow-up is a PR against `IceWhaleTech/CasaOS-AppStore` adding `ND_PLATFORM: zimaos` to the Navidrome recipe, plus the same ask to the other platforms.
