### PR TITLE
fix(playlist): block track edits on synced playlists across all APIs

### DIFF
--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -130,8 +130,7 @@ func (s *playlists) Create(ctx context.Context, playlistId string, name string, 
 			if err != nil {
 				return err
 			}
-			// Ownership before editability, matching checkTracksEditable, so a non-owner gets
-			// ErrNotAuthorized rather than a read-only conflict on someone else's public playlist.
+			// Ownership first: a non-owner must get ErrNotAuthorized, not a read-only conflict.
 			if !usr.IsAdmin && pls.OwnerID != usr.ID {
 				return model.ErrNotAuthorized
 			}

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -130,11 +130,13 @@ func (s *playlists) Create(ctx context.Context, playlistId string, name string, 
 			if err != nil {
 				return err
 			}
-			if !pls.TracksEditable() {
-				return model.ErrPlaylistNotEditable
-			}
+			// Ownership before editability, matching checkTracksEditable, so a non-owner gets
+			// ErrNotAuthorized rather than a read-only conflict on someone else's public playlist.
 			if !usr.IsAdmin && pls.OwnerID != usr.ID {
 				return model.ErrNotAuthorized
+			}
+			if !pls.TracksEditable() {
+				return model.ErrPlaylistNotEditable
 			}
 		} else {
 			pls = &model.Playlist{Name: name}

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -130,7 +130,7 @@ func (s *playlists) Create(ctx context.Context, playlistId string, name string, 
 			if err != nil {
 				return err
 			}
-			if pls.IsSmartPlaylist() {
+			if !pls.TracksEditable() {
 				return model.ErrNotAuthorized
 			}
 			if !usr.IsAdmin && pls.OwnerID != usr.ID {
@@ -230,13 +230,13 @@ func (s *playlists) checkWritable(ctx context.Context, id string) (*model.Playli
 	return pls, nil
 }
 
-// checkTracksEditable verifies the user can modify tracks (ownership + not smart playlist).
+// checkTracksEditable verifies the user owns the playlist and its tracks are editable.
 func (s *playlists) checkTracksEditable(ctx context.Context, playlistID string) (*model.Playlist, error) {
 	pls, err := s.checkWritable(ctx, playlistID)
 	if err != nil {
 		return nil, err
 	}
-	if pls.IsSmartPlaylist() {
+	if !pls.TracksEditable() {
 		return nil, model.ErrNotAuthorized
 	}
 	return pls, nil

--- a/core/playlists/playlists.go
+++ b/core/playlists/playlists.go
@@ -131,7 +131,7 @@ func (s *playlists) Create(ctx context.Context, playlistId string, name string, 
 				return err
 			}
 			if !pls.TracksEditable() {
-				return model.ErrNotAuthorized
+				return model.ErrPlaylistNotEditable
 			}
 			if !usr.IsAdmin && pls.OwnerID != usr.ID {
 				return model.ErrNotAuthorized
@@ -237,7 +237,7 @@ func (s *playlists) checkTracksEditable(ctx context.Context, playlistID string) 
 		return nil, err
 	}
 	if !pls.TracksEditable() {
-		return nil, model.ErrNotAuthorized
+		return nil, model.ErrPlaylistNotEditable
 	}
 	return pls, nil
 }

--- a/core/playlists/playlists_test.go
+++ b/core/playlists/playlists_test.go
@@ -102,6 +102,7 @@ var _ = Describe("Playlists", func() {
 				"pls-2": {ID: "pls-2", Name: "Other's", OwnerID: "other-user"},
 				"pls-smart": {ID: "pls-smart", Name: "Smart", OwnerID: "user-1",
 					Rules: &criteria.Criteria{Expression: criteria.Contains{"title": "test"}}},
+				"pls-synced": {ID: "pls-synced", Name: "Synced", OwnerID: "user-1", Sync: true},
 			}
 			ps = playlists.NewPlaylists(ds, artwork.NewUploader(ds))
 		})
@@ -147,6 +148,12 @@ var _ = Describe("Playlists", func() {
 			_, err := ps.Create(ctx, "pls-smart", "", []string{"song-1"})
 			Expect(err).To(MatchError(model.ErrNotAuthorized))
 		})
+
+		It("denies replacing tracks on a synced playlist", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			_, err := ps.Create(ctx, "pls-synced", "", []string{"song-1"})
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
+		})
 	})
 
 	Describe("Update", func() {
@@ -159,6 +166,7 @@ var _ = Describe("Playlists", func() {
 				"pls-other": {ID: "pls-other", Name: "Other's", OwnerID: "other-user"},
 				"pls-smart": {ID: "pls-smart", Name: "Smart", OwnerID: "user-1",
 					Rules: &criteria.Criteria{Expression: criteria.Contains{"title": "test"}}},
+				"pls-synced": {ID: "pls-synced", Name: "Synced", OwnerID: "user-1", Sync: true},
 			}
 			mockPlsRepo.TracksRepo = mockTracks
 			ps = playlists.NewPlaylists(ds, artwork.NewUploader(ds))
@@ -205,6 +213,18 @@ var _ = Describe("Playlists", func() {
 			err := ps.Update(ctx, "pls-smart", new("Updated Smart"), nil, nil, nil, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
+
+		It("denies adding tracks to a synced playlist", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.Update(ctx, "pls-synced", nil, nil, nil, []string{"song-1"}, nil)
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
+		})
+
+		It("allows metadata updates on a synced playlist", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			err := ps.Update(ctx, "pls-synced", new("Renamed Synced"), nil, nil, nil, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Describe("AddTracks", func() {
@@ -216,7 +236,8 @@ var _ = Describe("Playlists", func() {
 				"pls-1": {ID: "pls-1", Name: "My Playlist", OwnerID: "user-1"},
 				"pls-smart": {ID: "pls-smart", Name: "Smart", OwnerID: "user-1",
 					Rules: &criteria.Criteria{Expression: criteria.Contains{"title": "test"}}},
-				"pls-other": {ID: "pls-other", Name: "Other's", OwnerID: "other-user"},
+				"pls-other":  {ID: "pls-other", Name: "Other's", OwnerID: "other-user"},
+				"pls-synced": {ID: "pls-synced", Name: "Synced", OwnerID: "user-1", Sync: true},
 			}
 			mockPlsRepo.TracksRepo = mockTracks
 			ps = playlists.NewPlaylists(ds, artwork.NewUploader(ds))
@@ -246,6 +267,12 @@ var _ = Describe("Playlists", func() {
 		It("denies editing smart playlists", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			_, err := ps.AddTracks(ctx, "pls-smart", []string{"song-1"})
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
+		})
+
+		It("denies editing synced playlists", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			_, err := ps.AddTracks(ctx, "pls-synced", []string{"song-1"})
 			Expect(err).To(MatchError(model.ErrNotAuthorized))
 		})
 

--- a/core/playlists/playlists_test.go
+++ b/core/playlists/playlists_test.go
@@ -146,13 +146,13 @@ var _ = Describe("Playlists", func() {
 		It("denies replacing tracks on a smart playlist", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			_, err := ps.Create(ctx, "pls-smart", "", []string{"song-1"})
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 
 		It("denies replacing tracks on a synced playlist", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			_, err := ps.Create(ctx, "pls-synced", "", []string{"song-1"})
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 	})
 
@@ -199,13 +199,13 @@ var _ = Describe("Playlists", func() {
 		It("denies adding tracks to a smart playlist", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.Update(ctx, "pls-smart", nil, nil, nil, []string{"song-1"}, nil)
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 
 		It("denies removing tracks from a smart playlist", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.Update(ctx, "pls-smart", nil, nil, nil, nil, []int{0})
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 
 		It("allows metadata updates on a smart playlist", func() {
@@ -217,7 +217,7 @@ var _ = Describe("Playlists", func() {
 		It("denies adding tracks to a synced playlist", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.Update(ctx, "pls-synced", nil, nil, nil, []string{"song-1"}, nil)
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 
 		It("allows metadata updates on a synced playlist", func() {
@@ -267,13 +267,13 @@ var _ = Describe("Playlists", func() {
 		It("denies editing smart playlists", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			_, err := ps.AddTracks(ctx, "pls-smart", []string{"song-1"})
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 
 		It("denies editing synced playlists", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			_, err := ps.AddTracks(ctx, "pls-synced", []string{"song-1"})
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 
 		It("returns error when playlist not found", func() {
@@ -307,7 +307,7 @@ var _ = Describe("Playlists", func() {
 		It("denies on smart playlist", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.RemoveTracks(ctx, "pls-smart", []string{"track-1"})
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 
 		It("denies non-owner", func() {
@@ -341,7 +341,7 @@ var _ = Describe("Playlists", func() {
 		It("denies on smart playlist", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			err := ps.ReorderTrack(ctx, "pls-smart", 1, 3)
-			Expect(err).To(MatchError(model.ErrNotAuthorized))
+			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
 		})
 	})
 

--- a/core/playlists/playlists_test.go
+++ b/core/playlists/playlists_test.go
@@ -102,7 +102,8 @@ var _ = Describe("Playlists", func() {
 				"pls-2": {ID: "pls-2", Name: "Other's", OwnerID: "other-user"},
 				"pls-smart": {ID: "pls-smart", Name: "Smart", OwnerID: "user-1",
 					Rules: &criteria.Criteria{Expression: criteria.Contains{"title": "test"}}},
-				"pls-synced": {ID: "pls-synced", Name: "Synced", OwnerID: "user-1", Sync: true},
+				"pls-synced":       {ID: "pls-synced", Name: "Synced", OwnerID: "user-1", Sync: true},
+				"pls-synced-other": {ID: "pls-synced-other", Name: "Other's Synced", OwnerID: "other-user", Sync: true, Public: true},
 			}
 			ps = playlists.NewPlaylists(ds, artwork.NewUploader(ds))
 		})
@@ -153,6 +154,12 @@ var _ = Describe("Playlists", func() {
 			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
 			_, err := ps.Create(ctx, "pls-synced", "", []string{"song-1"})
 			Expect(err).To(MatchError(model.ErrPlaylistNotEditable))
+		})
+
+		It("denies a non-owner with authorization, not a conflict, on a public synced playlist", func() {
+			ctx = request.WithUser(ctx, model.User{ID: "user-1", IsAdmin: false})
+			_, err := ps.Create(ctx, "pls-synced-other", "", []string{"song-1"})
+			Expect(err).To(MatchError(model.ErrNotAuthorized))
 		})
 	})
 

--- a/model/errors.go
+++ b/model/errors.go
@@ -10,7 +10,6 @@ var (
 	ErrNotAvailable  = errors.New("functionality not available")
 	ErrValidation    = errors.New("validation error")
 
-	// ErrPlaylistNotEditable means the playlist's tracks are managed automatically
-	// (smart playlist rules, or a synced file) and cannot be modified by a user.
+	// ErrPlaylistNotEditable: tracks are server-managed, so nobody can edit them (not an ACL failure).
 	ErrPlaylistNotEditable = errors.New("playlist tracks are not editable")
 )

--- a/model/errors.go
+++ b/model/errors.go
@@ -9,4 +9,8 @@ var (
 	ErrExpired       = errors.New("access expired")
 	ErrNotAvailable  = errors.New("functionality not available")
 	ErrValidation    = errors.New("validation error")
+
+	// ErrPlaylistNotEditable means the playlist's tracks are managed automatically
+	// (smart playlist rules, or a synced file) and cannot be modified by a user.
+	ErrPlaylistNotEditable = errors.New("playlist tracks are not editable")
 )

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -42,8 +42,7 @@ func (pls Playlist) IsSmartPlaylist() bool {
 	return pls.Rules != nil && pls.Rules.Expression != nil
 }
 
-// TracksEditable reports whether a user may modify the track list: false for smart
-// playlists (tracks come from rules) and synced playlists (tracks come from the file).
+// TracksEditable reports whether the track list is user-owned rather than server-managed.
 func (pls Playlist) TracksEditable() bool {
 	return !pls.IsSmartPlaylist() && !pls.Sync
 }

--- a/model/playlist.go
+++ b/model/playlist.go
@@ -42,6 +42,12 @@ func (pls Playlist) IsSmartPlaylist() bool {
 	return pls.Rules != nil && pls.Rules.Expression != nil
 }
 
+// TracksEditable reports whether a user may modify the track list: false for smart
+// playlists (tracks come from rules) and synced playlists (tracks come from the file).
+func (pls Playlist) TracksEditable() bool {
+	return !pls.IsSmartPlaylist() && !pls.Sync
+}
+
 // RefreshDelay returns the playlist's own refresh window when set, falling
 // back to the global SmartPlaylistRefreshDelay.
 func (pls Playlist) RefreshDelay() time.Duration {

--- a/model/playlist_test.go
+++ b/model/playlist_test.go
@@ -73,4 +73,19 @@ var _ = Describe("Playlist", func() {
 			Expect(pls.RefreshDelay()).To(Equal(5 * time.Second))
 		})
 	})
+
+	Describe("TracksEditable", func() {
+		It("is true for a plain playlist", func() {
+			Expect(model.Playlist{}.TracksEditable()).To(BeTrue())
+		})
+
+		It("is false for a smart playlist", func() {
+			pls := model.Playlist{Rules: &criteria.Criteria{Expression: criteria.Is{"loved": true}}}
+			Expect(pls.TracksEditable()).To(BeFalse())
+		})
+
+		It("is false for a synced playlist", func() {
+			Expect(model.Playlist{Sync: true}.TracksEditable()).To(BeFalse())
+		})
+	})
 })

--- a/server/jellyfin/playlists.go
+++ b/server/jellyfin/playlists.go
@@ -319,14 +319,35 @@ func (api *Router) removeFromPlaylist(w http.ResponseWriter, r *http.Request) {
 }
 
 // getPlaylistUsers and getPlaylistUser answer client probes (e.g. Finamp) made before allowing
-// edits. Navidrome has no per-playlist ACL, so every user is reported CanEdit; ownership is still
-// enforced by AddTracks/RemoveTracks.
+// edits. Navidrome has no per-playlist ACL, so CanEdit reflects only whether the playlist's tracks
+// are editable (false for smart/synced); ownership is still enforced by AddTracks/RemoveTracks. Any
+// lookup error maps to 404 so private playlists can't be probed.
 func (api *Router) getPlaylistUsers(w http.ResponseWriter, r *http.Request) {
-	u, _ := request.UserFrom(r.Context())
-	api.ok(w, r, []dto.PlaylistUserPermissions{{UserId: dto.EncodeID(u.ID), CanEdit: true}})
+	ctx := r.Context()
+	id, ok := itemIDParam(w, r, "playlistId")
+	if !ok {
+		return
+	}
+	pls, err := api.playlists.Get(ctx, id)
+	if err != nil {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+	u, _ := request.UserFrom(ctx)
+	api.ok(w, r, []dto.PlaylistUserPermissions{{UserId: dto.EncodeID(u.ID), CanEdit: pls.TracksEditable()}})
 }
 
 func (api *Router) getPlaylistUser(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id, ok := itemIDParam(w, r, "playlistId")
+	if !ok {
+		return
+	}
+	pls, err := api.playlists.Get(ctx, id)
+	if err != nil {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
 	userId := chi.URLParam(r, "userId")
-	api.ok(w, r, dto.PlaylistUserPermissions{UserId: userId, CanEdit: true})
+	api.ok(w, r, dto.PlaylistUserPermissions{UserId: userId, CanEdit: pls.TracksEditable()})
 }

--- a/server/jellyfin/playlists.go
+++ b/server/jellyfin/playlists.go
@@ -264,7 +264,7 @@ func (api *Router) songIDs(ctx context.Context, opts model.QueryOptions) []strin
 }
 
 // addToPlaylist appends items by id, expanding containers into tracks (see expandContainerIDs).
-// AddTracks enforces ownership; any error maps to 404.
+// AddTracks enforces ownership; a locked (synced/smart) playlist maps to 409, any other error to 404.
 func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, ok := itemIDParam(w, r, "playlistId")
@@ -278,6 +278,10 @@ func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 	}
 	ids := api.expandContainerIDs(ctx, decoded)
 	if _, err := api.playlists.AddTracks(ctx, id, ids); err != nil {
+		if errors.Is(err, model.ErrPlaylistNotEditable) {
+			http.Error(w, "Conflict", http.StatusConflict)
+			return
+		}
 		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}
@@ -286,7 +290,7 @@ func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 
 // removeFromPlaylist removes entries by entryIds — playlist-entry ids (PlaylistItemId), not media
 // file ids, since RemoveTracks deletes playlist_tracks rows by that id. RemoveTracks enforces
-// ownership; any error maps to 404.
+// ownership; a locked (synced/smart) playlist maps to 409, any other error to 404.
 func (api *Router) removeFromPlaylist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, ok := itemIDParam(w, r, "playlistId")
@@ -304,6 +308,10 @@ func (api *Router) removeFromPlaylist(w http.ResponseWriter, r *http.Request) {
 		ids = append(ids, entry)
 	}
 	if err := api.playlists.RemoveTracks(ctx, id, ids); err != nil {
+		if errors.Is(err, model.ErrPlaylistNotEditable) {
+			http.Error(w, "Conflict", http.StatusConflict)
+			return
+		}
 		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}

--- a/server/jellyfin/playlists.go
+++ b/server/jellyfin/playlists.go
@@ -30,13 +30,12 @@ func playlistsFolder() dto.BaseItemDto {
 }
 
 // playlistError maps core/playlists write errors to HTTP status: ownership -> 403, missing/invisible
-// -> 404 (never revealing another user's private playlist), else -> 500.
+// -> 404 (never revealing another user's private playlist), else -> 500. A locked playlist is also
+// 403, matching Jellyfin, which refuses edits on its own file-backed playlists with Forbid().
 func (api *Router) playlistError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
-	case errors.Is(err, model.ErrNotAuthorized):
+	case errors.Is(err, model.ErrNotAuthorized), errors.Is(err, model.ErrPlaylistNotEditable):
 		http.Error(w, "Forbidden", http.StatusForbidden)
-	case errors.Is(err, model.ErrPlaylistNotEditable):
-		http.Error(w, "Conflict", http.StatusConflict)
 	case errors.Is(err, model.ErrNotFound):
 		http.Error(w, "Not Found", http.StatusNotFound)
 	default:
@@ -264,7 +263,8 @@ func (api *Router) songIDs(ctx context.Context, opts model.QueryOptions) []strin
 }
 
 // addToPlaylist appends items by id, expanding containers into tracks (see expandContainerIDs).
-// AddTracks enforces ownership; a locked (synced/smart) playlist maps to 409, any other error to 404.
+// AddTracks enforces ownership; a locked (synced/smart) playlist maps to 403 like Jellyfin, any
+// other error to 404.
 func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, ok := itemIDParam(w, r, "playlistId")
@@ -279,7 +279,7 @@ func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 	ids := api.expandContainerIDs(ctx, decoded)
 	if _, err := api.playlists.AddTracks(ctx, id, ids); err != nil {
 		if errors.Is(err, model.ErrPlaylistNotEditable) {
-			http.Error(w, "Conflict", http.StatusConflict)
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
 		http.Error(w, "Not Found", http.StatusNotFound)
@@ -290,7 +290,7 @@ func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 
 // removeFromPlaylist removes entries by entryIds — playlist-entry ids (PlaylistItemId), not media
 // file ids, since RemoveTracks deletes playlist_tracks rows by that id. RemoveTracks enforces
-// ownership; a locked (synced/smart) playlist maps to 409, any other error to 404.
+// ownership; a locked (synced/smart) playlist maps to 403 like Jellyfin, any other error to 404.
 func (api *Router) removeFromPlaylist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, ok := itemIDParam(w, r, "playlistId")
@@ -309,7 +309,7 @@ func (api *Router) removeFromPlaylist(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := api.playlists.RemoveTracks(ctx, id, ids); err != nil {
 		if errors.Is(err, model.ErrPlaylistNotEditable) {
-			http.Error(w, "Conflict", http.StatusConflict)
+			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
 		http.Error(w, "Not Found", http.StatusNotFound)

--- a/server/jellyfin/playlists.go
+++ b/server/jellyfin/playlists.go
@@ -35,6 +35,8 @@ func (api *Router) playlistError(w http.ResponseWriter, r *http.Request, err err
 	switch {
 	case errors.Is(err, model.ErrNotAuthorized):
 		http.Error(w, "Forbidden", http.StatusForbidden)
+	case errors.Is(err, model.ErrPlaylistNotEditable):
+		http.Error(w, "Conflict", http.StatusConflict)
 	case errors.Is(err, model.ErrNotFound):
 		http.Error(w, "Not Found", http.StatusNotFound)
 	default:

--- a/server/jellyfin/playlists.go
+++ b/server/jellyfin/playlists.go
@@ -29,9 +29,8 @@ func playlistsFolder() dto.BaseItemDto {
 	}
 }
 
-// playlistError maps core/playlists write errors to HTTP status: ownership -> 403, missing/invisible
-// -> 404 (never revealing another user's private playlist), else -> 500. A locked playlist is also
-// 403, matching Jellyfin, which refuses edits on its own file-backed playlists with Forbid().
+// playlistError maps core/playlists write errors to HTTP status: ownership or locked -> 403,
+// missing/invisible -> 404 (never revealing another user's private playlist), else -> 500.
 func (api *Router) playlistError(w http.ResponseWriter, r *http.Request, err error) {
 	switch {
 	case errors.Is(err, model.ErrNotAuthorized), errors.Is(err, model.ErrPlaylistNotEditable):
@@ -263,8 +262,7 @@ func (api *Router) songIDs(ctx context.Context, opts model.QueryOptions) []strin
 }
 
 // addToPlaylist appends items by id, expanding containers into tracks (see expandContainerIDs).
-// AddTracks enforces ownership; a locked (synced/smart) playlist maps to 403 like Jellyfin, any
-// other error to 404.
+// AddTracks enforces ownership; a locked playlist maps to 403, any other error to 404.
 func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, ok := itemIDParam(w, r, "playlistId")
@@ -290,7 +288,7 @@ func (api *Router) addToPlaylist(w http.ResponseWriter, r *http.Request) {
 
 // removeFromPlaylist removes entries by entryIds — playlist-entry ids (PlaylistItemId), not media
 // file ids, since RemoveTracks deletes playlist_tracks rows by that id. RemoveTracks enforces
-// ownership; a locked (synced/smart) playlist maps to 403 like Jellyfin, any other error to 404.
+// ownership; a locked playlist maps to 403, any other error to 404.
 func (api *Router) removeFromPlaylist(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, ok := itemIDParam(w, r, "playlistId")
@@ -318,10 +316,8 @@ func (api *Router) removeFromPlaylist(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-// getPlaylistUsers and getPlaylistUser answer client probes (e.g. Finamp) made before allowing
-// edits. Navidrome has no per-playlist ACL, so CanEdit reflects only whether the playlist's tracks
-// are editable (false for smart/synced); ownership is still enforced by AddTracks/RemoveTracks. Any
-// lookup error maps to 404 so private playlists can't be probed.
+// Clients probe these before offering edits. Navidrome has no per-playlist ACL, so CanEdit carries
+// only editability; ownership is enforced on write, and a lookup error 404s to prevent probing.
 func (api *Router) getPlaylistUsers(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 	id, ok := itemIDParam(w, r, "playlistId")

--- a/server/jellyfin/playlists_test.go
+++ b/server/jellyfin/playlists_test.go
@@ -381,6 +381,15 @@ var _ = Describe("Playlists", func() {
 			Expect(w.Code).To(Equal(http.StatusNotFound))
 		})
 
+		It("returns 409 when the playlist is not editable (synced/smart)", func() {
+			fp.addErr = model.ErrPlaylistNotEditable
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("POST", "/Playlists/"+dto.EncodeID(testID("pl1"))+"/Items?ids="+dto.EncodeID(testID("s1")), nil).WithContext(context.Background())
+			r = withChiURLParam(r, "playlistId", dto.EncodeID(testID("pl1")))
+			invoke(api.addToPlaylist, w, r)
+			Expect(w.Code).To(Equal(http.StatusConflict))
+		})
+
 		It("passes no ids (not a spurious empty string) when the ids param is absent", func() {
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("POST", "/Playlists/"+dto.EncodeID(testID("pl1"))+"/Items", nil).WithContext(context.Background())
@@ -428,6 +437,15 @@ var _ = Describe("Playlists", func() {
 			r = withChiURLParam(r, "playlistId", dto.EncodeID(testID("pl1")))
 			invoke(api.removeFromPlaylist, w, r)
 			Expect(w.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("returns 409 when the playlist is not editable (synced/smart)", func() {
+			fp.removeErr = model.ErrPlaylistNotEditable
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("DELETE", "/Playlists/"+dto.EncodeID(testID("pl1"))+"/Items?entryIds="+dto.EncodePlaylistEntryID("1"), nil).WithContext(context.Background())
+			r = withChiURLParam(r, "playlistId", dto.EncodeID(testID("pl1")))
+			invoke(api.removeFromPlaylist, w, r)
+			Expect(w.Code).To(Equal(http.StatusConflict))
 		})
 
 		It("passes no ids (not a spurious empty string) when the entryIds param is absent", func() {

--- a/server/jellyfin/playlists_test.go
+++ b/server/jellyfin/playlists_test.go
@@ -381,13 +381,13 @@ var _ = Describe("Playlists", func() {
 			Expect(w.Code).To(Equal(http.StatusNotFound))
 		})
 
-		It("returns 409 when the playlist is not editable (synced/smart)", func() {
+		It("returns 403 when the playlist is not editable (synced/smart), like Jellyfin", func() {
 			fp.addErr = model.ErrPlaylistNotEditable
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("POST", "/Playlists/"+dto.EncodeID(testID("pl1"))+"/Items?ids="+dto.EncodeID(testID("s1")), nil).WithContext(context.Background())
 			r = withChiURLParam(r, "playlistId", dto.EncodeID(testID("pl1")))
 			invoke(api.addToPlaylist, w, r)
-			Expect(w.Code).To(Equal(http.StatusConflict))
+			Expect(w.Code).To(Equal(http.StatusForbidden))
 		})
 
 		It("passes no ids (not a spurious empty string) when the ids param is absent", func() {
@@ -439,13 +439,13 @@ var _ = Describe("Playlists", func() {
 			Expect(w.Code).To(Equal(http.StatusNotFound))
 		})
 
-		It("returns 409 when the playlist is not editable (synced/smart)", func() {
+		It("returns 403 when the playlist is not editable (synced/smart), like Jellyfin", func() {
 			fp.removeErr = model.ErrPlaylistNotEditable
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("DELETE", "/Playlists/"+dto.EncodeID(testID("pl1"))+"/Items?entryIds="+dto.EncodePlaylistEntryID("1"), nil).WithContext(context.Background())
 			r = withChiURLParam(r, "playlistId", dto.EncodeID(testID("pl1")))
 			invoke(api.removeFromPlaylist, w, r)
-			Expect(w.Code).To(Equal(http.StatusConflict))
+			Expect(w.Code).To(Equal(http.StatusForbidden))
 		})
 
 		It("passes no ids (not a spurious empty string) when the entryIds param is absent", func() {

--- a/server/jellyfin/playlists_test.go
+++ b/server/jellyfin/playlists_test.go
@@ -460,7 +460,8 @@ var _ = Describe("Playlists", func() {
 	})
 
 	Describe("getPlaylistUsers", func() {
-		It("returns the current user with CanEdit true", func() {
+		It("returns the current user with CanEdit true for an editable playlist", func() {
+			fp.getByIDPls = &model.Playlist{ID: testID("pl1")}
 			w := httptest.NewRecorder()
 			ctx := request.WithUser(context.Background(), model.User{ID: testID("u1"), UserName: "alice"})
 			r := httptest.NewRequest("GET", "/Playlists/"+testID("pl1")+"/Users", nil).WithContext(ctx)
@@ -471,21 +472,59 @@ var _ = Describe("Playlists", func() {
 			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
 			Expect(res).To(Equal([]dto.PlaylistUserPermissions{{UserId: dto.EncodeID(testID("u1")), CanEdit: true}}))
 		})
+
+		It("reports CanEdit false for a synced playlist", func() {
+			fp.getByIDPls = &model.Playlist{ID: testID("pl1"), Sync: true}
+			w := httptest.NewRecorder()
+			ctx := request.WithUser(context.Background(), model.User{ID: testID("u1"), UserName: "alice"})
+			r := httptest.NewRequest("GET", "/Playlists/"+testID("pl1")+"/Users", nil).WithContext(ctx)
+			r = withChiURLParam(r, "playlistId", dto.EncodeID(testID("pl1")))
+			api.getPlaylistUsers(w, r)
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res []dto.PlaylistUserPermissions
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res[0].CanEdit).To(BeFalse())
+		})
+
+		It("returns 404 when the playlist is not visible", func() {
+			fp.getByIDErr = model.ErrNotFound
+			w := httptest.NewRecorder()
+			ctx := request.WithUser(context.Background(), model.User{ID: testID("u1"), UserName: "alice"})
+			r := httptest.NewRequest("GET", "/Playlists/"+testID("pl1")+"/Users", nil).WithContext(ctx)
+			r = withChiURLParam(r, "playlistId", dto.EncodeID(testID("pl1")))
+			api.getPlaylistUsers(w, r)
+			Expect(w.Code).To(Equal(http.StatusNotFound))
+		})
 	})
 
 	Describe("getPlaylistUser", func() {
-		It("returns CanEdit true for the requested user", func() {
+		requestUser := func() *httptest.ResponseRecorder {
 			w := httptest.NewRecorder()
 			r := httptest.NewRequest("GET", "/Playlists/"+testID("pl1")+"/Users/"+testID("u1"), nil).WithContext(context.Background())
 			rctx := chi.NewRouteContext()
-			rctx.URLParams.Add("playlistId", testID("pl1"))
+			rctx.URLParams.Add("playlistId", dto.EncodeID(testID("pl1")))
 			rctx.URLParams.Add("userId", testID("u1"))
 			r = r.WithContext(context.WithValue(r.Context(), chi.RouteCtxKey, rctx))
 			api.getPlaylistUser(w, r)
+			return w
+		}
+
+		It("returns CanEdit true for an editable playlist", func() {
+			fp.getByIDPls = &model.Playlist{ID: testID("pl1")}
+			w := requestUser()
 			Expect(w.Code).To(Equal(http.StatusOK))
 			var res dto.PlaylistUserPermissions
 			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
 			Expect(res).To(Equal(dto.PlaylistUserPermissions{UserId: testID("u1"), CanEdit: true}))
+		})
+
+		It("reports CanEdit false for a synced playlist", func() {
+			fp.getByIDPls = &model.Playlist{ID: testID("pl1"), Sync: true}
+			w := requestUser()
+			Expect(w.Code).To(Equal(http.StatusOK))
+			var res dto.PlaylistUserPermissions
+			Expect(json.Unmarshal(w.Body.Bytes(), &res)).To(Succeed())
+			Expect(res.CanEdit).To(BeFalse())
 		})
 	})
 })

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -20,6 +20,21 @@ import (
 
 type restHandler = func(rest.RepositoryConstructor, ...rest.Logger) http.HandlerFunc
 
+// writePlaylistError maps a playlist service error to an HTTP status. defaultStatus
+// is used for errors that aren't one of the recognized sentinels.
+func writePlaylistError(w http.ResponseWriter, err error, defaultStatus int) {
+	switch {
+	case errors.Is(err, model.ErrNotFound):
+		http.Error(w, err.Error(), http.StatusNotFound)
+	case errors.Is(err, model.ErrNotAuthorized):
+		http.Error(w, err.Error(), http.StatusForbidden)
+	case errors.Is(err, model.ErrPlaylistNotEditable):
+		http.Error(w, err.Error(), http.StatusConflict)
+	default:
+		http.Error(w, err.Error(), defaultStatus)
+	}
+}
+
 func playlistTracksHandler(pls playlists.Playlists, handler restHandler, refreshSmartPlaylist func(*http.Request) bool) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		plsId := chi.URLParam(r, "playlistId")
@@ -111,7 +126,7 @@ func deleteFromPlaylist(pls playlists.Playlists) http.HandlerFunc {
 		}
 		if err != nil {
 			log.Error(r.Context(), "Error deleting tracks from playlist", "playlistId", playlistId, "ids", ids, err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			writePlaylistError(w, err, http.StatusInternalServerError)
 			return
 		}
 		writeDeleteManyResponse(w, r, ids)
@@ -138,22 +153,22 @@ func addToPlaylist(pls playlists.Playlists) http.HandlerFunc {
 		}
 		count, c := 0, 0
 		if c, err = pls.AddTracks(ctx, playlistId, payload.Ids); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			writePlaylistError(w, err, http.StatusBadRequest)
 			return
 		}
 		count += c
 		if c, err = pls.AddAlbums(ctx, playlistId, payload.AlbumIds); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			writePlaylistError(w, err, http.StatusBadRequest)
 			return
 		}
 		count += c
 		if c, err = pls.AddArtists(ctx, playlistId, payload.ArtistIds); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			writePlaylistError(w, err, http.StatusBadRequest)
 			return
 		}
 		count += c
 		if c, err = pls.AddDiscs(ctx, playlistId, payload.Discs); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			writePlaylistError(w, err, http.StatusBadRequest)
 			return
 		}
 		count += c
@@ -192,12 +207,8 @@ func reorderItem(pls playlists.Playlists) http.HandlerFunc {
 			return
 		}
 		err = pls.ReorderTrack(ctx, playlistId, id, newPos)
-		if errors.Is(err, model.ErrNotAuthorized) {
-			http.Error(w, err.Error(), http.StatusForbidden)
-			return
-		}
 		if err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			writePlaylistError(w, err, http.StatusBadRequest)
 			return
 		}
 

--- a/server/nativeapi/playlists.go
+++ b/server/nativeapi/playlists.go
@@ -20,8 +20,7 @@ import (
 
 type restHandler = func(rest.RepositoryConstructor, ...rest.Logger) http.HandlerFunc
 
-// writePlaylistError maps a playlist service error to an HTTP status. defaultStatus
-// is used for errors that aren't one of the recognized sentinels.
+// writePlaylistError maps a playlist service error to an HTTP status, or defaultStatus if unknown.
 func writePlaylistError(w http.ResponseWriter, err error, defaultStatus int) {
 	switch {
 	case errors.Is(err, model.ErrNotFound):

--- a/server/nativeapi/playlists_test.go
+++ b/server/nativeapi/playlists_test.go
@@ -183,6 +183,20 @@ var _ = Describe("Playlist Tracks Endpoint", func() {
 	})
 })
 
+var _ = Describe("writePlaylistError", func() {
+	DescribeTable("maps a service error to an HTTP status",
+		func(err error, expected int) {
+			w := httptest.NewRecorder()
+			writePlaylistError(w, err, http.StatusBadRequest)
+			Expect(w.Code).To(Equal(expected))
+		},
+		Entry("not found -> 404", model.ErrNotFound, http.StatusNotFound),
+		Entry("not authorized -> 403", model.ErrNotAuthorized, http.StatusForbidden),
+		Entry("not editable -> 409", model.ErrPlaylistNotEditable, http.StatusConflict),
+		Entry("unrecognized -> default", model.ErrValidation, http.StatusBadRequest),
+	)
+})
+
 type mockPlaylistTrackRepo struct {
 	model.PlaylistTrackRepository
 	tracks model.PlaylistTracks

--- a/server/subsonic/api.go
+++ b/server/subsonic/api.go
@@ -304,7 +304,8 @@ func mapToSubsonicError(err error) subError {
 		err = newError(responses.ErrorGeneric, err.Error())
 	case errors.Is(err, model.ErrNotFound), errors.Is(err, rest.ErrNotFound):
 		err = newError(responses.ErrorDataNotFound, "data not found")
-	case errors.Is(err, model.ErrNotAuthorized), errors.Is(err, rest.ErrPermissionDenied):
+	case errors.Is(err, model.ErrNotAuthorized), errors.Is(err, rest.ErrPermissionDenied),
+		errors.Is(err, model.ErrPlaylistNotEditable): // Subsonic has no code for "read-only resource"
 		err = newError(responses.ErrorAuthorizationFail)
 	case errors.Is(err, stream.ErrTooManyTranscodes):
 		err = newError(responses.ErrorGeneric, "too many concurrent transcodes, please retry shortly")

--- a/server/subsonic/playlists.go
+++ b/server/subsonic/playlists.go
@@ -172,7 +172,7 @@ func buildOSPlaylist(ctx context.Context, p model.Playlist) *responses.OpenSubso
 		}
 	} else {
 		user, ok := request.UserFrom(ctx)
-		pls.Readonly = !ok || p.OwnerID != user.ID
+		pls.Readonly = !ok || p.OwnerID != user.ID || !p.TracksEditable()
 	}
 
 	return &pls

--- a/server/subsonic/playlists_test.go
+++ b/server/subsonic/playlists_test.go
@@ -111,6 +111,15 @@ var _ = Describe("buildPlaylist", func() {
 				Expect(result.Public).To(BeTrue())
 				Expect(result.Readonly).To(BeFalse())
 			})
+
+			It("is read-only for a synced playlist even as owner", func() {
+				ctx = request.WithUser(ctx, model.User{ID: "1234", UserName: "admin"})
+				playlist.Sync = true
+
+				result := router.buildPlaylist(ctx, playlist)
+
+				Expect(result.Readonly).To(BeTrue())
+			})
 		})
 
 		Context("when minimal clients list is empty", func() {

--- a/ui/src/common/playlistUtils.js
+++ b/ui/src/common/playlistUtils.js
@@ -12,4 +12,4 @@ export const isReadOnly = (ownerId) => {
 export const isSmartPlaylist = (pls) => !!pls.rules
 
 export const canChangeTracks = (pls) =>
-  isWritable(pls.ownerId) && !isSmartPlaylist(pls)
+  isWritable(pls.ownerId) && !isSmartPlaylist(pls) && !pls.sync

--- a/ui/src/common/playlistUtils.test.js
+++ b/ui/src/common/playlistUtils.test.js
@@ -74,5 +74,11 @@ describe('playlistUtils', () => {
       const playlist = { ownerId: 'user1', rules: [] }
       expect(canChangeTracks(playlist)).toBe(false)
     })
+
+    it('returns false if playlist is synced', () => {
+      localStorage.setItem('userId', 'user1')
+      const playlist = { ownerId: 'user1', sync: true }
+      expect(canChangeTracks(playlist)).toBe(false)
+    })
   })
 })

--- a/ui/src/dialogs/SelectPlaylistInput.jsx
+++ b/ui/src/dialogs/SelectPlaylistInput.jsx
@@ -16,7 +16,7 @@ import {
 import AddIcon from '@material-ui/icons/Add'
 import { useGetList, useTranslate } from 'react-admin'
 import PropTypes from 'prop-types'
-import { isWritable } from '../common'
+import { canChangeTracks } from '../common'
 import { makeStyles } from '@material-ui/core'
 
 const useStyles = makeStyles((theme) => ({
@@ -268,8 +268,7 @@ export const SelectPlaylistInput = ({ onChange }) => {
   )
 
   const options =
-    ids &&
-    ids.map((id) => data[id]).filter((option) => isWritable(option.ownerId))
+    ids && ids.map((id) => data[id]).filter((option) => canChangeTracks(option))
 
   // Filter playlists based on search text
   const filteredOptions =

--- a/ui/src/dialogs/SelectPlaylistInput.test.jsx
+++ b/ui/src/dialogs/SelectPlaylistInput.test.jsx
@@ -16,7 +16,7 @@ const mockPlaylists = [
   { id: 'playlist-2', name: 'Jazz Collection', ownerId: 'admin' },
   { id: 'playlist-3', name: 'Electronic Beats', ownerId: 'admin' },
   { id: 'playlist-4', name: 'Chill Vibes', ownerId: 'user2' }, // Not writable by admin
-  { id: 'playlist-5', name: 'Synced List', ownerId: 'admin', sync: true }, // Synced: tracks not editable
+  { id: 'playlist-5', name: 'Synced List', ownerId: 'admin', sync: true },
 ]
 
 const mockIndexedData = {

--- a/ui/src/dialogs/SelectPlaylistInput.test.jsx
+++ b/ui/src/dialogs/SelectPlaylistInput.test.jsx
@@ -16,6 +16,7 @@ const mockPlaylists = [
   { id: 'playlist-2', name: 'Jazz Collection', ownerId: 'admin' },
   { id: 'playlist-3', name: 'Electronic Beats', ownerId: 'admin' },
   { id: 'playlist-4', name: 'Chill Vibes', ownerId: 'user2' }, // Not writable by admin
+  { id: 'playlist-5', name: 'Synced List', ownerId: 'admin', sync: true }, // Synced: tracks not editable
 ]
 
 const mockIndexedData = {
@@ -27,6 +28,12 @@ const mockIndexedData = {
     ownerId: 'admin',
   },
   'playlist-4': { id: 'playlist-4', name: 'Chill Vibes', ownerId: 'user2' },
+  'playlist-5': {
+    id: 'playlist-5',
+    name: 'Synced List',
+    ownerId: 'admin',
+    sync: true,
+  },
 }
 
 const createTestComponent = (
@@ -89,6 +96,8 @@ describe('SelectPlaylistInput', () => {
 
       // Should not show playlists not owned by admin (not writable)
       expect(screen.queryByText('Chill Vibes')).not.toBeInTheDocument()
+      // Should not show synced playlists (their tracks are not editable)
+      expect(screen.queryByText('Synced List')).not.toBeInTheDocument()
     })
 
     it('should filter playlists based on search input', async () => {


### PR DESCRIPTION
### Description

Editing the tracks of a synced playlist (an `.m3u`/`.nsp` imported from a file in the library) was silently pointless: the change was accepted, then reverted on the next scan when the file was re-imported. This blocks those edits up front. A synced playlist's tracks are owned by its source file, so track mutations are rejected. Metadata edits (name, comment, public, the sync flag itself) are unaffected.

Track mutations funnel through two service guards, `checkTracksEditable` (incremental add/remove/reorder) and `Create` (wholesale replace, used by Subsonic `createPlaylist` and Jellyfin's replace path), which each duplicated the smart-playlist check. Both now consult a shared `model.Playlist.TracksEditable()` predicate, so the Native, Subsonic, and Jellyfin APIs are all covered by one rule. Smart playlists were already blocked from track edits; this extends the same protection to synced file-backed playlists.

Because "these tracks are immutable for everyone" is a property of the resource and not an authorization failure, the rejection uses a dedicated `ErrPlaylistNotEditable` rather than `ErrNotAuthorized`. Each API maps it to whatever is correct for that API: the Native API returns `409 Conflict`, Subsonic returns error 50 (its closest code, since it has no read-only concept), and the Jellyfin routes return `403` to match Jellyfin itself, which refuses edits on its own file-backed playlists with `Forbid()` (its `CanEdit` is a per-user ACL field, and Jellyfin core has no server-managed playlist type). Genuine authorization failures still return `ErrNotAuthorized`.

The read-only state is also advertised, not just enforced, so clients stop offering edits that are guaranteed to fail: the Add to Playlist picker filters with `canChangeTracks`, OpenSubsonic reports `readonly` for synced playlists as it already did for smart ones, and Jellyfin's playlist permission probes report `CanEdit` from the playlist's editability. In the web UI a synced playlist's track list is read-only, mirroring smart playlists.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Drop an `.m3u` into a folder under your library and scan, so it imports as a synced playlist.
2. In the web UI, open the synced playlist: the track list is read-only (no selection checkboxes, no drag-reorder, no remove). It is also absent from the Add to Playlist dialog.
3. Via Subsonic, `createPlaylist?playlistId=<synced-id>&songId=<id>` returns error 50, and the playlist reports `readonly=true` in `getPlaylists`.
4. Via the Native API, `POST /api/playlist/<synced-id>/tracks` returns 409, while the same call on a normal playlist still succeeds (200).
5. Via Jellyfin, adding or removing items on a synced playlist returns 403, and `GET /Playlists/<id>/Users` reports `CanEdit: false`.
6. Metadata edits (rename, toggle public/sync) on a synced playlist still work.

### Additional Notes

This changes Subsonic API behavior: track edits on a synced playlist now fail (error 50) where they previously succeeded and were silently reverted on the next scan.
