### PR TITLE
fix(ui): restore the player when the window grows into desktop

### DIFF
--- a/ui/src/audioplayer/Player.jsx
+++ b/ui/src/audioplayer/Player.jsx
@@ -49,12 +49,22 @@ const Player = () => {
   const stoppedRef = useRef(false)
   const [audioInstance, setAudioInstance] = useState(null)
   const isDesktop = useMediaQuery('(min-width:810px)')
+  const [playerMode, setPlayerMode] = useState('full')
   const isMobilePlayer =
     /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
       navigator.userAgent,
     )
 
   const { authenticated } = useAuthState()
+
+  // On desktop the player is the footer panel and `toggleMode` is disabled, so
+  // a player left collapsed while the window was narrow can never be reopened.
+  // Driving `mode` back to full on the transition restores the footer layout.
+  useEffect(() => {
+    if (isDesktop) {
+      setPlayerMode('full')
+    }
+  }, [isDesktop])
 
   // Keep a ref to playerState so the mount effect can read the latest value
   // without re-triggering on every queue/position change
@@ -207,7 +217,8 @@ const Player = () => {
       theme: playerTheme,
       bounds: 'body',
       playMode: playerState.mode,
-      mode: 'full',
+      mode: playerMode,
+      onModeChange: setPlayerMode,
       loadAudioErrorPlayNext: false,
       autoPlayInitLoadPlayList: true,
       clearPriorAudioLists: false,
@@ -236,7 +247,7 @@ const Player = () => {
       locale: locale(translate),
       sortableOptions: { delay: 200, delayOnTouchOnly: true },
     }),
