### PR TITLE
fix(artwork): ramp the external circuit breaker back up instead of closing on one answer

### DIFF
--- a/core/artwork/gate.go
+++ b/core/artwork/gate.go
@@ -49,7 +49,8 @@ type extGate struct {
 // gate runs a named external step through that agent's rate limiter and circuit breaker.
 func (w *Worker) gate(name string, f func() (io.ReadCloser, string, error)) (io.ReadCloser, string, error) {
 	g := w.gateFor(name)
-	if !g.breaker.allow() {
+	allowed, gen := g.breaker.allow()
+	if !allowed {
 		log.Debug(w.runCtx, "Artwork: Skipping agent, circuit breaker open", "agent", name)
 		return nil, "", errBreakerOpen
 	}
@@ -60,7 +61,7 @@ func (w *Worker) gate(name string, f func() (io.ReadCloser, string, error)) (io.
 	}
 	callStart := time.Now()
 	r, path, err := f()
-	g.breaker.record(name, err)
+	g.breaker.record(name, gen, err)
 	log.Trace(w.runCtx, "Artwork: External agent call", "agent", name, "hit", r != nil,
 		"limiterWait", callStart.Sub(waitStart), "elapsed", time.Since(callStart), err)
 	return r, path, err
@@ -91,24 +92,29 @@ type breaker struct {
 	openedAt time.Time
 	// recoveries counts consecutive good answers while open; a single failure discards them.
 	recoveries int
+	// generation identifies the current open episode, so an answer from a call admitted before
+	// the breaker opened cannot be mistaken for evidence that it has recovered.
+	generation int
 }
 
 func newBreaker() *breaker { return &breaker{} }
 
-func (b *breaker) allow() bool {
+// allow reports whether a call may proceed, and the open episode it was admitted under: zero
+// when the breaker was closed, the current generation when admitted as a half-open probe.
+func (b *breaker) allow() (bool, int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	if b.failures < breakerThreshold {
-		return true
+		return true, 0
 	}
 	if time.Since(b.openedAt) >= breakerProbeAfter {
 		b.openedAt = time.Now() // start a fresh probe window so only one caller passes
-		return true
+		return true, b.generation
 	}
-	return false
+	return false, 0
 }
 
-func (b *breaker) record(name string, err error) {
+func (b *breaker) record(name string, gen int, err error) {
 	// A cancelled run says nothing about the provider, so it neither counts nor clears.
 	if errors.Is(err, context.Canceled) {
 		return
@@ -120,6 +126,7 @@ func (b *breaker) record(name string, err error) {
 		b.failures++
 		if b.failures == breakerThreshold {
 			b.openedAt = time.Now()
+			b.generation++
 			log.Warn("Artwork: Circuit breaker opened for agent", "agent", name,
 				"consecutiveFailures", b.failures, "probeAfter", breakerProbeAfter, err)
 		}
@@ -129,8 +136,14 @@ func (b *breaker) record(name string, err error) {
 		b.failures = 0
 		return
 	}
-	// Open: ramp back up over several probes. A not-found counts here because the provider did
-	// answer, but on its own it is thin evidence that a provider which just blocked us is well.
+	// Only a probe from this open episode is evidence of recovery. The worker drains concurrently,
+	// so answers keep arriving from calls admitted before the breaker opened; counting those would
+	// close it with no probe interval elapsed, which is the burst this exists to prevent.
+	if gen == 0 || gen != b.generation {
+		return
+	}
+	// A not-found counts because the provider did answer, but on its own it is thin evidence that
+	// a provider which just blocked us is well.
 	b.recoveries++
 	if b.recoveries < breakerRecoveries {
 		return

--- a/core/artwork/gate.go
+++ b/core/artwork/gate.go
@@ -17,6 +17,11 @@ import (
 const (
 	breakerThreshold  = 5
 	breakerProbeAfter = time.Minute
+	// breakerRecoveries is how many consecutive answers an open breaker needs before it trusts the
+	// provider again. One is not enough: a provider that is rate-limiting or blocking us still
+	// answers the occasional request, and closing on the first of those puts the agent straight
+	// back to full rate, which is what earns the next block.
+	breakerRecoveries = 3
 )
 
 var errBreakerOpen = errors.New("artwork: external circuit breaker open")
@@ -84,6 +89,8 @@ type breaker struct {
 	mu       sync.Mutex
 	failures int
 	openedAt time.Time
+	// recoveries counts consecutive good answers while open; a single failure discards them.
+	recoveries int
 }
 
 func newBreaker() *breaker { return &breaker{} }
@@ -108,17 +115,27 @@ func (b *breaker) record(name string, err error) {
 	}
 	b.mu.Lock()
 	defer b.mu.Unlock()
-	if !isTransientExternal(err) {
-		if b.failures >= breakerThreshold {
-			log.Info("Artwork: Circuit breaker closed for agent", "agent", name)
+	if isTransientExternal(err) {
+		b.recoveries = 0
+		b.failures++
+		if b.failures == breakerThreshold {
+			b.openedAt = time.Now()
+			log.Warn("Artwork: Circuit breaker opened for agent", "agent", name,
+				"consecutiveFailures", b.failures, "probeAfter", breakerProbeAfter, err)
 		}
+		return
+	}
+	if b.failures < breakerThreshold {
 		b.failures = 0
 		return
 	}
-	b.failures++
-	if b.failures == breakerThreshold {
-		b.openedAt = time.Now()
-		log.Warn("Artwork: Circuit breaker opened for agent", "agent", name,
-			"consecutiveFailures", b.failures, "probeAfter", breakerProbeAfter, err)
+	// Open: ramp back up over several probes. A not-found counts here because the provider did
+	// answer, but on its own it is thin evidence that a provider which just blocked us is well.
+	b.recoveries++
+	if b.recoveries < breakerRecoveries {
+		return
 	}
+	log.Info("Artwork: Circuit breaker closed for agent", "agent", name,
+		"consecutiveAnswers", b.recoveries)
+	b.failures, b.recoveries = 0, 0
 }

--- a/core/artwork/gate_test.go
+++ b/core/artwork/gate_test.go
@@ -1,0 +1,43 @@
+package artwork
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// allowed drops the generation token when a caller only cares about admission.
+func allowed(b *breaker) bool { ok, _ := b.allow(); return ok }
+
+var _ = Describe("breaker", func() {
+	// The worker drains concurrently, so when the breaker opens there are already calls past
+	// allow(), queued in the rate limiter or waiting on a response. Their answers arrive
+	// afterwards. Counting those as recovery closes the breaker with no probe interval elapsed,
+	// which is the burst the ramp exists to prevent. No clock is involved: the race is an
+	// ordering, so it is reproduced by making the calls in the order concurrency produces.
+	It("ignores answers from calls admitted before it opened", func() {
+		b := newBreaker()
+
+		// A batch clears allow() while the breaker is still closed.
+		for range breakerThreshold + breakerRecoveries {
+			ok, gen := b.allow()
+			Expect(ok).To(BeTrue())
+			Expect(gen).To(BeZero(), "admitted with the breaker closed, so not a probe")
+		}
+
+		// The fast failures in that batch open it.
+		for range breakerThreshold {
+			b.record("agentA", 0, errors.New("blocked"))
+		}
+		Expect(allowed(b)).To(BeFalse(), "breaker is open")
+
+		// The slower answers from the same batch land now.
+		for range breakerRecoveries {
+			b.record("agentA", 0, nil)
+		}
+
+		Expect(allowed(b)).To(BeFalse(),
+			"answers from calls admitted before the breaker opened must not close it")
+	})
+})

--- a/core/artwork/worker_timing_test.go
+++ b/core/artwork/worker_timing_test.go
@@ -12,6 +12,9 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+// allowed drops the generation token when a test only cares about admission.
+func allowed(b *breaker) bool { ok, _ := b.allow(); return ok }
+
 // Drives the real breaker state machine with the fake clock. Plain test: testing/synctest
 // needs a *testing.T, which Ginkgo doesn't give.
 func TestArtworkBreakerHalfOpen(t *testing.T) {
@@ -20,33 +23,37 @@ func TestArtworkBreakerHalfOpen(t *testing.T) {
 		b := newBreaker()
 
 		for range breakerThreshold {
-			b.record("agentA", errors.New("boom"))
+			b.record("agentA", 0, errors.New("boom"))
 		}
-		g.Expect(b.allow()).To(BeFalse(), "breaker opens after consecutive errors")
+		g.Expect(allowed(b)).To(BeFalse(), "breaker opens after consecutive errors")
 
 		time.Sleep(breakerProbeAfter - time.Nanosecond)
-		g.Expect(b.allow()).To(BeFalse(), "still open before the probe interval")
+		g.Expect(allowed(b)).To(BeFalse(), "still open before the probe interval")
 
 		time.Sleep(time.Nanosecond)
-		g.Expect(b.allow()).To(BeTrue(), "half-open: one probe is granted")
-		g.Expect(b.allow()).To(BeFalse(), "only a single probe per interval")
+		ok, gen := b.allow()
+		g.Expect(ok).To(BeTrue(), "half-open: one probe is granted")
+		g.Expect(gen).ToNot(BeZero(), "a probe carries the open episode it belongs to")
+		g.Expect(allowed(b)).To(BeFalse(), "only a single probe per interval")
 
-		b.record("agentA", errors.New("boom")) // probe fails -> stay open
+		b.record("agentA", gen, errors.New("boom")) // probe fails -> stay open
 		time.Sleep(breakerProbeAfter)
-		g.Expect(b.allow()).To(BeTrue(), "another probe after the next interval")
+		ok, gen = b.allow()
+		g.Expect(ok).To(BeTrue(), "another probe after the next interval")
 
 		// One good answer must not reopen the floodgates: closing here is what let a burst out at
 		// full rate and got the provider to escalate from throttling to blocking.
-		b.record("agentA", nil)
-		g.Expect(b.allow()).To(BeFalse(), "a single good answer does not close the breaker")
+		b.record("agentA", gen, nil)
+		g.Expect(allowed(b)).To(BeFalse(), "a single good answer does not close the breaker")
 
 		for range breakerRecoveries - 1 {
 			time.Sleep(breakerProbeAfter)
-			g.Expect(b.allow()).To(BeTrue())
-			b.record("agentA", nil)
+			ok, gen = b.allow()
+			g.Expect(ok).To(BeTrue())
+			b.record("agentA", gen, nil)
 		}
-		g.Expect(b.allow()).To(BeTrue(), "closed breaker admits freely")
-		g.Expect(b.allow()).To(BeTrue())
+		g.Expect(allowed(b)).To(BeTrue(), "closed breaker admits freely")
+		g.Expect(allowed(b)).To(BeTrue())
 	})
 }
 
@@ -59,7 +66,7 @@ func TestArtworkBreakerDoesNotCloseOnAnIsolatedAnswer(t *testing.T) {
 		b := newBreaker()
 		open := func() {
 			for range breakerThreshold {
-				b.record("agentA", errors.New("blocked"))
+				b.record("agentA", 0, errors.New("blocked"))
 			}
 		}
 		open()
@@ -67,10 +74,11 @@ func TestArtworkBreakerDoesNotCloseOnAnIsolatedAnswer(t *testing.T) {
 		// A not-found is an answer, so it counts toward recovery, but never on its own.
 		for range breakerRecoveries * 2 {
 			time.Sleep(breakerProbeAfter)
-			g.Expect(b.allow()).To(BeTrue(), "one probe per interval")
-			b.record("agentA", agents.ErrNotFound)
-			b.record("agentA", errors.New("blocked")) // the very next call is refused again
-			g.Expect(b.allow()).To(BeFalse(), "an answer between failures must not close the breaker")
+			ok, gen := b.allow()
+			g.Expect(ok).To(BeTrue(), "one probe per interval")
+			b.record("agentA", gen, agents.ErrNotFound)
+			b.record("agentA", 0, errors.New("blocked")) // the very next call is refused again
+			g.Expect(allowed(b)).To(BeFalse(), "an answer between failures must not close the breaker")
 		}
 	})
 }
@@ -107,4 +115,34 @@ func TestArtworkGatePerAgentBreakerIsolation(t *testing.T) {
 		g.Expect(err).To(MatchError(errBreakerOpen), "the probe failed, so A stays open")
 		g.Expect(aCalls).To(Equal(1))
 	})
+}
+
+// The worker drains concurrently, so when the breaker opens there are already calls past allow(),
+// queued in the rate limiter or waiting on an HTTP response. Their answers arrive afterwards.
+// Counting those as recovery closes the breaker with no probe interval elapsed, which is exactly
+// the burst the ramp exists to prevent. No fake clock: the race is an ordering, not a duration.
+func TestArtworkBreakerIgnoresAnswersAdmittedBeforeItOpened(t *testing.T) {
+	g := NewWithT(t)
+	b := newBreaker()
+
+	// A batch clears allow() while the breaker is still closed.
+	for range breakerThreshold + breakerRecoveries {
+		ok, gen := b.allow()
+		g.Expect(ok).To(BeTrue())
+		g.Expect(gen).To(BeZero(), "admitted with the breaker closed, so not a probe")
+	}
+
+	// The fast failures in that batch open it.
+	for range breakerThreshold {
+		b.record("agentA", 0, errors.New("blocked"))
+	}
+	g.Expect(allowed(b)).To(BeFalse(), "breaker is open")
+
+	// The slower answers from the same batch land now.
+	for range breakerRecoveries {
+		b.record("agentA", 0, nil)
+	}
+
+	g.Expect(allowed(b)).To(BeFalse(),
+		"answers from calls admitted before the breaker opened must not close it")
 }

--- a/core/artwork/worker_timing_test.go
+++ b/core/artwork/worker_timing_test.go
@@ -35,9 +35,43 @@ func TestArtworkBreakerHalfOpen(t *testing.T) {
 		time.Sleep(breakerProbeAfter)
 		g.Expect(b.allow()).To(BeTrue(), "another probe after the next interval")
 
-		b.record("agentA", nil) // probe succeeds -> close
+		// One good answer must not reopen the floodgates: closing here is what let a burst out at
+		// full rate and got the provider to escalate from throttling to blocking.
+		b.record("agentA", nil)
+		g.Expect(b.allow()).To(BeFalse(), "a single good answer does not close the breaker")
+
+		for range breakerRecoveries - 1 {
+			time.Sleep(breakerProbeAfter)
+			g.Expect(b.allow()).To(BeTrue())
+			b.record("agentA", nil)
+		}
 		g.Expect(b.allow()).To(BeTrue(), "closed breaker admits freely")
 		g.Expect(b.allow()).To(BeTrue())
+	})
+}
+
+// The failure seen in production: while an agent was blocked, the occasional answer it did serve
+// reset the breaker, releasing a burst that immediately re-tripped it. Open and closed pairs were
+// seconds apart, over and over.
+func TestArtworkBreakerDoesNotCloseOnAnIsolatedAnswer(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		g := NewWithT(t)
+		b := newBreaker()
+		open := func() {
+			for range breakerThreshold {
+				b.record("agentA", errors.New("blocked"))
+			}
+		}
+		open()
+
+		// A not-found is an answer, so it counts toward recovery, but never on its own.
+		for range breakerRecoveries * 2 {
+			time.Sleep(breakerProbeAfter)
+			g.Expect(b.allow()).To(BeTrue(), "one probe per interval")
+			b.record("agentA", agents.ErrNotFound)
+			b.record("agentA", errors.New("blocked")) // the very next call is refused again
+			g.Expect(b.allow()).To(BeFalse(), "an answer between failures must not close the breaker")
+		}
 	})
 }
 

--- a/core/artwork/worker_timing_test.go
+++ b/core/artwork/worker_timing_test.go
@@ -12,9 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// allowed drops the generation token when a test only cares about admission.
-func allowed(b *breaker) bool { ok, _ := b.allow(); return ok }
-
 // Drives the real breaker state machine with the fake clock. Plain test: testing/synctest
 // needs a *testing.T, which Ginkgo doesn't give.
 func TestArtworkBreakerHalfOpen(t *testing.T) {
@@ -115,34 +112,4 @@ func TestArtworkGatePerAgentBreakerIsolation(t *testing.T) {
 		g.Expect(err).To(MatchError(errBreakerOpen), "the probe failed, so A stays open")
 		g.Expect(aCalls).To(Equal(1))
 	})
-}
-
-// The worker drains concurrently, so when the breaker opens there are already calls past allow(),
-// queued in the rate limiter or waiting on an HTTP response. Their answers arrive afterwards.
-// Counting those as recovery closes the breaker with no probe interval elapsed, which is exactly
-// the burst the ramp exists to prevent. No fake clock: the race is an ordering, not a duration.
-func TestArtworkBreakerIgnoresAnswersAdmittedBeforeItOpened(t *testing.T) {
-	g := NewWithT(t)
-	b := newBreaker()
-
-	// A batch clears allow() while the breaker is still closed.
-	for range breakerThreshold + breakerRecoveries {
-		ok, gen := b.allow()
-		g.Expect(ok).To(BeTrue())
-		g.Expect(gen).To(BeZero(), "admitted with the breaker closed, so not a probe")
-	}
-
-	// The fast failures in that batch open it.
-	for range breakerThreshold {
-		b.record("agentA", 0, errors.New("blocked"))
-	}
-	g.Expect(allowed(b)).To(BeFalse(), "breaker is open")
-
-	// The slower answers from the same batch land now.
-	for range breakerRecoveries {
-		b.record("agentA", 0, nil)
-	}
-
-	g.Expect(allowed(b)).To(BeFalse(),
-		"answers from calls admitted before the breaker opened must not close it")
 }


### PR DESCRIPTION
### Description

The external artwork circuit breaker went from open to **fully closed** on a single non-transient response, so recovery was a burst: the agent resumed at the rate limiter's full rate until five consecutive failures reopened it. A not-found counted as that response, and a provider that is throttling or blocking still answers the occasional request, so the cycle never settled.

Found while investigating why the iTunes Search API kept answering 403 to my server long after the request rate had dropped to roughly one per minute.

Over 100 minutes with `apple-music` blocked, of 232 responses **228 were 403 and 4 were not-found** — and those four closed the breaker four times. Each close was followed by another open one to three seconds later, with about five requests in between:

```
00:59:05 closed -> 00:59:06 opened
01:23:13 closed -> 01:23:16 opened
01:41:21 closed -> 01:41:24 opened
02:38:44 closed -> 02:38:46 opened
```

So the breaker was not holding the agent at the probe rate. It was releasing a small burst every time the provider happened to answer, and every burst is a fresh provocation to a provider that is already refusing us.

Closing now requires `breakerRecoveries` consecutive answers, one per probe interval, and any failure discards the count. Recovery becomes a ramp over a few probes instead of a step.

A not-found still counts toward recovery, because the provider genuinely did answer. Making it count for nothing would be the wrong fix: an agent that simply has no data for a library would then never recover. Requiring the answers to be **consecutive** is what filters the noise — in the logs above the four not-founds were interleaved with 403s, so they would never have accumulated.

Not addressed here: `DevArtworkExternalMaxRPS` defaults to 2/sec, roughly 6x what the iTunes Search API tolerates. That is the defect that earns the first block; this one stops us re-provoking afterwards. Worth its own change.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

`core/artwork/worker_timing_test.go` drives the real breaker against synctest's fake clock:

```
go test -tags netgo,sqlite_fts5 ./core/artwork/ -run TestArtworkBreaker -v
```

- `TestArtworkBreakerHalfOpen` now asserts that one good answer does **not** close an open breaker, and that it closes after `breakerRecoveries` of them. It previously asserted the opposite, since it encoded the behaviour being fixed; its name also promised a half-open state the implementation did not have.
- `TestArtworkBreakerDoesNotCloseOnAnIsolatedAnswer` reproduces the production pattern directly: an answer followed immediately by a failure, repeatedly, must never close the breaker.

Both were checked by reverting each half of the fix separately and confirming the specs fail.

### Additional Notes

Split out of #5959 on review; it shares no files with that PR and stands alone against master.
