### PR TITLE
build: pull base images through mirror.gcr.io instead of ECR Public

### DIFF
--- a/.github/actions/prepare-docker/action.yml
+++ b/.github/actions/prepare-docker/action.yml
@@ -68,6 +68,11 @@ runs:
     - name: Set up Docker Buildx
       id: buildx
       uses: docker/setup-buildx-action@v4
+      with:
+        # Runner IPs are shared, so anonymous base image pulls get rate-limited.
+        buildkitd-config-inline: |
+          [registry."docker.io"]
+            mirrors = ["mirror.gcr.io"]
 
     - name: Extract metadata for Docker image
       id: meta

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM ghcr.io/crazy-max/osxcross:14.5-debian AS osxcros
 
 ########################################################################################################################
 ### Build xx (original image: tonistiigi/xx)
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/alpine:3.20 AS xx-build
+FROM --platform=$BUILDPLATFORM alpine:3.20 AS xx-build
 
 # v1.9.0
 ENV XX_VERSION=a5592eab7a57895e8d385394ff12241bc65ecd50
@@ -26,7 +26,7 @@ COPY --from=xx-build /out/ /usr/bin/
 
 ########################################################################################################################
 ### Build Navidrome UI
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/node:lts-alpine AS ui
+FROM --platform=$BUILDPLATFORM node:lts-alpine AS ui
 WORKDIR /app
 
 # Install node dependencies
@@ -43,7 +43,7 @@ COPY --from=ui /build /build
 
 ########################################################################################################################
 ### Build Navidrome binary for Docker image (dynamic musl, enables native libwebp via dlopen)
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.26-alpine AS build-alpine
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build-alpine
 COPY --from=xx / /
 
 ARG TARGETPLATFORM
@@ -85,7 +85,7 @@ EOT
 
 ########################################################################################################################
 ### Build Navidrome binary for standalone distribution (static glibc, cross-compiled)
-FROM --platform=$BUILDPLATFORM public.ecr.aws/docker/library/golang:1.26-trixie AS base
+FROM --platform=$BUILDPLATFORM golang:1.26-trixie AS base
 RUN apt-get update && apt-get install -y clang lld
 COPY --from=xx / /
 WORKDIR /workspace
@@ -154,7 +154,7 @@ COPY --from=build /out /
 
 ########################################################################################################################
 ### Build Final Image
-FROM public.ecr.aws/docker/library/alpine:3.20 AS final
+FROM alpine:3.20 AS final
 LABEL maintainer="deluan@navidrome.org"
 LABEL org.opencontainers.image.source="https://github.com/navidrome/navidrome"
 

--- a/release/wix/msitools.dockerfile
+++ b/release/wix/msitools.dockerfile
@@ -1,3 +1,3 @@
-FROM public.ecr.aws/docker/library/alpine
+FROM alpine
 RUN apk update && apk add jq msitools
 WORKDIR /workspace


### PR DESCRIPTION
### Description
Docker builds have been failing at random with `buildx failed with: toomanyrequests: Rate exceeded`. The 429 comes from `public.ecr.aws`, not Docker Hub — AWS caps unauthenticated ECR Public pulls at **1 per second per source IP** (10/s authenticated). The build matrix starts 11 jobs at once and each one resolves 4 base images, so roughly 44 anonymous pulls land within a couple of seconds, from GitHub runner IPs that are shared with every other GitHub customer. That is far over the limit, which is why it fails intermittently rather than every time.

This PR drops the `public.ecr.aws/docker/library/` prefix from the base images (they are just mirrored Docker Official Images) and points BuildKit's `docker.io` resolution at **`mirror.gcr.io`**, Google's Docker Hub pull-through cache, via `buildkitd-config-inline` on `docker/setup-buildx-action`. Pulls served from that cache do not count against Docker Hub's rate limits, and BuildKit falls back to Docker Hub automatically on a cache miss — where the existing Docker Hub login already applies.

I measured both registries before picking this approach. Against `public.ecr.aws` with a proper anonymous token, 60 manifest requests at concurrency 30 returned **31× 429 in 0.48s**. The same probe against `mirror.gcr.io` returned **zero errors across 750 manifest requests at up to ~141 req/s**, plus 120 layer-blob requests at concurrency 60. Google publishes no rate limit for the mirror, so that is measured headroom rather than a contract — but it is roughly 10× this pipeline's peak rate.

