### PR TITLE
feat(jellyfin): non-expiring, audience-scoped tokens revocable by password change

### DIFF
--- a/adapters/lastfm/auth_router_test.go
+++ b/adapters/lastfm/auth_router_test.go
@@ -214,5 +214,14 @@ var _ = Describe("auth_router", func() {
 			_, err = verifyLinkToken(nonExpiringToken)
 			Expect(err).To(MatchError("link token missing expiration"))
 		})
+
+		It("rejects a Jellyfin access token", func() {
+			usr := &model.User{ID: "u1", UserName: "johndoe"}
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = verifyLinkToken(tokenStr)
+			Expect(err).To(HaveOccurred())
+		})
 	})
 })

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -133,11 +133,17 @@ func ValidatePublic(tokenStr string) (Claims, error) {
 var (
 	ErrTokenRevoked  = errors.New("token revoked")
 	ErrWrongAudience = errors.New("token not valid for this API")
+	ErrWrongUser     = errors.New("token issued for a different user")
 )
 
 // CheckClaims gates a session token against the user it names. Callers must have already
 // verified the signature; this adds revocation and API scoping on top.
 func CheckClaims(c Claims, usr model.User, audience string) error {
+	// Usernames can be reused: deleting a user and recreating the name yields a new random id
+	// at epoch 0, which an old token would otherwise match.
+	if c.UserID != "" && c.UserID != usr.ID {
+		return ErrWrongUser
+	}
 	if c.Epoch != usr.TokenEpoch {
 		return ErrTokenRevoked
 	}

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -26,6 +26,13 @@ var (
 	PublicTokenAuth *jwtauth.JWTAuth
 )
 
+// Audiences a session token can be scoped to. A token with no audience is accepted anywhere.
+const (
+	AudienceJellyfin = "jellyfin"
+	AudienceSubsonic = "subsonic"
+	AudienceNative   = "native"
+)
+
 // Init creates the JWTAuth objects from the secrets stored in the DB.
 // Missing or undecryptable secrets are regenerated and stored.
 func Init(ds model.DataStore) {
@@ -73,6 +80,7 @@ func CreateToken(u *model.User) (string, error) {
 		IssuedAt: time.Now(),
 		UserID:   u.ID,
 		IsAdmin:  u.IsAdmin,
+		Epoch:    u.TokenEpoch,
 	}
 	token, _, err := TokenAuth.Encode(claims.ToMap())
 	if err != nil {
@@ -82,10 +90,29 @@ func CreateToken(u *model.User) (string, error) {
 	return TouchToken(token)
 }
 
+// CreateAPIToken mints a non-expiring token scoped to one API, matching how Jellyfin
+// clients expect tokens to behave. Revocation is by token epoch, not expiry.
+func CreateAPIToken(u *model.User, audience string) (string, error) {
+	claims := Claims{
+		Issuer:   consts.JWTIssuer,
+		Subject:  u.UserName,
+		IssuedAt: time.Now(),
+		UserID:   u.ID,
+		IsAdmin:  u.IsAdmin,
+		Epoch:    u.TokenEpoch,
+		Audience: []string{audience},
+	}
+	_, token, err := TokenAuth.Encode(claims.ToMap())
+	return token, err
+}
+
 func TouchToken(token jwt.Token) (string, error) {
-	claims := ClaimsFromToken(token).
-		WithExpiresAt(time.Now().UTC().Add(conf.Server.SessionTimeout))
-	_, newToken, err := TokenAuth.Encode(claims.ToMap())
+	return TouchClaims(ClaimsFromToken(token))
+}
+
+func TouchClaims(c Claims) (string, error) {
+	c = c.WithExpiresAt(time.Now().UTC().Add(conf.Server.SessionTimeout))
+	_, newToken, err := TokenAuth.Encode(c.ToMap())
 	return newToken, err
 }
 

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -4,6 +4,8 @@ import (
 	"cmp"
 	"context"
 	"crypto/sha256"
+	"errors"
+	"slices"
 	"sync"
 	"time"
 
@@ -131,6 +133,23 @@ func ValidatePublic(tokenStr string) (Claims, error) {
 		return Claims{}, err
 	}
 	return ClaimsFromToken(token), nil
+}
+
+var (
+	ErrTokenRevoked  = errors.New("token revoked")
+	ErrWrongAudience = errors.New("token not valid for this API")
+)
+
+// CheckClaims gates a session token against the user it names. Callers must have already
+// verified the signature; this adds revocation and API scoping on top.
+func CheckClaims(c Claims, usr model.User, audience string) error {
+	if c.Epoch != usr.TokenEpoch {
+		return ErrTokenRevoked
+	}
+	if len(c.Audience) > 0 && !slices.Contains(c.Audience, audience) {
+		return ErrWrongAudience
+	}
+	return nil
 }
 
 func WithAdminUser(ctx context.Context, ds model.DataStore) context.Context {

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -75,16 +75,20 @@ func CreateExpiringPublicToken(exp time.Time, claims Claims) (string, error) {
 	return token, err
 }
 
-func CreateToken(u *model.User) (string, error) {
-	claims := Claims{
+func userClaims(u *model.User, audience []string) Claims {
+	return Claims{
 		Issuer:   consts.JWTIssuer,
 		Subject:  u.UserName,
 		IssuedAt: time.Now(),
 		UserID:   u.ID,
 		IsAdmin:  u.IsAdmin,
 		Epoch:    u.TokenEpoch,
+		Audience: audience,
 	}
-	token, _, err := TokenAuth.Encode(claims.ToMap())
+}
+
+func CreateToken(u *model.User) (string, error) {
+	token, _, err := TokenAuth.Encode(userClaims(u, nil).ToMap())
 	if err != nil {
 		return "", err
 	}
@@ -95,16 +99,7 @@ func CreateToken(u *model.User) (string, error) {
 // CreateAPIToken mints a non-expiring token scoped to one API, matching how Jellyfin
 // clients expect tokens to behave. Revocation is by token epoch, not expiry.
 func CreateAPIToken(u *model.User, audience string) (string, error) {
-	claims := Claims{
-		Issuer:   consts.JWTIssuer,
-		Subject:  u.UserName,
-		IssuedAt: time.Now(),
-		UserID:   u.ID,
-		IsAdmin:  u.IsAdmin,
-		Epoch:    u.TokenEpoch,
-		Audience: []string{audience},
-	}
-	_, token, err := TokenAuth.Encode(claims.ToMap())
+	_, token, err := TokenAuth.Encode(userClaims(u, []string{audience}).ToMap())
 	return token, err
 }
 

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -250,7 +250,6 @@ var _ = Describe("Auth", func() {
 		})
 
 		It("rejects a token for a deleted user recreated under the same name", func() {
-			// Same username and a fresh epoch 0, but a new random ID.
 			recreated := model.User{ID: "new-random-id", UserName: "johndoe"}
 			c := auth.Claims{UserID: "123", Audience: []string{auth.AudienceJellyfin}}
 			Expect(auth.CheckClaims(c, recreated, auth.AudienceJellyfin)).To(MatchError(auth.ErrWrongUser))

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -151,4 +151,60 @@ var _ = Describe("Auth", func() {
 			Expect(decodedClaims.ExpiresAt.Sub(yesterday)).To(BeNumerically(">=", oneDay))
 		})
 	})
+
+	Describe("CreateAPIToken", func() {
+		var usr *model.User
+
+		BeforeEach(func() {
+			usr = &model.User{ID: "123", UserName: "johndoe", TokenEpoch: 4}
+		})
+
+		It("does not expire", func() {
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+			Expect(err).ToNot(HaveOccurred())
+
+			claims, err := auth.Validate(tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims.ExpiresAt.IsZero()).To(BeTrue())
+		})
+
+		It("carries the audience and the user's epoch", func() {
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+			Expect(err).ToNot(HaveOccurred())
+
+			claims, err := auth.Validate(tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims.Audience).To(Equal([]string{"jellyfin"}))
+			Expect(claims.Epoch).To(Equal(4))
+			Expect(claims.Subject).To(Equal("johndoe"))
+			Expect(claims.UserID).To(Equal("123"))
+		})
+	})
+
+	Describe("CreateToken with an epoch", func() {
+		It("carries the epoch and still expires", func() {
+			usr := &model.User{ID: "123", UserName: "johndoe", TokenEpoch: 9}
+			tokenStr, err := auth.CreateToken(usr)
+			Expect(err).ToNot(HaveOccurred())
+
+			claims, err := auth.Validate(tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims.Epoch).To(Equal(9))
+			Expect(claims.Audience).To(BeEmpty())
+			Expect(claims.ExpiresAt).To(BeTemporally(">", time.Now()))
+		})
+	})
+
+	Describe("TouchClaims", func() {
+		It("preserves custom claims and refreshes the expiry", func() {
+			tokenStr, err := auth.TouchClaims(auth.Claims{Subject: "johndoe", UserID: "123", Epoch: 5})
+			Expect(err).ToNot(HaveOccurred())
+
+			claims, err := auth.Validate(tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims.Epoch).To(Equal(5))
+			Expect(claims.Subject).To(Equal("johndoe"))
+			Expect(claims.ExpiresAt).To(BeTemporally(">", time.Now()))
+		})
+	})
 })

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -243,5 +243,22 @@ var _ = Describe("Auth", func() {
 			fresh := model.User{ID: "456", UserName: "newbie"}
 			Expect(auth.CheckClaims(auth.Claims{}, fresh, auth.AudienceNative)).To(Succeed())
 		})
+
+		It("accepts a token whose user id matches", func() {
+			c := auth.Claims{UserID: "123", Epoch: 2}
+			Expect(auth.CheckClaims(c, usr, auth.AudienceNative)).To(Succeed())
+		})
+
+		It("rejects a token for a deleted user recreated under the same name", func() {
+			// Same username and a fresh epoch 0, but a new random ID.
+			recreated := model.User{ID: "new-random-id", UserName: "johndoe"}
+			c := auth.Claims{UserID: "123", Audience: []string{auth.AudienceJellyfin}}
+			Expect(auth.CheckClaims(c, recreated, auth.AudienceJellyfin)).To(MatchError(auth.ErrWrongUser))
+		})
+
+		It("accepts a token that carries no user id", func() {
+			fresh := model.User{ID: "456", UserName: "newbie"}
+			Expect(auth.CheckClaims(auth.Claims{}, fresh, auth.AudienceNative)).To(Succeed())
+		})
 	})
 })

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -207,4 +207,41 @@ var _ = Describe("Auth", func() {
 			Expect(claims.ExpiresAt).To(BeTemporally(">", time.Now()))
 		})
 	})
+
+	Describe("CheckClaims", func() {
+		usr := model.User{ID: "123", UserName: "johndoe", TokenEpoch: 2}
+
+		It("accepts a matching epoch and audience", func() {
+			c := auth.Claims{Epoch: 2, Audience: []string{auth.AudienceJellyfin}}
+			Expect(auth.CheckClaims(c, usr, auth.AudienceJellyfin)).To(Succeed())
+		})
+
+		It("accepts a token with no audience on any API", func() {
+			c := auth.Claims{Epoch: 2}
+			Expect(auth.CheckClaims(c, usr, auth.AudienceNative)).To(Succeed())
+			Expect(auth.CheckClaims(c, usr, auth.AudienceJellyfin)).To(Succeed())
+			Expect(auth.CheckClaims(c, usr, auth.AudienceSubsonic)).To(Succeed())
+		})
+
+		It("rejects a stale epoch", func() {
+			c := auth.Claims{Epoch: 1, Audience: []string{auth.AudienceJellyfin}}
+			Expect(auth.CheckClaims(c, usr, auth.AudienceJellyfin)).To(MatchError(auth.ErrTokenRevoked))
+		})
+
+		It("rejects a token minted for another API", func() {
+			c := auth.Claims{Epoch: 2, Audience: []string{auth.AudienceJellyfin}}
+			Expect(auth.CheckClaims(c, usr, auth.AudienceNative)).To(MatchError(auth.ErrWrongAudience))
+			Expect(auth.CheckClaims(c, usr, auth.AudienceSubsonic)).To(MatchError(auth.ErrWrongAudience))
+		})
+
+		It("accepts a multi-audience token that includes this API", func() {
+			c := auth.Claims{Epoch: 2, Audience: []string{"other", auth.AudienceNative}}
+			Expect(auth.CheckClaims(c, usr, auth.AudienceNative)).To(Succeed())
+		})
+
+		It("accepts a pre-upgrade token against a never-bumped user", func() {
+			fresh := model.User{ID: "456", UserName: "newbie"}
+			Expect(auth.CheckClaims(auth.Claims{}, fresh, auth.AudienceNative)).To(Succeed())
+		})
+	})
 })