-    [gainInfo, isDesktop, playerTheme, translate, playerState.mode],
+    [gainInfo, isDesktop, playerMode, playerTheme, translate, playerState.mode],
   )
 
   const options = useMemo(() => {

--- a/ui/src/audioplayer/Player.test.jsx
+++ b/ui/src/audioplayer/Player.test.jsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { render, act, cleanup } from '@testing-library/react'
+import { useMediaQuery } from '@material-ui/core'
+import { useAuthState } from 'react-admin'
+import { useSelector } from 'react-redux'
+import { Player } from './Player'
+
+// Captures the props the music player is rendered with, and exposes the
+// onModeChange callback so a test can simulate the user collapsing the player.
+const playerProps = { current: null }
+
+vi.mock('navidrome-music-player', () => ({
+  default: (props) => {
+    playerProps.current = props
+    return <div data-testid="music-player" />
+  },
+}))
+vi.mock('navidrome-music-player/assets/index.css', () => ({}))
+
+vi.mock('@material-ui/core', async () => {
+  const actual = await import('@material-ui/core')
+  return { ...actual, useMediaQuery: vi.fn() }
+})
+
+vi.mock('react-admin', async () => {
+  const actual = await import('react-admin')
+  return {
+    ...actual,
+    useAuthState: vi.fn(),
+    useDataProvider: () => ({ getOne: vi.fn().mockResolvedValue({}) }),
+    useTranslate: () => (key) => key,
+  }
+})
+
+vi.mock('react-redux', () => ({
+  useDispatch: () => vi.fn(),
+  useSelector: vi.fn(),
+}))
+
+vi.mock('../transcode', () => ({
+  detectBrowserProfile: () => ({}),
+  decisionService: {
+    setProfile: vi.fn(),
+    resolveStreamUrl: vi.fn().mockResolvedValue(''),
+    prefetchDecisions: vi.fn(),
+    invalidateAll: vi.fn(),
+  },
+}))
+
+vi.mock('./PlayerToolbar', () => ({ default: () => <div /> }))
+vi.mock('../subsonic', () => ({ default: { reportPlayback: vi.fn() } }))
+
+const state = {
+  player: {
+    queue: [{ trackId: 't1', uuid: 'u1', isRadio: false }],
+    playIndex: 0,
+    volume: 1,
+    mode: 'order',
+    current: { trackId: 't1' },
+    clear: false,
+    savedPlayIndex: 0,
+  },
+  settings: { notifications: false },
+  replayGain: { gainMode: 'none' },
+  theme: 'dark',
+}
+
+describe('<Player />', () => {
+  beforeEach(() => {
+    playerProps.current = null
+    useAuthState.mockReturnValue({ authenticated: true })
+    useSelector.mockImplementation((selector) => selector(state))
+  })
+
+  afterEach(cleanup)
+
+  // Regression test for #5917: a player collapsed while the window was narrow
+  // could never be reopened once the window grew past the desktop breakpoint,
+  // because toggleMode is disabled on desktop.
+  it('returns to full mode when the viewport grows into desktop', () => {
+    useMediaQuery.mockReturnValue(false)
+    const { rerender } = render(<Player />)
+    expect(playerProps.current.mode).toBe('full')
+
+    // The user collapses the player into the mini circle.
+    act(() => playerProps.current.onModeChange('mini'))
+    expect(playerProps.current.mode).toBe('mini')
+
+    // The window is widened past the desktop breakpoint.
+    useMediaQuery.mockReturnValue(true)
+    act(() => {
+      rerender(<Player />)
+    })
+
+    expect(playerProps.current.mode).toBe('full')
+  })
+
+  it('keeps the collapsed mode while the viewport stays narrow', () => {
+    useMediaQuery.mockReturnValue(false)
+    const { rerender } = render(<Player />)
+
+    act(() => playerProps.current.onModeChange('mini'))
+    act(() => {
+      rerender(<Player />)
+    })
+
+    expect(playerProps.current.mode).toBe('mini')
+  })
+})


### PR DESCRIPTION
Fixes #5917

## Problem

Collapse the player into the mini circle while the window is narrow, then
widen the window past the 810px desktop breakpoint: the circle stays on
screen, labelled **"Open"**, and clicking it does nothing. The footer player
never appears, so playback controls become unreachable until a reload.

Reproduced with a scripted browser run against a dev instance:

| Step | `.react-jinke-music-player` | `.music-player-panel` |
| --- | --- | --- |
| 1. Narrow (500px), playing | – | – |
| 2. Collapsed to mini circle | present | – |
| 3. Resized to 1400px | **present** | **absent** |
| 4. Clicked the mini circle | **present** | **absent** |

Step 3 is where it goes wrong: the player should have become the footer
panel and did not.

Note the bug only reproduces from the *collapsed* state. Widening with the
panel open converts to the footer correctly, which is probably why it has
been easy to miss.

## Root cause

Three things in `navidrome-music-player` combine:

- `onOpenPanel` — what runs when the mini circle is clicked — is gated on
  `toggleMode`. `Player.jsx` sets `toggleMode: !isDesktop`, so on desktop the
  handler is a no-op and the circle is inert.
- `mode` is a controlled prop paired with `onModeChange`, but `updateMode`
  only acts when the value actually changes (`mode !== this.props.mode`).
  `Player.jsx` passed a hardcoded `mode: 'full'`, so it never fired.
- Nothing else brings the player back to full mode on resize, so the
  collapsed state survives the breakpoint change.

## Change

Track the mode in component state, feed the library's `onModeChange` back
into it, and reset it to `full` when the viewport crosses into desktop:

```jsx
const [playerMode, setPlayerMode] = useState('full')

useEffect(() => {
  if (isDesktop) {
    setPlayerMode('full')
  }
}, [isDesktop])
```

`mode: playerMode` and `onModeChange: setPlayerMode` replace the hardcoded
prop. Because the value now genuinely changes on the transition,
`updateMode` runs and the footer panel is restored.

### Alternatives considered

Forcing `toggleMode: true` on desktop is a smaller diff and does un-gate
`onOpenPanel`, but `toggleMode` is also passed down to the panel, so it
would add a collapse control to the desktop footer — a UX change beyond the
scope of this bug. Keeping `toggleMode: !isDesktop` and driving `mode`
instead leaves desktop behaviour as it is.

## Verification

- Same scripted run after the change: step 3 becomes `.music-player-panel`
  present, mini circle gone. Steps 1 and 2 are unchanged, so the
  narrow-window experience is untouched.
- Added `ui/src/audioplayer/Player.test.jsx` with two regression tests.
  Reverting the `Player.jsx` change makes both fail.
- `npm test` — 78 files, 660 tests passing.
- `npm run lint` (`--max-warnings 0`) and Prettier are clean.
