### PR TITLE
fix(scanner): re-resolve album artwork when only a folder's images change

### DIFF
--- a/scanner/folder_entry.go
+++ b/scanner/folder_entry.go
@@ -48,6 +48,9 @@ type folderEntry struct {
 	artists         model.Artists
 	tags            model.TagList
 	missingTracks   []*model.MediaFile
+	// DB IDs of the albums whose tracks in this folder are all unchanged. The import path
+	// enqueues no artwork for them, so a folder image change would otherwise go unnoticed.
+	keptAlbumIDs []string
 }
 
 func (f *folderEntry) hasNoFiles() bool {

--- a/scanner/phase_1_folders.go
+++ b/scanner/phase_1_folders.go
@@ -225,6 +225,7 @@ func (p *phaseFolders) processFolder(entry *folderEntry) (*folderEntry, error) {
 	// Get list of files to import, based on modtime (or all if fullScan),
 	// leave in dbTracks only tracks that are missing (not found in the FS)
 	filesToImport := make(map[string]*model.MediaFile, len(entry.audioFiles))
+	keptAlbumIDs := make(map[string]struct{})
 	for afPath, af := range entry.audioFiles {
 		fullPath := path.Join(entry.path, afPath)
 		dbTrack, foundInDB := dbTracks[fullPath]
@@ -240,6 +241,11 @@ func (p *phaseFolders) processFolder(entry *folderEntry) (*folderEntry, error) {
 			if info.ModTime().After(dbTrack.UpdatedAt) || dbTrack.Missing {
 				filesToImport[fullPath] = dbTrack
 			}
+		}
+		// Track the albums this scan leaves alone. "Unknown Album" is left out for the same
+		// reason the import path below leaves it out: it lumps unrelated tracks together.
+		if _, importing := filesToImport[fullPath]; !importing && dbTrack.Album != consts.UnknownAlbum {
+			keptAlbumIDs[dbTrack.AlbumID] = struct{}{}
 		}
 		delete(dbTracks, fullPath)
 	}
@@ -258,7 +264,13 @@ func (p *phaseFolders) processFolder(entry *folderEntry) (*folderEntry, error) {
 
 		p.createAlbumsFromMediaFiles(entry)
 		p.createArtistsFromMediaFiles(entry)
+
+		// Re-imported albums are enqueued for artwork on their own, so they are not "kept".
+		for _, album := range entry.albums {
+			delete(keptAlbumIDs, album.ID)
+		}
 	}
+	entry.keptAlbumIDs = slices.Collect(maps.Keys(keptAlbumIDs))
 
 	return entry, nil
 }
@@ -388,6 +400,16 @@ func (p *phaseFolders) persistChanges(entry *folderEntry) (*folderEntry, error) 
 					Priority: model.ArtworkPriorityScan,
 				})
 			}
+		}
+
+		// Image files are part of the folder content hash, so a folder can arrive here with
+		// new or replaced cover art and no track to import. Nothing above would ask for the
+		// artwork of these albums again. A full scan imports every track, so the list is empty.
+		for _, albumID := range entry.keptAlbumIDs {
+			queueItems = append(queueItems, model.ArtworkQueueItem{
+				ItemKind: model.KindAlbumArtwork.Prefix(), ItemID: albumID, ImageType: model.ImageTypePrimary,
+				Priority: model.ArtworkPriorityScan,
+			})
 		}
 
 		// Save all tracks to DB

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -276,6 +276,109 @@ var _ = Describe("Scanner", Ordered, func() {
 				Expect(err).To(MatchError(model.ErrNotFound))
 			})
 		})
