### PR TITLE
feat(artwork): report what a config-fingerprint backfill enqueued

### DIFF
--- a/cmd/artwork.go
+++ b/cmd/artwork.go
@@ -339,7 +339,7 @@ func runReprocess(ctx context.Context) {
 	if needsImageAgents(kinds) {
 		mgr := loadPluginAgents(ctx, false)
 		defer func() { _ = mgr.Stop() }()
-		imageAgents = imageAgentCount(ds, mgr)
+		imageAgents = artwork.NewImageAgentCount(agents.GetAgents(ds, mgr))
 	}
 
 	if err := reprocessArtwork(ctx, ds, kinds, repositorySources(artworkSources), imageAgents,
@@ -395,11 +395,6 @@ func externalEstimate(n int64) string {
 
 func externalLookupLine(n int64) string {
 	return fmt.Sprintf("External lookups: %s.", externalEstimate(n))
-}
-
-func imageAgentCount(ds model.DataStore, mgr *plugins.Manager) artwork.ImageAgentCount {
-	ag := agents.GetAgents(ds, mgr)
-	return artwork.ImageAgentCount{Artist: len(ag.ArtistImageAgents()), Album: len(ag.AlbumImageAgents())}
 }
 
 // loadPluginAgents loads the plugins named in Agents, so the CLI resolves through the same agents a

--- a/core/artwork/housekeeping.go
+++ b/core/artwork/housekeeping.go
@@ -72,18 +72,27 @@ func ConfigFingerprint() string {
 	return fmt.Sprintf("%016x", xxh3.Hash([]byte(raw)))
 }
 
+// backfillSummary is what a backfill enqueued. MaxExternalLookups is a ceiling, not a forecast:
+// an item served by a local source never reaches an agent.
+type backfillSummary struct {
+	Ran                bool
+	PerKind            map[string]int64
+	Items              int64
+	MaxExternalLookups int64
+}
+
 // backfill enqueues artwork resolution for every entity when the config fingerprint changed.
-func backfill(ctx context.Context, ds model.DataStore) (bool, error) {
+func backfill(ctx context.Context, ds model.DataStore, agentCount ImageAgentCount) (backfillSummary, error) {
 	start := time.Now()
 	ctx = auth.WithAdminUser(ctx, ds)
 	current := ConfigFingerprint()
 	props := ds.Property(ctx)
 	stored, err := props.DefaultGet(consts.ArtConfFingerprintPropertyKey, "")
 	if err != nil {
-		return false, err
+		return backfillSummary{}, err
 	}
 	if stored == current {
-		return false, nil
+		return backfillSummary{}, nil
 	}
 
 	// Artists first: few entities, most external-dependent, so they get a queue headstart.
@@ -96,21 +105,28 @@ func backfill(ctx context.Context, ds model.DataStore) (bool, error) {
 		{model.KindPlaylistArtwork, func() ([]string, error) { return ds.Playlist(ctx).GetAllIDs() }},
 		{model.KindRadioArtwork, func() ([]string, error) { return ds.Radio(ctx).GetAllIDs() }},
 	}
+	summary := backfillSummary{Ran: true, PerKind: map[string]int64{}}
 	for _, k := range kinds {
 		ids, err := k.fetch()
 		if err != nil {
-			return false, err
+			return backfillSummary{}, err
 		}
 		if err := enqueueBackfillKind(ctx, ds, k.kind, ids); err != nil {
-			return false, err
+			return backfillSummary{}, err
 		}
+		n := int64(len(ids))
+		summary.PerKind[k.kind.Prefix()] = n
+		summary.Items += n
+		summary.MaxExternalLookups += n * ExternalLookupsPerItem(k.kind, agentCount)
 	}
 
 	if err := props.Put(consts.ArtConfFingerprintPropertyKey, current); err != nil {
-		return false, err
+		return backfillSummary{}, err
 	}
-	log.Info(ctx, "Artwork: Config fingerprint changed, backfill enqueued", "elapsed", time.Since(start))
-	return true, nil
+	log.Info(ctx, "Artwork: Config fingerprint changed, backfill enqueued", "items", summary.Items,
+		"byKind", summary.PerKind, "maxExternalLookups", summary.MaxExternalLookups,
+		"elapsed", time.Since(start))
+	return summary, nil
 }
 
 func enqueueBackfillKind(ctx context.Context, ds model.DataStore, kind model.Kind, ids []string) error {

--- a/core/artwork/housekeeping.go
+++ b/core/artwork/housekeeping.go
@@ -82,7 +82,7 @@ type backfillSummary struct {
 }
 
 // backfill enqueues artwork resolution for every entity when the config fingerprint changed.
-func backfill(ctx context.Context, ds model.DataStore, agentCount ImageAgentCount) (backfillSummary, error) {
+func backfill(ctx context.Context, ds model.DataStore, agentCount func() ImageAgentCount) (backfillSummary, error) {
 	start := time.Now()
 	ctx = auth.WithAdminUser(ctx, ds)
 	current := ConfigFingerprint()
@@ -105,6 +105,9 @@ func backfill(ctx context.Context, ds model.DataStore, agentCount ImageAgentCoun
 		{model.KindPlaylistArtwork, func() ([]string, error) { return ds.Playlist(ctx).GetAllIDs() }},
 		{model.KindRadioArtwork, func() ([]string, error) { return ds.Radio(ctx).GetAllIDs() }},
 	}
+	// Counted here, not by the caller: building the agent list constructs every enabled agent, and
+	// an unchanged fingerprint returns above without ever needing the number.
+	agents := agentCount()
 	summary := backfillSummary{Ran: true, PerKind: map[string]int64{}}
 	for _, k := range kinds {
 		ids, err := k.fetch()
@@ -117,7 +120,7 @@ func backfill(ctx context.Context, ds model.DataStore, agentCount ImageAgentCoun
 		n := int64(len(ids))
 		summary.PerKind[k.kind.Prefix()] = n
 		summary.Items += n
-		summary.MaxExternalLookups += n * ExternalLookupsPerItem(k.kind, agentCount)
+		summary.MaxExternalLookups += n * ExternalLookupsPerItem(k.kind, agents)
 	}
 
 	if err := props.Put(consts.ArtConfFingerprintPropertyKey, current); err != nil {

--- a/core/artwork/housekeeping.go
+++ b/core/artwork/housekeeping.go
@@ -72,8 +72,8 @@ func ConfigFingerprint() string {
 	return fmt.Sprintf("%016x", xxh3.Hash([]byte(raw)))
 }
 
-// backfillSummary is what a backfill enqueued. MaxExternalLookups is a ceiling, not a forecast:
-// an item served by a local source never reaches an agent.
+// backfillSummary is what a backfill enqueued. MaxExternalLookups is an upper estimate for one
+// attempt per item, not a bound: a local hit ends the walk, and a retry asks the agents again.
 type backfillSummary struct {
 	Ran                bool
 	PerKind            map[string]int64

--- a/core/artwork/housekeeping_test.go
+++ b/core/artwork/housekeeping_test.go
@@ -164,9 +164,9 @@ var _ = Describe("Housekeeping", func() {
 			seedEntities()
 			Expect(propRepo.Put(consts.ArtConfFingerprintPropertyKey, ConfigFingerprint())).To(Succeed())
 
-			did, err := backfill(ctx, ds)
+			s, err := backfill(ctx, ds, ImageAgentCount{Artist: 3, Album: 2})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(did).To(BeFalse())
+			Expect(s).To(Equal(backfillSummary{}))
 
 			count, err := queueRepo.Count()
 			Expect(err).ToNot(HaveOccurred())
@@ -176,9 +176,9 @@ var _ = Describe("Housekeeping", func() {
 		It("runs the backfill when no fingerprint was ever stored", func() {
 			seedEntities()
 
-			did, err := backfill(ctx, ds)
+			s, err := backfill(ctx, ds, ImageAgentCount{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(did).To(BeTrue())
+			Expect(s.Ran).To(BeTrue())
 
 			count, err := queueRepo.Count()
 			Expect(err).ToNot(HaveOccurred())
@@ -197,9 +197,9 @@ var _ = Describe("Housekeeping", func() {
 				tracks:        &tests.MockPlaylistTrackRepo{},
 			}
 
-			did, err := backfill(ctx, vds)
+			s, err := backfill(ctx, vds, ImageAgentCount{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(did).To(BeTrue())
+			Expect(s.Ran).To(BeTrue())
 			Expect(findQueued(queueRepo.MockArtworkQueueRepo, "pl", "plPrivate")).ToNot(BeNil())
 		})
 
@@ -207,9 +207,9 @@ var _ = Describe("Housekeeping", func() {
 			seedEntities()
 			Expect(propRepo.Put(consts.ArtConfFingerprintPropertyKey, "stale-fingerprint")).To(Succeed())
 
-			did, err := backfill(ctx, ds)
+			s, err := backfill(ctx, ds, ImageAgentCount{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(did).To(BeTrue())
+			Expect(s.Ran).To(BeTrue())
 
 			Expect(queueRepo.callKinds).ToNot(BeEmpty())
 			firstOther := slices.IndexFunc(queueRepo.callKinds, func(k string) bool { return k != "ar" })
@@ -223,6 +223,23 @@ var _ = Describe("Housekeeping", func() {
 				Expect(it.Priority).To(Equal(model.ArtworkPriorityBackfill))
 				Expect(it.ItemKind).To(BeElementOf("ar", "al", "pl", "ra"))
 			}
+		})
+
+		It("reports what it enqueued, per kind and as an external-lookup ceiling", func() {
+			DeferCleanup(configtest.SetupConfig())
+			conf.Server.ArtistArtPriority = "artist.*, external"
+			conf.Server.CoverArtPriority = "cover.*, external"
+			conf.Server.EnableM3UExternalAlbumArt = false
+			seedEntities()
+
+			s, err := backfill(ctx, ds, ImageAgentCount{Artist: 3, Album: 2})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(s.Ran).To(BeTrue())
+
+			Expect(s.PerKind).To(Equal(map[string]int64{"ar": 2, "al": 1, "pl": 1, "ra": 1}))
+			Expect(s.Items).To(Equal(int64(5)))
+			// 2 artists x 3 agents, 1 album x 2, 1 playlist grid x 2, and radios never fetch.
+			Expect(s.MaxExternalLookups).To(Equal(int64(6 + 2 + PlaylistGridSamples*2)))
 		})
 	})
 

--- a/core/artwork/housekeeping_test.go
+++ b/core/artwork/housekeeping_test.go
@@ -39,6 +39,8 @@ func adminUserRepo() *tests.MockedUserRepo {
 	return repo
 }
 
+func noAgents() ImageAgentCount { return ImageAgentCount{} }
+
 // orderTrackingQueueRepo records the item kind of each Enqueue call, so tests can
 // assert phase ordering (artists-first) that same-priority timestamps can't guarantee.
 type orderTrackingQueueRepo struct {
@@ -164,9 +166,14 @@ var _ = Describe("Housekeeping", func() {
 			seedEntities()
 			Expect(propRepo.Put(consts.ArtConfFingerprintPropertyKey, ConfigFingerprint())).To(Succeed())
 
-			s, err := backfill(ctx, ds, ImageAgentCount{Artist: 3, Album: 2})
+			counted := false
+			s, err := backfill(ctx, ds, func() ImageAgentCount {
+				counted = true
+				return ImageAgentCount{Artist: 3, Album: 2}
+			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s).To(Equal(backfillSummary{}))
+			Expect(counted).To(BeFalse(), "building the agent list constructs every agent; an unchanged fingerprint must not pay for it")
 
 			count, err := queueRepo.Count()
 			Expect(err).ToNot(HaveOccurred())
@@ -176,7 +183,7 @@ var _ = Describe("Housekeeping", func() {
 		It("runs the backfill when no fingerprint was ever stored", func() {
 			seedEntities()
 
-			s, err := backfill(ctx, ds, ImageAgentCount{})
+			s, err := backfill(ctx, ds, noAgents)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Ran).To(BeTrue())
 
@@ -197,7 +204,7 @@ var _ = Describe("Housekeeping", func() {
 				tracks:        &tests.MockPlaylistTrackRepo{},
 			}
 
-			s, err := backfill(ctx, vds, ImageAgentCount{})
+			s, err := backfill(ctx, vds, noAgents)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Ran).To(BeTrue())
 			Expect(findQueued(queueRepo.MockArtworkQueueRepo, "pl", "plPrivate")).ToNot(BeNil())
@@ -207,7 +214,7 @@ var _ = Describe("Housekeeping", func() {
 			seedEntities()
 			Expect(propRepo.Put(consts.ArtConfFingerprintPropertyKey, "stale-fingerprint")).To(Succeed())
 
-			s, err := backfill(ctx, ds, ImageAgentCount{})
+			s, err := backfill(ctx, ds, noAgents)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Ran).To(BeTrue())
 
@@ -226,13 +233,12 @@ var _ = Describe("Housekeeping", func() {
 		})
 
 		It("reports what it enqueued, per kind and as an external-lookup ceiling", func() {
-			DeferCleanup(configtest.SetupConfig())
 			conf.Server.ArtistArtPriority = "artist.*, external"
 			conf.Server.CoverArtPriority = "cover.*, external"
 			conf.Server.EnableM3UExternalAlbumArt = false
 			seedEntities()
 
-			s, err := backfill(ctx, ds, ImageAgentCount{Artist: 3, Album: 2})
+			s, err := backfill(ctx, ds, func() ImageAgentCount { return ImageAgentCount{Artist: 3, Album: 2} })
 			Expect(err).ToNot(HaveOccurred())
 			Expect(s.Ran).To(BeTrue())
 

--- a/core/artwork/resolve.go
+++ b/core/artwork/resolve.go
@@ -85,6 +85,18 @@ func newResolver(ds model.DataStore, ag *agents.Agents, ffm ffmpeg.FFmpeg, gate 
 	return &resolver{ds: ds, ffmpeg: ffm, ext: &externalSource{agents: ag, gate: gate}}
 }
 
+// imageAgentCount reports how many agents an external step would consult; zero for a resolver
+// built without agents, which reaches no network at all.
+func (r *resolver) imageAgentCount() ImageAgentCount {
+	if r.ext == nil || r.ext.agents == nil {
+		return ImageAgentCount{}
+	}
+	return ImageAgentCount{
+		Artist: len(r.ext.agents.ArtistImageAgents()),
+		Album:  len(r.ext.agents.AlbumImageAgents()),
+	}
+}
+
 // newLocalResolver builds a resolver that can neither reach the network nor sample album art
 // for the worker-built grid.
 func newLocalResolver(ds model.DataStore, ffm ffmpeg.FFmpeg) *resolver {

--- a/core/artwork/resolve.go
+++ b/core/artwork/resolve.go
@@ -85,18 +85,6 @@ func newResolver(ds model.DataStore, ag *agents.Agents, ffm ffmpeg.FFmpeg, gate 
 	return &resolver{ds: ds, ffmpeg: ffm, ext: &externalSource{agents: ag, gate: gate}}
 }
 
-// imageAgentCount reports how many agents an external step would consult; zero for a resolver
-// built without agents, which reaches no network at all.
-func (r *resolver) imageAgentCount() ImageAgentCount {
-	if r.ext == nil || r.ext.agents == nil {
-		return ImageAgentCount{}
-	}
-	return ImageAgentCount{
-		Artist: len(r.ext.agents.ArtistImageAgents()),
-		Album:  len(r.ext.agents.AlbumImageAgents()),
-	}
-}
-
 // newLocalResolver builds a resolver that can neither reach the network nor sample album art
 // for the worker-built grid.
 func newLocalResolver(ds model.DataStore, ffm ffmpeg.FFmpeg) *resolver {
@@ -148,6 +136,15 @@ func MayFetchExternal(kind model.Kind) bool {
 
 // ImageAgentCount is how many enabled agents provide artist and album images.
 type ImageAgentCount struct{ Artist, Album int }
+
+// NewImageAgentCount counts what an external step would consult, so an estimate and the gate that
+// guards it cannot disagree about which agents exist.
+func NewImageAgentCount(ag *agents.Agents) ImageAgentCount {
+	if ag == nil {
+		return ImageAgentCount{}
+	}
+	return ImageAgentCount{Artist: len(ag.ArtistImageAgents()), Album: len(ag.AlbumImageAgents())}
+}
 
 // ExternalLookupsPerItem reports what resolving one item of this kind can cost: every image agent is
 // tried, and a zero count still bills one, so agents the caller cannot see never read as free.

--- a/core/artwork/worker.go
+++ b/core/artwork/worker.go
@@ -134,7 +134,8 @@ func (w *Worker) RunPrune(ctx context.Context) error {
 // Backfill enqueues every entity for re-resolution when the artwork config fingerprint changed,
 // artists first. It reports whether anything was enqueued.
 func (w *Worker) Backfill(ctx context.Context) (bool, error) {
-	return backfill(ctx, w.proc.ds)
+	s, err := backfill(ctx, w.proc.ds, w.proc.resolver.imageAgentCount())
+	return s.Ran, err
 }
 
 // EnqueueStaleAbsentAll requeues known-absent entries older than StaleAbsentAge, at most

--- a/core/artwork/worker.go
+++ b/core/artwork/worker.go
@@ -40,6 +40,7 @@ type drainPool struct {
 // independently, and pruneMu serializes prune against the store-write window.
 type Worker struct {
 	proc    *processor
+	agents  *agents.Agents
 	cache   cache.FileCache
 	ffmpeg  ffmpeg.FFmpeg
 	broker  events.Broker
@@ -54,6 +55,7 @@ type Worker struct {
 func NewWorker(ds model.DataStore, store *ImageStore, ag *agents.Agents, ffmpeg ffmpeg.FFmpeg, broker events.Broker, imgCache cache.FileCache) *Worker {
 	w := &Worker{
 		proc:   &processor{ds: ds, store: store},
+		agents: ag,
 		cache:  imgCache,
 		ffmpeg: ffmpeg,
 		broker: broker,
@@ -132,9 +134,9 @@ func (w *Worker) RunPrune(ctx context.Context) error {
 }
 
 // Backfill enqueues every entity for re-resolution when the artwork config fingerprint changed,
-// artists first. It reports whether anything was enqueued.
+// artists first. It reports whether the backfill ran.
 func (w *Worker) Backfill(ctx context.Context) (bool, error) {
-	s, err := backfill(ctx, w.proc.ds, w.proc.resolver.imageAgentCount())
+	s, err := backfill(ctx, w.proc.ds, func() ImageAgentCount { return NewImageAgentCount(w.agents) })
 	return s.Ran, err
 }
 


### PR DESCRIPTION
### Description
A config-fingerprint change re-resolves every entity in the library. On a 29k-artist library that is over 100,000 external agent calls, and the only announcement was one log line carrying an elapsed time. The size of the job stayed invisible until the request volume showed up at the providers hours later.

The backfill now logs the item count, the per-kind breakdown, and a ceiling on the external lookups the queued work can cost:

```
Artwork: Config fingerprint changed, backfill enqueued items=36422 byKind=map[al:6995 ar:29427 pl:60 rd:6] maxExternalLookups=145796 elapsed=1.2s
```

The ceiling reuses `ExternalLookupsPerItem`, the same estimator behind the `artwork reprocess` preview, so both report the same cost for the same work.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [x] Other (please describe): observability

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Run `navidrome artwork status` and note the stored fingerprint.
2. Change any fingerprint input in `navidrome.toml`, for example reorder `CoverArtPriority`, then restart the server.
3. The `Artwork: Config fingerprint changed, backfill enqueued` line now carries `items`, `byKind` and `maxExternalLookups`.
4. Restart again with no config change. No backfill line appears, and the agent list is never built.
5. `navidrome artwork reprocess --all --dry-run` reports an external-lookup count derived from the same agent set, so the CLI preview and the server log agree.

### Additional Notes
`maxExternalLookups` is a ceiling, not a forecast. `ExternalLookupsPerItem` bills every item of a fetchable kind, but an album served from a local `folder.jpg` never reaches an agent. On a 29k-artist library the real figure was about 116k against a stated ceiling of 146k. The `artwork reprocess` preview already had this property, so the two agree.