### PR TITLE
fix(playlists): keep smart playlist counters when the .nsp file is re-imported

### DIFF
--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -32,12 +32,25 @@ func (p *dbPlaylist) PostScan() error {
 	return nil
 }
 
+// playlistCounterColumns are derived from the playlist's tracks and are only ever written by
+// refreshCounters. Writing them from a model instance would zero them for smart playlists, as
+// Put does not refresh their tracks (and thus their counters). New rows fall back to the column
+// defaults (0), which refreshCounters fixes on the first evaluation.
+var playlistCounterColumns = []string{"song_count", "duration", "size"}
+
 func (p dbPlaylist) PostMapArgs(args map[string]any) error {
 	var err error
 	if p.Playlist.IsSmartPlaylist() {
 		args["rules"], err = json.Marshal(p.Playlist.Rules)
 		if err != nil {
 			return fmt.Errorf("invalid criteria expression: %w", err)
+		}
+		// Keep the counters from the last evaluation. Without this, re-importing an .nsp file
+		// (the scanner re-imports every playlist in a touched folder) would save the freshly
+		// parsed playlist with zeroed counters, showing 0 songs in the playlist list until the
+		// playlist was opened and re-evaluated.
+		for _, col := range playlistCounterColumns {
+			delete(args, col)
 		}
 		return nil
 	}

--- a/persistence/smart_playlist_repository_test.go
+++ b/persistence/smart_playlist_repository_test.go
@@ -58,6 +58,44 @@ var _ = Describe("PlaylistRepository - Smart Playlists", func() {
 			})
 		})
 
+		Context("re-imported from disk", func() {
+			// The scanner re-imports every playlist file in a touched folder, and a freshly parsed
+			// .nsp has no stats yet. Putting it must not wipe the counters of the playlist already
+			// in the DB, or the playlist list shows 0 songs until the playlist is opened again.
+			It("keeps the stored counters when a freshly parsed playlist is saved over it", func() {
+				rules = &criteria.Criteria{
+					Expression: criteria.All{
+						criteria.Contains{"title": "Antenna"},
+					},
+				}
+				pls := model.Playlist{Name: "Smart", OwnerID: "userid", Rules: rules, Path: "/music/smart.nsp", Sync: true}
+				Expect(repo.Put(&pls)).To(Succeed())
+				DeferCleanup(func() { _ = repo.Delete(pls.ID) })
+
+				// First read evaluates the criteria and stores the counters
+				evaluated, err := repo.GetWithTracks(pls.ID, true, false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(evaluated.SongCount).To(BeNumerically(">", 0))
+
+				stored, err := repo.Get(pls.ID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stored.SongCount).To(Equal(evaluated.SongCount))
+
+				// Scanner re-imports the file: same playlist, but parsed from disk, so with zeroed stats
+				reimported := model.Playlist{
+					ID: pls.ID, Name: pls.Name, OwnerID: "userid", Rules: rules,
+					Path: pls.Path, Sync: true,
+				}
+				Expect(repo.Put(&reimported)).To(Succeed())
+
+				afterImport, err := repo.Get(pls.ID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(afterImport.SongCount).To(Equal(stored.SongCount))
+				Expect(afterImport.Duration).To(Equal(stored.Duration))
+				Expect(afterImport.Size).To(Equal(stored.Size))
+			})
+		})
+
 		Context("child smart playlists", func() {
 			BeforeEach(func() {
 				DeferCleanup(configtest.SetupConfig())


### PR DESCRIPTION
Fixes #5907

## Problem

After adding a new playlist file to the playlists folder, existing smart playlists (`.nsp`) show **0 songs** in the playlist list. Opening the playlist shows all the tracks again, and from then on the list is correct until the next import.

## Root cause

The reset comes from the playlist write path, not from the evaluation itself.

1. The scanner re-imports *every* playlist file in a folder it touched (`scanner/phase_4_playlists.go`, `processPlaylistsInFolder`), so dropping one new file also re-imports the `.nsp` files that were already there. There is still an open `BFR: Check if playlist needs to be refreshed` TODO for that.
2. `core/playlists/import.go` `updatePlaylist` copies only `ID`, `Name`, `Comment`, `OwnerID`, `Public` and `UploadedImage` from the stored row onto the freshly parsed playlist, sets `EvaluatedAt = nil` and calls `Put`. The parsed playlist has never been evaluated, so its `SongCount`, `Duration` and `Size` are zero.
3. `playlistRepository.Put` writes the full row through `sqlRepository.put`, including those three derived columns, and then returns early for smart playlists (`Do not update tracks at this point...`) without calling `refreshCounters`. The zeros are persisted.
4. `GetAll` reads the stored row and never refreshes smart playlists, so the list shows 0. `GetWithTracks(..., refreshSmartPlaylist=true, ...)` runs `refreshSmartPlaylist` and `refreshCounters`, which repairs the counters, which is why opening the playlist "fixes" it.

Regular M3U playlists are unaffected because their `Put` path always ends in `updateTracks` and `refreshCounters`.

## Fix

Stop writing the derived counter columns for smart playlists. This is done in `dbPlaylist.PostMapArgs`, the hook that already tailors the write args for smart playlists (it is where `rules` is set): when the playlist is smart, `song_count`, `duration` and `size` are removed from the args map, so neither the UPDATE nor the INSERT touches them.

Those columns are then written only by `refreshCounters`, which owns the `playlist_tracks` rows they are computed from and uses a direct squirrel `UPDATE` that does not go through `PostMapArgs`. Brand new smart playlists insert with the schema defaults (`0 not null`), which the first evaluation fills in.

`evaluated_at` is still written as `NULL` on import, so the playlist is still marked for re-evaluation exactly as before. The non-smart branch is untouched.

Net effect: re-importing an `.nsp` keeps the counters from the last evaluation in the playlist list instead of resetting them to 0.

## Tests

Added to `persistence/smart_playlist_repository_test.go`:

`PlaylistRepository - Smart Playlists > Smart Playlists > re-imported from disk > keeps the stored counters when a freshly parsed playlist is saved over it`

It stores a smart playlist, reads it once with `GetWithTracks(..., true, ...)` so the counters get evaluated, then `Put`s a freshly parsed copy of the same playlist (same ID, rules and path, zeroed stats) the way the scanner does, and asserts that `SongCount`, `Duration` and `Size` are unchanged.

With only the test applied on top of master the spec fails with `Expected <int>: 0 to equal <int>: 3`; with the fix it passes.

Ran `go test -tags netgo,sqlite_fts5 ./persistence/... ./core/playlists/... ./scanner/... -count=1`, all green (`persistence`, `persistence/e2e`, `core/playlists`, `scanner`, `scanner/metadata_old`, `scanner/metadata_old/ffmpeg`). `go vet` on `./persistence/...` is clean.

## Notes / limits

- The scanner still re-imports unchanged playlist files. That was left alone on purpose, since the counter reset happened on a legitimate file change too, so it needed fixing at the write path regardless.
- A brand new `.nsp` still lists 0 until its first evaluation. That is unchanged behavior.
- If the rules in an `.nsp` legitimately change, the list shows the counts from the last evaluation until the playlist is read again. That is the same lazy behavior smart playlists already have elsewhere, and it is a smaller staleness than showing 0.

