### PR TITLE
docs(plugins): document how a metadata agent signals "not found"

### DIFF
--- a/plugins/README.md
+++ b/plugins/README.md
@@ -174,6 +174,14 @@ Capabilities define what your plugin can do. They're automatically detected base
 
 Provides artist and album metadata. All methods are **optional** — implement only the ones your data source supports.
 
+> **Returning "not found".** When you have no data for an item, return an empty response and no
+> error. In the Go PDK that is `return nil, nil`. Navidrome reads it as a definitive "not found"
+> and stops asking.
+>
+> Return an error only when the plugin itself failed, such as an unreachable API or a broken host
+> call. Navidrome retries failed calls with backoff. A plugin that errors on "no data" makes
+> Navidrome retry every item it has no data for.
+
 | Function                          | Input                      | Output                           | Description              |
 |-----------------------------------|----------------------------|----------------------------------|--------------------------|
 | `nd_get_artist_mbid`              | `{id, name}`               | `{mbid}`                         | Get MusicBrainz ID       |

--- a/plugins/capabilities/metadata_agent.go
+++ b/plugins/capabilities/metadata_agent.go
@@ -9,6 +9,9 @@ import "github.com/navidrome/navidrome/plugins/types"
 // Plugins implementing this capability can choose which methods to implement.
 // Each method is optional - plugins only need to provide the functionality they support.
 //
+// To say "no data for this item", return a nil response and a nil error. Return an error only when
+// the plugin itself failed, because Navidrome retries failed calls with backoff.
+//
 //nd:capability name=metadata
 type MetadataAgent interface {
 	// GetArtistMBID retrieves the MusicBrainz ID for an artist.

--- a/plugins/pdk/go/metadata/metadata.go
+++ b/plugins/pdk/go/metadata/metadata.go
@@ -186,6 +186,9 @@ type TopSongsResponse struct {
 //
 // Plugins implementing this capability can choose which methods to implement.
 // Each method is optional - plugins only need to provide the functionality they support.
+//
+// To say "no data for this item", return a nil response and a nil error. Return an error only when
+// the plugin itself failed, because Navidrome retries failed calls with backoff.
 type Metadata interface{}
 
 // ArtistMBIDProvider provides the GetArtistMBID function.

--- a/plugins/pdk/go/metadata/metadata_stub.go
+++ b/plugins/pdk/go/metadata/metadata_stub.go
@@ -184,6 +184,9 @@ type TopSongsResponse struct {
 //
 // Plugins implementing this capability can choose which methods to implement.
 // Each method is optional - plugins only need to provide the functionality they support.
+//
+// To say "no data for this item", return a nil response and a nil error. Return an error only when
+// the plugin itself failed, because Navidrome retries failed calls with backoff.
 type Metadata interface{}
 
 // ArtistMBIDProvider provides the GetArtistMBID function.


### PR DESCRIPTION
### Description
A `MetadataAgent` plugin signals "no data for this item" by returning an empty response with a nil error. Any error it returns is treated as a plugin fault and retried with backoff. That convention was undocumented, so authors reasonably return an error on a miss, and Navidrome then retries every item their source doesn't cover.

Real case: the community `artist-nfo-metadata` plugin errors for every artist without an `artist.nfo`, keeping them in the artwork retry queue for hours and tripping the artwork circuit breaker for the whole plugin.

Documented in two places: `plugins/capabilities/metadata_agent.go` (ndpgen copies it into the Go PDK, so it reaches godoc and editor tooltips) and the `MetadataAgent` section of `plugins/README.md`.

Docs only, no behaviour change. `MetadataAgent` is the only capability whose adapter maps an empty response to `agents.ErrNotFound`, so the wording isn't repeated elsewhere.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No tests added: comments and Markdown only. The regenerated PDK files are covered by the existing `ndpgen` suite.

### How to Test
```
make gen && git diff --exit-code          # generated files match source
go doc ./plugins/pdk/go/metadata Metadata # doc comment reaches the PDK
```

### Additional Notes
The wording avoids naming the artwork retry budget or breaker thresholds, since other callers consume `MetadataAgent` results too.

Possible follow-up, not in this PR: plugins have no way to signal "not found" *explicitly*, so they can't log why they found nothing without it reading as a fault. A `NotFoundCode` alongside the existing `NotImplementedCode` (`-2`), mapped in `callPluginFunction`, would cover every capability.
