### PR TITLE
fix(plugins): guard the plugin map read during concurrent loading

### DIFF
--- a/plugins/manager_loader.go
+++ b/plugins/manager_loader.go
@@ -434,8 +434,7 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 		return fmt.Errorf("manifest validation: %w", err)
 	}
 
-	m.mu.Lock()
-	m.plugins[p.ID] = &plugin{
+	loadedPlugin := &plugin{
 		name:           p.ID,
 		path:           p.Path,
 		manifest:       pkg.Manifest,
@@ -449,13 +448,16 @@ func (m *Manager) loadPluginWithConfig(p *model.Plugin) error {
 		fsConfig:       fsConfig,
 		lyricsSem:      make(chan struct{}, maxConcurrentLyricsCalls),
 	}
+	m.mu.Lock()
+	m.plugins[p.ID] = loadedPlugin
 	m.mu.Unlock()
 	loaded = true
 
 	// Init is the plugin's first chance to run arbitrary code: open sockets, create task queues,
 	// schedule work. Only a caller that already intends to reach the network asks for it.
+	// Use the local: loads run concurrently, so reading the map back here would race the writes.
 	if m.transient == nil || m.transient.runInit {
-		callPluginInit(ctx, m.plugins[p.ID])
+		callPluginInit(ctx, loadedPlugin)
 	}
 
 	return nil


### PR DESCRIPTION
### Description

Master's pipeline failed on a data race in the plugins package ([run 32608293134](https://github.com/navidrome/navidrome/actions/runs/32608293134/job/97116910153)). All 640 specs passed; the job failed only on `testing.go:1712: race detected during execution of test`.

`loadEnabledPlugins` loads plugins concurrently through an errgroup. Inside `loadPluginWithConfig`, the write to `m.plugins` was guarded by `m.mu`, but the read that follows was not:

```go
m.mu.Lock()
m.plugins[p.ID] = &plugin{ ... }        // write, under the lock
m.mu.Unlock()

if m.transient == nil || m.transient.runInit {
    callPluginInit(ctx, m.plugins[p.ID])  // read, unguarded
}
```

A Go map is unsafe for concurrent read and write even when only one side holds the mutex, so one goroutine writing at line 438 while another read at line 458 is a real race. The detector's report names exactly those two lines, with both goroutine stacks originating from the errgroup.

The fix captures the pointer while holding the lock and passes the local to `callPluginInit`. Holding `m.mu` across that call would be the wrong shape, since it is the plugin's first chance to run arbitrary code (open sockets, create task queues, schedule work) and the manager lock should not be held across it.

I audited the other eleven accesses to `m.plugins`; all were already correctly guarded by `Lock` or `RLock`. This was the only unguarded one.

The defect is not new. `plugins/manager_loader.go` last changed in #5959 on 2026-08-15, and whether the race fires depends on `-shuffle=on` ordering and goroutine interleaving, which is why it stayed latent until now.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

`make test-race PKG=./plugins`, and the full `make test`.

No new test accompanies this. A data race is only observable through the detector, and whether it fires depends on goroutine interleaving that a test cannot pin deterministically. I tried: replaying the exact shuffle seed from the failing CI run (`-shuffle=1787445461345669451`) under `-race` on this machine passed cleanly, because the seed fixes spec order and not interleaving. A probabilistic test that fails once in some runs would be worse than none. The existing suite already exercises concurrent loading through `manager.Start()`, so `-race` in CI remains the regression check, and the unguarded access it flagged is now gone.

Verified: `make test-race PKG=./plugins` three times, full `make test` (76 packages), and lint clean.

### Additional Notes

The race is in plugin loading only and does not depend on which plugins are installed, so re-running the failed job would likely go green without fixing anything.
