### PR TITLE
feat(cli): add `artwork cancel` to call off queued artwork work

### DIFF
--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -34,6 +34,14 @@ var (
 	reprocessYes     bool
 )
 
+var (
+	cancelKinds      []string
+	cancelPriorities []string
+	cancelAll        bool
+	cancelDryRun     bool
+	cancelYes        bool
+)
+
 func init() {
 	artworkExplainCmd.Flags().BoolVar(&explainLive, "live", false,
 		"walk the chain again now, performing real external lookups, instead of reporting the "+
@@ -47,9 +55,18 @@ func init() {
 	artworkReprocessCmd.Flags().BoolVar(&reprocessDryRun, "dry-run", false,
 		"report what would be queued and exit without queueing")
 	artworkReprocessCmd.Flags().BoolVarP(&reprocessYes, "yes", "y", false, "skip the confirmation prompt")
+	artworkCancelCmd.Flags().StringSliceVar(&cancelKinds, "kind", nil,
+		"kinds to cancel ("+kindPrefixes(artwork.RefreshableKinds)+"); repeatable")
+	artworkCancelCmd.Flags().StringSliceVar(&cancelPriorities, "priority", nil,
+		"only rows queued at these priorities ("+priorityNames()+"); repeatable")
+	artworkCancelCmd.Flags().BoolVar(&cancelAll, "all", false, "cancel every kind at every priority")
+	artworkCancelCmd.Flags().BoolVar(&cancelDryRun, "dry-run", false,
+		"report what would be cancelled and exit without cancelling")
+	artworkCancelCmd.Flags().BoolVarP(&cancelYes, "yes", "y", false, "skip the confirmation prompt")
 	artworkCmd.AddCommand(artworkExplainCmd)
 	artworkCmd.AddCommand(artworkRefreshCmd)
 	artworkCmd.AddCommand(artworkReprocessCmd)
+	artworkCmd.AddCommand(artworkCancelCmd)
 	artworkCmd.AddCommand(artworkStatusCmd)
 	rootCmd.AddCommand(artworkCmd)
 }
@@ -90,6 +107,21 @@ var artworkReprocessCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		runReprocess(cmd.Context())
+	},
+}
+
+var artworkCancelCmd = &cobra.Command{
+	Use:   "cancel",
+	Short: "Cancel pending artwork work in bulk, by kind and/or queue priority",
+	Long: "Cancel pending artwork work in bulk, by kind and/or queue priority.\n\n" +
+		"Only the queue is touched: resolved artwork and the state behind `artwork explain` are\n" +
+		"left alone, and the trace of why a cancelled item last failed goes with its queue row.\n\n" +
+		"Work already picked up is not interrupted, and an item with no artwork yet can be\n" +
+		"queued again by the hourly re-check. Use it to call off a bulk backfill, not to stop\n" +
+		"the worker.",
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		runCancel(cmd.Context())
 	},
 }
 
@@ -253,18 +285,40 @@ func kindName(prefix string) string {
 	return prefix
 }
 
+type artworkPriority struct {
+	name  string
+	value int
+}
+
+// artworkPriorities is the one listing behind both the name and the parse, so they cannot drift.
+var artworkPriorities = []artworkPriority{
+	{"bump", model.ArtworkPriorityBump},
+	{"scan", model.ArtworkPriorityScan},
+	{"backfill", model.ArtworkPriorityBackfill},
+	{"recheck", model.ArtworkPriorityRecheck},
+}
+
+// priorityName falls back to the number: a row written by a newer version still has to print.
 func priorityName(p int) string {
-	switch p {
-	case model.ArtworkPriorityRecheck:
-		return "recheck"
-	case model.ArtworkPriorityBackfill:
-		return "backfill"
-	case model.ArtworkPriorityScan:
-		return "scan"
-	case model.ArtworkPriorityBump:
-		return "bump"
+	for _, ap := range artworkPriorities {
+		if ap.value == p {
+			return ap.name
+		}
 	}
 	return strconv.Itoa(p)
+}
+
+func priorityNames() string {
+	return strings.Join(slice.Map(artworkPriorities, func(ap artworkPriority) string { return ap.name }), ", ")
+}
+
+func parseArtworkPriority(s string) (int, error) {
+	for _, ap := range artworkPriorities {
+		if ap.name == s {
+			return ap.value, nil
+		}
+	}
+	return 0, fmt.Errorf("invalid priority %q, expected one of: %s", s, priorityNames())
 }
 
 func runReprocess(ctx context.Context) {
@@ -286,7 +340,7 @@ func runReprocess(ctx context.Context) {
 	}
 
 	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(reprocessSources), imageAgents,
-		reprocessDryRun, reprocessConfirm(reprocessYes, os.Stdin), os.Stdout); err != nil {
+		reprocessDryRun, confirmUnlessYes(reprocessYes, os.Stdin, "re-resolve"), os.Stdout); err != nil {
 		log.Fatal(ctx, err)
 	}
 }
@@ -327,11 +381,11 @@ func displaySource(s string) string { return cmp.Or(s, absentSource) }
 
 type confirmFunc func(out io.Writer, total, external int64) bool
 