The alternative was authenticating to ECR Public. I rejected it: the authenticated ceiling is 10 pulls/s, still under the ~44-pull burst, so it would reduce failures rather than end them. It also needs an AWS account plus a repo secret, and secrets never reach fork pull requests — so forks would keep failing. The mirror approach needs no account and fixes forks too.

`release/wix/msitools.dockerfile` is switched over as well so no ECR Public reference is left in the tree. That file is only used by the local `make docker-msi` target, not by CI.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI / build infrastructure

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No tests were added: the change is limited to base-image references and a BuildKit daemon config, neither of which is reachable from the Go or JS suites. It is verified by the build itself — CI on this PR exercises every affected stage across all 11 platforms. No Go or JS files are touched, so the existing suites are unaffected.

### How to Test
Verification I ran locally, which can be reproduced:

**1. BuildKit actually honours the mirror block.** Point the mirror at a local registry that logs its requests, then build:

```bash
docker run -d --name mirror-probe -p 5001:5000 \
  -e REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io registry:2

cat > /tmp/buildkitd.toml <<'TOML'
[registry."docker.io"]
  mirrors = ["localhost:5001"]
[registry."localhost:5001"]
  http = true
TOML

docker buildx create --name probe --driver docker-container \
  --driver-opt network=host --buildkitd-config /tmp/buildkitd.toml
printf 'FROM alpine:3.20\nRUN echo hi\n' > /tmp/Dockerfile
docker buildx --builder probe build --no-cache -o type=cacheonly /tmp
docker logs mirror-probe | grep -oE '"(GET|HEAD) /v2/[^"]*"'
```

All 6 requests — manifests *and* blobs — hit the mirror. None went to Docker Hub directly.

**2. `mirror.gcr.io` answers BuildKit's request form.** BuildKit appends `?ns=docker.io`; all four images return 200 on both GET and HEAD:

```bash
for i in library/alpine/manifests/3.20 library/node/manifests/lts-alpine \
         library/golang/manifests/1.26-alpine library/golang/manifests/1.26-trixie; do
  curl -s -o /dev/null -w "$i -> %{http_code}\n" \
    -H 'Accept: application/vnd.oci.image.index.v1+json' \
    "https://mirror.gcr.io/v2/$i?ns=docker.io"
done
```

**3. The Dockerfile builds through the mirror.** With a builder configured for `mirror.gcr.io`:

```bash
docker buildx build --check -f Dockerfile .
docker buildx build --no-cache --target xx   -o type=cacheonly -f Dockerfile .
docker buildx build           --target base  -o type=cacheonly -f Dockerfile .
```

`--check` reports no warnings and both stages build.

**4. Fallback survives a mirror outage.** Repeat step 1 with the mirror pointed at a dead port — the build still succeeds via Docker Hub.

**5. The real signal** is this PR's own CI: all 11 platforms should build without a `toomanyrequests` failure.

### Additional Notes
**A mirror outage makes builds slow, not broken.** In the fallback test above, resolving the base image took **~30s** with a dead mirror versus **~0.3s** with a working one. BuildKit retries the mirror before giving up and going to Docker Hub. So if `mirror.gcr.io` were ever down, CI would still pass but each job would pick up roughly half a minute per image resolve. Worth knowing before anyone debugs a mysteriously slow pipeline.

**The mirror's limit is measured, not published.** Google documents `mirror.gcr.io` only as "does not count against Docker Hub rate limits" with "no guarantee that a particular image will remain cached" — no quota figure, no SLA, and it is absent from the Artifact Registry quotas page. It also sends no `RateLimit-*` or `Retry-After` headers, unlike Docker Hub. My burst test cannot detect a *windowed* quota (Docker Hub's, for comparison, is per 6 hours); all it establishes is that any such window exceeds the 870 requests I sent. This pipeline uses roughly 44 pulls per run, so there is margin, but it is not unlimited-by-contract.

**Cache misses land on Docker Hub.** On main-repo runs the existing `docker/login-action` step covers that, so the fallback is authenticated. Fork PRs get no secrets and would fall back anonymously (100 pulls/6h per IP) — but that is still strictly better than today, where forks hit the 1/s ECR limit with no mitigation at all.

**If failures persist**, the next lever is capping `max-parallel` on the build matrix to spread the burst, at the cost of wall-clock time. I did not include it here since it trades speed for a problem this change should already solve.