--- a/core/auth/claims.go
+++ b/core/auth/claims.go
@@ -102,21 +102,24 @@ func ClaimsFromToken(token jwt.Token) Claims {
 	if err := token.Get("f", &f); err == nil {
 		c.Format = f
 	}
-	if err := token.Get("b", &c.BitRate); err != nil {
-		var bf float64
-		if err := token.Get("b", &bf); err == nil {
-			c.BitRate = int(bf)
-		}
-	}
+	c.BitRate = intClaim(token, "b")
 	var sid string
 	if err := token.Get("sid", &sid); err == nil {
 		c.ShareID = sid
 	}
-	if err := token.Get("ep", &c.Epoch); err != nil {
-		var ef float64
-		if err := token.Get("ep", &ef); err == nil {
-			c.Epoch = int(ef)
-		}
-	}
+	c.Epoch = intClaim(token, "ep")
 	return c
+}
+
+// intClaim reads a numeric claim, which a parsed token may decode as either int or float64.
+func intClaim(token jwt.Token, key string) int {
+	var i int
+	if err := token.Get(key, &i); err == nil {
+		return i
+	}
+	var f float64
+	if err := token.Get(key, &f); err == nil {
+		return int(f)
+	}
+	return 0
 }

--- a/core/auth/claims.go
+++ b/core/auth/claims.go
@@ -16,12 +16,14 @@ type Claims struct {
 	ExpiresAt time.Time
 
 	// Custom claims
-	UserID  string // "uid"
-	IsAdmin bool   // "adm"
-	ID      string // "id" - artwork/mediafile ID
-	Format  string // "f" - audio format
-	BitRate int    // "b" - audio bitrate
-	ShareID string // "sid" - share ID for share stream tokens
+	UserID   string   // "uid"
+	IsAdmin  bool     // "adm"
+	ID       string   // "id" - artwork/mediafile ID
+	Format   string   // "f" - audio format
+	BitRate  int      // "b" - audio bitrate
+	ShareID  string   // "sid" - share ID for share stream tokens
+	Audience []string // "aud" - which API may accept this token; empty means any
+	Epoch    int      // "ep" - the user's token_epoch at mint time
 }
 
 // ToMap converts Claims to a map[string]any for use with TokenAuth.Encode().
@@ -58,6 +60,12 @@ func (c Claims) ToMap() map[string]any {
 	if c.ShareID != "" {
 		m["sid"] = c.ShareID
 	}
+	if len(c.Audience) > 0 {
+		m[jwt.AudienceKey] = c.Audience
+	}
+	if c.Epoch != 0 {
+		m["ep"] = c.Epoch
+	}
 	return m
 }
 
@@ -73,6 +81,10 @@ func ClaimsFromToken(token jwt.Token) Claims {
 	c.Subject, _ = token.Subject()
 	c.IssuedAt, _ = token.IssuedAt()
 	c.ExpiresAt, _ = token.Expiration()
+
+	if aud, ok := token.Audience(); ok {
+		c.Audience = aud
+	}
 
 	var uid string
 	if err := token.Get("uid", &uid); err == nil {
@@ -99,6 +111,12 @@ func ClaimsFromToken(token jwt.Token) Claims {
 	var sid string
 	if err := token.Get("sid", &sid); err == nil {
 		c.ShareID = sid
+	}
+	if err := token.Get("ep", &c.Epoch); err != nil {
+		var ef float64
+		if err := token.Get("ep", &ef); err == nil {
+			c.Epoch = int(ef)
+		}
 	}
 	return c
 }

--- a/core/auth/claims.go
+++ b/core/auth/claims.go
@@ -81,10 +81,7 @@ func ClaimsFromToken(token jwt.Token) Claims {
 	c.Subject, _ = token.Subject()
 	c.IssuedAt, _ = token.IssuedAt()
 	c.ExpiresAt, _ = token.Expiration()
-
-	if aud, ok := token.Audience(); ok {
-		c.Audience = aud
-	}
+	c.Audience, _ = token.Audience()
 
 	var uid string
 	if err := token.Get("uid", &uid); err == nil {

--- a/core/auth/claims.go
+++ b/core/auth/claims.go
@@ -11,19 +11,19 @@ import (
 type Claims struct {
 	// Standard JWT claims
 	Issuer    string
-	Subject   string // username for session tokens
+	Subject   string   // username for session tokens
+	Audience  []string // which API may accept this token; empty means any
 	IssuedAt  time.Time
 	ExpiresAt time.Time
 
 	// Custom claims
-	UserID   string   // "uid"
-	IsAdmin  bool     // "adm"
-	ID       string   // "id" - artwork/mediafile ID
-	Format   string   // "f" - audio format
-	BitRate  int      // "b" - audio bitrate
-	ShareID  string   // "sid" - share ID for share stream tokens
-	Audience []string // "aud" - which API may accept this token; empty means any
-	Epoch    int      // "ep" - the user's token_epoch at mint time
+	UserID  string // "uid"
+	IsAdmin bool   // "adm"
+	ID      string // "id" - artwork/mediafile ID
+	Format  string // "f" - audio format
+	BitRate int    // "b" - audio bitrate
+	ShareID string // "sid" - share ID for share stream tokens
+	Epoch   int    // "ep" - the user's token_epoch at mint time
 }
 
 // ToMap converts Claims to a map[string]any for use with TokenAuth.Encode().
@@ -35,6 +35,9 @@ func (c Claims) ToMap() map[string]any {
 	}
 	if c.Subject != "" {
 		m[jwt.SubjectKey] = c.Subject
+	}
+	if len(c.Audience) > 0 {
+		m[jwt.AudienceKey] = c.Audience
 	}
 	if !c.IssuedAt.IsZero() {
 		m[jwt.IssuedAtKey] = c.IssuedAt.UTC().Unix()
@@ -59,9 +62,6 @@ func (c Claims) ToMap() map[string]any {
 	}
 	if c.ShareID != "" {
 		m["sid"] = c.ShareID
-	}
-	if len(c.Audience) > 0 {
-		m[jwt.AudienceKey] = c.Audience
 	}
 	if c.Epoch != 0 {
 		m["ep"] = c.Epoch

--- a/core/auth/claims_test.go
+++ b/core/auth/claims_test.go
@@ -105,4 +105,44 @@ var _ = Describe("Claims", func() {
 		})
 	})
 
+	Describe("Audience and Epoch claims", func() {
+		It("omits both when zero", func() {
+			m := auth.Claims{ID: "artwork-id"}.ToMap()
+			Expect(m).ToNot(HaveKey("aud"))
+			Expect(m).ToNot(HaveKey("ep"))
+		})
+
+		It("includes them when set", func() {
+			m := auth.Claims{Subject: "u", Epoch: 3, Audience: []string{"jellyfin"}}.ToMap()
+			Expect(m).To(HaveKeyWithValue("ep", 3))
+			Expect(m).To(HaveKeyWithValue("aud", []string{"jellyfin"}))
+		})
+
+		It("round-trips through a signed token", func() {
+			tokenAuth := jwtauth.New("HS256", []byte("test-secret"), nil)
+			_, tokenStr, err := tokenAuth.Encode(auth.Claims{
+				Subject: "u", Epoch: 7, Audience: []string{"jellyfin"},
+			}.ToMap())
+			Expect(err).ToNot(HaveOccurred())
+
+			token, err := jwtauth.VerifyToken(tokenAuth, tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			claims := auth.ClaimsFromToken(token)
+			Expect(claims.Epoch).To(Equal(7))
+			Expect(claims.Audience).To(Equal([]string{"jellyfin"}))
+		})
+
+		It("reads a token that has neither claim", func() {
+			tokenAuth := jwtauth.New("HS256", []byte("test-secret"), nil)
+			_, tokenStr, err := tokenAuth.Encode(auth.Claims{Subject: "u"}.ToMap())
+			Expect(err).ToNot(HaveOccurred())
+
+			token, err := jwtauth.VerifyToken(tokenAuth, tokenStr)
+			Expect(err).ToNot(HaveOccurred())
+			claims := auth.ClaimsFromToken(token)
+			Expect(claims.Epoch).To(BeZero())
+			Expect(claims.Audience).To(BeEmpty())
+		})
+	})
+
 })

--- a/core/stream/token_test.go
+++ b/core/stream/token_test.go
@@ -232,6 +232,16 @@ var _ = Describe("Token", func() {
 			_, err := svc.ResolveRequestFromToken(ctx, token, mf, 0)
 			Expect(err).To(MatchError(ErrTokenStale))
 		})
+
+		It("rejects a Jellyfin access token", func() {
+			mf := &model.MediaFile{ID: "song-1", UpdatedAt: sourceTime}
+			usr := &model.User{ID: "u1", UserName: "johndoe"}
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = svc.ResolveRequestFromToken(ctx, tokenStr, mf, 0)
+			Expect(err).To(MatchError(ErrTokenInvalid))
+		})
 	})
 
 	Describe("paramsFromToken", func() {

--- a/db/migrations/20260822062750_add_user_token_epoch.sql
+++ b/db/migrations/20260822062750_add_user_token_epoch.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+
+ALTER TABLE user ADD COLUMN token_epoch INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+
+ALTER TABLE user DROP COLUMN token_epoch;

--- a/log/log.go
+++ b/log/log.go
@@ -47,8 +47,9 @@ var redacted = &Hook{
 
 		// External services query params. Values can be JWTs (dots, dashes), so match everything up
 		// to the next query separator or whitespace, not just word chars. A [\w]+ class would stop
-		// at a JWT's first '.' and leak its payload and signature.
-		"([^\\w]api_key=)[^&\\s]+",
+		// at a JWT's first '.' and leak its payload and signature. Case-insensitive and with an
+		// optional underscore, because the Jellyfin API accepts api_key, apikey and ApiKey alike.
+		"(?i)([^\\w]api_?key=)[^&\\s]+",
 	},
 }
 

--- a/log/log.go
+++ b/log/log.go
@@ -47,8 +47,8 @@ var redacted = &Hook{
 
 		// External services query params. Values can be JWTs (dots, dashes), so match everything up
 		// to the next query separator or whitespace, not just word chars. A [\w]+ class would stop
-		// at a JWT's first '.' and leak its payload and signature. Case-insensitive and with an
-		// optional underscore, because the Jellyfin API accepts api_key, apikey and ApiKey alike.
+		// at a JWT's first '.' and leak its payload and signature. Case-insensitive with an
+		// optional underscore: the API accepts api_key, apikey and ApiKey alike.
 		"(?i)([^\\w]api_?key=)[^&\\s]+",
 	},
 }

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -264,5 +264,16 @@ var _ = Describe("Logger", func() {
 			msg := "/jellyfin/Audio/abc/universal?static=true&api_key=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiJ9.c2ln-X_1&other=1"
 			Expect(Redact(msg)).To(Equal("/jellyfin/Audio/abc/universal?static=true&api_key=[REDACTED]&other=1"))
 		})
+
+		DescribeTable("redacts every api_key spelling the Jellyfin API accepts",
+			func(param string) {
+				msg := "/jellyfin/Audio/abc/File?" + param + "=SECRET&other=1"
+				Expect(Redact(msg)).To(Equal("/jellyfin/Audio/abc/File?" + param + "=[REDACTED]&other=1"))
+			},
+			Entry("api_key", "api_key"),
+			Entry("apikey", "apikey"),
+			Entry("ApiKey", "ApiKey"),
+			Entry("APIKEY", "APIKEY"),
+		)
 	})
 })

