### PR TITLE
fix(plugins): load plugin agents in CLI commands

### DIFF
--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -357,7 +357,6 @@ func imageAgentCount(ds model.DataStore, mgr *plugins.Manager) artwork.ImageAgen
 
 // loadPluginAgents loads the plugins named in Agents, so the CLI resolves through the same agents a
 // running server would. A load failure is reported, not fatal: the built-in agents still answer.
-// runInit is passed through to the plugin's own init — see plugins.Manager.LoadPlugins.
 func loadPluginAgents(ctx context.Context, runInit bool) *plugins.Manager {
 	mgr := getPluginManager()
 	if err := mgr.LoadPlugins(ctx, configuredAgents(), runInit); err != nil {
@@ -366,16 +365,13 @@ func loadPluginAgents(ctx context.Context, runInit bool) *plugins.Manager {
 	return mgr
 }
 
-// needsImageAgents reports whether the estimate for any selected kind depends on how many image
-// agents there are. It asks the same question ExternalLookupsPerItem does, so the two cannot
-// disagree; an artist/album test would look equivalent and would silently zero the playlist
-// estimate, whose generated grid resolves album art through those agents.
+// needsImageAgents asks exactly what ExternalLookupsPerItem asks, so the gate cannot disagree with
+// the estimate it guards. Playlists count: their generated grid resolves album art through agents.
 func needsImageAgents(kinds []model.Kind) bool {
 	return slices.ContainsFunc(kinds, artwork.MayFetchExternal)
 }
 
-// configuredAgents names the agents in priority order. A plugin absent from this list can never
-// supply an image, so loading it would buy nothing and start its host services for free.
+// configuredAgents names the agents in priority order; one absent from it can never supply an image.
 func configuredAgents() []string {
 	var names []string
 	for name := range strings.SplitSeq(conf.Server.Agents, ",") {
@@ -746,8 +742,8 @@ func runExplain(ctx context.Context, kind model.Kind, id string) {
 	}
 
 	if artwork.Explainable(kind) {
-		// Disc and media file artwork never reaches an agent, so only artist and album pay to load
-		// one. Loading happens before the resolver is built: it reads the same manager.
+		// Only artist and album reach an agent, and the load must precede the resolver, which reads
+		// the same manager.
 		if kind == model.KindArtistArtwork || kind == model.KindAlbumArtwork {
 			mgr := loadPluginAgents(ctx, explainLive)
 			defer func() { _ = mgr.Stop() }()

--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -279,11 +279,16 @@ func runReprocess(ctx context.Context) {
 	defer db.Init(ctx)()
 	ds, ctx := getAdminContext(ctx)
 
-	// A preview must not reach the network, so the plugins load without running their init.
-	mgr := loadPluginAgents(ctx, false)
-	defer func() { _ = mgr.Stop() }()
+	// Only a kind that can reach an agent needs the count, and loading a plugin creates its
+	// services. A preview must not reach the network, so init never runs here.
+	var imageAgents artwork.ImageAgentCount
+	if needsImageAgents(kinds) {
+		mgr := loadPluginAgents(ctx, false)
+		defer func() { _ = mgr.Stop() }()
+		imageAgents = imageAgentCount(ds, mgr)
+	}
 
-	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(reprocessSources), imageAgentCount(ds, mgr),
+	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(reprocessSources), imageAgents,
 		reprocessDryRun, reprocessConfirm(reprocessYes, os.Stdin), os.Stdout); err != nil {
 		log.Fatal(ctx, err)
 	}
@@ -359,6 +364,14 @@ func loadPluginAgents(ctx context.Context, runInit bool) *plugins.Manager {
 		log.Warn(ctx, "Could not load plugins; plugin-provided agents will be missing", err)
 	}
 	return mgr
+}
+
+// needsImageAgents reports whether the estimate for any selected kind depends on how many image
+// agents there are. It asks the same question ExternalLookupsPerItem does, so the two cannot
+// disagree; an artist/album test would look equivalent and would silently zero the playlist
+// estimate, whose generated grid resolves album art through those agents.
+func needsImageAgents(kinds []model.Kind) bool {
+	return slices.ContainsFunc(kinds, artwork.MayFetchExternal)
 }
 
 // configuredAgents names the agents in priority order. A plugin absent from this list can never
@@ -733,10 +746,11 @@ func runExplain(ctx context.Context, kind model.Kind, id string) {
 	}
 
 	if artwork.Explainable(kind) {
-		// Loading before the resolver is built: it reads the agent list from the same manager.
-		mgr := loadPluginAgents(ctx, explainLive)
-		defer func() { _ = mgr.Stop() }()
+		// Disc and media file artwork never reaches an agent, so only artist and album pay to load
+		// one. Loading happens before the resolver is built: it reads the same manager.
 		if kind == model.KindArtistArtwork || kind == model.KindAlbumArtwork {
+			mgr := loadPluginAgents(ctx, explainLive)
+			defer func() { _ = mgr.Stop() }()
 			rep.agents = explainAgents(conf.Server.Agents, availableImageAgents(ds, mgr, kind))
 		}
 		trace := &artwork.ChainTrace{}

--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -36,7 +36,8 @@ var (
 
 func init() {
 	artworkExplainCmd.Flags().BoolVar(&explainLive, "live", false,
-		"perform real external lookups instead of reporting what would be tried")
+		"perform real external lookups instead of reporting what would be tried; "+
+			"also initializes plugin agents, which may open external connections")
 	artworkReprocessCmd.Flags().StringSliceVar(&reprocessKinds, "kind", nil,
 		"kinds to reprocess ("+kindPrefixes(artwork.RecheckKinds)+"); repeatable")
 	artworkReprocessCmd.Flags().StringSliceVar(&reprocessSources, "source", nil,
@@ -278,7 +279,8 @@ func runReprocess(ctx context.Context) {
 	defer db.Init(ctx)()
 	ds, ctx := getAdminContext(ctx)
 
-	mgr := loadPluginAgents(ctx)
+	// A preview must not reach the network, so the plugins load without running their init.
+	mgr := loadPluginAgents(ctx, false)
 	defer func() { _ = mgr.Stop() }()
 
 	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(reprocessSources), imageAgentCount(ds, mgr),
@@ -348,14 +350,27 @@ func imageAgentCount(ds model.DataStore, mgr *plugins.Manager) artwork.ImageAgen
 	return artwork.ImageAgentCount{Artist: len(ag.ArtistImageAgents()), Album: len(ag.AlbumImageAgents())}
 }
 
-// loadPluginAgents loads the enabled plugins so the CLI resolves through the same agents a running
-// server would. A load failure is reported, not fatal: the built-in agents still answer.
-func loadPluginAgents(ctx context.Context) *plugins.Manager {
+// loadPluginAgents loads the plugins named in Agents, so the CLI resolves through the same agents a
+// running server would. A load failure is reported, not fatal: the built-in agents still answer.
+// runInit is passed through to the plugin's own init — see plugins.Manager.LoadPlugins.
+func loadPluginAgents(ctx context.Context, runInit bool) *plugins.Manager {
 	mgr := getPluginManager()
-	if err := mgr.LoadPlugins(ctx); err != nil {
+	if err := mgr.LoadPlugins(ctx, configuredAgents(), runInit); err != nil {
 		log.Warn(ctx, "Could not load plugins; plugin-provided agents will be missing", err)
 	}
 	return mgr
+}
+
+// configuredAgents names the agents in priority order. A plugin absent from this list can never
+// supply an image, so loading it would buy nothing and start its host services for free.
+func configuredAgents() []string {
+	var names []string
+	for name := range strings.SplitSeq(conf.Server.Agents, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			names = append(names, name)
+		}
+	}
+	return names
 }
 
 func promptConfirm(in io.Reader) confirmFunc {
@@ -719,7 +734,7 @@ func runExplain(ctx context.Context, kind model.Kind, id string) {
 
 	if artwork.Explainable(kind) {
 		// Loading before the resolver is built: it reads the agent list from the same manager.
-		mgr := loadPluginAgents(ctx)
+		mgr := loadPluginAgents(ctx, explainLive)
 		defer func() { _ = mgr.Stop() }()
 		if kind == model.KindArtistArtwork || kind == model.KindAlbumArtwork {
 			rep.agents = explainAgents(conf.Server.Agents, availableImageAgents(ds, mgr, kind))

--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -19,6 +19,7 @@ import (
 	"github.com/navidrome/navidrome/db"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/plugins"
 	"github.com/navidrome/navidrome/utils/slice"
 	"github.com/spf13/cobra"
 )
@@ -277,7 +278,10 @@ func runReprocess(ctx context.Context) {
 	defer db.Init(ctx)()
 	ds, ctx := getAdminContext(ctx)
 
-	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(reprocessSources), imageAgentCount(ds),
+	mgr := loadPluginAgents(ctx)
+	defer func() { _ = mgr.Stop() }()
+
+	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(reprocessSources), imageAgentCount(ds, mgr),
 		reprocessDryRun, reprocessConfirm(reprocessYes, os.Stdin), os.Stdout); err != nil {
 		log.Fatal(ctx, err)
 	}
@@ -339,10 +343,19 @@ func externalLookupLine(n int64) string {
 	return fmt.Sprintf("External lookups: %s.", externalEstimate(n))
 }
 
-// imageAgentCount counts only the built-in image agents, for the same reason.
-func imageAgentCount(ds model.DataStore) artwork.ImageAgentCount {
-	ag := agents.GetAgents(ds, getPluginManager())
+func imageAgentCount(ds model.DataStore, mgr *plugins.Manager) artwork.ImageAgentCount {
+	ag := agents.GetAgents(ds, mgr)
 	return artwork.ImageAgentCount{Artist: len(ag.ArtistImageAgents()), Album: len(ag.AlbumImageAgents())}
+}
+
+// loadPluginAgents loads the enabled plugins so the CLI resolves through the same agents a running
+// server would. A load failure is reported, not fatal: the built-in agents still answer.
+func loadPluginAgents(ctx context.Context) *plugins.Manager {
+	mgr := getPluginManager()
+	if err := mgr.LoadPlugins(ctx); err != nil {
+		log.Warn(ctx, "Could not load plugins; plugin-provided agents will be missing", err)
+	}
+	return mgr
 }
 
 func promptConfirm(in io.Reader) confirmFunc {
@@ -533,8 +546,8 @@ func explainAgents(configured string, available []string) string {
 }
 
 // availableImageAgents names the agents that can actually supply an image for kind.
-func availableImageAgents(ds model.DataStore, kind model.Kind) []string {
-	ag := agents.GetAgents(ds, getPluginManager())
+func availableImageAgents(ds model.DataStore, mgr *plugins.Manager, kind model.Kind) []string {
+	ag := agents.GetAgents(ds, mgr)
 	if kind == model.KindArtistArtwork {
 		return slice.Map(ag.ArtistImageAgents(), func(a agents.ArtistImageAgent) string { return a.Name })
 	}
@@ -705,8 +718,11 @@ func runExplain(ctx context.Context, kind model.Kind, id string) {
 	}
 
 	if artwork.Explainable(kind) {
+		// Loading before the resolver is built: it reads the agent list from the same manager.
+		mgr := loadPluginAgents(ctx)
+		defer func() { _ = mgr.Stop() }()
 		if kind == model.KindArtistArtwork || kind == model.KindAlbumArtwork {
-			rep.agents = explainAgents(conf.Server.Agents, availableImageAgents(ds, kind))
+			rep.agents = explainAgents(conf.Server.Agents, availableImageAgents(ds, mgr, kind))
 		}
 		trace := &artwork.ChainTrace{}
 		rep.source, rep.resolveErr = CreateArtworkResolver(trace, explainLive).Resolve(ctx, kind, id)

--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -330,13 +330,13 @@ func reprocessConfirm(yes bool, in io.Reader) confirmFunc {
 	return promptConfirm(in)
 }
 
-// externalEstimate claims no bound: a local hit ends the walk before any agent is asked, and plugin
-// agents are unregistered in a CLI that never starts the plugin manager.
+// externalEstimate claims no bound: a local hit ends the walk before any agent is asked, and the
+// plugin agents it counts are only the ones this process managed to load.
 func externalEstimate(n int64) string {
 	if n == 0 {
 		return "none"
 	}
-	return fmt.Sprintf("~%d estimated (plugin agents not counted; local hits may need fewer)", n)
+	return fmt.Sprintf("~%d estimated (plugin agents counted only when they load; local hits may need fewer)", n)
 }
 
 func externalLookupLine(n int64) string {

--- a/cmd/artwork_test.go
+++ b/cmd/artwork_test.go
@@ -594,7 +594,9 @@ var _ = Describe("reprocessArtwork", func() {
 	It("names the estimate's blind spots instead of claiming a bound it cannot hold", func() {
 		Expect(reprocessArtwork(ctx, ds, kinds, nil, imageAgents, true, accept, &out)).To(Succeed())
 
-		Expect(out.String()).To(ContainSubstring("plugin agents not counted"))
+		// The count includes plugin agents once they load, so the caveat is about a failed load,
+		// not about plugins being invisible to the CLI.
+		Expect(out.String()).To(ContainSubstring("plugin agents counted only when they load"))
 		Expect(out.String()).To(ContainSubstring("local hits may need fewer"))
 		Expect(out.String()).ToNot(ContainSubstring("up to"), "plugin agents make any ceiling false")
 		Expect(out.String()).ToNot(ContainSubstring("at least"), "a local hit makes any floor false")

--- a/cmd/artwork_test.go
+++ b/cmd/artwork_test.go
@@ -899,3 +899,48 @@ var _ = Describe("refreshItems", func() {
 			"the ids after a failure are still refreshed")
 	})
 })
+
+var _ = Describe("needsImageAgents", func() {
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.CoverArtPriority = "cover.*, external"
+		conf.Server.ArtistArtPriority = "artist.*, external"
+		conf.Server.EnableM3UExternalAlbumArt = false
+	})
+
+	It("is false for a selection no agent can serve", func() {
+		Expect(needsImageAgents([]model.Kind{model.KindRadioArtwork})).To(BeFalse())
+	})
+
+	// The generated playlist grid resolves album art through the image agents, so a playlist
+	// selection needs the count even though no agent is asked for a playlist image directly.
+	It("is true for playlists, whose grid tiles resolve through the album chain", func() {
+		Expect(needsImageAgents([]model.Kind{model.KindPlaylistArtwork})).To(BeTrue())
+	})
+
+	It("is true when any one of several kinds can reach an agent", func() {
+		Expect(needsImageAgents([]model.Kind{model.KindRadioArtwork, model.KindAlbumArtwork})).To(BeTrue())
+	})
+
+	It("is false once the chains no longer reach an agent", func() {
+		conf.Server.CoverArtPriority = "cover.*"
+		conf.Server.ArtistArtPriority = "artist.*"
+		Expect(needsImageAgents(artwork.RecheckKinds)).To(BeFalse())
+	})
+})
+
+var _ = Describe("configuredAgents", func() {
+	BeforeEach(func() { DeferCleanup(configtest.SetupConfig()) })
+
+	It("splits and trims the configured list", func() {
+		conf.Server.Agents = "lastfm, spotify ,deezer"
+		Expect(configuredAgents()).To(Equal([]string{"lastfm", "spotify", "deezer"}))
+	})
+
+	// An empty name would match no plugin, but it also must not make the list look non-empty:
+	// LoadPlugins treats an empty list as "load nothing".
+	It("drops empty entries rather than passing a name nothing can match", func() {
+		conf.Server.Agents = " , ,"
+		Expect(configuredAgents()).To(BeEmpty())
+	})
+})

--- a/core/artwork/gate.go
+++ b/core/artwork/gate.go
@@ -85,7 +85,7 @@ func (w *Worker) gateFor(name string) *extGate {
 }
 
 // breaker opens after breakerThreshold consecutive errors and admits a single probe once
-// breakerProbeAfter has elapsed; a success re-closes it.
+// breakerProbeAfter has elapsed; it closes after breakerRecoveries consecutive answers.
 type breaker struct {
 	mu       sync.Mutex
 	failures int

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -61,8 +61,8 @@ type Manager struct {
 	debounceTimers map[string]*time.Timer
 	debounceMu     sync.Mutex
 
-	// inspect is set by LoadPlugins, and nil for a server Start.
-	inspect *inspectOpts
+	// transient is set by LoadPlugins, and nil for a server Start.
+	transient *transientLoad
 
 	// SubsonicAPI host function dependencies (set once before Start, not modified after)
 	subsonicRouter SubsonicRouter
@@ -180,8 +180,8 @@ func (m *Manager) initRuntime(ctx context.Context, cacheDir string) error {
 	return nil
 }
 
-// inspectOpts scopes a read-only load; see LoadPlugins for what only and runInit mean.
-type inspectOpts struct {
+// transientLoad scopes a load that will not outlive the command asking for it; see LoadPlugins.
+type transientLoad struct {
 	only    []string
 	runInit bool
 }
@@ -192,7 +192,7 @@ func (m *Manager) LoadPlugins(ctx context.Context, only []string, runInit bool) 
 	if !conf.Server.Plugins.Enabled || conf.Server.Plugins.Folder.String() == "" || len(only) == 0 {
 		return nil
 	}
-	m.inspect = &inspectOpts{only: only, runInit: runInit}
+	m.transient = &transientLoad{only: only, runInit: runInit}
 
 	cacheDir := filepath.Join(conf.Server.CacheFolder.MustPath(), "plugins")
 	if err := m.initRuntime(ctx, cacheDir); err != nil {

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -61,6 +61,9 @@ type Manager struct {
 	debounceTimers map[string]*time.Timer
 	debounceMu     sync.Mutex
 
+	// readOnly is set by LoadPlugins: the manager may instantiate plugins but must not write.
+	readOnly bool
+
 	// SubsonicAPI host function dependencies (set once before Start, not modified after)
 	subsonicRouter SubsonicRouter
 	ds             model.DataStore
@@ -110,27 +113,14 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	if m.subsonicRouter == nil {
-		log.Fatal(ctx, "Plugin manager requires DataStore to be configured")
+		log.Fatal(ctx, "Plugin manager requires the SubsonicAPI router to be configured")
 	}
 
-	// Set extism log level based on plugin-specific config or global log level
-	pluginLogLevel := conf.Server.Plugins.LogLevel
-	if pluginLogLevel == "" {
-		pluginLogLevel = conf.Server.LogLevel
-	}
-	extism.SetLogLevel(toExtismLogLevel(log.ParseLogLevel(pluginLogLevel)))
-
-	m.ctx, m.cancel = context.WithCancel(ctx)
-
-	// Initialize wazero compilation cache for better performance
 	cacheDir := filepath.Join(conf.Server.CacheFolder.MustPath(), "plugins")
 	purgeCacheBySize(ctx, cacheDir, conf.Server.Plugins.CacheSize)
 
-	var err error
-	m.cache, err = wazero.NewCompilationCacheWithDir(cacheDir)
-	if err != nil {
-		log.Error(ctx, "Failed to create wazero compilation cache", err)
-		return fmt.Errorf("creating wazero compilation cache: %w", err)
+	if err := m.initRuntime(ctx, cacheDir); err != nil {
+		return err
 	}
 
 	if conf.Server.Plugins.Folder.String() == "" {
@@ -168,6 +158,48 @@ func (m *Manager) Start(ctx context.Context) error {
 		}
 	}
 
+	return nil
+}
+
+// initRuntime prepares the extism/wazero runtime that instantiating a plugin needs.
+func (m *Manager) initRuntime(ctx context.Context, cacheDir string) error {
+	pluginLogLevel := conf.Server.Plugins.LogLevel
+	if pluginLogLevel == "" {
+		pluginLogLevel = conf.Server.LogLevel
+	}
+	extism.SetLogLevel(toExtismLogLevel(log.ParseLogLevel(pluginLogLevel)))
+
+	m.ctx, m.cancel = context.WithCancel(ctx)
+
+	var err error
+	m.cache, err = wazero.NewCompilationCacheWithDir(cacheDir)
+	if err != nil {
+		log.Error(ctx, "Failed to create wazero compilation cache", err)
+		return fmt.Errorf("creating wazero compilation cache: %w", err)
+	}
+	return nil
+}
+
+// LoadPlugins loads the enabled plugins so a CLI command sees the same agents a running server
+// would, without any of Start's side effects: it does not reconcile the plugins folder, record
+// load errors, purge the compilation cache, or watch for changes. Capabilities are detected from
+// the WASM exports, so this is also the only accurate source for what a plugin actually provides.
+//
+// The SubsonicAPI host function is unavailable without a router, and reports that if a plugin
+// calls it. Call Stop when done.
+func (m *Manager) LoadPlugins(ctx context.Context) error {
+	if !conf.Server.Plugins.Enabled || conf.Server.Plugins.Folder.String() == "" {
+		return nil
+	}
+	m.readOnly = true
+
+	cacheDir := filepath.Join(conf.Server.CacheFolder.MustPath(), "plugins")
+	if err := m.initRuntime(ctx, cacheDir); err != nil {
+		return err
+	}
+	if err := m.loadEnabledPlugins(ctx); err != nil {
+		return fmt.Errorf("loading enabled plugins: %w", err)
+	}
 	return nil
 }
 

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -61,8 +61,8 @@ type Manager struct {
 	debounceTimers map[string]*time.Timer
 	debounceMu     sync.Mutex
 
-	// readOnly is set by LoadPlugins: the manager may instantiate plugins but must not write.
-	readOnly bool
+	// inspect is set by LoadPlugins, and nil for a server Start.
+	inspect *inspectOpts
 
 	// SubsonicAPI host function dependencies (set once before Start, not modified after)
 	subsonicRouter SubsonicRouter
@@ -180,18 +180,32 @@ func (m *Manager) initRuntime(ctx context.Context, cacheDir string) error {
 	return nil
 }
 
-// LoadPlugins loads the enabled plugins so a CLI command sees the same agents a running server
-// would, without any of Start's side effects: it does not reconcile the plugins folder, record
-// load errors, purge the compilation cache, or watch for changes. Capabilities are detected from
-// the WASM exports, so this is also the only accurate source for what a plugin actually provides.
+// inspectOpts scopes a read-only load. only lists the plugins worth instantiating — loading one
+// creates its host services, so a command loads the agents it may consult and nothing else.
+// runInit decides whether the plugin's own init runs; see LoadPlugins.
+type inspectOpts struct {
+	only    []string
+	runInit bool
+}
+
+// LoadPlugins loads the plugins named in only, so a CLI command sees the same agents a running
+// server would. It skips what Start does around the load — folder reconciliation, error recording,
+// cache purging, the watcher — but the load itself is the real thing: capabilities are detected
+// from the WASM exports, which is the only accurate source, and a plugin that declares the KVStore,
+// TaskQueue or Storage permission gets that service, database and directory included. Naming only
+// the agents a command may consult is what keeps that footprint down.
+//
+// runInit runs the plugin's init, which is its first chance to execute arbitrary code — opening
+// sockets, creating task queues, scheduling work. Pass true only from a command that already
+// intends to reach the network; a command promising no external requests must pass false.
 //
 // The SubsonicAPI host function is unavailable without a router, and reports that if a plugin
 // calls it. Call Stop when done.
-func (m *Manager) LoadPlugins(ctx context.Context) error {
-	if !conf.Server.Plugins.Enabled || conf.Server.Plugins.Folder.String() == "" {
+func (m *Manager) LoadPlugins(ctx context.Context, only []string, runInit bool) error {
+	if !conf.Server.Plugins.Enabled || conf.Server.Plugins.Folder.String() == "" || len(only) == 0 {
 		return nil
 	}
-	m.readOnly = true
+	m.inspect = &inspectOpts{only: only, runInit: runInit}
 
 	cacheDir := filepath.Join(conf.Server.CacheFolder.MustPath(), "plugins")
 	if err := m.initRuntime(ctx, cacheDir); err != nil {

--- a/plugins/manager.go
+++ b/plugins/manager.go
@@ -180,27 +180,14 @@ func (m *Manager) initRuntime(ctx context.Context, cacheDir string) error {
 	return nil
 }
 
-// inspectOpts scopes a read-only load. only lists the plugins worth instantiating — loading one
-// creates its host services, so a command loads the agents it may consult and nothing else.
-// runInit decides whether the plugin's own init runs; see LoadPlugins.
+// inspectOpts scopes a read-only load; see LoadPlugins for what only and runInit mean.
 type inspectOpts struct {
 	only    []string
 	runInit bool
 }
 
-// LoadPlugins loads the plugins named in only, so a CLI command sees the same agents a running
-// server would. It skips what Start does around the load — folder reconciliation, error recording,
-// cache purging, the watcher — but the load itself is the real thing: capabilities are detected
-// from the WASM exports, which is the only accurate source, and a plugin that declares the KVStore,
-// TaskQueue or Storage permission gets that service, database and directory included. Naming only
-// the agents a command may consult is what keeps that footprint down.
-//
-// runInit runs the plugin's init, which is its first chance to execute arbitrary code — opening
-// sockets, creating task queues, scheduling work. Pass true only from a command that already
-// intends to reach the network; a command promising no external requests must pass false.
-//
-// The SubsonicAPI host function is unavailable without a router, and reports that if a plugin
-// calls it. Call Stop when done.
+// LoadPlugins loads the plugins named in only, so a CLI sees the agents a server would. Each is
+// instantiated, creating any KVStore, TaskQueue or Storage it declares; call Stop when done.
 func (m *Manager) LoadPlugins(ctx context.Context, only []string, runInit bool) error {
 	if !conf.Server.Plugins.Enabled || conf.Server.Plugins.Folder.String() == "" || len(only) == 0 {
 		return nil

--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -246,19 +246,21 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 			}()
 
 			if err := m.loadPluginWithConfig(&plugin); err != nil {
-				// Store error in DB
-				plugin.LastError = err.Error()
-				plugin.Enabled = false
-				plugin.UpdatedAt = time.Now()
-				if putErr := repo.Put(&plugin); putErr != nil {
-					log.Error(ctx, "Failed to update plugin error in DB", "plugin", plugin.ID, putErr)
+				// A read-only load must not disable the user's plugin just for inspecting it.
+				if !m.readOnly {
+					plugin.LastError = err.Error()
+					plugin.Enabled = false
+					plugin.UpdatedAt = time.Now()
+					if putErr := repo.Put(&plugin); putErr != nil {
+						log.Error(ctx, "Failed to update plugin error in DB", "plugin", plugin.ID, putErr)
+					}
 				}
 				log.Error(ctx, "Failed to load plugin", "plugin", plugin.ID, err)
 				return nil
 			}
 
 			// Clear any previous error
-			if plugin.LastError != "" {
+			if plugin.LastError != "" && !m.readOnly {
 				plugin.LastError = ""
 				plugin.UpdatedAt = time.Now()
 				if putErr := repo.Put(&plugin); putErr != nil {

--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"slices"
 	"time"
 
 	extism "github.com/extism/go-sdk"
@@ -232,6 +233,11 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 		if !p.Enabled {
 			continue
 		}
+		// Instantiating a plugin creates its host services, so an inspecting caller loads only the
+		// ones it may actually consult.
+		if m.inspect != nil && !slices.Contains(m.inspect.only, p.ID) {
+			continue
+		}
 
 		plugin := p // Capture for goroutine
 		g.Go(func() error {
@@ -247,7 +253,7 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 
 			if err := m.loadPluginWithConfig(&plugin); err != nil {
 				// A read-only load must not disable the user's plugin just for inspecting it.
-				if !m.readOnly {
+				if m.inspect == nil {
 					plugin.LastError = err.Error()
 					plugin.Enabled = false
 					plugin.UpdatedAt = time.Now()
@@ -260,7 +266,7 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 			}
 
 			// Clear any previous error
-			if plugin.LastError != "" && !m.readOnly {
+			if plugin.LastError != "" && m.inspect == nil {
 				plugin.LastError = ""
 				plugin.UpdatedAt = time.Now()
 				if putErr := repo.Put(&plugin); putErr != nil {
@@ -446,8 +452,11 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 	m.mu.Unlock()
 	loaded = true
 
-	// Call plugin init function
-	callPluginInit(ctx, m.plugins[p.ID])
+	// Init is the plugin's first chance to run arbitrary code: open sockets, create task queues,
+	// schedule work. Only a caller that already intends to reach the network asks for it.
+	if m.inspect == nil || m.inspect.runInit {
+		callPluginInit(ctx, m.plugins[p.ID])
+	}
 
 	return nil
 }

--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -233,9 +233,9 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 		if !p.Enabled {
 			continue
 		}
-		// Instantiating a plugin creates its host services, so an inspecting caller loads only the
+		// Instantiating a plugin creates its host services, so a transient load takes only the
 		// ones it may actually consult.
-		if m.inspect != nil && !slices.Contains(m.inspect.only, p.ID) {
+		if m.transient != nil && !slices.Contains(m.transient.only, p.ID) {
 			continue
 		}
 
@@ -252,8 +252,8 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 			}()
 
 			if err := m.loadPluginWithConfig(&plugin); err != nil {
-				// A read-only load must not disable the user's plugin just for inspecting it.
-				if m.inspect == nil {
+				// A transient load must not disable the user's plugin just for looking at it.
+				if m.transient == nil {
 					plugin.LastError = err.Error()
 					plugin.Enabled = false
 					plugin.UpdatedAt = time.Now()
@@ -266,7 +266,7 @@ func (m *Manager) loadEnabledPlugins(ctx context.Context) error {
 			}
 
 			// Clear any previous error
-			if plugin.LastError != "" && m.inspect == nil {
+			if plugin.LastError != "" && m.transient == nil {
 				plugin.LastError = ""
 				plugin.UpdatedAt = time.Now()
 				if putErr := repo.Put(&plugin); putErr != nil {
@@ -454,7 +454,7 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 
 	// Init is the plugin's first chance to run arbitrary code: open sockets, create task queues,
 	// schedule work. Only a caller that already intends to reach the network asks for it.
-	if m.inspect == nil || m.inspect.runInit {
+	if m.transient == nil || m.transient.runInit {
 		callPluginInit(ctx, m.plugins[p.ID])
 	}
 

--- a/plugins/manager_readonly_test.go
+++ b/plugins/manager_readonly_test.go
@@ -80,9 +80,8 @@ var _ = Describe("Manager.LoadPlugins", func() {
 			Expect(stored.LastError).To(BeEmpty())
 		})
 
-		// The same load, not read-only, must still record the failure — otherwise the test above
-		// passes for the wrong reason. Start is not usable here: it syncs the folder to the DB
-		// first, which drops a row whose file is missing before any load is attempted.
+		// Without this the test above would pass for the wrong reason. Start cannot be used: it
+		// syncs the folder first, dropping a row whose file is missing before any load.
 		It("still disables it when not read-only", func() {
 			mgr = newManager(brokenRows())
 

--- a/plugins/manager_readonly_test.go
+++ b/plugins/manager_readonly_test.go
@@ -16,15 +16,17 @@ import (
 
 var _ = Describe("Manager.LoadPlugins", func() {
 	var (
-		mgr  *Manager
-		repo *tests.MockPluginRepo
+		mgr    *Manager
+		repo   *tests.MockPluginRepo
+		tmpDir string
 	)
 
 	// newManager builds a manager over rows the caller can corrupt, with no Subsonic router: a CLI
 	// has none, and Start would log.Fatal on that.
 	newManager := func(rows model.Plugins) *Manager {
 		DeferCleanup(configtest.SetupConfig())
-		tmpDir, err := os.MkdirTemp("", "plugins-readonly-*")
+		var err error
+		tmpDir, err = os.MkdirTemp("", "plugins-readonly-*")
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(func() { _ = os.RemoveAll(tmpDir) })
 
@@ -54,7 +56,7 @@ var _ = Describe("Manager.LoadPlugins", func() {
 	It("detects capabilities without a Subsonic router configured", func() {
 		mgr = newManager(nil)
 
-		Expect(mgr.LoadPlugins(GinkgoT().Context())).To(Succeed())
+		Expect(mgr.LoadPlugins(GinkgoT().Context(), []string{"test-metadata-agent", "broken"}, false)).To(Succeed())
 
 		Expect(mgr.PluginNames(string(CapabilityMetadataAgent))).To(ContainElement("test-metadata-agent"))
 	})
@@ -70,7 +72,7 @@ var _ = Describe("Manager.LoadPlugins", func() {
 		It("leaves the stored row untouched", func() {
 			mgr = newManager(brokenRows())
 
-			Expect(mgr.LoadPlugins(GinkgoT().Context())).To(Succeed())
+			Expect(mgr.LoadPlugins(GinkgoT().Context(), []string{"test-metadata-agent", "broken"}, false)).To(Succeed())
 
 			stored, err := repo.Get("broken")
 			Expect(err).ToNot(HaveOccurred())
@@ -93,11 +95,31 @@ var _ = Describe("Manager.LoadPlugins", func() {
 		})
 	})
 
+	// Loading a plugin creates its host services — a KVStore or task queue database on disk — so a
+	// plugin that could never supply an image must not be instantiated just to be ignored.
+	It("does not load a plugin that is not in the agent list", func() {
+		mgr = newManager(nil)
+
+		Expect(mgr.LoadPlugins(GinkgoT().Context(), []string{"some-other-agent"}, false)).To(Succeed())
+
+		Expect(mgr.PluginNames(string(CapabilityMetadataAgent))).To(BeEmpty())
+	})
+
+	It("does nothing when no agents are configured", func() {
+		mgr = newManager(nil)
+
+		Expect(mgr.LoadPlugins(GinkgoT().Context(), nil, false)).To(Succeed())
+
+		Expect(mgr.PluginNames(string(CapabilityMetadataAgent))).To(BeEmpty())
+		// Not even the wazero cache: with nothing to load there is nothing to compile.
+		Expect(filepath.Join(tmpDir, "plugins")).ToNot(BeADirectory())
+	})
+
 	It("does nothing when the plugin system is disabled", func() {
 		mgr = newManager(nil)
 		conf.Server.Plugins.Enabled = false
 
-		Expect(mgr.LoadPlugins(GinkgoT().Context())).To(Succeed())
+		Expect(mgr.LoadPlugins(GinkgoT().Context(), []string{"test-metadata-agent", "broken"}, false)).To(Succeed())
 
 		Expect(mgr.PluginNames(string(CapabilityMetadataAgent))).To(BeEmpty())
 	})

--- a/plugins/manager_readonly_test.go
+++ b/plugins/manager_readonly_test.go
@@ -1,0 +1,104 @@
+//go:build !windows
+
+package plugins
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Manager.LoadPlugins", func() {
+	var (
+		mgr  *Manager
+		repo *tests.MockPluginRepo
+	)
+
+	// newManager builds a manager over rows the caller can corrupt, with no Subsonic router: a CLI
+	// has none, and Start would log.Fatal on that.
+	newManager := func(rows model.Plugins) *Manager {
+		DeferCleanup(configtest.SetupConfig())
+		tmpDir, err := os.MkdirTemp("", "plugins-readonly-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+		conf.Server.Plugins.Enabled = true
+		conf.Server.Plugins.Folder = conf.NewDir(tmpDir)
+		conf.Server.Plugins.AutoReload = false
+		conf.Server.CacheFolder = conf.NewDir(tmpDir)
+
+		if rows == nil {
+			rows = installTestPlugins(tmpDir, "test-metadata-agent"+PackageExtension)
+			for i := range rows {
+				rows[i].AllUsers = true
+			}
+		}
+		repo = tests.CreateMockPluginRepo()
+		repo.Permitted = true
+		repo.SetData(rows)
+		m := &Manager{
+			plugins: make(map[string]*plugin),
+			ds:      &tests.MockDataStore{MockedPlugin: repo},
+			metrics: noopMetricsRecorder{},
+		}
+		DeferCleanup(func() { _ = m.Stop() })
+		return m
+	}
+
+	It("detects capabilities without a Subsonic router configured", func() {
+		mgr = newManager(nil)
+
+		Expect(mgr.LoadPlugins(GinkgoT().Context())).To(Succeed())
+
+		Expect(mgr.PluginNames(string(CapabilityMetadataAgent))).To(ContainElement("test-metadata-agent"))
+	})
+
+	Context("when a plugin cannot be loaded", func() {
+		brokenRows := func() model.Plugins {
+			return model.Plugins{{
+				ID: "broken", Path: filepath.Join(GinkgoT().TempDir(), "does-not-exist.ndp"),
+				Enabled: true, AllUsers: true,
+			}}
+		}
+
+		It("leaves the stored row untouched", func() {
+			mgr = newManager(brokenRows())
+
+			Expect(mgr.LoadPlugins(GinkgoT().Context())).To(Succeed())
+
+			stored, err := repo.Get("broken")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Enabled).To(BeTrue(), "inspecting a plugin must never disable it")
+			Expect(stored.LastError).To(BeEmpty())
+		})
+
+		// The same load, not read-only, must still record the failure — otherwise the test above
+		// passes for the wrong reason. Start is not usable here: it syncs the folder to the DB
+		// first, which drops a row whose file is missing before any load is attempted.
+		It("still disables it when not read-only", func() {
+			mgr = newManager(brokenRows())
+
+			Expect(mgr.loadEnabledPlugins(GinkgoT().Context())).To(Succeed())
+
+			stored, err := repo.Get("broken")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stored.Enabled).To(BeFalse())
+			Expect(stored.LastError).ToNot(BeEmpty())
+		})
+	})
+
+	It("does nothing when the plugin system is disabled", func() {
+		mgr = newManager(nil)
+		conf.Server.Plugins.Enabled = false
+
+		Expect(mgr.LoadPlugins(GinkgoT().Context())).To(Succeed())
+
+		Expect(mgr.PluginNames(string(CapabilityMetadataAgent))).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
### Description

Follow-up to #5957 (merged), closing the known limitation called out there: a CLI command that resolves artwork saw only *built-in* agents. `agents.getEnabledAgentNames` asks `Manager.PluginNames`, which reads a map populated solely by `Manager.Start`, and only the server calls that. On a plugin-using install the CLI's agent list was quietly short — not empty, just missing every plugin.

On my library (`Agents = artist-nfo-metadata,apple-music,audiomuseai,deezer,lastfm`) three of five agents were invisible, including the two ranked highest, and `explain --live` **named the wrong provider**:

```
Stored   Source: external:apple-music

# before
external:deezer  hit  https://cdn-images.dzcdn.net/…
Result  resolved from external:deezer          ← wrong, and stated without hedging

# after
external:artist-nfo-metadata  error  plugin call failed: artist.nfo file not found…
external:apple-music          hit    https://is1-ssl.mzstatic.com/…
Result  resolved from external:apple-music     ← matches the stored source
```

`Manager.LoadPlugins` is the read-only counterpart to `Start`: extism/wazero init plus `loadEnabledPlugins`, without the folder sync, the error clearing, the cache purge, or the file watcher.

This follows what the read-only plugin commands already do — `plugin list`, `info` and `validate` read the DB and never start the manager. The one thing they *can* do and this cannot is trust the manifest: `PluginNames` filters on capabilities from `detectCapabilities`, which inspects the instantiated WASM's exports, so the manifest's declared `capabilities` is not the source of truth (`manifest.go:97` says as much for Scrobbler). Instantiating is the only accurate answer to "what does this plugin provide".

Two behaviours worth calling out:

- **`loadEnabledPlugins` used to write on the read path.** On a load failure it set `LastError` *and flipped `Enabled = false`*; on success it cleared `LastError`. Correct for the server, wrong for a diagnostic — `artwork explain` must not disable a plugin as a side effect of looking at it. Now gated on the read-only flag. Verified against a copy of my production database: after several runs all six plugins were still enabled with no errors and untouched `updated_at`.
- **No Subsonic router is required.** `Start` `log.Fatal`s without one, but `subsonicAPIServiceImpl.executeRequest` already nil-checks it and returns `"SubsonicAPI router not available"` at call time, so a plugin that reaches for it gets an error rather than taking the process down. That `Fatal`'s message also claimed the *DataStore* was missing when it checks the router — fixed.

A load failure is reported and non-fatal: the built-in agents still answer.


### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

With at least one MetadataAgent plugin installed and listed in `Agents`:

```
go run . artwork explain ar <artist-id>          # Config block lists every agent, no "*" markers
go run . artwork explain ar <artist-id> --live   # chain shows external:<plugin> candidates
```

Then confirm the `plugin` table is untouched — `enabled`, `last_error` and `updated_at` unchanged — including for a plugin that fails to load.

`plugins/manager_readonly_test.go` covers capability detection with no router, the untouched row on a failed read-only load, the same load still recording the failure when not read-only, and the disabled-plugins no-op. The paired read-only/normal tests matter: without the second one the first passes for the wrong reason.

### Additional Notes

`Start` cannot be reused for the contrast test: it syncs the folder to the DB first, which drops a row whose file is missing before any load is attempted. The test calls `loadEnabledPlugins` directly to isolate exactly the changed behaviour.

Docs for the command group are in navidrome/website#422; nothing there changes, since this makes the documented behaviour correct rather than altering it.



