### PR TITLE
ci: lint with the golangci-lint version the Makefile declares

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -68,10 +68,16 @@ jobs:
         with:
           go-version-file: go.mod
 
+      # Keep CI on the same version `make lint` installs, so a clean local run
+      # cannot turn red in CI just because a new golangci-lint was released.
+      - name: Resolve golangci-lint version
+        id: golangci-version
+        run: echo "version=$(grep '^GOLANGCI_LINT_VERSION' Makefile | cut -d ' ' -f 3)" >> "$GITHUB_OUTPUT"
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: ${{ steps.golangci-version.outputs.version }}
           problem-matchers: true
           args: --timeout 2m
 


### PR DESCRIPTION
Fixes #5993

## Problem

`Lint Go code` started failing on unchanged code. The workflow resolves
`version: latest`, while the Makefile declares `GOLANGCI_LINT_VERSION ?=
v2.12.0`, so `make lint` and CI have been running different linters.

golangci-lint v2.13.0 was published at 2026-08-19T22:59Z and began reporting
G404 on three existing `rand.Shuffle` calls. CI picked it up about an hour
later and every PR went red.

Verified locally against the same tree:

| golangci-lint | Result |
| --- | --- |
| v2.12.0 — what `make lint` installs | `0 issues.` |
| v2.13.0 — what CI resolved `latest` to | `3 issues: gosec: 3` |

The three findings are in `core/external/provider_similarsongs.go`,
`core/playback/queue.go` and `db/backup_test.go`.

## Change

Read the version from the Makefile and pass it to the action, so the Makefile
stays the single source of truth:

```yaml
- name: Resolve golangci-lint version
  id: golangci-version
  run: echo "version=$(grep '^GOLANGCI_LINT_VERSION' Makefile | cut -d ' ' -f 3)" >> "$GITHUB_OUTPUT"

- name: golangci-lint
  uses: golangci/golangci-lint-action@v9
  with:
    version: ${{ steps.golangci-version.outputs.version }}
```

A clean local run can no longer turn red in CI because a new golangci-lint was
released, and bumping the linter becomes a deliberate one-line change to the
Makefile that lands with whatever fixes it requires.

### Alternative considered

Adding `G404` to the `gosec.excludes` list in `.golangci.yml` would clear
today's failure in one line, and the three call sites — a similar-songs list, a
playback queue and a test fixture — are not security-relevant. But that
silences a rule to work around a version mismatch, and leaves CI free to drift
again on the next release. Happy to switch to that (or do both) if you would
rather keep tracking the latest linter.

## Verification

- golangci-lint v2.12.0 over this branch: `0 issues.`
- golangci-lint v2.13.0 over the same tree reproduces the three CI findings
  exactly, confirming the version is the only variable.
- The workflow file parses, and the extraction step resolves to `v2.12.0`.
