### PR TITLE
perf(artwork): compute the blurhash DCT separably

### DIFF
--- a/core/artwork/blurhash/blurhash.go
+++ b/core/artwork/blurhash/blurhash.go
@@ -52,6 +52,12 @@ func Encode(img image.Image) (string, error) {
 
 	lin := srgbToLinearTable()
 	factors := make([][3]float64, xComp*yComp)
+	linR := make([]float64, w)
+	linG := make([]float64, w)
+	linB := make([]float64, w)
+	rowR := make([]float64, xComp)
+	rowG := make([]float64, xComp)
+	rowB := make([]float64, xComp)
 	for y := range h {
 		row := src.pix[y*src.stride:]
 		for x := range w {
@@ -60,15 +66,26 @@ func Encode(img image.Image) (string, error) {
 			if src.straight {
 				r, g, b = premultiply(r, g, b, row[p+3])
 			}
-			lr, lg, lb := lin[r], lin[g], lin[b]
-			for j := range yComp {
-				for i := range xComp {
-					basis := cosX[i][x] * cosY[j][y]
-					f := &factors[j*xComp+i]
-					f[0] += basis * lr
-					f[1] += basis * lg
-					f[2] += basis * lb
-				}
+			linR[x], linG[x], linB[x] = lin[r], lin[g], lin[b]
+		}
+		// The basis is separable, so a row costs xComp dot products plus one fold over yComp,
+		// rather than xComp*yComp multiply-accumulates per pixel.
+		for i := range xComp {
+			var sr, sg, sb float64
+			for x, c := range cosX[i] {
+				sr += c * linR[x]
+				sg += c * linG[x]
+				sb += c * linB[x]
+			}
+			rowR[i], rowG[i], rowB[i] = sr, sg, sb
+		}
+		for j := range yComp {
+			cy := cosY[j][y]
+			for i := range xComp {
+				f := &factors[j*xComp+i]
+				f[0] += cy * rowR[i]
+				f[1] += cy * rowG[i]
+				f[2] += cy * rowB[i]
 			}
 		}
 	}


### PR DESCRIPTION
### Description
`blurhash.Encode` computed each DCT coefficient independently, so the pixel loop ran `xComp * yComp` multiply-accumulates for every pixel — roughly 16 per pixel at our derived component counts. The cosine basis is separable (`cosX[i][x] * cosY[j][y]`), which means the x and y halves can be applied in sequence instead of as a product: each row collapses to `xComp` dot products over that row's linear-RGB values, and those are folded into the coefficients once per row. Total work drops from `w*h*xComp*yComp` to `w*h*xComp + h*xComp*yComp`.

Encoding gets ~60% faster at every input size, and ~80% faster at the 128px size the artwork pipeline actually feeds it. This is on the artwork ingest path, where a blurhash is computed for every album and artist image, so it shows up during scans and backfills rather than on a single request.

The output is byte-identical, so the existing golden-value specs cover the rewrite unchanged.

`benchstat` over `BenchmarkHashEncoders`, 10 runs, Apple M4 Max:

| benchmark | before | after | delta |
|---|---|---|---|
| blurhash @ pipeline input size (128px) | 262.6µs | 52.7µs | **-79.9%** |
| blurhash 300x300 | 554.3µs | 221.7µs | **-60.0%** |
| blurhash 600x600 | 553.4µs | 222.3µs | **-59.8%** |
| blurhash 900x900 | 558.0µs | 224.1µs | **-59.9%** |
| blurhash 1200x1200 | 566.3µs | 230.4µs | **-59.3%** |
| blurhash 1500x1500 | 562.7µs | 226.3µs | **-59.8%** |

At sizes above 128px the remaining time is dominated by the encoder's own defensive downscale, not the DCT, which is why the ratio flattens out. `thumbhash`, untouched by this PR, moved +2-4% across the same two runs — that is the machine-noise floor for these numbers.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Other (please describe): performance

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No new tests: the change is a pure refactor of an internal loop and must not alter output. The existing `blurhash` specs and the artwork e2e suite already assert exact hash strings, so they are the regression check — they pass without modification.

### How to Test
1. `make test PKG=./core/artwork/...` — all suites pass, including the golden blurhash values in `core/artwork/blurhash` and `core/artwork/e2e`.
2. Compare against master to confirm the timing:
   ```
   git stash                # or check out master
   go test -run '^$' -bench BenchmarkHashEncoders -benchtime=300ms -count=10 ./core/artwork/ > before.txt
   git stash pop            # or check out this branch
   go test -run '^$' -bench BenchmarkHashEncoders -benchtime=300ms -count=10 ./core/artwork/ > after.txt
   benchstat before.txt after.txt
   ```
3. Scan a library with fresh artwork and confirm the placeholder blurhashes rendered by clients are unchanged.

### Additional Notes
The rewrite adds 6 allocations per `Encode` call (three `w`-length scratch rows for linear RGB, three `xComp`-length row accumulators), about +3KiB. They are hoisted out of the pixel loop, and the trade is heavily in favour of the time saved.

The same separable structure is already how `core/artwork/thumbhash` works, so this brings the two encoders in line with each other.