--- a/model/request/request.go
+++ b/model/request/request.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"context"
+	"sync/atomic"
 
 	"github.com/navidrome/navidrome/model"
 )
@@ -9,15 +10,16 @@ import (
 type contextKey string
 
 const (
-	User           = contextKey("user")
-	Username       = contextKey("username")
-	Client         = contextKey("client")
-	Version        = contextKey("version")
-	Player         = contextKey("player")
-	Transcoding    = contextKey("transcoding")
-	ClientUniqueId = contextKey("clientUniqueId")
-	ReverseProxyIp = contextKey("reverseProxyIp")
-	InternalAuth   = contextKey("internalAuth") // Used for internal API calls, e.g., from the plugins
+	User             = contextKey("user")
+	Username         = contextKey("username")
+	Client           = contextKey("client")
+	Version          = contextKey("version")
+	Player           = contextKey("player")
+	Transcoding      = contextKey("transcoding")
+	ClientUniqueId   = contextKey("clientUniqueId")
+	ReverseProxyIp   = contextKey("reverseProxyIp")
+	InternalAuth     = contextKey("internalAuth") // Used for internal API calls, e.g., from the plugins
+	TokenEpochHolder = contextKey("tokenEpochHolder")
 )
 
 var allKeys = []contextKey{
@@ -124,4 +126,33 @@ func AddValues(ctx, requestCtx context.Context) context.Context {
 		}
 	}
 	return ctx
+}
+
+type tokenEpochHolder struct {
+	value atomic.Int64
+}
+
+// WithTokenEpochHolder installs a slot a handler can use to report a bumped token epoch
+// back to middleware that has already returned from the handler's perspective.
+func WithTokenEpochHolder(ctx context.Context) context.Context {
+	h := &tokenEpochHolder{}
+	h.value.Store(-1)
+	return context.WithValue(ctx, TokenEpochHolder, h)
+}
+
+func SetTokenEpoch(ctx context.Context, epoch int) {
+	if h, ok := ctx.Value(TokenEpochHolder).(*tokenEpochHolder); ok {
+		h.value.Store(int64(epoch))
+	}
+}
+
+func TokenEpochFrom(ctx context.Context) (int, bool) {
+	h, ok := ctx.Value(TokenEpochHolder).(*tokenEpochHolder)
+	if !ok {
+		return 0, false
+	}
+	if v := h.value.Load(); v >= 0 {
+		return int(v), true
+	}
+	return 0, false
 }

--- a/model/request/request_suite_test.go
+++ b/model/request/request_suite_test.go
@@ -1,0 +1,17 @@
+package request
+
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// tests.Init is not used here: the tests package imports model/request, so importing it
+// back would create an import cycle.
+func TestRequest(t *testing.T) {
+	log.SetLevel(log.LevelFatal)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Request Suite")
+}

--- a/model/request/request_test.go
+++ b/model/request/request_test.go
@@ -1,0 +1,40 @@
+package request
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Token epoch holder", func() {
+	It("reports nothing when unset", func() {
+		ctx := WithTokenEpochHolder(context.TODO())
+		_, ok := TokenEpochFrom(ctx)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("round-trips a value set by the handler", func() {
+		ctx := WithTokenEpochHolder(context.TODO())
+		SetTokenEpoch(ctx, 7)
+
+		epoch, ok := TokenEpochFrom(ctx)
+		Expect(ok).To(BeTrue())
+		Expect(epoch).To(Equal(7))
+	})
+
+	It("survives being wrapped in a derived context", func() {
+		ctx := WithTokenEpochHolder(context.TODO())
+		SetTokenEpoch(context.WithValue(ctx, contextKey("unrelated"), 1), 3)
+
+		epoch, ok := TokenEpochFrom(ctx)
+		Expect(ok).To(BeTrue())
+		Expect(epoch).To(Equal(3))
+	})
+
+	It("is a no-op with no holder installed", func() {
+		Expect(func() { SetTokenEpoch(context.TODO(), 5) }).ToNot(Panic())
+		_, ok := TokenEpochFrom(context.TODO())
+		Expect(ok).To(BeFalse())
+	})
+})

