### PR TITLE
fix(cli): write `pls -p` playlist output to stdout

### DIFF
--- a/cmd/pls.go
+++ b/cmd/pls.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -141,14 +142,16 @@ func findPlaylist(ctx context.Context, ds model.DataStore, nameOrID string) *mod
 func runExporter(ctx context.Context) {
 	ds, ctx := getAdminContext(ctx)
 	playlist := findPlaylist(ctx, ds, playlistID)
-	pls := playlist.ToM3U8()
-	if outputFile == "-" || outputFile == "" {
-		println(pls)
+	writePlaylist(playlist.ToM3U8(), os.Stdout, outputFile)
+}
+
+func writePlaylist(m3u string, out io.Writer, file string) {
+	if file == "" || file == "-" {
+		fmt.Fprint(out, m3u)
 		return
 	}
-	err := os.WriteFile(outputFile, []byte(pls), 0600)
-	if err != nil {
-		log.Fatal("Error writing to the output file", "file", outputFile, err)
+	if err := os.WriteFile(file, []byte(m3u), 0600); err != nil {
+		log.Fatal("Error writing to the output file", "file", file, err)
 	}
 }
 
@@ -157,7 +160,7 @@ func runExport(ctx context.Context) {
 
 	if playlistID != "" && outputFile == "" {
 		playlist := findPlaylist(ctx, ds, playlistID)
-		println(playlist.ToM3U8())
+		writePlaylist(playlist.ToM3U8(), os.Stdout, outputFile)
 		return
 	}
 

--- a/cmd/pls_test.go
+++ b/cmd/pls_test.go
@@ -1,0 +1,35 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("writePlaylist", func() {
+	const m3u = "#EXTM3U\n#PLAYLIST:DJ Wave\n#EXTINF:364,Bel Canto - Dreaming Girl\n"
+	plsFile := filepath.Join(os.TempDir(), fmt.Sprintf("navidrome-pls-%d.m3u8", os.Getpid()))
+
+	BeforeEach(func() {
+		DeferCleanup(func() { _ = os.Remove(plsFile) })
+	})
+
+	DescribeTable("writes the playlist to exactly one destination",
+		func(file, wantStream, wantFile string) {
+			var out strings.Builder
+
+			writePlaylist(m3u, &out, file)
+
+			written, _ := os.ReadFile(plsFile)
+			Expect(out.String()).To(Equal(wantStream))
+			Expect(string(written)).To(Equal(wantFile))
+		},
+		Entry("no file name writes to the stream", "", m3u, ""),
+		Entry("a dash writes to the stream", "-", m3u, ""),
+		Entry("a path writes to the file", plsFile, "", m3u),
+	)
+})


### PR DESCRIPTION
### Description
`navidrome pls -p <playlist>` used Go's builtin `println`, which writes to **stderr**. So `navidrome pls -p X > playlist.m3u8` exited 0 and produced an empty file, while the M3U body was interleaved with the startup logs on stderr. This replaces it with a real stdout write.

`println` also appended a newline that `ToM3U8` already provides, so the piped output carried a stray trailing blank line that `-o <file>` did not. Both destinations are now byte-identical.

`pls -p` and `pls export -p` had the same bug in two separate call sites. The stdout/file choice now lives in a single `writePlaylist` helper that takes the destination as an `io.Writer`, matching the existing convention in `cmd/artwork.go`.

Note that the startup banner (`cmd/root.go`) and the `svc` status messages also use builtin `println`. The banner going to stderr is load-bearing — it prints for every subcommand via `PersistentPreRun`, so moving it to stdout would reintroduce this exact bug. Both are left alone here.

### Related Issues
Fixes #5995

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Against a library with at least one playlist:

```sh
./navidrome pls -p "<playlist>" >/tmp/out.m3u8 2>/tmp/err.log
wc -c /tmp/out.m3u8          # was 0 before this PR, now the full M3U
head -3 /tmp/out.m3u8        # #EXTM3U / #PLAYLIST:... / #EXTINF:...
```

`/tmp/err.log` should contain only the banner and log lines, no M3U content.

Verify stdout matches the file output byte for byte, and that `pls export -p` agrees:

```sh
./navidrome pls -p "<playlist>" -o /tmp/via-flag.m3u8
cmp /tmp/out.m3u8 /tmp/via-flag.m3u8

./navidrome pls export -p "<playlist>" >/tmp/via-export.m3u8
cmp /tmp/out.m3u8 /tmp/via-export.m3u8
```

`-o -` should also write to stdout.

### Additional Notes
The stdout output is one byte shorter than before (the stray trailing newline is gone). Anything diffing against previously captured output will see that one-line change; every M3U consumer should be unaffected.