+
+		When("a cover art file was added", func() {
+			albumID := func(name string) string {
+				GinkgoHelper()
+				albums, err := ds.Album(ctx).GetAll(model.QueryOptions{Filters: squirrel.Eq{"album.name": name}})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(albums).ToNot(BeEmpty())
+				return albums[0].ID
+			}
+
+			It("should record the new image in the folder on a quick scan", func() {
+				Expect(runScanner(ctx, true)).To(Succeed())
+
+				fsys.Add("The Beatles/Help!/cover.jpg", &fstest.MapFile{Data: []byte("cover")})
+				Expect(runScanner(ctx, false)).To(Succeed())
+
+				folders, err := ds.Folder(ctx).GetAll(model.QueryOptions{Filters: squirrel.Eq{"folder.name": "Help!"}})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(folders).To(HaveLen(1))
+				Expect(folders[0].ImageFiles).To(ConsistOf("cover.jpg"))
+			})
+
+			It("should enqueue the album artwork on a quick scan, even with no audio file changes", func() {
+				Expect(runScanner(ctx, true)).To(Succeed())
+				resolveQueuedArtwork()
+				id := albumID("Help!")
+
+				fsys.Add("The Beatles/Help!/cover.jpg", &fstest.MapFile{Data: []byte("cover")})
+				Expect(runScanner(ctx, false)).To(Succeed())
+
+				requeued, err := ds.ArtworkQueue(ctx).DequeueBatch(1000)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(requeued).To(ContainElement(SatisfyAll(
+					HaveField("ItemKind", "al"),
+					HaveField("ItemID", id),
+					HaveField("Priority", model.ArtworkPriorityScan),
+				)))
+			})
+
+			It("should enqueue the album artwork when an existing cover art file is replaced", func() {
+				fsys.Add("The Beatles/Help!/cover.jpg", &fstest.MapFile{Data: []byte("cover")})
+				Expect(runScanner(ctx, true)).To(Succeed())
+				resolveQueuedArtwork()
+				id := albumID("Help!")
+
+				fsys.Add("The Beatles/Help!/cover.jpg", &fstest.MapFile{Data: []byte("a different cover")})
+				Expect(runScanner(ctx, false)).To(Succeed())
+
+				requeued, err := ds.ArtworkQueue(ctx).DequeueBatch(1000)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(requeued).To(ContainElement(SatisfyAll(
+					HaveField("ItemKind", "al"),
+					HaveField("ItemID", id),
+				)))
+			})
+
+			It("should not enqueue the album artwork when nothing changed", func() {
+				fsys.Add("The Beatles/Help!/cover.jpg", &fstest.MapFile{Data: []byte("cover")})
+				Expect(runScanner(ctx, true)).To(Succeed())
+				Expect(resolveQueuedArtwork()).ToNot(BeEmpty())
+
+				Expect(runScanner(ctx, false)).To(Succeed())
+
+				requeued, err := ds.ArtworkQueue(ctx).DequeueBatch(1000)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(requeued).To(BeEmpty())
+			})
+		})
+	})
+
+	Context("Two albums sharing one folder", func() {
+		var fsys storagetest.FakeFS
+		BeforeEach(func() {
+			first := template(_t{"albumartist": "Various", "album": "First", "year": 2001})
+			second := template(_t{"albumartist": "Various", "album": "Second", "year": 2002})
+			fsys = createFS(fstest.MapFS{
+				"Various/Mixed/01 - One.mp3": first(track(1, "One")),
+				"Various/Mixed/02 - Two.mp3": second(track(2, "Two")),
+			})
+		})
+
+		It("should enqueue the artwork of every album in the folder, not just the re-imported one", func() {
+			Expect(runScanner(ctx, true)).To(Succeed())
+			Expect(resolveQueuedArtwork()).ToNot(BeEmpty())
+
+			albums, err := ds.Album(ctx).GetAll(model.QueryOptions{Sort: "name"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(albums).To(HaveLen(2))
+
+			// The new cover art is shared by both albums, but only one track is re-imported.
+			fsys.UpdateTags("Various/Mixed/01 - One.mp3", _t{"comment": "touched"})
+			fsys.Add("Various/Mixed/cover.jpg", &fstest.MapFile{Data: []byte("cover")})
+			Expect(runScanner(ctx, false)).To(Succeed())
+
+			requeued, err := ds.ArtworkQueue(ctx).DequeueBatch(1000)
+			Expect(err).ToNot(HaveOccurred())
+			for _, al := range albums {
+				Expect(requeued).To(ContainElement(SatisfyAll(
+					HaveField("ItemKind", "al"),
+					HaveField("ItemID", al.ID),
+				)))
+			}
+		})
 	})
 
 	Context("Artist with atomic non-ASCII letters, 'GØGGS'", func() {


### PR DESCRIPTION
### Description

A quick scan already notices new or replaced cover art, but it never asks for the album artwork to be resolved again, so the old image (or the placeholder, for an album that had no art) stays until a full scan.

**What is not the cause.** The issue suggests the folder content hash has no signal for image files. That is not the case any more: since 4483420 (v0.57.0) `folderEntry.hash()` in `scanner/folder_entry.go` mixes in every image file as `name:size:modtime`, and `scanner/folder_entry_test.go` pins that. I verified it, a quick scan does detect the folder change and does rewrite `folder.image_files` / `folder.images_updated_at`.

**What is the cause.** The second half of the work never runs, in `scanner/phase_1_folders.go`:

* `processFolder` only builds `entry.albums` / `entry.artists` inside `if len(filesToImport) > 0`.
* `persistChanges` builds its `model.ArtworkQueueItem` list solely from `entry.albums` and `entry.artists`.

Dropping a `cover.jpg` next to unchanged audio files imports nothing, so `filesToImport` is empty, `entry.albums` is empty, and no artwork re-resolution is ever enqueued. The albums keep their IDs and their existing `item_artwork` rows, so nothing changes for the user.

Nothing else covers this promptly. `openOriginal` in `core/artwork/artwork.go` has an mtime check, but it only self-heals when an existing file-backed image is replaced in place, not when a new image appears or a higher-priority filename shows up. `serveEntity` re-enqueues a settled absent row only after `requestRecheckAge` (1 hour). And `EnqueueAllMissing` skips albums that already have an `item_artwork` row, including a settled absent one.

A second, related gap fell out of the same code: in a folder holding two albums where only one track changed, only the re-imported album was enqueued, although the folder's cover art applies to both.

### The fix

* `processFolder` collects `keptAlbumIDs`, the DB album IDs of the folder's tracks that this scan is not re-importing, excluding the `consts.UnknownAlbum` bucket (mirroring the guard the import path already has), and removes any album that was re-imported anyway.
* `persistChanges` appends one `model.ArtworkQueueItem` (`KindAlbumArtwork`, `ImageTypePrimary`, `ArtworkPriorityScan`) per kept album to the same `queueItems` slice the imported albums and artists already use, so it goes through the identical `Enqueue` / `EnqueueIfMissing` selection inside the same transaction.

Full scan behavior is unchanged by construction: a full scan pushes every track into `filesToImport`, so `keptAlbumIDs` is always empty there and `EnqueueIfMissing` still applies. On a quick scan a folder only reaches this phase when its content hash changed, so the extra enqueues are bounded by folders that actually changed.

One new field, `folderEntry.keptAlbumIDs []string`. No DB schema, model, or repository changes. Diff is +128 lines over three files, no deletions.

### Related Issues

Fixes #5469

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed (no user-facing docs affected)
- [x] I have added tests that prove my fix works
- [x] All existing and new tests pass

### How to Test

```
go test -tags netgo,sqlite_fts5 ./scanner/ -count=1
```

`ok github.com/navidrome/navidrome/scanner`, 317 specs, no regressions. `core/artwork/...`, `persistence/...`, `model/...` are green as well, and `go vet -tags netgo,sqlite_fts5 ./scanner/...` is clean.

New specs in `scanner/scanner_test.go`:

* `Simple library > when a cover art file was added`
  * should record the new image in the folder on a quick scan
  * should enqueue the album artwork on a quick scan, even with no audio file changes
  * should enqueue the album artwork when an existing cover art file is replaced
  * should not enqueue the album artwork when nothing changed
* `Two albums sharing one folder > should enqueue the artwork of every album in the folder, not just the re-imported one`

Three of those fail on master and pass with the change: the two quick-scan enqueue specs and the shared-folder one. I confirmed this by reverting only `scanner/folder_entry.go` and `scanner/phase_1_folders.go` and re-running. The other two are pins for the existing hash behavior and a negative control.

Manual check: start with a library where an album has no cover file, run a scan, add `cover.jpg` to that album's folder, run a quick scan. On master the album still shows the placeholder; with this change the artwork is picked up.

### Additional Notes

Two limits I want to be upfront about, in case you would rather have a different shape:

1. **Scope.** This only enqueues albums that have tracks in the changed folder. A `cover.jpg` dropped into an album root whose tracks live in `CD1` / `CD2` subfolders (resolved at serve time by `artwork.albumRootParent`) is still not caught, because the changed folder has no tracks of its own. Same for artist images in an artist-level folder. Covering those needs a folder-tree-to-albums lookup that I left out on purpose.

2. **Precision.** The trigger is "the folder's content hash changed and these albums were not re-imported", not "an image file specifically changed". Making it exact would mean carrying the previous `image_files` / `images_updated_at` in `model.FolderUpdateInfo`, which is loaded for every folder in the library. I judged that memory cost not worth it, since the over-trigger costs one cheap local re-resolution per genuinely changed folder. One side effect worth knowing: for those albums the enqueue path resets `attempts` and `retry_at`, so an external agent's backoff for that album is cleared. Happy to switch to the precise variant if you prefer it.