--- a/model/user.go
+++ b/model/user.go
@@ -54,8 +54,6 @@ type UserRepository interface {
 	Put(*User) error
 	UpdateLastLoginAt(id string) error
 	UpdateLastAccessAt(id string) error
-	// BumpTokenEpoch invalidates every token issued for this user, returning the new epoch.
-	BumpTokenEpoch(id string) (int, error)
 	FindFirstAdmin() (*User, error)
 	// FindByUsername must be case-insensitive
 	FindByUsername(username string) (*User, error)

--- a/model/user.go
+++ b/model/user.go
@@ -22,6 +22,8 @@ type User struct {
 
 	// This is only available on the backend, and it is never sent over the wire
 	Password string `structs:"-" json:"-"`
+	// Bumped on password change to invalidate every issued token for this user.
+	TokenEpoch int `structs:"-" json:"-"`
 	// This is used to set or change a password when calling Put. If it is empty, the password is not changed.
 	// It is received from the UI with the name "password"
 	NewPassword string `structs:"password,omitempty" json:"password,omitempty"` //nolint:gosec
@@ -52,6 +54,8 @@ type UserRepository interface {
 	Put(*User) error
 	UpdateLastLoginAt(id string) error
 	UpdateLastAccessAt(id string) error
+	// BumpTokenEpoch invalidates every token issued for this user, returning the new epoch.
+	BumpTokenEpoch(id string) (int, error)
 	FindFirstAdmin() (*User, error)
 	// FindByUsername must be case-insensitive
 	FindByUsername(username string) (*User, error)

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -221,19 +221,17 @@ func (r *userRepository) UpdateLastAccessAt(id string) error {
 	return err
 }
 
+// BumpTokenEpoch invalidates every token issued for this user, returning the new epoch.
+// RETURNING keeps the increment and the read in one statement: a separate read can observe a
+// concurrent bump and hand back an epoch this call did not produce, leaving that session valid.
 func (r *userRepository) BumpTokenEpoch(id string) (int, error) {
-	upd := Update(r.tableName).Set("token_epoch", Expr("token_epoch + 1")).Where(Eq{"id": id})
-	count, err := r.executeSQL(upd)
-	if err != nil {
+	upd := Update(r.tableName).Set("token_epoch", Expr("token_epoch + 1")).Where(Eq{"id": id}).
+		Suffix("RETURNING token_epoch")
+	var res struct{ TokenEpoch int }
+	if err := r.queryOne(upd, &res); err != nil {
 		return 0, err
 	}
-	if count == 0 {
-		return 0, model.ErrNotFound
-	}
-
-	var res struct{ TokenEpoch int }
-	err = r.queryOne(Select("token_epoch").From(r.tableName).Where(Eq{"id": id}), &res)
-	return res.TokenEpoch, err
+	return res.TokenEpoch, nil
 }
 
 func (r *userRepository) Count(options ...rest.QueryOptions) (int64, error) {

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -208,6 +208,22 @@ func (r *userRepository) UpdateLastAccessAt(id string) error {
 	return err
 }
 
+func (r *userRepository) BumpTokenEpoch(id string) (int, error) {
+	upd := Update(r.tableName).Set("token_epoch", Expr("token_epoch + 1")).Where(Eq{"id": id})
+	count, err := r.executeSQL(upd)
+	if err != nil {
+		return 0, err
+	}
+	if count == 0 {
+		return 0, model.ErrNotFound
+	}
+	usr, err := r.Get(id)
+	if err != nil {
+		return 0, err
+	}
+	return usr.TokenEpoch, nil
+}
+
 func (r *userRepository) Count(options ...rest.QueryOptions) (int64, error) {
 	usr := loggedUser(r.ctx)
 	if !usr.IsAdmin {

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -18,6 +18,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
 	"github.com/navidrome/navidrome/model/id"
+	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/utils"
 	"github.com/navidrome/navidrome/utils/slice"
 	"github.com/pocketbase/dbx"
@@ -160,6 +161,18 @@ func (r *userRepository) Put(u *model.User) error {
 		)
 		if _, err := r.executeSQL(sql); err != nil {
 			return fmt.Errorf("failed to assign default libraries to new user: %w", err)
+		}
+	}
+
+	if u.NewPassword != "" && !isNewUser {
+		epoch, err := r.BumpTokenEpoch(u.ID)
+		if err != nil {
+			return err
+		}
+		// Only the caller's own token can be refreshed in-flight; an admin resetting another
+		// user must keep their own epoch.
+		if actor, ok := request.UserFrom(r.ctx); ok && actor.ID == u.ID {
+			request.SetTokenEpoch(r.ctx, epoch)
 		}
 	}
 

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -127,14 +127,31 @@ func (r *userRepository) Put(u *model.User) error {
 	}
 	delete(values, "current_password")
 
-	// Save/update the user
+	// Save/update the user. A password change bumps the token epoch in the same statement:
+	// as two statements they can interleave with a concurrent change and leave a session
+	// valid that the other change should have revoked.
 	update := Update(r.tableName).Where(Eq{"id": u.ID}).SetMap(values)
-	count, err := r.executeSQL(update)
-	if err != nil {
-		return err
+	var isNewUser bool
+	var epoch int
+	if u.NewPassword != "" {
+		var res struct{ TokenEpoch int }
+		err = r.queryOne(update.Set("token_epoch", Expr("token_epoch + 1")).
+			Suffix("RETURNING token_epoch"), &res)
+		switch {
+		case errors.Is(err, model.ErrNotFound):
+			isNewUser = true
+		case err != nil:
+			return err
+		default:
+			epoch = res.TokenEpoch
+		}
+	} else {
+		count, err := r.executeSQL(update)
+		if err != nil {
+			return err
+		}
+		isNewUser = count == 0
 	}
-
-	isNewUser := count == 0
 	if isNewUser {
 		values["created_at"] = time.Now()
 		insert := Insert(r.tableName).SetMap(values)
@@ -164,16 +181,10 @@ func (r *userRepository) Put(u *model.User) error {
 		}
 	}
 
-	if u.NewPassword != "" && !isNewUser {
-		epoch, err := r.BumpTokenEpoch(u.ID)
-		if err != nil {
-			return err
-		}
-		// Only the caller's own token can be refreshed in-flight; an admin resetting another
-		// user must keep their own epoch.
-		if loggedUser(r.ctx).ID == u.ID {
-			request.SetTokenEpoch(r.ctx, epoch)
-		}
+	// Only the caller's own token can be refreshed in-flight; an admin resetting another
+	// user must keep their own epoch.
+	if u.NewPassword != "" && !isNewUser && loggedUser(r.ctx).ID == u.ID {
+		request.SetTokenEpoch(r.ctx, epoch)
 	}
 
 	return nil
@@ -219,19 +230,6 @@ func (r *userRepository) UpdateLastAccessAt(id string) error {
 	upd := Update(r.tableName).Where(Eq{"id": id}).Set("last_access_at", now)
 	_, err := r.executeSQL(upd)
 	return err
-}
-
-// BumpTokenEpoch invalidates every token issued for this user, returning the new epoch.
-// RETURNING keeps the increment and the read in one statement: a separate read can observe a
-// concurrent bump and hand back an epoch this call did not produce, leaving that session valid.
-func (r *userRepository) BumpTokenEpoch(id string) (int, error) {
-	upd := Update(r.tableName).Set("token_epoch", Expr("token_epoch + 1")).Where(Eq{"id": id}).
-		Suffix("RETURNING token_epoch")
-	var res struct{ TokenEpoch int }
-	if err := r.queryOne(upd, &res); err != nil {
-		return 0, err
-	}
-	return res.TokenEpoch, nil
 }
 
 func (r *userRepository) Count(options ...rest.QueryOptions) (int64, error) {

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -127,9 +127,8 @@ func (r *userRepository) Put(u *model.User) error {
 	}
 	delete(values, "current_password")
 
-	// Save/update the user. A password change bumps the token epoch in the same statement:
-	// as two statements they can interleave with a concurrent change and leave a session
-	// valid that the other change should have revoked.
+	// The epoch bump rides the password UPDATE: as two statements they can interleave with a
+	// concurrent change and leave a session valid that the other change should have revoked.
 	update := Update(r.tableName).Where(Eq{"id": u.ID}).SetMap(values)
 	var isNewUser bool
 	var epoch int

--- a/persistence/user_repository.go
+++ b/persistence/user_repository.go
@@ -171,7 +171,7 @@ func (r *userRepository) Put(u *model.User) error {
 		}
 		// Only the caller's own token can be refreshed in-flight; an admin resetting another
 		// user must keep their own epoch.
-		if actor, ok := request.UserFrom(r.ctx); ok && actor.ID == u.ID {
+		if loggedUser(r.ctx).ID == u.ID {
 			request.SetTokenEpoch(r.ctx, epoch)
 		}
 	}
@@ -230,11 +230,10 @@ func (r *userRepository) BumpTokenEpoch(id string) (int, error) {
 	if count == 0 {
 		return 0, model.ErrNotFound
 	}
-	usr, err := r.Get(id)
-	if err != nil {
-		return 0, err
-	}
-	return usr.TokenEpoch, nil
+
+	var res struct{ TokenEpoch int }
+	err = r.queryOne(Select("token_epoch").From(r.tableName).Where(Eq{"id": id}), &res)
+	return res.TokenEpoch, err
 }
 
 func (r *userRepository) Count(options ...rest.QueryOptions) (int64, error) {

--- a/persistence/user_repository_test.go
+++ b/persistence/user_repository_test.go
@@ -736,9 +736,7 @@ var _ = Describe("UserRepository", func() {
 		})
 
 		It("never signals the same epoch to two concurrent password changes", func() {
-			// Each writer's epoch must be the one its own UPDATE produced. As two statements the
-			// bump can interleave with a concurrent change, leaving a session the other change
-			// should have revoked holding a still-valid epoch.
+			// Each writer's epoch must be the one its own UPDATE produced.
 			const callers = 4
 			var mu sync.Mutex
 			var signalled []int

--- a/persistence/user_repository_test.go
+++ b/persistence/user_repository_test.go
@@ -723,4 +723,76 @@ var _ = Describe("UserRepository", func() {
 			Expect(err).To(MatchError(model.ErrNotFound))
 		})
 	})
+
+	Describe("Put and the token epoch", func() {
+		newRepo := func(actingUserID string) model.UserRepository {
+			ctx := log.NewContext(context.TODO())
+			ctx = request.WithUser(ctx, model.User{ID: actingUserID, IsAdmin: true})
+			ctx = request.WithTokenEpochHolder(ctx)
+			return NewUserRepository(ctx, GetDBXBuilder())
+		}
+
+		It("does not bump when creating a user", func() {
+			repo := newRepo("admin")
+			usr := model.User{ID: id.NewRandom(), UserName: "fresh", NewPassword: "pw1"}
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			got, err := repo.Get(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.TokenEpoch).To(Equal(0))
+		})
+
+		It("bumps when the password changes", func() {
+			repo := newRepo("admin")
+			usr := model.User{ID: id.NewRandom(), UserName: "changer", NewPassword: "pw1"}
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			usr.NewPassword = "pw2"
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			got, err := repo.Get(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.TokenEpoch).To(Equal(1))
+		})
+
+		It("does not bump on an edit that leaves the password alone", func() {
+			repo := newRepo("admin")
+			usr := model.User{ID: id.NewRandom(), UserName: "renamer", NewPassword: "pw1"}
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			usr.NewPassword = ""
+			usr.Name = "New Display Name"
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			got, err := repo.Get(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.TokenEpoch).To(Equal(0))
+		})
+
+		It("signals the new epoch when a user changes their own password", func() {
+			userID := id.NewRandom()
+			repo := newRepo(userID)
+			usr := model.User{ID: userID, UserName: "self", NewPassword: "pw1"}
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			usr.NewPassword = "pw2"
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			epoch, ok := request.TokenEpochFrom(repo.(*userRepository).ctx)
+			Expect(ok).To(BeTrue())
+			Expect(epoch).To(Equal(1))
+		})
+
+		It("does not signal when an admin changes someone else's password", func() {
+			repo := newRepo("some-admin")
+			usr := model.User{ID: id.NewRandom(), UserName: "other", NewPassword: "pw1"}
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			usr.NewPassword = "pw2"
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			_, ok := request.TokenEpochFrom(repo.(*userRepository).ctx)
+			Expect(ok).To(BeFalse())
+		})
+	})
 })

--- a/persistence/user_repository_test.go
+++ b/persistence/user_repository_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"slices"
+	"sync"
 
 	"github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
@@ -13,6 +14,7 @@ import (
 	"github.com/navidrome/navidrome/model/id"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/tests"
+	"github.com/navidrome/navidrome/utils/slice"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -721,6 +723,30 @@ var _ = Describe("UserRepository", func() {
 		It("returns ErrNotFound for an unknown user", func() {
 			_, err := repo.BumpTokenEpoch("does-not-exist")
 			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+
+		It("never hands the same epoch to two concurrent callers", func() {
+			// Each caller must get the value its own increment produced. If the read is a
+			// separate statement, a concurrent bump lands in between and both read the same
+			// value, so a session that should have been revoked keeps a valid token.
+			const callers = 4
+			var mu sync.Mutex
+			var got []int
+			var wg sync.WaitGroup
+			for range callers {
+				wg.Go(func() {
+					epoch, err := repo.BumpTokenEpoch(usr.ID)
+					if err != nil {
+						return // the shared in-memory test DB can raise SQLITE_LOCKED
+					}
+					mu.Lock()
+					defer mu.Unlock()
+					got = append(got, epoch)
+				})
+			}
+			wg.Wait()
+
+			Expect(got).To(HaveLen(len(slice.Unique(got))), "an epoch was handed to more than one caller: %v", got)
 		})
 	})
 

--- a/persistence/user_repository_test.go
+++ b/persistence/user_repository_test.go
@@ -683,4 +683,44 @@ var _ = Describe("UserRepository", func() {
 			Expect(query).To(ContainSubstring("user.id = {:p0}"))
 		})
 	})
+
+	Describe("BumpTokenEpoch", func() {
+		var repo model.UserRepository
+		var usr model.User
+
+		BeforeEach(func() {
+			ctx := log.NewContext(context.TODO())
+			ctx = request.WithUser(ctx, model.User{ID: "userid", IsAdmin: true})
+			repo = NewUserRepository(ctx, GetDBXBuilder())
+			uid := id.NewRandom()
+			// user_name is unique; suffix it so each It gets its own row in the shared suite DB.
+			usr = model.User{ID: uid, UserName: "epoch-user-" + uid, Name: "Epoch", NewPassword: "hunter2"}
+			Expect(repo.Put(&usr)).To(Succeed())
+		})
+
+		It("starts at zero", func() {
+			got, err := repo.Get(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.TokenEpoch).To(Equal(0))
+		})
+
+		It("increments and returns the new value", func() {
+			epoch, err := repo.BumpTokenEpoch(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(epoch).To(Equal(1))
+
+			epoch, err = repo.BumpTokenEpoch(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(epoch).To(Equal(2))
+
+			got, err := repo.Get(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.TokenEpoch).To(Equal(2))
+		})
+
+		It("returns ErrNotFound for an unknown user", func() {
+			_, err := repo.BumpTokenEpoch("does-not-exist")
+			Expect(err).To(MatchError(model.ErrNotFound))
+		})
+	})
 })

--- a/persistence/user_repository_test.go
+++ b/persistence/user_repository_test.go
@@ -686,67 +686,88 @@ var _ = Describe("UserRepository", func() {
 		})
 	})
 
-	Describe("BumpTokenEpoch", func() {
+	Describe("token epoch", func() {
 		var repo model.UserRepository
 		var usr model.User
+
+		newUser := func() model.User {
+			uid := id.NewRandom()
+			// user_name is unique; suffix it so each It gets its own row in the shared suite DB.
+			return model.User{ID: uid, UserName: "epoch-user-" + uid, Name: "Epoch", NewPassword: "hunter2"}
+		}
 
 		BeforeEach(func() {
 			ctx := log.NewContext(context.TODO())
 			ctx = request.WithUser(ctx, model.User{ID: "userid", IsAdmin: true})
 			repo = NewUserRepository(ctx, GetDBXBuilder())
-			uid := id.NewRandom()
-			// user_name is unique; suffix it so each It gets its own row in the shared suite DB.
-			usr = model.User{ID: uid, UserName: "epoch-user-" + uid, Name: "Epoch", NewPassword: "hunter2"}
+			usr = newUser()
 			Expect(repo.Put(&usr)).To(Succeed())
 		})
 
-		It("starts at zero", func() {
+		It("starts at zero for a new user", func() {
 			got, err := repo.Get(usr.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(got.TokenEpoch).To(Equal(0))
 		})
 
-		It("increments and returns the new value", func() {
-			epoch, err := repo.BumpTokenEpoch(usr.ID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(epoch).To(Equal(1))
-
-			epoch, err = repo.BumpTokenEpoch(usr.ID)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(epoch).To(Equal(2))
-
+		It("increments once per password change", func() {
+			usr.NewPassword = "second"
+			Expect(repo.Put(&usr)).To(Succeed())
 			got, err := repo.Get(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.TokenEpoch).To(Equal(1))
+
+			usr.NewPassword = "third"
+			Expect(repo.Put(&usr)).To(Succeed())
+			got, err = repo.Get(usr.ID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(got.TokenEpoch).To(Equal(2))
 		})
 
-		It("returns ErrNotFound for an unknown user", func() {
-			_, err := repo.BumpTokenEpoch("does-not-exist")
-			Expect(err).To(MatchError(model.ErrNotFound))
+		It("leaves the epoch alone when the password is untouched", func() {
+			usr.NewPassword = ""
+			usr.Name = "Renamed"
+			Expect(repo.Put(&usr)).To(Succeed())
+
+			got, err := repo.Get(usr.ID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(got.TokenEpoch).To(Equal(0))
+			Expect(got.Name).To(Equal("Renamed"))
 		})
 
-		It("never hands the same epoch to two concurrent callers", func() {
-			// Each caller must get the value its own increment produced. If the read is a
-			// separate statement, a concurrent bump lands in between and both read the same
-			// value, so a session that should have been revoked keeps a valid token.
+		It("never signals the same epoch to two concurrent password changes", func() {
+			// Each writer's epoch must be the one its own UPDATE produced. As two statements the
+			// bump can interleave with a concurrent change, leaving a session the other change
+			// should have revoked holding a still-valid epoch.
 			const callers = 4
 			var mu sync.Mutex
-			var got []int
+			var signalled []int
 			var wg sync.WaitGroup
 			for range callers {
 				wg.Go(func() {
-					epoch, err := repo.BumpTokenEpoch(usr.ID)
-					if err != nil {
+					ctx := log.NewContext(context.TODO())
+					ctx = request.WithUser(ctx, model.User{ID: usr.ID})
+					ctx = request.WithTokenEpochHolder(ctx)
+					own := NewUserRepository(ctx, GetDBXBuilder())
+
+					u := usr
+					u.NewPassword = "concurrent"
+					if err := own.Put(&u); err != nil {
 						return // the shared in-memory test DB can raise SQLITE_LOCKED
+					}
+					epoch, ok := request.TokenEpochFrom(ctx)
+					if !ok {
+						return
 					}
 					mu.Lock()
 					defer mu.Unlock()
-					got = append(got, epoch)
+					signalled = append(signalled, epoch)
 				})
 			}
 			wg.Wait()
 
-			Expect(got).To(HaveLen(len(slice.Unique(got))), "an epoch was handed to more than one caller: %v", got)
+			Expect(signalled).To(HaveLen(len(slice.Unique(signalled))),
+				"an epoch was signalled to more than one writer: %v", signalled)
 		})
 	})
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -262,11 +262,7 @@ func Authenticator(ds model.DataStore) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx, err := authenticateRequest(ds, r, UsernameFromConfig, UsernameFromToken, UsernameFromExtAuthHeader)
-			if err != nil {
-				_ = rest.RespondWithError(w, http.StatusUnauthorized, "Not authenticated")
-				return
-			}
-			if !tokenAllowed(ctx) {
+			if err != nil || !tokenAllowed(ctx) {
 				_ = rest.RespondWithError(w, http.StatusUnauthorized, "Not authenticated")
 				return
 			}

--- a/server/auth.go
+++ b/server/auth.go
@@ -12,10 +12,12 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/deluan/rest"
 	"github.com/go-chi/jwtauth/v5"
+	"github.com/lestrrat-go/jwx/v3/jwt"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/auth"
@@ -296,24 +298,61 @@ func tokenAllowed(ctx context.Context, r *http.Request) bool {
 	return true
 }
 
-// JWTRefresher updates the expiry date of the received JWT token, and add the new one to the Authorization Header
+// refreshingWriter defers the refreshed-token header until the handler's first write, so a
+// handler that bumps the token epoch is reflected in the token the client stores.
+type refreshingWriter struct {
+	http.ResponseWriter
+	ctx   context.Context
+	token jwt.Token
+	once  sync.Once
+}
+
+func (w *refreshingWriter) setToken() {
+	w.once.Do(func() {
+		claims := auth.ClaimsFromToken(w.token)
+		if epoch, ok := request.TokenEpochFrom(w.ctx); ok {
+			claims.Epoch = epoch
+		}
+		newToken, err := auth.TouchClaims(claims)
+		if err != nil {
+			log.Error(w.ctx, "Could not sign new token", err)
+			return
+		}
+		w.Header().Set(consts.UIAuthorizationHeader, newToken)
+	})
+}
+
+func (w *refreshingWriter) WriteHeader(code int) {
+	w.setToken()
+	w.ResponseWriter.WriteHeader(code)
+}
+
+func (w *refreshingWriter) Write(b []byte) (int, error) {
+	w.setToken()
+	return w.ResponseWriter.Write(b)
+}
+
+// Flush keeps the SSE events route working through the wrap.
+func (w *refreshingWriter) Flush() {
+	w.setToken()
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
+// JWTRefresher updates the expiry date of the received JWT token, and adds the new one to
+// the Authorization Header.
 func JWTRefresher(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		token, _, err := jwtauth.FromContext(ctx)
-		if err != nil {
+		token, _, err := jwtauth.FromContext(r.Context())
+		if err != nil || token == nil {
 			next.ServeHTTP(w, r)
 			return
 		}
-		newTokenString, err := auth.TouchToken(token)
-		if err != nil {
-			log.Error(r, "Could not sign new token", err)
-			_ = rest.RespondWithError(w, http.StatusUnauthorized, "Not authenticated")
-			return
-		}
-
-		w.Header().Set(consts.UIAuthorizationHeader, newTokenString)
-		next.ServeHTTP(w, r)
+		ctx := request.WithTokenEpochHolder(r.Context())
+		rw := &refreshingWriter{ResponseWriter: w, ctx: ctx, token: token}
+		next.ServeHTTP(rw, r.WithContext(ctx))
+		rw.setToken()
 	})
 }
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -286,7 +286,7 @@ func tokenAllowed(ctx context.Context, r *http.Request) bool {
 		return true
 	}
 	claims := auth.ClaimsFromToken(token)
-	if claims.Subject != usr.UserName {
+	if !strings.EqualFold(claims.Subject, usr.UserName) {
 		return true
 	}
 	if err := auth.CheckClaims(claims, usr, auth.AudienceNative); err != nil {

--- a/server/auth.go
+++ b/server/auth.go
@@ -340,6 +340,12 @@ func (w *refreshingWriter) Flush() {
 	}
 }
 
+// Unwrap lets http.ResponseController (e.g. SSE's write-deadline lookup) see past this
+// wrap to the underlying writer's capabilities, such as SetWriteDeadline.
+func (w *refreshingWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
 // JWTRefresher updates the expiry date of the received JWT token, and adds the new one to
 // the Authorization Header.
 func JWTRefresher(next http.Handler) http.Handler {

--- a/server/auth.go
+++ b/server/auth.go
@@ -279,7 +279,7 @@ func Authenticator(ds model.DataStore) func(next http.Handler) http.Handler {
 // tokenAllowed re-checks a JWT that actually identifies the resolved user. Header and
 // config auth carry no token, so they short-circuit to true.
 func tokenAllowed(ctx context.Context, r *http.Request) bool {
-	token, _, err := jwtauth.FromContext(r.Context())
+	token, _, err := jwtauth.FromContext(ctx)
 	if err != nil || token == nil {
 		return true
 	}
@@ -292,7 +292,7 @@ func tokenAllowed(ctx context.Context, r *http.Request) bool {
 		return true
 	}
 	if err := auth.CheckClaims(claims, usr, auth.AudienceNative); err != nil {
-		log.Warn(r, "Native API: rejected token", "user", claims.Subject, err)
+		log.Warn(ctx, "Native API: rejected token", "user", claims.Subject, err)
 		return false
 	}
 	return true

--- a/server/auth.go
+++ b/server/auth.go
@@ -264,10 +264,36 @@ func Authenticator(ds model.DataStore) func(next http.Handler) http.Handler {
 				_ = rest.RespondWithError(w, http.StatusUnauthorized, "Not authenticated")
 				return
 			}
+			if !tokenAllowed(ctx, r) {
+				_ = rest.RespondWithError(w, http.StatusUnauthorized, "Not authenticated")
+				return
+			}
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+// tokenAllowed re-checks a JWT that actually identifies the resolved user. Header and
+// config auth carry no token, so they short-circuit to true.
+func tokenAllowed(ctx context.Context, r *http.Request) bool {
+	token, _, err := jwtauth.FromContext(r.Context())
+	if err != nil || token == nil {
+		return true
+	}
+	usr, ok := request.UserFrom(ctx)
+	if !ok {
+		return true
+	}
+	claims := auth.ClaimsFromToken(token)
+	if claims.Subject != usr.UserName {
+		return true
+	}
+	if err := auth.CheckClaims(claims, usr, auth.AudienceNative); err != nil {
+		log.Warn(r, "Native API: rejected token", "user", claims.Subject, err)
+		return false
+	}
+	return true
 }
 
 // JWTRefresher updates the expiry date of the received JWT token, and add the new one to the Authorization Header

--- a/server/auth.go
+++ b/server/auth.go
@@ -294,8 +294,8 @@ func tokenAllowed(ctx context.Context) bool {
 	return true
 }
 
-// refreshingWriter defers the refreshed-token header until the handler's first write, so a
-// handler that bumps the token epoch is reflected in the token the client stores.
+// refreshingWriter defers the refreshed-token header until the handler's first write, so an
+// epoch the handler bumped reaches the token the client stores.
 type refreshingWriter struct {
 	http.ResponseWriter
 	ctx   context.Context
@@ -336,8 +336,7 @@ func (w *refreshingWriter) Flush() {
 	}
 }
 
-// Unwrap lets http.ResponseController (e.g. SSE's write-deadline lookup) see past this
-// wrap to the underlying writer's capabilities, such as SetWriteDeadline.
+// Unwrap lets capability lookups, such as SSE's write deadline, see past this wrap.
 func (w *refreshingWriter) Unwrap() http.ResponseWriter {
 	return w.ResponseWriter
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -266,7 +266,7 @@ func Authenticator(ds model.DataStore) func(next http.Handler) http.Handler {
 				_ = rest.RespondWithError(w, http.StatusUnauthorized, "Not authenticated")
 				return
 			}
-			if !tokenAllowed(ctx, r) {
+			if !tokenAllowed(ctx) {
 				_ = rest.RespondWithError(w, http.StatusUnauthorized, "Not authenticated")
 				return
 			}
@@ -278,7 +278,7 @@ func Authenticator(ds model.DataStore) func(next http.Handler) http.Handler {
 
 // tokenAllowed re-checks a JWT that actually identifies the resolved user. Header and
 // config auth carry no token, so they short-circuit to true.
-func tokenAllowed(ctx context.Context, r *http.Request) bool {
+func tokenAllowed(ctx context.Context) bool {
 	token, _, err := jwtauth.FromContext(ctx)
 	if err != nil || token == nil {
 		return true

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -458,13 +458,23 @@ var _ = Describe("Auth", func() {
 			Expect(claims.Epoch).To(Equal(1))
 		})
 
-		It("keeps the ResponseWriter flushable", func() {
-			var flushable bool
-			_ = serveWith(func(w http.ResponseWriter, _ *http.Request) {
-				_, flushable = w.(http.Flusher)
+		It("propagates Flush to the underlying ResponseWriter", func() {
+			w := serveWith(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				w.(http.Flusher).Flush()
+			})
+			Expect(w.Flushed).To(BeTrue())
+		})
+
+		It("exposes the underlying ResponseWriter via Unwrap, for http.ResponseController lookups", func() {
+			var unwrapped http.ResponseWriter
+			w := serveWith(func(w http.ResponseWriter, _ *http.Request) {
+				u, ok := w.(interface{ Unwrap() http.ResponseWriter })
+				Expect(ok).To(BeTrue())
+				unwrapped = u.Unwrap()
 				w.WriteHeader(http.StatusOK)
 			})
-			Expect(flushable).To(BeTrue())
+			Expect(unwrapped).To(BeIdenticalTo(w))
 		})
 	})
 })

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -387,5 +387,19 @@ var _ = Describe("Auth", func() {
 			usr.TokenEpoch = 3
 			Expect(serve(tokenStr).Code).To(Equal(http.StatusUnauthorized))
 		})
+
+		It("ignores a stray token for someone else when config auto-login resolves the user", func() {
+			conf.Server.DevAutoLoginUsername = usr.UserName
+			tokenStr, err := auth.CreateToken(&model.User{UserName: "someone-else"})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusOK))
+		})
+
+		It("rejects a stale-epoch token whose subject differs only in case from the resolved user", func() {
+			tokenStr, err := auth.CreateToken(&model.User{UserName: strings.ToUpper(usr.UserName), TokenEpoch: usr.TokenEpoch})
+			Expect(err).ToNot(HaveOccurred())
+			usr.TokenEpoch = 5
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusUnauthorized))
+		})
 	})
 })

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -402,4 +402,69 @@ var _ = Describe("Auth", func() {
 			Expect(serve(tokenStr).Code).To(Equal(http.StatusUnauthorized))
 		})
 	})
+
+	Describe("JWTRefresher", func() {
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
+			// TouchClaims reads this; left at zero every refreshed token is born expired.
+			conf.Server.SessionTimeout = time.Hour
+			auth.Init(&tests.MockDataStore{})
+		})
+
+		serveWith := func(handler http.HandlerFunc) *httptest.ResponseRecorder {
+			usr := model.User{ID: "u1", UserName: "johndoe", TokenEpoch: 1}
+			tokenStr, err := auth.CreateToken(&usr)
+			Expect(err).ToNot(HaveOccurred())
+
+			r := httptest.NewRequest("GET", "/api/song", nil)
+			r.Header.Set(consts.UIAuthorizationHeader, "Bearer "+tokenStr)
+			w := httptest.NewRecorder()
+			JWTVerifier(JWTRefresher(handler)).ServeHTTP(w, r)
+			return w
+		}
+
+		It("writes a refreshed token when the handler writes a body", func() {
+			w := serveWith(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("ok"))
+			})
+			Expect(w.Header().Get(consts.UIAuthorizationHeader)).ToNot(BeEmpty())
+		})
+
+		It("writes a refreshed token when the handler writes no body", func() {
+			w := serveWith(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNoContent)
+			})
+			Expect(w.Header().Get(consts.UIAuthorizationHeader)).ToNot(BeEmpty())
+		})
+
+		It("picks up an epoch the handler reported", func() {
+			w := serveWith(func(w http.ResponseWriter, r *http.Request) {
+				request.SetTokenEpoch(r.Context(), 42)
+				w.WriteHeader(http.StatusOK)
+			})
+
+			claims, err := auth.Validate(w.Header().Get(consts.UIAuthorizationHeader))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims.Epoch).To(Equal(42))
+		})
+
+		It("keeps the original epoch when the handler reports nothing", func() {
+			w := serveWith(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+
+			claims, err := auth.Validate(w.Header().Get(consts.UIAuthorizationHeader))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims.Epoch).To(Equal(1))
+		})
+
+		It("keeps the ResponseWriter flushable", func() {
+			var flushable bool
+			_ = serveWith(func(w http.ResponseWriter, _ *http.Request) {
+				_, flushable = w.(http.Flusher)
+				w.WriteHeader(http.StatusOK)
+			})
+			Expect(flushable).To(BeTrue())
+		})
+	})
 })

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/core/auth"
 	"github.com/navidrome/navidrome/model"
@@ -340,6 +341,51 @@ var _ = Describe("Auth", func() {
 			u, err := ds.User(context.Background()).FindByUsername("seconduser")
 			Expect(err).To(BeNil())
 			Expect(u.IsAdmin).To(BeFalse())
+		})
+	})
+
+	Describe("Authenticator token gating", func() {
+		var ds *tests.MockDataStore
+		var usr *model.User
+
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
+			conf.Server.SessionTimeout = time.Hour
+			ds = &tests.MockDataStore{}
+			auth.Init(ds)
+			ur := ds.User(context.TODO()).(*tests.MockedUserRepo)
+			usr = &model.User{ID: "u1", UserName: "johndoe", NewPassword: "pw", TokenEpoch: 2}
+			Expect(ur.Put(usr)).To(Succeed())
+		})
+
+		serve := func(token string) *httptest.ResponseRecorder {
+			r := httptest.NewRequest("GET", "/api/song", nil)
+			r.Header.Set(consts.UIAuthorizationHeader, "Bearer "+token)
+			w := httptest.NewRecorder()
+			handler := JWTVerifier(Authenticator(ds)(http.HandlerFunc(
+				func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) },
+			)))
+			handler.ServeHTTP(w, r)
+			return w
+		}
+
+		It("accepts a current session token", func() {
+			tokenStr, err := auth.CreateToken(usr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusOK))
+		})
+
+		It("rejects a jellyfin-scoped token", func() {
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("rejects a token with a stale epoch", func() {
+			tokenStr, err := auth.CreateToken(usr)
+			Expect(err).ToNot(HaveOccurred())
+			usr.TokenEpoch = 3
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusUnauthorized))
 		})
 	})
 })

--- a/server/jellyfin/README.md
+++ b/server/jellyfin/README.md
@@ -58,6 +58,8 @@ query param — all forms are accepted, matching what different clients do).
 `/auth/login` (`AuthRequestLimit`/`AuthWindowLength`), since it's an unauthenticated brute-force
 surface.
 
+Access tokens do not expire, matching real Jellyfin. They are revoked by a password change, which bumps the user's token epoch.
+
 ### Public user list (login picker)
 
 `GET /Users/Public` lets a client render a login user-picker (tap a user, then just type the

--- a/server/jellyfin/auth.go
+++ b/server/jellyfin/auth.go
@@ -36,7 +36,7 @@ func (api *Router) authenticateByName(w http.ResponseWriter, r *http.Request) {
 		log.Error(ctx, "Jellyfin API: could not update last login date", "username", body.Username, err)
 	}
 
-	token, err := auth.CreateToken(usr)
+	token, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
 	if err != nil {
 		api.internalError(w, r, err)
 		return

--- a/server/jellyfin/e2e/auth_test.go
+++ b/server/jellyfin/e2e/auth_test.go
@@ -86,8 +86,11 @@ var _ = Describe("Authentication", func() {
 			router.ServeHTTP(pw, r)
 			Expect(pw.Code).To(Equal(http.StatusOK))
 
-			_, err := ds.User(ctx).BumpTokenEpoch(testID("admin-1"))
+			// A real password change through the repository, which is what revokes in production.
+			admin, err := ds.User(ctx).Get(testID("admin-1"))
 			Expect(err).ToNot(HaveOccurred())
+			admin.NewPassword = "rotated"
+			Expect(ds.User(ctx).Put(admin)).To(Succeed())
 
 			r = httptest.NewRequest("GET", "/Users/Me", nil)
 			r.Header.Set("X-Emby-Token", res.AccessToken)

--- a/server/jellyfin/e2e/auth_test.go
+++ b/server/jellyfin/e2e/auth_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/core/auth"
 	"github.com/navidrome/navidrome/server/jellyfin/dto"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -60,6 +61,39 @@ var _ = Describe("Authentication", func() {
 
 		It("rejects a malformed body", func() {
 			Expect(rawReq("POST", "/Users/AuthenticateByName", "not json").Code).To(Equal(http.StatusBadRequest))
+		})
+
+		It("mints a non-expiring token scoped to the Jellyfin audience", func() {
+			w := authenticate("admin", "password")
+			var res dto.AuthenticationResult
+			parseInto(w, &res)
+
+			claims, err := auth.Validate(res.AccessToken)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(claims.ExpiresAt.IsZero()).To(BeTrue())
+			Expect(claims.Audience).To(Equal([]string{"jellyfin"}))
+			Expect(claims.Subject).To(Equal("admin"))
+		})
+
+		It("revokes an already-issued token when the user's epoch is bumped", func() {
+			w := authenticate("admin", "password")
+			var res dto.AuthenticationResult
+			parseInto(w, &res)
+
+			r := httptest.NewRequest("GET", "/Users/Me", nil)
+			r.Header.Set("X-Emby-Token", res.AccessToken)
+			pw := httptest.NewRecorder()
+			router.ServeHTTP(pw, r)
+			Expect(pw.Code).To(Equal(http.StatusOK))
+
+			_, err := ds.User(ctx).BumpTokenEpoch(testID("admin-1"))
+			Expect(err).ToNot(HaveOccurred())
+
+			r = httptest.NewRequest("GET", "/Users/Me", nil)
+			r.Header.Set("X-Emby-Token", res.AccessToken)
+			pw = httptest.NewRecorder()
+			router.ServeHTTP(pw, r)
+			Expect(pw.Code).To(Equal(http.StatusUnauthorized))
 		})
 	})
 

--- a/server/jellyfin/middlewares.go
+++ b/server/jellyfin/middlewares.go
@@ -167,6 +167,10 @@ func (api *Router) userFromToken(r *http.Request) (model.User, bool) {
 		log.Warn(r.Context(), "Jellyfin API: token subject not found", "user", claims.Subject, err)
 		return model.User{}, false
 	}
+	if err := auth.CheckClaims(claims, *usr, auth.AudienceJellyfin); err != nil {
+		log.Warn(r.Context(), "Jellyfin API: rejected token", "user", claims.Subject, err)
+		return model.User{}, false
+	}
 	return *usr, true
 }
 

--- a/server/jellyfin/middlewares_test.go
+++ b/server/jellyfin/middlewares_test.go
@@ -95,6 +95,52 @@ var _ = Describe("authenticate middleware", func() {
 		api.authenticate(next).ServeHTTP(w, r)
 		Expect(w.Code).To(Equal(http.StatusUnauthorized))
 	})
+
+	Context("token scoping and revocation", func() {
+		var usr *model.User
+
+		BeforeEach(func() {
+			ur := ds.User(context.Background()).(*tests.MockedUserRepo)
+			usr = &model.User{ID: testID("u2"), UserName: "bob", NewPassword: "secret", TokenEpoch: 3}
+			Expect(ur.Put(usr)).To(Succeed())
+		})
+
+		serve := func(token string) *httptest.ResponseRecorder {
+			next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			})
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest("GET", "/Items", nil)
+			r.Header.Set("X-Emby-Token", token)
+			api.authenticate(next).ServeHTTP(w, r)
+			return w
+		}
+
+		It("accepts a jellyfin-scoped token with the current epoch", func() {
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusOK))
+		})
+
+		It("rejects a token whose epoch is stale", func() {
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+			Expect(err).ToNot(HaveOccurred())
+			usr.TokenEpoch = 4
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("rejects a token minted for another API", func() {
+			tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceNative)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("still accepts an unscoped session token", func() {
+			tokenStr, err := auth.CreateToken(usr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(serve(tokenStr).Code).To(Equal(http.StatusOK))
+		})
+	})
 })
 
 var _ = Describe("withPlayer middleware", func() {

--- a/server/nativeapi/user_password_token_refresh_test.go
+++ b/server/nativeapi/user_password_token_refresh_test.go
@@ -27,8 +27,7 @@ type noopPluginUnloader struct{}
 
 func (noopPluginUnloader) UnloadDisabledPlugins(context.Context) {}
 
-// Drives a real self password change through the real middleware chain, to pin that the
-// token-epoch handoff survives an actual request instead of two separately-tested halves.
+// Pins that the token-epoch handoff survives a real request through the real middleware chain.
 var _ = Describe("PUT /user/{id}: token refresh on self password change", func() {
 	var ds model.DataStore
 	var router http.Handler

--- a/server/nativeapi/user_password_token_refresh_test.go
+++ b/server/nativeapi/user_password_token_refresh_test.go
@@ -34,6 +34,7 @@ var _ = Describe("PUT /user/{id}: token refresh on self password change", func()
 	var router http.Handler
 
 	BeforeEach(func() {
+		// db.Db() is a process-wide singleton that this DeferCleanup closes for the whole binary; keep this the only real-DB spec in this package.
 		DeferCleanup(configtest.SetupConfig())
 		conf.Server.EnableUserEditing = true
 		conf.Server.EnableSharing = false

--- a/server/nativeapi/user_password_token_refresh_test.go
+++ b/server/nativeapi/user_password_token_refresh_test.go
@@ -1,0 +1,80 @@
+package nativeapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"time"
+
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/core"
+	"github.com/navidrome/navidrome/core/auth"
+	"github.com/navidrome/navidrome/db"
+	"github.com/navidrome/navidrome/model"
+	"github.com/navidrome/navidrome/persistence"
+	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+type noopPluginUnloader struct{}
+
+func (noopPluginUnloader) UnloadDisabledPlugins(context.Context) {}
+
+// Drives a real self password change through the real middleware chain, to pin that the
+// token-epoch handoff survives an actual request instead of two separately-tested halves.
+var _ = Describe("PUT /user/{id}: token refresh on self password change", func() {
+	var ds model.DataStore
+	var router http.Handler
+
+	BeforeEach(func() {
+		DeferCleanup(configtest.SetupConfig())
+		conf.Server.EnableUserEditing = true
+		conf.Server.EnableSharing = false
+		conf.Server.SessionTimeout = time.Hour
+		conf.Server.DbPath = filepath.Join(GinkgoT().TempDir(), "nativeapi-user-refresh.db") + "?_journal_mode=WAL"
+		DeferCleanup(db.Init(GinkgoT().Context()))
+
+		ds = &tests.MockDataStore{RealDS: persistence.New(db.Db())}
+		auth.Init(ds)
+
+		userService := core.NewUser(ds, noopPluginUnloader{})
+		nativeRouter := New(ds, nil, nil, nil, tests.NewMockLibraryService(), userService, nil, nil, nil)
+		router = server.JWTVerifier(nativeRouter)
+	})
+
+	It("carries the bumped epoch in the refreshed token, not the epoch the token was minted with", func() {
+		usr := model.User{UserName: "selfchanger", Name: "Self Changer", NewPassword: "old-password"}
+		Expect(ds.User(GinkgoT().Context()).Put(&usr)).To(Succeed())
+
+		token, err := auth.CreateToken(&usr)
+		Expect(err).ToNot(HaveOccurred())
+
+		body, _ := json.Marshal(map[string]any{
+			"userName":        usr.UserName,
+			"name":            usr.Name,
+			"currentPassword": "old-password",
+			"password":        "new-password",
+		})
+		req := createAuthenticatedRequest(http.MethodPut, "/user/"+usr.ID, bytes.NewBuffer(body), token)
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+		Expect(w.Code).To(Equal(http.StatusOK), w.Body.String())
+
+		refreshed := w.Header().Get(consts.UIAuthorizationHeader)
+		Expect(refreshed).ToNot(BeEmpty())
+		claims, err := auth.Validate(refreshed)
+		Expect(err).ToNot(HaveOccurred())
+
+		reloaded, err := ds.User(GinkgoT().Context()).Get(usr.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reloaded.TokenEpoch).To(Equal(1))
+		Expect(claims.Epoch).To(Equal(reloaded.TokenEpoch))
+	})
+})

--- a/server/subsonic/middlewares.go
+++ b/server/subsonic/middlewares.go
@@ -178,7 +178,9 @@ func validateCredentials(user *model.User, pass, token, salt, jwt string) error 
 	switch {
 	case jwt != "":
 		claims, err := auth.Validate(jwt)
-		valid = err == nil && claims.Subject == user.UserName
+		valid = err == nil &&
+			claims.Subject == user.UserName &&
+			auth.CheckClaims(claims, *user, auth.AudienceSubsonic) == nil
 	case pass != "":
 		if strings.HasPrefix(pass, "enc:") {
 			if dec, err := hex.DecodeString(pass[4:]); err == nil {

--- a/server/subsonic/middlewares_test.go
+++ b/server/subsonic/middlewares_test.go
@@ -499,6 +499,35 @@ var _ = Describe("Middlewares", func() {
 				Expect(err).To(MatchError(model.ErrInvalidAuth))
 			})
 		})
+
+		Context("JWT credentials", func() {
+			var usr *model.User
+
+			BeforeEach(func() {
+				conf.Server.SessionTimeout = time.Minute
+				auth.Init(ds)
+				usr = &model.User{ID: "u1", UserName: "johndoe", TokenEpoch: 1}
+			})
+
+			It("accepts an unscoped session token", func() {
+				tokenStr, err := auth.CreateToken(usr)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(validateCredentials(usr, "", "", "", tokenStr)).To(Succeed())
+			})
+
+			It("rejects a jellyfin-scoped token", func() {
+				tokenStr, err := auth.CreateAPIToken(usr, auth.AudienceJellyfin)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(validateCredentials(usr, "", "", "", tokenStr)).To(MatchError(model.ErrInvalidAuth))
+			})
+
+			It("rejects a token with a stale epoch", func() {
+				tokenStr, err := auth.CreateToken(usr)
+				Expect(err).ToNot(HaveOccurred())
+				usr.TokenEpoch = 2
+				Expect(validateCredentials(usr, "", "", "", tokenStr)).To(MatchError(model.ErrInvalidAuth))
+			})
+		})
 	})
 })
 

--- a/server/subsonic/middlewares_test.go
+++ b/server/subsonic/middlewares_test.go
@@ -470,6 +470,7 @@ var _ = Describe("Middlewares", func() {
 			var validToken string
 
 			BeforeEach(func() {
+				DeferCleanup(configtest.SetupConfig())
 				conf.Server.SessionTimeout = time.Minute
 				auth.Init(ds)
 
@@ -504,6 +505,7 @@ var _ = Describe("Middlewares", func() {
 			var usr *model.User
 
 			BeforeEach(func() {
+				DeferCleanup(configtest.SetupConfig())
 				conf.Server.SessionTimeout = time.Minute
 				auth.Init(ds)
 				usr = &model.User{ID: "u1", UserName: "johndoe", TokenEpoch: 1}

--- a/tests/mock_user_repo.go
+++ b/tests/mock_user_repo.go
@@ -112,19 +112,6 @@ func (u *MockedUserRepo) UpdateLastAccessAt(id string) error {
 	return u.Error
 }
 
-func (u *MockedUserRepo) BumpTokenEpoch(id string) (int, error) {
-	if u.Error != nil {
-		return 0, u.Error
-	}
-	for _, usr := range u.Data {
-		if usr.ID == id {
-			usr.TokenEpoch++
-			return usr.TokenEpoch, nil
-		}
-	}
-	return 0, model.ErrNotFound
-}
-
 // Library association methods - mock implementations
 
 func (u *MockedUserRepo) GetUserLibraries(userID string) (model.Libraries, error) {

--- a/tests/mock_user_repo.go
+++ b/tests/mock_user_repo.go
@@ -112,6 +112,19 @@ func (u *MockedUserRepo) UpdateLastAccessAt(id string) error {
 	return u.Error
 }
 
+func (u *MockedUserRepo) BumpTokenEpoch(id string) (int, error) {
+	if u.Error != nil {
+		return 0, u.Error
+	}
+	for _, usr := range u.Data {
+		if usr.ID == id {
+			usr.TokenEpoch++
+			return usr.TokenEpoch, nil
+		}
+	}
+	return 0, model.ErrNotFound
+}
+
 // Library association methods - mock implementations
 
 func (u *MockedUserRepo) GetUserLibraries(userID string) (model.Libraries, error) {


### PR DESCRIPTION
### Description

Jellyfin clients lose their session roughly every two days. Jellyfin login mints an ordinary Navidrome session JWT, which expires after `SessionTimeout` (48h by default), and the Jellyfin router has no token refresh. Real Jellyfin access tokens never expire, so clients built against that API have no re-auth-on-401 path and simply break.

This makes Jellyfin tokens non-expiring, and replaces expiry with actual revocation.

Three parts:

**A `token_epoch` counter on `user`.** Every session token carries the value it was minted with, in a new `ep` claim. Changing a password increments the column, which invalidates every token issued for that user across all APIs at once. The counter starts at 0 and `ToMap` omits zero-valued claims, so tokens issued before this change decode as 0, match, and keep working. Upgrading logs nobody out.

**Audience scoping via the standard `aud` claim.** Jellyfin login now mints through `CreateAPIToken`, which sets `aud: ["jellyfin"]` and no `exp`. A token carrying an audience is only accepted by that API. A token without one is accepted anywhere, which is what keeps existing sessions working. One shared `auth.CheckClaims` does both the epoch and audience checks, called from the three surfaces that accept session tokens: the native API, Subsonic `?jwt=`, and Jellyfin.

**A lazily written refresh header.** `JWTRefresher` used to set the refreshed-token header before running the handler, so on the request that changes a password it handed back a token carrying the old epoch, killing the user's own tab. It now defers the write until the handler's first write and picks up the new epoch through a slot in the request context. Changing your own password signs out every other session and leaves the current one alive.

### Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Verified as a real upgrade: a binary built from `master` and one from this branch, pointed at the same data folder, so the branch inherits the JWT secret and tokens minted before the migration.

1. Run a `master` build with `ND_JELLYFIN_ENABLED=true`. Log in through the web UI, through `POST /jellyfin/Users/AuthenticateByName`, and keep the native JWT for `?jwt=`. Create a share.
2. Stop it, start this branch on the same data folder. The migration applies on boot.
3. Every token from step 1 still works, on all three APIs, and the share still resolves. The refreshed token carries no `ep`, because the epoch is still 0.
4. Log in to Jellyfin again. The token has `aud: ["jellyfin"]` and no `exp`. It returns 200 on `/jellyfin`, 401 on the native API, and error 40 on `/rest?jwt=`. A native token still works on all three.
5. Change your password in the web UI. The tab stays logged in and its stored token rotates to the next epoch. Every other browser session, Jellyfin client, and `?jwt=` token returns 401. Subsonic needs the new password.
6. As an admin, reset another user's password. Their tokens die, yours keeps working and is not stamped with their epoch.

Behind an authenticating reverse proxy, tested with a proxy that strips any client-supplied `Remote-User` and injects its own: header-only requests authenticate, an untrusted source is ignored and logged, and a browser still holding a password-era token gets one 401 until it clears the token.

### Additional Notes

**Release note.** With `ExtAuth` enabled, a browser holding a stale-epoch token for the same user now gets a 401 instead of falling through to header auth, because `UsernameFromToken` is consulted before `UsernameFromExtAuthHeader`. It self-heals: the UI clears the token and a reload authenticates through the header again. One bounce, once, only for proxy users who still hold a token from before the change.

**Signing failure in the refresher no longer returns 401.** Once the header is written after the handler, the status is no longer ours to set. A failure logs and leaves the client's existing token in place, valid until its own `exp`.

**Revocation is all-or-nothing per user.** There is no per-device logout and no "sign out everywhere" button. Subsonic authenticates from the password on every request, so it has no session to revoke and such a button would promise more than it could deliver. Per-device revocation belongs with the device grants in the v1 API design.

**Epoch increment is atomic.** `BumpTokenEpoch` uses `UPDATE ... RETURNING token_epoch`, so each caller gets the value its own increment produced. An earlier revision read the value back in a separate statement, which let a self-service password change racing an admin reset be refreshed to the admin's epoch and survive a reset whose whole purpose is to kick every session out.

**Log redaction widened.** Request URIs go through the redaction hook, which already covered `api_key=`, `jwt=` and the Subsonic `p=`/`t=`/`s=` params. It missed `apikey=` and `ApiKey=`, which the Jellyfin API also accepts and which Finamp's just_audio engine uses for direct-file URLs. That was survivable when a leaked token expired in 48 hours. It is not once the token is permanent, so the pattern is now case-insensitive with an optional underscore.

**Known follow-up, not in this PR.** `refreshingWriter` implements `Flush()` unconditionally and so claims to be an `http.Flusher` even when wrapping something that is not. Moving `server/events/sse.go` to `http.ResponseController` would let the wrapper drop `Flush()` and rely on `Unwrap()` alone.
