### PR TITLE
fix(playlists): chunk track deletes to stay under the SQLite variable limit

### DIFF
--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -2,6 +2,7 @@ package persistence
 
 import (
 	"database/sql"
+	"slices"
 
 	. "github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
@@ -224,10 +225,14 @@ func (r *playlistTrackRepository) AddDiscs(discs []model.DiscID) (int, error) {
 	return r.addMediaFileIds(clauses)
 }
 
+// deleteChunkSize keeps each DELETE under SQLITE_MAX_VARIABLE_NUMBER, matching addTracks.
+const deleteChunkSize = 200
+
 func (r *playlistTrackRepository) Delete(ids ...string) error {
-	err := r.delete(And{Eq{"playlist_id": r.playlistId}, Eq{"id": ids}})
-	if err != nil {
-		return err
+	for chunk := range slices.Chunk(ids, deleteChunkSize) {
+		if err := r.delete(And{Eq{"playlist_id": r.playlistId}, Eq{"id": chunk}}); err != nil {
+			return err
+		}
 	}
 
 	return r.playlistRepo.renumber(r.playlistId)

--- a/persistence/playlist_track_repository_test.go
+++ b/persistence/playlist_track_repository_test.go
@@ -1,12 +1,17 @@
 package persistence
 
 import (
+	"strconv"
+
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+// sqliteMaxVariables is SQLITE_MAX_VARIABLE_NUMBER as compiled into the driver
+const sqliteMaxVariables = 32766
 
 var _ = Describe("PlaylistTrackRepository", func() {
 	var repo model.PlaylistTrackRepository
@@ -70,6 +75,51 @@ var _ = Describe("PlaylistTrackRepository", func() {
 		It("honors Max and Offset", func() {
 			Expect(repo.GetMediaFileIDs(model.QueryOptions{Sort: "id", Max: 1, Offset: 1})).
 				To(Equal([]string{songRadioactivity.ID}))
+		})
+	})
+
+	Describe("Delete", func() {
+		var tracks model.PlaylistTrackRepository
+		const numTracks = deleteChunkSize*2 + 1
+
+		positionsUpTo := func(n int) []string {
+			positions := make([]string, 0, n)
+			for i := 1; i <= n; i++ {
+				positions = append(positions, strconv.Itoa(i))
+			}
+			return positions
+		}
+
+		BeforeEach(func() {
+			ctx := log.NewContext(GinkgoT().Context())
+			ctx = request.WithUser(ctx, model.User{ID: "userid", UserName: "userid", IsAdmin: true})
+			plsRepo := NewPlaylistRepository(ctx, GetDBXBuilder())
+
+			pls := model.Playlist{Name: "Chunked Delete", OwnerID: "userid", OwnerName: "userid"}
+			Expect(plsRepo.Put(&pls)).To(Succeed())
+			DeferCleanup(func() { Expect(plsRepo.Delete(pls.ID)).To(Succeed()) })
+
+			tracks = plsRepo.Tracks(pls.ID, false)
+			songIds := make([]string, numTracks)
+			for i := range songIds {
+				songIds[i] = songDayInALife.ID
+			}
+			Expect(tracks.Add(songIds)).To(Equal(numTracks))
+		})
+
+		It("removes positions spanning several chunks, and renumbers what is left", func() {
+			Expect(tracks.Delete(positionsUpTo(numTracks - 1)...)).To(Succeed())
+
+			Expect(tracks.CountAll()).To(Equal(int64(1)))
+			remaining, err := tracks.GetAll(model.QueryOptions{Sort: "id"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(remaining[0].ID).To(Equal("1"), "the surviving track must be renumbered to position 1")
+		})
+
+		It("accepts more ids than SQLite allows as bind variables", func() {
+			Expect(tracks.Delete(positionsUpTo(sqliteMaxVariables + 100)...)).To(Succeed())
+
+			Expect(tracks.CountAll()).To(BeZero())
 		})
 	})
 })


### PR DESCRIPTION
### Description

`PlaylistTrackRepository.Delete` built a single `IN` clause with one bind variable per track, so removing more tracks than `SQLITE_MAX_VARIABLE_NUMBER` (32766, as compiled into go-sqlite3) failed with `too many SQL variables`. Every other bulk path in `persistence/` already chunks for exactly this reason (`addTracks` uses 200, `playqueue_repository` uses 500, `folder_repository` uses 100/200); this delete was the one that did not.

The user-visible damage is worse than a failed request. Clients that sync a large playlist by first adding the desired tracks and then removing the stale ones get the add committed (it chunks, so it succeeds) and the removal rejected, which leaves the playlist holding both sets of tracks. Every subsequent sync piles more on top. The reporter ended up with 163k tracks in a playlist that should have held 43k.

`Delete` now deletes in chunks of 200, matching `addTracks`, and calls `renumber` once after the last chunk rather than per chunk. Both callers (`Update` for the Subsonic `updatePlaylist` path, and `RemoveTracks` for the native API) already wrap this in a transaction, so the chunked delete stays atomic.

### Related Issues

Related to #1368 (same class of bug, fixed elsewhere at the time but missed in this code path).

Reported in https://github.com/navidrome/navidrome/discussions/5972.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Unit tests:

```
make test PKG=./persistence/
```

Two tests were added to `persistence/playlist_track_repository_test.go`. The second one, "accepts more ids than SQLite allows as bind variables", fails on master with `too many SQL variables`, so it is a genuine regression guard. They build and tear down their own playlist so the shared fixtures are untouched.

End to end, reproducing the reported flow. Note that removing N tracks also sends N query parameters, so Go's own 10000 parameter cap has to be lifted first, otherwise you hit that instead:

1. Start the server with `GODEBUG=urlmaxqueryparams=0`.
2. `POST /rest/createPlaylist.view` with 33000 `songId` parameters (any valid song id, repeated). Expect `status=ok`, `songCount=33000`.
3. `POST /rest/updatePlaylist.view` with that `playlistId` and `songIndexToRemove=0..32999`.
4. Expect `status=ok`, and `getPlaylist` to report `songCount=0`.

On master, step 3 returns `Internal Server Error: too many SQL variables` and the playlist still reports 33000 tracks. I ran this against two builds off this branch, one with the fix and one without:

| Step | Without fix | With fix |
| --- | --- | --- |
| `createPlaylist`, 33000 tracks | ok, 33000 | ok, 33000 |
| `updatePlaylist`, remove all | failed, `too many SQL variables` | ok |
| `songCount` after removal | 33000 | 0 |

### Additional Notes

The chunk size of 200 is copied from `addTracks` for consistency rather than tuned. It is well under the 32766 limit and leaves room if the delete ever grows more bound columns.