-func reprocessConfirm(yes bool, in io.Reader) confirmFunc {
+func confirmUnlessYes(yes bool, in io.Reader, verb string) confirmFunc {
 	if yes {
 		return func(io.Writer, int64, int64) bool { return true }
 	}
-	return promptConfirm(in)
+	return promptConfirm(in, verb)
 }
 
 // externalEstimate claims no bound: a local hit ends the walk before any agent is asked, and the
@@ -379,13 +433,13 @@ func configuredAgents() []string {
 	return names
 }
 
-func promptConfirm(in io.Reader) confirmFunc {
+func promptConfirm(in io.Reader, verb string) confirmFunc {
 	return func(out io.Writer, total, external int64) bool {
 		var cost string
 		if external > 0 {
 			cost = fmt.Sprintf(" %s", externalLookupLine(external))
 		}
-		fmt.Fprintf(out, "\nThis will re-resolve %d items.%s Continue? [y/N] ", total, cost)
+		fmt.Fprintf(out, "\nThis will %s %d items.%s Continue? [y/N] ", verb, total, cost)
 		var answer string
 		if _, err := fmt.Fscanln(in, &answer); err != nil {
 			return false
@@ -475,6 +529,107 @@ func reprocessArtwork(ctx context.Context, ds model.DataStore, kinds []model.Kin
 		fmt.Fprintf(out, "Already queued, left unchanged: %d (priority and retry backoff untouched).\n", skipped)
 	}
 	return nil
+}
+
+func runCancel(ctx context.Context) {
+	kinds, priorities, err := cancelSelection(cancelKinds, cancelPriorities, cancelAll)
+	if err != nil {
+		log.Fatal(ctx, err)
+	}
+
+	defer db.Init(ctx)()
+	ds, ctx := getAdminContext(ctx)
+
+	if err := cancelArtwork(ctx, ds, kinds, priorities, cancelDryRun,
+		confirmUnlessYes(cancelYes, os.Stdin, "cancel"), os.Stdout); err != nil {
+		log.Fatal(ctx, err)
+	}
+}
+
+// An empty filter means every one, and either flag alone is a complete selection.
+func cancelSelection(kinds, priorities []string, all bool) ([]model.Kind, []int, error) {
+	if all {
+		return artwork.RefreshableKinds, nil, nil
+	}
+	if len(kinds) == 0 && len(priorities) == 0 {
+		return nil, nil, fmt.Errorf("no selector given: pass --kind, --priority or --all")
+	}
+	outKinds := make([]model.Kind, 0, len(kinds))
+	for _, k := range kinds {
+		// RefreshableKinds, not RecheckKinds: media files are queued, so --kind must reach them.
+		kind, err := parseArtworkKind(k, artwork.RefreshableKinds)
+		if err != nil {
+			return nil, nil, err
+		}
+		outKinds = append(outKinds, kind)
+	}
+	outPriorities := make([]int, 0, len(priorities))
+	for _, p := range priorities {
+		priority, err := parseArtworkPriority(p)
+		if err != nil {
+			return nil, nil, err
+		}
+		outPriorities = append(outPriorities, priority)
+	}
+	// A repeated selector would be counted twice, overstating the total the operator confirms.
+	return slice.Unique(outKinds), slice.Unique(outPriorities), nil
+}
+
+func cancelArtwork(ctx context.Context, ds model.DataStore, kinds []model.Kind, priorities []int,
+	dryRun bool, confirm confirmFunc, out io.Writer) error {
+	q := ds.ArtworkQueue(ctx)
+	stats, err := q.CountByKindAndPriority()
+	if err != nil {
+		return fmt.Errorf("counting queued artwork: %w", err)
+	}
+	matched := matchingQueueStats(stats, kinds, priorities)
+	var total int64
+	for _, s := range matched {
+		total += s.Count
+	}
+	printCancelPreview(out, matched, total)
+
+	switch {
+	case dryRun:
+		fmt.Fprintln(out, "\nDry run: nothing was cancelled.")
+		return nil
+	case total == 0:
+		fmt.Fprintln(out, "Nothing was cancelled.")
+		return nil
+	case !confirm(out, total, 0):
+		fmt.Fprintln(out, "Aborted: nothing was cancelled.")
+		return nil
+	}
+
+	cancelled, err := q.PurgeQueued(kinds, priorities)
+	if err != nil {
+		return fmt.Errorf("cancelling queued artwork: %w", err)
+	}
+	// Count and delete are separate statements, so a drain in between makes these two differ.
+	fmt.Fprintf(out, "Cancelled %d of %d matched items.\n", cancelled, total)
+	return nil
+}
+
+func matchingQueueStats(stats []model.ArtworkQueueStat, kinds []model.Kind, priorities []int) []model.ArtworkQueueStat {
+	prefixes := slice.Map(kinds, func(k model.Kind) string { return k.Prefix() })
+	return slice.Filter(stats, func(s model.ArtworkQueueStat) bool {
+		return (len(prefixes) == 0 || slices.Contains(prefixes, s.ItemKind)) &&
+			(len(priorities) == 0 || slices.Contains(priorities, s.Priority))
+	})
+}
+
+func printCancelPreview(out io.Writer, matched []model.ArtworkQueueStat, total int64) {
+	w := newTabWriter(out)
+	fmt.Fprintln(w, "KIND\tPRIORITY\tMATCHED")
+	for _, s := range matched {
+		fmt.Fprintf(w, "%s\t%s\t%d\n", kindName(s.ItemKind), priorityName(s.Priority), s.Count)
+	}
+	fmt.Fprintf(w, "TOTAL\t\t%d\n", total)
+	w.Flush()
+
+	if total == 0 {
+		fmt.Fprintln(out, "\nNothing matches this selection.")
+	}
 }
 
 // printReprocessPreview also states the external estimate, which --dry-run must show because it

--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -26,20 +26,14 @@ import (
 
 var explainLive bool
 
+// Only one subcommand runs per invocation, so reprocess and cancel bind the same flag targets.
 var (
-	reprocessKinds   []string
-	reprocessSources []string
-	reprocessAll     bool
-	reprocessDryRun  bool
-	reprocessYes     bool
-)
-
-var (
-	cancelKinds      []string
-	cancelPriorities []string
-	cancelAll        bool
-	cancelDryRun     bool
-	cancelYes        bool
+	artworkKinds      []string
+	artworkSources    []string
+	artworkPriorities []string
+	artworkAll        bool
+	artworkDryRun     bool
+	artworkYes        bool
 )
 
 func init() {
@@ -47,22 +41,22 @@ func init() {
 		"walk the chain again now, performing real external lookups, instead of reporting the "+
 			"stored trace of the last resolution; also initializes plugin agents, which may open "+
 			"external connections")
-	artworkReprocessCmd.Flags().StringSliceVar(&reprocessKinds, "kind", nil,
+	artworkReprocessCmd.Flags().StringSliceVar(&artworkKinds, "kind", nil,
 		"kinds to reprocess ("+kindPrefixes(artwork.RecheckKinds)+"); repeatable")
-	artworkReprocessCmd.Flags().StringSliceVar(&reprocessSources, "source", nil,
+	artworkReprocessCmd.Flags().StringSliceVar(&artworkSources, "source", nil,
 		"only items currently resolved from these sources (e.g. folder, external:deezer, absent)")
-	artworkReprocessCmd.Flags().BoolVar(&reprocessAll, "all", false, "reprocess every kind")
-	artworkReprocessCmd.Flags().BoolVar(&reprocessDryRun, "dry-run", false,
+	artworkReprocessCmd.Flags().BoolVar(&artworkAll, "all", false, "reprocess every kind")
+	artworkReprocessCmd.Flags().BoolVar(&artworkDryRun, "dry-run", false,
 		"report what would be queued and exit without queueing")
-	artworkReprocessCmd.Flags().BoolVarP(&reprocessYes, "yes", "y", false, "skip the confirmation prompt")
-	artworkCancelCmd.Flags().StringSliceVar(&cancelKinds, "kind", nil,
+	artworkReprocessCmd.Flags().BoolVarP(&artworkYes, "yes", "y", false, "skip the confirmation prompt")
+	artworkCancelCmd.Flags().StringSliceVar(&artworkKinds, "kind", nil,
 		"kinds to cancel ("+kindPrefixes(artwork.RefreshableKinds)+"); repeatable")
-	artworkCancelCmd.Flags().StringSliceVar(&cancelPriorities, "priority", nil,
+	artworkCancelCmd.Flags().StringSliceVar(&artworkPriorities, "priority", nil,
 		"only rows queued at these priorities ("+priorityNames()+"); repeatable")
-	artworkCancelCmd.Flags().BoolVar(&cancelAll, "all", false, "cancel every kind at every priority")
-	artworkCancelCmd.Flags().BoolVar(&cancelDryRun, "dry-run", false,
+	artworkCancelCmd.Flags().BoolVar(&artworkAll, "all", false, "cancel every kind at every priority")
+	artworkCancelCmd.Flags().BoolVar(&artworkDryRun, "dry-run", false,
 		"report what would be cancelled and exit without cancelling")
-	artworkCancelCmd.Flags().BoolVarP(&cancelYes, "yes", "y", false, "skip the confirmation prompt")
+	artworkCancelCmd.Flags().BoolVarP(&artworkYes, "yes", "y", false, "skip the confirmation prompt")
 	artworkCmd.AddCommand(artworkExplainCmd)
 	artworkCmd.AddCommand(artworkRefreshCmd)
 	artworkCmd.AddCommand(artworkReprocessCmd)
@@ -298,8 +292,8 @@ type artworkPriority struct {
 	value int
 }
 
-// artworkPriorities is the one listing behind both the name and the parse, so they cannot drift.
-var artworkPriorities = []artworkPriority{
+// knownPriorities is the one listing behind both the name and the parse, so they cannot drift.
+var knownPriorities = []artworkPriority{
 	{"bump", model.ArtworkPriorityBump},
 	{"scan", model.ArtworkPriorityScan},
 	{"backfill", model.ArtworkPriorityBackfill},
@@ -308,7 +302,7 @@ var artworkPriorities = []artworkPriority{
 
 // priorityName falls back to the number: a row written by a newer version still has to print.
 func priorityName(p int) string {
-	for _, ap := range artworkPriorities {
+	for _, ap := range knownPriorities {
 		if ap.value == p {
 			return ap.name
 		}
@@ -317,11 +311,11 @@ func priorityName(p int) string {
 }
 
 func priorityNames() string {
-	return strings.Join(slice.Map(artworkPriorities, func(ap artworkPriority) string { return ap.name }), ", ")
+	return strings.Join(slice.Map(knownPriorities, func(ap artworkPriority) string { return ap.name }), ", ")
 }
 
 func parseArtworkPriority(s string) (int, error) {
-	for _, ap := range artworkPriorities {
+	for _, ap := range knownPriorities {
 		if ap.name == s {
 			return ap.value, nil
 		}
@@ -330,7 +324,7 @@ func parseArtworkPriority(s string) (int, error) {
 }
 
 func runReprocess(ctx context.Context) {
-	kinds, err := selectedKinds(reprocessKinds, reprocessSources, reprocessAll)
+	kinds, err := selectedKinds(artworkKinds, artworkSources, artworkAll)
 	if err != nil {
 		log.Fatal(ctx, err)
 	}
@@ -347,8 +341,8 @@ func runReprocess(ctx context.Context) {
 		imageAgents = imageAgentCount(ds, mgr)
 	}
 
-	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(reprocessSources), imageAgents,
-		reprocessDryRun, confirmUnlessYes(reprocessYes, os.Stdin, "re-resolve"), os.Stdout); err != nil {
+	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(artworkSources), imageAgents,
+		artworkDryRun, confirmUnlessYes(artworkYes, os.Stdin, "re-resolve"), os.Stdout); err != nil {
 		log.Fatal(ctx, err)
 	}
 }
@@ -533,7 +527,7 @@ func reprocessArtwork(ctx context.Context, ds model.DataStore, kinds []model.Kin
 }
 
 func runCancel(ctx context.Context) {
-	kinds, priorities, err := cancelSelection(cancelKinds, cancelPriorities, cancelAll)
+	kinds, priorities, err := cancelSelection(artworkKinds, artworkPriorities, artworkAll)
 	if err != nil {
 		log.Fatal(ctx, err)
 	}
@@ -541,8 +535,8 @@ func runCancel(ctx context.Context) {
 	defer db.Init(ctx)()
 	ds, ctx := getAdminContext(ctx)
 
-	if err := cancelArtwork(ctx, ds, kinds, priorities, cancelDryRun,
-		confirmUnlessYes(cancelYes, os.Stdin, "cancel"), os.Stdout); err != nil {
+	if err := cancelArtwork(ctx, ds, kinds, priorities, artworkDryRun,
+		confirmUnlessYes(artworkYes, os.Stdin, "cancel"), os.Stdout); err != nil {
 		log.Fatal(ctx, err)
 	}
 }

--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -165,9 +165,11 @@ type statusReport struct {
 	current string
 }
 
-func (r statusReport) queueTotal() int64 {
+func (r statusReport) queueTotal() int64 { return queueTotal(r.queue) }
+
+func queueTotal(stats []model.ArtworkQueueStat) int64 {
 	var n int64
-	for _, s := range r.queue {
+	for _, s := range stats {
 		n += s.Count
 	}
 	return n
@@ -187,7 +189,7 @@ func collectStatus(ctx context.Context, ds model.DataStore) (statusReport, error
 	q := ds.ArtworkQueue(ctx)
 	var rep statusReport
 	var err error
-	if rep.queue, err = q.CountByKindAndPriority(); err != nil {
+	if rep.queue, err = q.CountQueued(nil, nil); err != nil {
 		return rep, fmt.Errorf("breaking the artwork queue down by kind: %w", err)
 	}
 
@@ -227,11 +229,7 @@ func formatStatus(rep statusReport) string {
 	if len(rep.queue) == 0 {
 		fmt.Fprintln(w, "  (empty)")
 	} else {
-		fmt.Fprintln(w, "  KIND\tPRIORITY\tITEMS")
-		for _, s := range rep.queue {
-			fmt.Fprintf(w, "  %s\t%s\t%d\n", kindName(s.ItemKind), priorityName(s.Priority), s.Count)
-		}
-		fmt.Fprintf(w, "  TOTAL\t\t%d\n", rep.queueTotal())
+		printQueueStats(w, rep.queue, rep.queueTotal(), "ITEMS", "  ")
 	}
 
 	fmt.Fprintln(w, "\nSources")
@@ -276,6 +274,15 @@ func backfillState(rep statusReport) string {
 		return pending
 	}
 	return "up to date"
+}
+
+// printQueueStats writes the shared queue breakdown; the caller owns the tab writer and flushes it.
+func printQueueStats(w io.Writer, stats []model.ArtworkQueueStat, total int64, countHeader, indent string) {
+	fmt.Fprintf(w, "%sKIND\tPRIORITY\t%s\n", indent, countHeader)
+	for _, s := range stats {
+		fmt.Fprintf(w, "%s%s\t%s\t%d\n", indent, kindName(s.ItemKind), priorityName(s.Priority), s.Count)
+	}
+	fmt.Fprintf(w, "%sTOTAL\t\t%d\n", indent, total)
 }
 
 func kindName(prefix string) string {
@@ -353,16 +360,9 @@ func selectedKinds(kinds, sources []string, all bool) ([]model.Kind, error) {
 	if len(kinds) == 0 {
 		return nil, fmt.Errorf("no selector given: pass --kind, --source or --all")
 	}
-	out := make([]model.Kind, 0, len(kinds))
-	for _, k := range kinds {
-		kind, err := parseArtworkKind(k, artwork.RecheckKinds)
-		if err != nil {
-			return nil, err
-		}
-		out = append(out, kind)
-	}
-	// A repeated kind would be counted twice, overstating the cost the operator confirms.
-	return slice.Unique(out), nil
+	return parseAll(kinds, func(s string) (model.Kind, error) {
+		return parseArtworkKind(s, artwork.RecheckKinds)
+	})
 }
 
 // absentSource is how the stored empty source — resolved, no image — is spelled on the CLI.
@@ -546,55 +546,60 @@ func runCancel(ctx context.Context) {
 	}
 }
 
-// An empty filter means every one, and either flag alone is a complete selection.
+// cancelSelection leaves --all as the empty filter the repository reads as "every one", so a row
+// whose kind this build does not know still gets cancelled.
 func cancelSelection(kinds, priorities []string, all bool) ([]model.Kind, []int, error) {
 	if all {
-		return artwork.RefreshableKinds, nil, nil
+		return nil, nil, nil
 	}
 	if len(kinds) == 0 && len(priorities) == 0 {
 		return nil, nil, fmt.Errorf("no selector given: pass --kind, --priority or --all")
 	}
-	outKinds := make([]model.Kind, 0, len(kinds))
-	for _, k := range kinds {
-		// RefreshableKinds, not RecheckKinds: media files are queued, so --kind must reach them.
-		kind, err := parseArtworkKind(k, artwork.RefreshableKinds)
-		if err != nil {
-			return nil, nil, err
-		}
-		outKinds = append(outKinds, kind)
+	// RefreshableKinds, not RecheckKinds: media files are queued, so --kind must reach them.
+	outKinds, err := parseAll(kinds, func(s string) (model.Kind, error) {
+		return parseArtworkKind(s, artwork.RefreshableKinds)
+	})
+	if err != nil {
+		return nil, nil, err
 	}
-	outPriorities := make([]int, 0, len(priorities))
-	for _, p := range priorities {
-		priority, err := parseArtworkPriority(p)
-		if err != nil {
-			return nil, nil, err
-		}
-		outPriorities = append(outPriorities, priority)
+	outPriorities, err := parseAll(priorities, parseArtworkPriority)
+	if err != nil {
+		return nil, nil, err
 	}
-	// A repeated selector would be counted twice, overstating the total the operator confirms.
-	return slice.Unique(outKinds), slice.Unique(outPriorities), nil
+	return outKinds, outPriorities, nil
+}
+
+// parseAll drops repeats: a doubled selector would overstate the total the operator confirms.
+func parseAll[T comparable](values []string, parse func(string) (T, error)) ([]T, error) {
+	out := make([]T, 0, len(values))
+	for _, v := range values {
+		parsed, err := parse(v)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, parsed)
+	}
+	return slice.Unique(out), nil
 }
 
 func cancelArtwork(ctx context.Context, ds model.DataStore, kinds []model.Kind, priorities []int,
 	dryRun bool, confirm confirmFunc, out io.Writer) error {
 	q := ds.ArtworkQueue(ctx)
-	stats, err := q.CountByKindAndPriority()
+	matched, err := q.CountQueued(kinds, priorities)
 	if err != nil {
 		return fmt.Errorf("counting queued artwork: %w", err)
 	}
-	matched := matchingQueueStats(stats, kinds, priorities)
-	var total int64
-	for _, s := range matched {
-		total += s.Count
-	}
-	printCancelPreview(out, matched, total)
+	total := queueTotal(matched)
+	w := newTabWriter(out)
+	printQueueStats(w, matched, total, "MATCHED", "")
+	w.Flush()
 
 	switch {
+	case total == 0:
+		fmt.Fprintln(out, "\nNothing matches this selection.")
+		return nil
 	case dryRun:
 		fmt.Fprintln(out, "\nDry run: nothing was cancelled.")
-		return nil
-	case total == 0:
-		fmt.Fprintln(out, "Nothing was cancelled.")
 		return nil
 	case !confirm(out, total, 0):
 		fmt.Fprintln(out, "Aborted: nothing was cancelled.")
@@ -608,28 +613,6 @@ func cancelArtwork(ctx context.Context, ds model.DataStore, kinds []model.Kind, 
 	// Count and delete are separate statements, so a drain in between makes these two differ.
 	fmt.Fprintf(out, "Cancelled %d of %d matched items.\n", cancelled, total)
 	return nil
-}
-
-func matchingQueueStats(stats []model.ArtworkQueueStat, kinds []model.Kind, priorities []int) []model.ArtworkQueueStat {
-	prefixes := slice.Map(kinds, func(k model.Kind) string { return k.Prefix() })
-	return slice.Filter(stats, func(s model.ArtworkQueueStat) bool {
-		return (len(prefixes) == 0 || slices.Contains(prefixes, s.ItemKind)) &&
-			(len(priorities) == 0 || slices.Contains(priorities, s.Priority))
-	})
-}
-
-func printCancelPreview(out io.Writer, matched []model.ArtworkQueueStat, total int64) {
-	w := newTabWriter(out)
-	fmt.Fprintln(w, "KIND\tPRIORITY\tMATCHED")
-	for _, s := range matched {
-		fmt.Fprintf(w, "%s\t%s\t%d\n", kindName(s.ItemKind), priorityName(s.Priority), s.Count)
-	}
-	fmt.Fprintf(w, "TOTAL\t\t%d\n", total)
-	w.Flush()
-
-	if total == 0 {
-		fmt.Fprintln(out, "\nNothing matches this selection.")
-	}
 }
 
 // printReprocessPreview also states the external estimate, which --dry-run must show because it
@@ -697,7 +680,7 @@ var explainKinds = []model.Kind{
 }
 
 func kindPrefixes(kinds []model.Kind) string {
-	return strings.Join(slice.Map(kinds, func(k model.Kind) string { return k.Prefix() }), ", ")
+	return strings.Join(model.KindPrefixes(kinds), ", ")
 }
 
 func parseArtworkKind(s string, valid []model.Kind) (model.Kind, error) {

--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -117,8 +117,9 @@ var artworkCancelCmd = &cobra.Command{
 		"Only the queue is touched: resolved artwork and the state behind `artwork explain` are\n" +
 		"left alone, and the trace of why a cancelled item last failed goes with its queue row.\n\n" +
 		"Work already picked up is not interrupted, and an item with no artwork yet can be\n" +
-		"queued again by the hourly re-check. Use it to call off a bulk backfill, not to stop\n" +
-		"the worker.",
+		"queued again by the hourly re-check. The selection is applied again when you confirm,\n" +
+		"so anything queued after the preview is cancelled too. Use it to call off a bulk\n" +
+		"backfill, not to stop the worker.",
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		runCancel(cmd.Context())

--- a/cmd/artwork_test.go
+++ b/cmd/artwork_test.go
@@ -549,36 +549,36 @@ var _ = Describe("promptConfirm", func() {
 	BeforeEach(func() { out.Reset() })
 
 	It("states the external cost and accepts an explicit yes", func() {
-		Expect(promptConfirm(strings.NewReader("y\n"))(&out, 42, 7)).To(BeTrue())
+		Expect(promptConfirm(strings.NewReader("y\n"), "re-resolve")(&out, 42, 7)).To(BeTrue())
 		Expect(out.String()).To(ContainSubstring("re-resolve 42 items"))
 		Expect(out.String()).To(ContainSubstring("External lookups: ~7 estimated"))
 	})
 
 	It("defaults to no on anything else", func() {
-		Expect(promptConfirm(strings.NewReader("\n"))(&out, 1, 1)).To(BeFalse())
-		Expect(promptConfirm(strings.NewReader("nope\n"))(&out, 1, 1)).To(BeFalse())
-		Expect(promptConfirm(strings.NewReader(""))(&out, 1, 1)).To(BeFalse())
+		Expect(promptConfirm(strings.NewReader("\n"), "re-resolve")(&out, 1, 1)).To(BeFalse())
+		Expect(promptConfirm(strings.NewReader("nope\n"), "re-resolve")(&out, 1, 1)).To(BeFalse())
+		Expect(promptConfirm(strings.NewReader(""), "re-resolve")(&out, 1, 1)).To(BeFalse())
 	})
 
 	It("drops the external clause when no lookup will be made", func() {
-		Expect(promptConfirm(strings.NewReader("y\n"))(&out, 3, 0)).To(BeTrue())
-		Expect(out.String()).To(ContainSubstring("re-resolve 3 items."))
+		Expect(promptConfirm(strings.NewReader("y\n"), "cancel")(&out, 3, 0)).To(BeTrue())
+		Expect(out.String()).To(ContainSubstring("cancel 3 items."))
 		Expect(out.String()).ToNot(ContainSubstring("External lookups"))
 	})
 })
 
-var _ = Describe("reprocessConfirm", func() {
+var _ = Describe("confirmUnlessYes", func() {
 	var out strings.Builder
 
 	BeforeEach(func() { out.Reset() })
 
 	It("prompts when --yes was not given", func() {
-		Expect(reprocessConfirm(false, strings.NewReader("n\n"))(&out, 5, 5)).To(BeFalse())
+		Expect(confirmUnlessYes(false, strings.NewReader("n\n"), "re-resolve")(&out, 5, 5)).To(BeFalse())
 		Expect(out.String()).To(ContainSubstring("Continue?"))
 	})
 
 	It("bypasses the prompt only for --yes", func() {
-		Expect(reprocessConfirm(true, strings.NewReader(""))(&out, 5, 5)).To(BeTrue())
+		Expect(confirmUnlessYes(true, strings.NewReader(""), "re-resolve")(&out, 5, 5)).To(BeTrue())
 		Expect(out.String()).To(BeEmpty(), "--yes must not print a prompt it never reads")
 	})
 })
@@ -1057,5 +1057,153 @@ var _ = Describe("configuredAgents", func() {
 	It("drops empty entries rather than passing a name nothing can match", func() {
 		conf.Server.Agents = " , ,"
 		Expect(configuredAgents()).To(BeEmpty())
+	})
+})
+
+var _ = Describe("parseArtworkPriority", func() {
+	It("accepts every name status prints", func() {
+		for _, p := range []int{model.ArtworkPriorityRecheck, model.ArtworkPriorityBackfill,
+			model.ArtworkPriorityScan, model.ArtworkPriorityBump} {
+			Expect(parseArtworkPriority(priorityName(p))).To(Equal(p))
+		}
+	})
+
+	It("rejects an unknown name and lists the valid ones", func() {
+		_, err := parseArtworkPriority("urgent")
+		Expect(err).To(MatchError(ContainSubstring(`invalid priority "urgent"`)))
+		Expect(err).To(MatchError(ContainSubstring("backfill")))
+	})
+
+	// Accepting the raw numbers would make the help text a lie and let a typo like 11 select nothing.
+	It("rejects the numeric form", func() {
+		_, err := parseArtworkPriority("10")
+		Expect(err).To(HaveOccurred())
+	})
+})
+
+var _ = Describe("artwork cancel selection", func() {
+	It("errors when no selector is given", func() {
+		_, _, err := cancelSelection(nil, nil, false)
+		Expect(err).To(MatchError(ContainSubstring("no selector given")))
+	})
+
+	It("returns every kind and every priority for --all", func() {
+		kinds, priorities, err := cancelSelection(nil, nil, true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kinds).To(Equal(artwork.RefreshableKinds))
+		Expect(priorities).To(BeEmpty(), "no priority filter means every priority")
+	})
+
+	// The queue holds media file rows, so --all must reach them.
+	It("accepts media file artwork, which reprocess does not", func() {
+		kinds, _, err := cancelSelection([]string{"mf"}, nil, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kinds).To(Equal([]model.Kind{model.KindMediaFileArtwork}))
+	})
+
+	It("treats a priority filter on its own as a complete selection", func() {
+		kinds, priorities, err := cancelSelection(nil, []string{"backfill"}, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kinds).To(BeEmpty(), "no kind filter means every kind")
+		Expect(priorities).To(Equal([]int{model.ArtworkPriorityBackfill}))
+	})
+
+	It("returns only the named kinds and priorities", func() {
+		kinds, priorities, err := cancelSelection([]string{"ar", "al"}, []string{"backfill", "scan"}, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kinds).To(Equal([]model.Kind{model.KindArtistArtwork, model.KindAlbumArtwork}))
+		Expect(priorities).To(Equal([]int{model.ArtworkPriorityBackfill, model.ArtworkPriorityScan}))
+	})
+
+	It("counts a repeated kind and a repeated priority once", func() {
+		kinds, priorities, err := cancelSelection([]string{"ar", "ar"}, []string{"bump", "bump"}, false)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(kinds).To(HaveLen(1))
+		Expect(priorities).To(HaveLen(1))
+	})
+
+	It("rejects an unknown kind", func() {
+		_, _, err := cancelSelection([]string{"zz"}, nil, false)
+		Expect(err).To(MatchError(ContainSubstring(`invalid kind "zz"`)))
+	})
+
+	It("rejects a kind that is never queued", func() {
+		_, _, err := cancelSelection([]string{"dc"}, nil, false)
+		Expect(err).To(MatchError(ContainSubstring("invalid kind")))
+	})
+
+	It("rejects an unknown priority", func() {
+		_, _, err := cancelSelection(nil, []string{"urgent"}, false)
+		Expect(err).To(MatchError(ContainSubstring("invalid priority")))
+	})
+})
+
+var _ = Describe("cancelArtwork", func() {
+	var ds *tests.MockDataStore
+	var queue *tests.MockArtworkQueueRepo
+	var out strings.Builder
+	ctx := context.Background()
+	accept := func(io.Writer, int64, int64) bool { return true }
+	decline := func(io.Writer, int64, int64) bool { return false }
+
+	BeforeEach(func() {
+		ds = &tests.MockDataStore{}
+		queue = ds.ArtworkQueue(ctx).(*tests.MockArtworkQueueRepo)
+		out.Reset()
+		Expect(queue.Enqueue(
+			model.ArtworkQueueItem{ItemKind: "ar", ItemID: "ar-1", ImageType: model.ImageTypePrimary,
+				Priority: model.ArtworkPriorityBackfill},
+			model.ArtworkQueueItem{ItemKind: "ar", ItemID: "ar-2", ImageType: model.ImageTypePrimary,
+				Priority: model.ArtworkPriorityBump},
+			model.ArtworkQueueItem{ItemKind: "al", ItemID: "al-1", ImageType: model.ImageTypePrimary,
+				Priority: model.ArtworkPriorityBackfill},
+		)).To(Succeed())
+	})
+
+	It("previews the per-kind breakdown and cancels nothing on a dry run", func() {
+		Expect(cancelArtwork(ctx, ds, []model.Kind{model.KindArtistArtwork}, nil, true, accept, &out)).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring("artist"))
+		Expect(out.String()).To(ContainSubstring("backfill"))
+		Expect(out.String()).To(ContainSubstring("TOTAL"))
+		Expect(out.String()).To(ContainSubstring("Dry run"))
+		Expect(queue.Count()).To(BeNumerically("==", 3))
+	})
+
+	It("cancels nothing when the operator declines", func() {
+		Expect(cancelArtwork(ctx, ds, nil, nil, false, decline, &out)).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring("Aborted"))
+		Expect(queue.Count()).To(BeNumerically("==", 3))
+	})
+
+	It("deletes the selected rows and leaves the rest queued", func() {
+		Expect(cancelArtwork(ctx, ds, nil, []int{model.ArtworkPriorityBackfill}, false, accept, &out)).To(Succeed())
+
+		Expect(queue.Count()).To(BeNumerically("==", 1))
+		_, err := queue.Get(model.KindArtistArtwork, "ar-2", model.ImageTypePrimary)
+		Expect(err).ToNot(HaveOccurred(), "a non-matching priority must stay queued")
+		Expect(out.String()).To(ContainSubstring("Cancelled 2 of 2 matched items."))
+	})
+
+	It("cancels every kind and priority when neither filter is given", func() {
+		Expect(cancelArtwork(ctx, ds, nil, nil, false, accept, &out)).To(Succeed())
+		Expect(queue.Count()).To(BeZero())
+	})
+
+	It("stops at a selection that matches nothing instead of prompting", func() {
+		refuse := func(io.Writer, int64, int64) bool {
+			Fail("must not prompt when nothing matches")
+			return false
+		}
+		Expect(cancelArtwork(ctx, ds, []model.Kind{model.KindPlaylistArtwork}, nil, false, refuse, &out)).To(Succeed())
+
+		Expect(out.String()).To(ContainSubstring("Nothing matches this selection."))
+		Expect(queue.Count()).To(BeNumerically("==", 3))
+	})
+
+	It("reports a queue read failure instead of reporting nothing to cancel", func() {
+		queue.Err = errors.New("read failed")
+		Expect(cancelArtwork(ctx, ds, nil, nil, false, accept, &out)).To(MatchError(ContainSubstring("read failed")))
 	})
 })

--- a/cmd/artwork_test.go
+++ b/cmd/artwork_test.go
@@ -1087,11 +1087,13 @@ var _ = Describe("artwork cancel selection", func() {
 		Expect(err).To(MatchError(ContainSubstring("no selector given")))
 	})
 
-	It("returns every kind and every priority for --all", func() {
+	// Empty, not an enumeration of the known kinds: --all must also take a queue row whose kind
+	// this build does not recognise.
+	It("selects with no filter at all for --all", func() {
 		kinds, priorities, err := cancelSelection(nil, nil, true)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(kinds).To(Equal(artwork.RefreshableKinds))
-		Expect(priorities).To(BeEmpty(), "no priority filter means every priority")
+		Expect(kinds).To(BeEmpty())
+		Expect(priorities).To(BeEmpty())
 	})
 
 	// The queue holds media file rows, so --all must reach them.

--- a/model/artwork.go
+++ b/model/artwork.go
@@ -164,6 +164,8 @@ type ArtworkQueueRepository interface {
 	CountAbsent(kind Kind, attemptedBefore time.Time) (ArtworkAbsentStat, error)
 	// PurgeDangling removes queue rows whose entity no longer exists.
 	PurgeDangling() (int64, error)
+	// PurgeQueued removes pending rows matching the kinds and priorities; an empty filter means every one.
+	PurgeQueued(kinds []Kind, priorities []int) (int64, error)
 }
 
 type ArtworkQueueStat struct {

--- a/model/artwork.go
+++ b/model/artwork.go
@@ -157,8 +157,9 @@ type ArtworkQueueRepository interface {
 	// DeleteIfUnchanged deletes only while retry_at still matches, sparing a concurrent re-enqueue.
 	DeleteIfUnchanged(kind, id, imageType string, retryAt time.Time) error
 	Count() (int64, error)
-	// CountByKindAndPriority reports the pending queue rows grouped by kind and priority.
-	CountByKindAndPriority() ([]ArtworkQueueStat, error)
+	// CountQueued reports the pending rows matching the kinds and priorities, grouped by both;
+	// an empty filter means every one.
+	CountQueued(kinds []Kind, priorities []int) ([]ArtworkQueueStat, error)
 	// CountAbsent reports the absent states of a kind, and how many of those EnqueueStaleAbsent
 	// would pick up at the given cutoff.
 	CountAbsent(kind Kind, attemptedBefore time.Time) (ArtworkAbsentStat, error)

--- a/model/artwork_id.go
+++ b/model/artwork_id.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/navidrome/navidrome/utils/slice"
 )
 
 type Kind struct {
@@ -38,6 +40,11 @@ var artworkKindMap = map[string]Kind{
 	KindPlaylistArtwork.prefix:  KindPlaylistArtwork,
 	KindDiscArtwork.prefix:      KindDiscArtwork,
 	KindRadioArtwork.prefix:     KindRadioArtwork,
+}
+
+// KindPrefixes leaves the typed Kind domain for the item_kind column, or for a help string.
+func KindPrefixes(kinds []Kind) []string {
+	return slice.Map(kinds, func(k Kind) string { return k.prefix })
 }
 
 // ParseKind resolves an item_kind prefix (e.g. "al") to its Kind, reporting whether it was known.

--- a/persistence/artwork_queue_repository.go
+++ b/persistence/artwork_queue_repository.go
@@ -191,6 +191,18 @@ func (r *artworkQueueRepository) PurgeDangling() (int64, error) {
 	return purgeDangling(r.sqlRepository)
 }
 
+// PurgeQueued ignores retry_at: a row still backing off is pending work that would drain later.
+func (r *artworkQueueRepository) PurgeQueued(kinds []model.Kind, priorities []int) (int64, error) {
+	del := Delete(r.tableName)
+	if len(kinds) > 0 {
+		del = del.Where(Eq{"item_kind": slice.Map(kinds, func(k model.Kind) string { return k.Prefix() })})
+	}
+	if len(priorities) > 0 {
+		del = del.Where(Eq{"priority": priorities})
+	}
+	return r.executeSQL(del)
+}
+
 func (r *artworkQueueRepository) Count() (int64, error) {
 	var res struct{ Count int64 }
 	err := r.queryOne(Select("count(*) as count").From(r.tableName), &res)

--- a/persistence/artwork_queue_repository.go
+++ b/persistence/artwork_queue_repository.go
@@ -191,14 +191,35 @@ func (r *artworkQueueRepository) PurgeDangling() (int64, error) {
 	return purgeDangling(r.sqlRepository)
 }
 
-// PurgeQueued ignores retry_at: a row still backing off is pending work that would drain later.
-func (r *artworkQueueRepository) PurgeQueued(kinds []model.Kind, priorities []int) (int64, error) {
-	del := Delete(r.tableName)
+// artworkQueueFilter returns no conditions for an empty filter, so an unfiltered DELETE keeps
+// SQLite's truncate path. It ignores retry_at: a backing-off row is pending work too.
+func artworkQueueFilter(kinds []model.Kind, priorities []int) And {
+	var f And
 	if len(kinds) > 0 {
-		del = del.Where(Eq{"item_kind": slice.Map(kinds, func(k model.Kind) string { return k.Prefix() })})
+		f = append(f, Eq{"item_kind": model.KindPrefixes(kinds)})
 	}
 	if len(priorities) > 0 {
-		del = del.Where(Eq{"priority": priorities})
+		f = append(f, Eq{"priority": priorities})
+	}
+	return f
+}
+
+// CountQueued shares its filter with PurgeQueued, so a preview cannot count rows the delete misses.
+func (r *artworkQueueRepository) CountQueued(kinds []model.Kind, priorities []int) ([]model.ArtworkQueueStat, error) {
+	sel := Select("item_kind", "priority", "count(*) as count").From(r.tableName).
+		GroupBy("item_kind", "priority").OrderBy("item_kind", "priority desc")
+	if f := artworkQueueFilter(kinds, priorities); len(f) > 0 {
+		sel = sel.Where(f)
+	}
+	var res []model.ArtworkQueueStat
+	err := r.queryAll(sel, &res)
+	return res, err
+}
+
+func (r *artworkQueueRepository) PurgeQueued(kinds []model.Kind, priorities []int) (int64, error) {
+	del := Delete(r.tableName)
+	if f := artworkQueueFilter(kinds, priorities); len(f) > 0 {
+		del = del.Where(f)
 	}
 	return r.executeSQL(del)
 }
@@ -207,13 +228,6 @@ func (r *artworkQueueRepository) Count() (int64, error) {
 	var res struct{ Count int64 }
 	err := r.queryOne(Select("count(*) as count").From(r.tableName), &res)
 	return res.Count, err
-}
-
-func (r *artworkQueueRepository) CountByKindAndPriority() ([]model.ArtworkQueueStat, error) {
-	var res []model.ArtworkQueueStat
-	err := r.queryAll(Select("item_kind", "priority", "count(*) as count").From(r.tableName).
-		GroupBy("item_kind", "priority").OrderBy("item_kind", "priority desc"), &res)
-	return res, err
 }
 
 // CountAbsent matches EnqueueStaleAbsent on hash, so the stale count is what a recheck would queue.

--- a/persistence/artwork_queue_repository_test.go
+++ b/persistence/artwork_queue_repository_test.go
@@ -442,4 +442,64 @@ var _ = Describe("ArtworkQueueRepository", func() {
 			Expect(repo.CountAbsent(model.KindRadioArtwork, time.Now())).To(Equal(model.ArtworkAbsentStat{}))
 		})
 	})
+
+	Describe("PurgeQueued", func() {
+		queuedIDs := func() []string {
+			GinkgoHelper()
+			got, err := repo.DequeueBatch(100)
+			Expect(err).ToNot(HaveOccurred())
+			return slice.Map(got, func(it model.ArtworkQueueItem) string { return it.ItemID })
+		}
+
+		BeforeEach(func() {
+			Expect(repo.Enqueue(
+				item("ar", "ar-backfill", model.ArtworkPriorityBackfill),
+				item("ar", "ar-bump", model.ArtworkPriorityBump),
+				item("al", "al-backfill", model.ArtworkPriorityBackfill),
+				item("mf", "mf-scan", model.ArtworkPriorityScan),
+			)).To(Succeed())
+		})
+
+		It("deletes only the given kinds", func() {
+			Expect(repo.PurgeQueued([]model.Kind{model.KindArtistArtwork}, nil)).To(BeNumerically("==", 2))
+			Expect(queuedIDs()).To(ConsistOf("al-backfill", "mf-scan"))
+		})
+
+		It("deletes only the given priorities", func() {
+			Expect(repo.PurgeQueued(nil, []int{model.ArtworkPriorityBackfill})).To(BeNumerically("==", 2))
+			Expect(queuedIDs()).To(ConsistOf("ar-bump", "mf-scan"))
+		})
+
+		It("intersects kinds and priorities", func() {
+			Expect(repo.PurgeQueued([]model.Kind{model.KindArtistArtwork}, []int{model.ArtworkPriorityBackfill})).
+				To(BeNumerically("==", 1))
+			Expect(queuedIDs()).To(ConsistOf("ar-bump", "al-backfill", "mf-scan"))
+		})
+
+		It("deletes every row when neither filter is given", func() {
+			Expect(repo.PurgeQueued(nil, nil)).To(BeNumerically("==", 4))
+			Expect(queuedIDs()).To(BeEmpty())
+		})
+
+		It("accepts several kinds and priorities at once", func() {
+			Expect(repo.PurgeQueued(
+				[]model.Kind{model.KindArtistArtwork, model.KindMediaFileArtwork},
+				[]int{model.ArtworkPriorityBackfill, model.ArtworkPriorityScan},
+			)).To(BeNumerically("==", 2))
+			Expect(queuedIDs()).To(ConsistOf("ar-bump", "al-backfill"))
+		})
+
+		It("reports zero when nothing matches, and leaves the queue alone", func() {
+			Expect(repo.PurgeQueued([]model.Kind{model.KindPlaylistArtwork}, nil)).To(BeNumerically("==", 0))
+			Expect(queuedIDs()).To(HaveLen(4))
+		})
+
+		It("deletes a row that is still backing off", func() {
+			backOff("ar", "ar-bump", time.Now().Add(time.Hour))
+
+			Expect(repo.PurgeQueued([]model.Kind{model.KindArtistArtwork}, nil)).To(BeNumerically("==", 2))
+			Expect(repo.Get(model.KindArtistArtwork, "ar-bump", model.ImageTypePrimary)).
+				Error().To(MatchError(model.ErrNotFound))
+		})
+	})
 })

--- a/persistence/artwork_queue_repository_test.go
+++ b/persistence/artwork_queue_repository_test.go
@@ -411,7 +411,7 @@ var _ = Describe("ArtworkQueueRepository", func() {
 			Expect(repo.Enqueue(item("ar", "a3", model.ArtworkPriorityBump))).To(Succeed())
 			Expect(repo.Enqueue(item("al", "b1", model.ArtworkPriorityScan))).To(Succeed())
 
-			Expect(repo.CountByKindAndPriority()).To(ConsistOf(
+			Expect(repo.CountQueued(nil, nil)).To(ConsistOf(
 				model.ArtworkQueueStat{ItemKind: "ar", Priority: model.ArtworkPriorityBackfill, Count: 2},
 				model.ArtworkQueueStat{ItemKind: "ar", Priority: model.ArtworkPriorityBump, Count: 1},
 				model.ArtworkQueueStat{ItemKind: "al", Priority: model.ArtworkPriorityScan, Count: 1},
@@ -419,7 +419,7 @@ var _ = Describe("ArtworkQueueRepository", func() {
 		})
 
 		It("reports an empty queue as no rows", func() {
-			Expect(repo.CountByKindAndPriority()).To(BeEmpty())
+			Expect(repo.CountQueued(nil, nil)).To(BeEmpty())
 		})
 
 		It("counts absent states and how many are due for recheck", func() {
@@ -460,39 +460,36 @@ var _ = Describe("ArtworkQueueRepository", func() {
 			)).To(Succeed())
 		})
 
-		It("deletes only the given kinds", func() {
-			Expect(repo.PurgeQueued([]model.Kind{model.KindArtistArtwork}, nil)).To(BeNumerically("==", 2))
-			Expect(queuedIDs()).To(ConsistOf("al-backfill", "mf-scan"))
-		})
+		// CountQueued feeds the preview and PurgeQueued does the delete; they share one filter, so
+		// every selection must count exactly what it deletes.
+		DescribeTable("selects the same rows to count and to delete",
+			func(kinds []model.Kind, priorities []int, deleted int, remaining []string) {
+				counted, err := repo.CountQueued(kinds, priorities)
+				Expect(err).ToNot(HaveOccurred())
+				var total int64
+				for _, s := range counted {
+					total += s.Count
+				}
+				Expect(total).To(BeNumerically("==", deleted), "the preview must match the delete")
 
-		It("deletes only the given priorities", func() {
-			Expect(repo.PurgeQueued(nil, []int{model.ArtworkPriorityBackfill})).To(BeNumerically("==", 2))
-			Expect(queuedIDs()).To(ConsistOf("ar-bump", "mf-scan"))
-		})
-
-		It("intersects kinds and priorities", func() {
-			Expect(repo.PurgeQueued([]model.Kind{model.KindArtistArtwork}, []int{model.ArtworkPriorityBackfill})).
-				To(BeNumerically("==", 1))
-			Expect(queuedIDs()).To(ConsistOf("ar-bump", "al-backfill", "mf-scan"))
-		})
-
-		It("deletes every row when neither filter is given", func() {
-			Expect(repo.PurgeQueued(nil, nil)).To(BeNumerically("==", 4))
-			Expect(queuedIDs()).To(BeEmpty())
-		})
-
-		It("accepts several kinds and priorities at once", func() {
-			Expect(repo.PurgeQueued(
+				Expect(repo.PurgeQueued(kinds, priorities)).To(BeNumerically("==", deleted))
+				Expect(queuedIDs()).To(ConsistOf(remaining))
+			},
+			Entry("only the given kinds", []model.Kind{model.KindArtistArtwork}, nil,
+				2, []string{"al-backfill", "mf-scan"}),
+			Entry("only the given priorities", nil, []int{model.ArtworkPriorityBackfill},
+				2, []string{"ar-bump", "mf-scan"}),
+			Entry("the intersection of both", []model.Kind{model.KindArtistArtwork}, []int{model.ArtworkPriorityBackfill},
+				1, []string{"ar-bump", "al-backfill", "mf-scan"}),
+			Entry("everything, when neither filter is given", nil, nil,
+				4, []string{}),
+			Entry("several kinds and priorities at once",
 				[]model.Kind{model.KindArtistArtwork, model.KindMediaFileArtwork},
 				[]int{model.ArtworkPriorityBackfill, model.ArtworkPriorityScan},
-			)).To(BeNumerically("==", 2))
-			Expect(queuedIDs()).To(ConsistOf("ar-bump", "al-backfill"))
-		})
-
-		It("reports zero when nothing matches, and leaves the queue alone", func() {
-			Expect(repo.PurgeQueued([]model.Kind{model.KindPlaylistArtwork}, nil)).To(BeNumerically("==", 0))
-			Expect(queuedIDs()).To(HaveLen(4))
-		})
+				2, []string{"ar-bump", "al-backfill"}),
+			Entry("nothing, leaving the queue alone", []model.Kind{model.KindPlaylistArtwork}, nil,
+				0, []string{"ar-backfill", "ar-bump", "al-backfill", "mf-scan"}),
+		)
 
 		It("deletes a row that is still backing off", func() {
 			backOff("ar", "ar-bump", time.Now().Add(time.Hour))
@@ -500,6 +497,16 @@ var _ = Describe("ArtworkQueueRepository", func() {
 			Expect(repo.PurgeQueued([]model.Kind{model.KindArtistArtwork}, nil)).To(BeNumerically("==", 2))
 			Expect(repo.Get(model.KindArtistArtwork, "ar-bump", model.ImageTypePrimary)).
 				Error().To(MatchError(model.ErrNotFound))
+		})
+
+		// A WHERE clause, even one that matches everything, costs SQLite its truncate optimization
+		// and turns `artwork cancel --all` into a full scan of the queue.
+		It("adds no conditions at all for an empty filter", func() {
+			Expect(artworkQueueFilter(nil, nil)).To(BeEmpty())
+			Expect(artworkQueueFilter([]model.Kind{model.KindArtistArtwork}, nil)).To(HaveLen(1))
+			Expect(artworkQueueFilter(nil, []int{model.ArtworkPriorityBump})).To(HaveLen(1))
+			Expect(artworkQueueFilter([]model.Kind{model.KindArtistArtwork}, []int{model.ArtworkPriorityBump})).
+				To(HaveLen(2))
 		})
 	})
 })

--- a/tests/mock_artwork_queue_repo.go
+++ b/tests/mock_artwork_queue_repo.go
@@ -167,6 +167,27 @@ func (m *MockArtworkQueueRepo) PurgeDangling() (int64, error) {
 	return purged, nil
 }
 
+func (m *MockArtworkQueueRepo) PurgeQueued(kinds []model.Kind, priorities []int) (int64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.Err != nil {
+		return 0, m.Err
+	}
+	prefixes := slice.Map(kinds, func(k model.Kind) string { return k.Prefix() })
+	var purged int64
+	for k, it := range m.Data {
+		if len(prefixes) > 0 && !slices.Contains(prefixes, it.ItemKind) {
+			continue
+		}
+		if len(priorities) > 0 && !slices.Contains(priorities, it.Priority) {
+			continue
+		}
+		delete(m.Data, k)
+		purged++
+	}
+	return purged, nil
+}
+
 func (m *MockArtworkQueueRepo) Count() (int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/tests/mock_artwork_queue_repo.go
+++ b/tests/mock_artwork_queue_repo.go
@@ -167,19 +167,22 @@ func (m *MockArtworkQueueRepo) PurgeDangling() (int64, error) {
 	return purged, nil
 }
 
+// queueFilterMatches mirrors artworkQueueFilter, so the mock cannot let a preview and a delete disagree.
+func queueFilterMatches(it model.ArtworkQueueItem, kinds []model.Kind, priorities []int) bool {
+	prefixes := model.KindPrefixes(kinds)
+	return (len(prefixes) == 0 || slices.Contains(prefixes, it.ItemKind)) &&
+		(len(priorities) == 0 || slices.Contains(priorities, it.Priority))
+}
+
 func (m *MockArtworkQueueRepo) PurgeQueued(kinds []model.Kind, priorities []int) (int64, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.Err != nil {
 		return 0, m.Err
 	}
-	prefixes := slice.Map(kinds, func(k model.Kind) string { return k.Prefix() })
 	var purged int64
 	for k, it := range m.Data {
-		if len(prefixes) > 0 && !slices.Contains(prefixes, it.ItemKind) {
-			continue
-		}
-		if len(priorities) > 0 && !slices.Contains(priorities, it.Priority) {
+		if !queueFilterMatches(it, kinds, priorities) {
 			continue
 		}
 		delete(m.Data, k)
@@ -197,7 +200,7 @@ func (m *MockArtworkQueueRepo) Count() (int64, error) {
 	return int64(len(m.Data)), nil
 }
 
-func (m *MockArtworkQueueRepo) CountByKindAndPriority() ([]model.ArtworkQueueStat, error) {
+func (m *MockArtworkQueueRepo) CountQueued(kinds []model.Kind, priorities []int) ([]model.ArtworkQueueStat, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.Err != nil {
@@ -205,6 +208,9 @@ func (m *MockArtworkQueueRepo) CountByKindAndPriority() ([]model.ArtworkQueueSta
 	}
 	var res []model.ArtworkQueueStat
 	for _, it := range m.Data {
+		if !queueFilterMatches(it, kinds, priorities) {
+			continue
+		}
 		i := slices.IndexFunc(res, func(s model.ArtworkQueueStat) bool {
 			return s.ItemKind == it.ItemKind && s.Priority == it.Priority
 		})


### PR DESCRIPTION
### Description

Adds `navidrome artwork cancel`, which deletes pending rows from the artwork queue, selected by `--kind` and/or `--priority`.

A bulk backfill currently has no off switch. Changing an artwork setting bumps the config fingerprint, and that enqueues every entity in the library. I hit this for real once: 29,372 items queued, and iTunes rate-limited me for hours. The only way to stop it was to turn agents off, which changes the fingerprint again and queues a second full backfill. The escape hatch was the trap.

Selecting by priority is the whole point. `artwork cancel --priority backfill` drops the runaway bulk job while leaving the bump-priority rows an operator queued by hand. The command follows the `--dry-run` / preview / confirm / `-y` flow that `artwork reprocess` already uses, so the two bulk commands stay symmetric.

It only touches the queue. Resolved artwork and the `item_artwork` state behind `artwork explain` are left alone. The trace of why a cancelled item last failed goes with its queue row, and the help text says so. I looked at preserving it and decided against: the only place to put it is `last_failure`, which `explain` prints under the heading "Gave up after". Writing a cancellation there would report it as an exhausted retry budget, and a diagnostic tool that lies is worse than one that says nothing.

Two limits are stated in the help text, because neither is guessable from the outside. Work the worker has already dequeued is not interrupted. An item with no artwork state yet can be queued again by the hourly missing-artwork recheck, so the durable case is aborting a backfill, where the state rows already exist. Cancel calls off queued work. It does not stop the worker, and I deliberately did not name it as though it did.

The second commit is a cleanup pass. The rule for "which rows does cancel touch" ended up written three times, as SQL in `PurgeQueued`, in Go in the command layer, and again in the mock, which meant the preview and the delete could drift apart while the mock kept the tests green. There is now one `artworkQueueFilter` in `persistence`, shared by `PurgeQueued` and a new `CountQueued`, and the command layer does no filtering at all. That also made the preview cheaper, because it used to count the whole queue and filter in Go.

### Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

The command's `--help` output documents the behaviour and both caveats, but the CLI reference on navidrome.org would want a line for this.

### How to Test

Work against a copy of a database, not your live one, since the command deletes rows.

```bash
sqlite3 /path/to/navidrome.db ".backup '/tmp/nd-test/navidrome.db'"
export ND_DATAFOLDER=/tmp/nd-test
```

Queue some work to cancel, either by letting a backfill run or by seeding rows directly:

```sql
INSERT INTO artwork_queue (item_kind,item_id,image_type,priority,attempts,retry_at,enqueued_at)
VALUES ('ar','a1','primary',10,0,datetime('now'),datetime('now')),
       ('ar','a2','primary',100,0,datetime('now'),datetime('now')),
       ('al','b1','primary',50,0,datetime('now'),datetime('now'));
```

Then check each of these:

1. `navidrome artwork cancel` fails with `no selector given: pass --kind, --priority or --all`.
2. `navidrome artwork cancel --kind zz` and `--priority urgent` both fail and list the valid values.
3. `navidrome artwork cancel --kind ar --dry-run` prints the per-kind and per-priority breakdown and deletes nothing. Confirm with `select count(*) from artwork_queue`.
4. `navidrome artwork cancel --kind pl` matches nothing, prints "Nothing matches this selection." and never prompts.
5. `navidrome artwork cancel --kind ar`, answered with `n`, leaves every row in place.
6. `navidrome artwork cancel --priority backfill -y` deletes the backfill row and leaves the bump and scan rows queued.
7. `select count(*) from item_artwork` is unchanged throughout. Cancelling must not touch resolved artwork.
8. `navidrome artwork status` still renders its queue table correctly, both populated and empty. It shares the table code with the new preview.

To check the `--all` behaviour specifically, insert a row with an `item_kind` this build does not know:

```sql
INSERT INTO artwork_queue (item_kind,item_id,image_type,priority,attempts,retry_at,enqueued_at)
VALUES ('zz','future-kind','primary',10,0,datetime('now'),datetime('now'));
```

`--kind ar` leaves it behind, and `artwork cancel --all -y` removes it.

### Additional Notes

`--all` selects with an empty filter rather than enumerating the known kinds. I wrote the enumeration first and it was wrong twice over. It was narrower than its own flag help, because a queue row whose `item_kind` this build does not recognise survived `--all` with no flag combination able to remove it. It also cost SQLite its truncate optimization: measured with `EXPLAIN QUERY PLAN`, a bare `DELETE FROM artwork_queue` plans to nothing, while `WHERE (1=1)`, which an empty squirrel `And` renders, plans to a full index scan of the queue. A test now pins the filter's emptiness so that cannot regress quietly.

`CountByKindAndPriority` is gone from `model.ArtworkQueueRepository`, replaced by `CountQueued(kinds, priorities)`. The old method is exactly `CountQueued(nil, nil)`. Only `artwork status`, the persistence implementation and the mock used it.

`--kind` validates against `artwork.RefreshableKinds`, while the sibling `reprocess` uses `RecheckKinds`. That difference is deliberate: the queue holds media file rows, so `--all` and `--kind mf` have to reach them. I considered adding a third named kind set for this and decided it would be a fourth listing of the same five kinds.

One thing I noticed and left alone: `worker.go` hardcodes its own list of drainable kind prefixes, independent of `RefreshableKinds`. Add a kind to a drain pool without adding it to `RefreshableKinds` and `--kind` will reject a kind that is genuinely sitting in the queue. That is pre-existing and outside this change, but it is worth a follow-up.
