### PR TITLE
feat: add optional natural sort order for names and titles

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -73,6 +73,7 @@ type configOptions struct {
 	Matcher                         matcherOptions `json:",omitzero"`
 	RecentlyAddedByModTime          bool
 	PreferSortTags                  bool
+	EnableNaturalSorting            bool
 	IgnoredArticles                 string
 	IndexGroups                     string
 	FFmpegPath                      string
@@ -973,6 +974,7 @@ func setViperDefaults() {
 	viper.SetDefault("matcher.fuzzythreshold", 85)
 	viper.SetDefault("recentlyaddedbymodtime", false)
 	viper.SetDefault("prefersorttags", false)
+	viper.SetDefault("enablenaturalsorting", false)
 	viper.SetDefault("ignoredarticles", "The El La Los Las Le Les Os As O A")
 	viper.SetDefault("indexgroups", "A B C D E F G H I J K L M N O P Q R S T U V W X-Z(XYZ) [Unknown]([)")
 	viper.SetDefault("ffmpegpath", "")

--- a/db/db.go
+++ b/db/db.go
@@ -13,9 +13,14 @@ import (
 	_ "github.com/navidrome/navidrome/db/migrations"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/utils/hasher"
+	"github.com/navidrome/navidrome/utils/natural"
 	"github.com/navidrome/navidrome/utils/singleton"
 	"github.com/pressly/goose/v3"
 )
+
+// NaturalCollation sorts embedded numbers by value. It is registered on every
+// connection, but only referenced when conf.Server.EnableNaturalSorting is on.
+const NaturalCollation = "NATSORT"
 
 var (
 	Dialect = "sqlite3"
@@ -32,7 +37,10 @@ func Db() *sql.DB {
 	return singleton.GetInstance(func() *sql.DB {
 		sql.Register(Driver, &sqlite3.SQLiteDriver{
 			ConnectHook: func(conn *sqlite3.SQLiteConn) error {
-				return conn.RegisterFunc("SEEDEDRAND", hasher.HashFunc(), false)
+				if err := conn.RegisterFunc("SEEDEDRAND", hasher.HashFunc(), false); err != nil {
+					return err
+				}
+				return conn.RegisterCollation(NaturalCollation, natural.CompareFold)
 			},
 		})
 		Path = conf.Server.DbPath

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -113,7 +113,7 @@ func NewAlbumRepository(ctx context.Context, db dbx.Builder) model.AlbumReposito
 		"artist":       "compilation, order_album_artist_name, order_album_name",
 		"album_artist": "compilation, order_album_artist_name, order_album_name",
 		// TODO Rename this to just year (or date)
-		"max_year":       "coalesce(nullif(original_date,''), cast(max_year as text)), release_date, " + collatedSort("album.name"),
+		"max_year":       "coalesce(nullif(original_date,''), cast(max_year as text)), release_date, " + naturalSort("album.name"),
 		"random":         "random",
 		"recently_added": recentlyAddedSort(),
 		"starred_at":     "starred, starred_at",

--- a/persistence/album_repository.go
+++ b/persistence/album_repository.go
@@ -113,7 +113,7 @@ func NewAlbumRepository(ctx context.Context, db dbx.Builder) model.AlbumReposito
 		"artist":       "compilation, order_album_artist_name, order_album_name",
 		"album_artist": "compilation, order_album_artist_name, order_album_name",
 		// TODO Rename this to just year (or date)
-		"max_year":       "coalesce(nullif(original_date,''), cast(max_year as text)), release_date, name",
+		"max_year":       "coalesce(nullif(original_date,''), cast(max_year as text)), release_date, " + collatedSort("album.name"),
 		"random":         "random",
 		"recently_added": recentlyAddedSort(),
 		"starred_at":     "starred, starred_at",

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/id"
@@ -36,6 +37,55 @@ var _ = Describe("AlbumRepository", func() {
 	BeforeEach(func() {
 		ctx = request.WithUser(GinkgoT().Context(), model.User{ID: "userid", UserName: "johndoe"})
 		albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
+	})
+
+	Describe("natural sorting", func() {
+		var ids []string
+
+		insertAlbums := func() {
+			ids = nil
+			for _, n := range []string{"foo 1", "foo 10", "foo 2", "foo 20", "foo 3"} {
+				aid := "nat-" + n
+				ids = append(ids, aid)
+				Expect(albumRepo.Put(&model.Album{
+					ID: aid, LibraryID: 1, Name: n, OrderAlbumName: n,
+				})).To(Succeed())
+			}
+			DeferCleanup(func() {
+				_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": ids}))
+			})
+		}
+
+		sortedNames := func() []string {
+			albums, err := albumRepo.GetAll(model.QueryOptions{
+				Sort: "name", Filters: squirrel.Eq{"album.id": ids},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			return slice.Map(albums, func(a model.Album) string { return a.Name })
+		}
+
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
+			insertAlbums()
+		})
+
+		It("sorts lexicographically by default", func() {
+			albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
+			Expect(sortedNames()).To(Equal([]string{"foo 1", "foo 10", "foo 2", "foo 20", "foo 3"}))
+		})
+
+		It("sorts numbers by value when EnableNaturalSorting is enabled", func() {
+			conf.Server.EnableNaturalSorting = true
+			albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
+			Expect(sortedNames()).To(Equal([]string{"foo 1", "foo 2", "foo 3", "foo 10", "foo 20"}))
+		})
+
+		It("sorts numbers by value with PreferSortTags enabled too", func() {
+			conf.Server.EnableNaturalSorting = true
+			conf.Server.PreferSortTags = true
+			albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
+			Expect(sortedNames()).To(Equal([]string{"foo 1", "foo 2", "foo 3", "foo 10", "foo 20"}))
+		})
 	})
 
 	Describe("Get", func() {

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -42,7 +42,8 @@ var _ = Describe("AlbumRepository", func() {
 	Describe("natural sorting", func() {
 		var ids []string
 
-		insertAlbums := func() {
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
 			ids = nil
 			for _, n := range []string{"foo 1", "foo 10", "foo 2", "foo 20", "foo 3"} {
 				aid := "nat-" + n
@@ -54,19 +55,6 @@ var _ = Describe("AlbumRepository", func() {
 			DeferCleanup(func() {
 				_, _ = albumRepo.executeSQL(squirrel.Delete("album").Where(squirrel.Eq{"id": ids}))
 			})
-		}
-
-		sortedNames := func() []string {
-			albums, err := albumRepo.GetAll(model.QueryOptions{
-				Sort: "name", Filters: squirrel.Eq{"album.id": ids},
-			})
-			Expect(err).ToNot(HaveOccurred())
-			return slice.Map(albums, func(a model.Album) string { return a.Name })
-		}
-
-		BeforeEach(func() {
-			DeferCleanup(configtest.SetupConfig())
-			insertAlbums()
 		})
 
 		DescribeTable("sorts albums by name",
@@ -74,7 +62,11 @@ var _ = Describe("AlbumRepository", func() {
 				conf.Server.EnableNaturalSorting = naturalSorting
 				conf.Server.PreferSortTags = preferSortTags
 				albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
-				Expect(sortedNames()).To(Equal(expected))
+				albums, err := albumRepo.GetAll(model.QueryOptions{
+					Sort: "name", Filters: squirrel.Eq{"album.id": ids},
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(slice.Map(albums, func(a model.Album) string { return a.Name })).To(Equal(expected))
 			},
 			Entry("lexicographically by default", false, false,
 				[]string{"foo 1", "foo 10", "foo 2", "foo 20", "foo 3"}),

--- a/persistence/album_repository_test.go
+++ b/persistence/album_repository_test.go
@@ -69,23 +69,20 @@ var _ = Describe("AlbumRepository", func() {
 			insertAlbums()
 		})
 
-		It("sorts lexicographically by default", func() {
-			albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
-			Expect(sortedNames()).To(Equal([]string{"foo 1", "foo 10", "foo 2", "foo 20", "foo 3"}))
-		})
-
-		It("sorts numbers by value when EnableNaturalSorting is enabled", func() {
-			conf.Server.EnableNaturalSorting = true
-			albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
-			Expect(sortedNames()).To(Equal([]string{"foo 1", "foo 2", "foo 3", "foo 10", "foo 20"}))
-		})
-
-		It("sorts numbers by value with PreferSortTags enabled too", func() {
-			conf.Server.EnableNaturalSorting = true
-			conf.Server.PreferSortTags = true
-			albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
-			Expect(sortedNames()).To(Equal([]string{"foo 1", "foo 2", "foo 3", "foo 10", "foo 20"}))
-		})
+		DescribeTable("sorts albums by name",
+			func(naturalSorting, preferSortTags bool, expected []string) {
+				conf.Server.EnableNaturalSorting = naturalSorting
+				conf.Server.PreferSortTags = preferSortTags
+				albumRepo = NewAlbumRepository(ctx, GetDBXBuilder()).(*albumRepository)
+				Expect(sortedNames()).To(Equal(expected))
+			},
+			Entry("lexicographically by default", false, false,
+				[]string{"foo 1", "foo 10", "foo 2", "foo 20", "foo 3"}),
+			Entry("by number value when natural sorting is enabled", true, false,
+				[]string{"foo 1", "foo 2", "foo 3", "foo 10", "foo 20"}),
+			Entry("by number value with sort tags preferred too", true, true,
+				[]string{"foo 1", "foo 2", "foo 3", "foo 10", "foo 20"}),
+		)
 	})
 
 	Describe("Get", func() {

--- a/persistence/helpers.go
+++ b/persistence/helpers.go
@@ -84,17 +84,13 @@ func (e existsCond) ToSql() (string, []any, error) {
 
 var sortOrderRegex = regexp.MustCompile(`order_([a-z_]+)`)
 
-func sortCollation() string {
-	if conf.Server.EnableNaturalSorting {
-		return db.NaturalCollation
+// naturalSort makes a plain text column sort numbers by value, leaving it alone
+// otherwise so it keeps its declared collation. Parens guard buildSortOrder's space split.
+func naturalSort(col string) string {
+	if !conf.Server.EnableNaturalSorting {
+		return col
 	}
-	return "nocase"
-}
-
-// collatedSort wraps a plain text column so it sorts with the configured
-// collation. The parens are required: buildSortOrder splits on spaces.
-func collatedSort(col string) string {
-	return fmt.Sprintf("(%s collate %s)", col, sortCollation())
+	return fmt.Sprintf("(%s collate %s)", col, db.NaturalCollation)
 }
 
 // Convert the order_* columns to a collated sort expression, falling back to the
@@ -106,5 +102,10 @@ func mapSortOrder(tableName, order string) string {
 	if conf.Server.PreferSortTags {
 		col = fmt.Sprintf("coalesce(nullif(%[1]s.sort_$1,''),%[1]s.order_$1)", tableName)
 	}
-	return sortOrderRegex.ReplaceAllString(strings.ToLower(order), collatedSort(col))
+	collation := "nocase"
+	if conf.Server.EnableNaturalSorting {
+		collation = db.NaturalCollation
+	}
+	repl := fmt.Sprintf("(%s collate %s)", col, collation)
+	return sortOrderRegex.ReplaceAllString(strings.ToLower(order), repl)
 }

--- a/persistence/helpers.go
+++ b/persistence/helpers.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/fatih/structs"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/db"
 )
 
 type PostMapper interface {
@@ -82,11 +84,32 @@ func (e existsCond) ToSql() (string, []any, error) {
 
 var sortOrderRegex = regexp.MustCompile(`order_([a-z_]+)`)
 
+func sortCollation() string {
+	if conf.Server.EnableNaturalSorting {
+		return db.NaturalCollation
+	}
+	return "nocase"
+}
+
+// collatedSort wraps a plain text column so it sorts with the configured
+// collation. The parens are required: buildSortOrder splits on spaces.
+func collatedSort(col string) string {
+	return fmt.Sprintf("(%s collate %s)", col, sortCollation())
+}
+
+// mapNaturalOrder qualifies the order_* columns and applies the natural collation.
+// Used when sort_* columns are not preferred, so mapSortOrder does not run.
+func mapNaturalOrder(tableName, order string) string {
+	order = strings.ToLower(order)
+	repl := fmt.Sprintf("(%[1]s.order_$1 collate %[2]s)", tableName, db.NaturalCollation)
+	return sortOrderRegex.ReplaceAllString(order, repl)
+}
+
 // Convert the order_* columns to an expression using sort_* columns. Example:
 // sort_album_name -> (coalesce(nullif(sort_album_name,”),order_album_name) collate nocase)
 // It finds order column names anywhere in the substring
 func mapSortOrder(tableName, order string) string {
 	order = strings.ToLower(order)
-	repl := fmt.Sprintf("(coalesce(nullif(%[1]s.sort_$1,''),%[1]s.order_$1) collate nocase)", tableName)
+	repl := fmt.Sprintf("(coalesce(nullif(%[1]s.sort_$1,''),%[1]s.order_$1) collate %[2]s)", tableName, sortCollation())
 	return sortOrderRegex.ReplaceAllString(order, repl)
 }

--- a/persistence/helpers.go
+++ b/persistence/helpers.go
@@ -97,19 +97,14 @@ func collatedSort(col string) string {
 	return fmt.Sprintf("(%s collate %s)", col, sortCollation())
 }
 
-// mapNaturalOrder qualifies the order_* columns and applies the natural collation.
-// Used when sort_* columns are not preferred, so mapSortOrder does not run.
-func mapNaturalOrder(tableName, order string) string {
-	order = strings.ToLower(order)
-	repl := fmt.Sprintf("(%[1]s.order_$1 collate %[2]s)", tableName, db.NaturalCollation)
-	return sortOrderRegex.ReplaceAllString(order, repl)
-}
-
-// Convert the order_* columns to an expression using sort_* columns. Example:
-// sort_album_name -> (coalesce(nullif(sort_album_name,”),order_album_name) collate nocase)
+// Convert the order_* columns to a collated sort expression, falling back to the
+// sort_* column when those are preferred. Example:
+// order_album_name -> (coalesce(nullif(sort_album_name,”),order_album_name) collate nocase)
 // It finds order column names anywhere in the substring
 func mapSortOrder(tableName, order string) string {
-	order = strings.ToLower(order)
-	repl := fmt.Sprintf("(coalesce(nullif(%[1]s.sort_$1,''),%[1]s.order_$1) collate %[2]s)", tableName, sortCollation())
-	return sortOrderRegex.ReplaceAllString(order, repl)
+	col := tableName + ".order_$1"
+	if conf.Server.PreferSortTags {
+		col = fmt.Sprintf("coalesce(nullif(%[1]s.sort_$1,''),%[1]s.order_$1)", tableName)
+	}
+	return sortOrderRegex.ReplaceAllString(strings.ToLower(order), collatedSort(col))
 }

--- a/persistence/helpers_test.go
+++ b/persistence/helpers_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Masterminds/squirrel"
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
-	"github.com/navidrome/navidrome/db"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -121,27 +120,18 @@ var _ = Describe("Helpers", func() {
 		})
 	})
 
-	Describe("collatedSort", func() {
-		It("wraps a plain column with the default collation", func() {
+	Describe("naturalSort", func() {
+		BeforeEach(func() {
 			DeferCleanup(configtest.SetupConfig())
-			Expect(collatedSort("name")).To(Equal("(name collate nocase)"))
 		})
-		It("wraps a plain column with the natural collation when enabled", func() {
-			DeferCleanup(configtest.SetupConfig())
-			conf.Server.EnableNaturalSorting = true
-			Expect(collatedSort("name")).To(Equal("(name collate NATSORT)"))
-		})
-	})
 
-	Describe("sortCollation", func() {
-		It("is nocase by default", func() {
-			DeferCleanup(configtest.SetupConfig())
-			Expect(sortCollation()).To(Equal("nocase"))
+		It("leaves the column alone by default, keeping its declared collation", func() {
+			Expect(naturalSort("media_file.title")).To(Equal("media_file.title"))
 		})
-		It("is the natural collation when enabled", func() {
-			DeferCleanup(configtest.SetupConfig())
+
+		It("applies the natural collation when enabled", func() {
 			conf.Server.EnableNaturalSorting = true
-			Expect(sortCollation()).To(Equal(db.NaturalCollation))
+			Expect(naturalSort("media_file.title")).To(Equal("(media_file.title collate NATSORT)"))
 		})
 	})
 })

--- a/persistence/helpers_test.go
+++ b/persistence/helpers_test.go
@@ -4,6 +4,9 @@ import (
 	"time"
 
 	"github.com/Masterminds/squirrel"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
+	"github.com/navidrome/navidrome/db"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -101,6 +104,54 @@ var _ = Describe("Helpers", func() {
 			mapped := mapSortOrder("album", sort)
 			Expect(mapped).To(Equal(`compilation, (coalesce(nullif(album.sort_title,''),album.order_title) collate nocase) asc,` +
 				` (coalesce(nullif(album.sort_album_artist_name,''),album.order_album_artist_name) collate nocase) desc, year desc`))
+		})
+		Context("with EnableNaturalSorting", func() {
+			BeforeEach(func() {
+				DeferCleanup(configtest.SetupConfig())
+				conf.Server.EnableNaturalSorting = true
+			})
+			It("uses the natural collation for order columns", func() {
+				mapped := mapSortOrder("album", "order_album_name asc")
+				Expect(mapped).To(Equal(`(coalesce(nullif(album.sort_album_name,''),album.order_album_name)` +
+					` collate NATSORT) asc`))
+			})
+			It("leaves plain columns alone", func() {
+				Expect(mapSortOrder("album", "year desc")).To(Equal("year desc"))
+			})
+		})
+	})
+
+	Describe("mapNaturalOrder", func() {
+		It("qualifies order columns and applies the natural collation", func() {
+			Expect(mapNaturalOrder("album", "order_album_name asc, year desc")).To(
+				Equal("(album.order_album_name collate NATSORT) asc, year desc"))
+		})
+		It("does not change a sort string without order columns", func() {
+			Expect(mapNaturalOrder("album", "year desc")).To(Equal("year desc"))
+		})
+	})
+
+	Describe("collatedSort", func() {
+		It("wraps a plain column with the default collation", func() {
+			DeferCleanup(configtest.SetupConfig())
+			Expect(collatedSort("name")).To(Equal("(name collate nocase)"))
+		})
+		It("wraps a plain column with the natural collation when enabled", func() {
+			DeferCleanup(configtest.SetupConfig())
+			conf.Server.EnableNaturalSorting = true
+			Expect(collatedSort("name")).To(Equal("(name collate NATSORT)"))
+		})
+	})
+
+	Describe("sortCollation", func() {
+		It("is nocase by default", func() {
+			DeferCleanup(configtest.SetupConfig())
+			Expect(sortCollation()).To(Equal("nocase"))
+		})
+		It("is the natural collation when enabled", func() {
+			DeferCleanup(configtest.SetupConfig())
+			conf.Server.EnableNaturalSorting = true
+			Expect(sortCollation()).To(Equal(db.NaturalCollation))
 		})
 	})
 })

--- a/persistence/helpers_test.go
+++ b/persistence/helpers_test.go
@@ -88,46 +88,36 @@ var _ = Describe("Helpers", func() {
 	})
 
 	Describe("mapSortOrder", func() {
-		It("does not change the sort string if there are no order columns", func() {
-			sort := "album_name asc"
-			mapped := mapSortOrder("album", sort)
-			Expect(mapped).To(Equal(sort))
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
 		})
-		It("changes order columns to sort expression", func() {
-			sort := "ORDER_ALBUM_NAME asc"
-			mapped := mapSortOrder("album", sort)
-			Expect(mapped).To(Equal(`(coalesce(nullif(album.sort_album_name,''),album.order_album_name)` +
-				` collate nocase) asc`))
-		})
-		It("changes multiple order columns to sort expressions", func() {
-			sort := "compilation, order_title asc, order_album_artist_name desc, year desc"
-			mapped := mapSortOrder("album", sort)
-			Expect(mapped).To(Equal(`compilation, (coalesce(nullif(album.sort_title,''),album.order_title) collate nocase) asc,` +
-				` (coalesce(nullif(album.sort_album_artist_name,''),album.order_album_artist_name) collate nocase) desc, year desc`))
-		})
-		Context("with EnableNaturalSorting", func() {
-			BeforeEach(func() {
-				DeferCleanup(configtest.SetupConfig())
-				conf.Server.EnableNaturalSorting = true
-			})
-			It("uses the natural collation for order columns", func() {
-				mapped := mapSortOrder("album", "order_album_name asc")
-				Expect(mapped).To(Equal(`(coalesce(nullif(album.sort_album_name,''),album.order_album_name)` +
-					` collate NATSORT) asc`))
-			})
-			It("leaves plain columns alone", func() {
-				Expect(mapSortOrder("album", "year desc")).To(Equal("year desc"))
-			})
-		})
-	})
 
-	Describe("mapNaturalOrder", func() {
-		It("qualifies order columns and applies the natural collation", func() {
-			Expect(mapNaturalOrder("album", "order_album_name asc, year desc")).To(
-				Equal("(album.order_album_name collate NATSORT) asc, year desc"))
+		It("does not change the sort string if there are no order columns", func() {
+			Expect(mapSortOrder("album", "album_name asc")).To(Equal("album_name asc"))
 		})
-		It("does not change a sort string without order columns", func() {
-			Expect(mapNaturalOrder("album", "year desc")).To(Equal("year desc"))
+
+		DescribeTable("maps order columns to a collated expression",
+			func(preferSortTags, naturalSorting bool, expected string) {
+				conf.Server.PreferSortTags = preferSortTags
+				conf.Server.EnableNaturalSorting = naturalSorting
+				Expect(mapSortOrder("album", "ORDER_ALBUM_NAME asc")).To(Equal(expected))
+			},
+			Entry("qualified column", false, false,
+				"(album.order_album_name collate nocase) asc"),
+			Entry("natural collation", false, true,
+				"(album.order_album_name collate NATSORT) asc"),
+			Entry("sort tags preferred", true, false,
+				`(coalesce(nullif(album.sort_album_name,''),album.order_album_name) collate nocase) asc`),
+			Entry("sort tags preferred, natural collation", true, true,
+				`(coalesce(nullif(album.sort_album_name,''),album.order_album_name) collate NATSORT) asc`),
+		)
+
+		It("changes multiple order columns to sort expressions", func() {
+			conf.Server.PreferSortTags = true
+			sort := "compilation, order_title asc, order_album_artist_name desc, year desc"
+			Expect(mapSortOrder("album", sort)).To(Equal(
+				`compilation, (coalesce(nullif(album.sort_title,''),album.order_title) collate nocase) asc,` +
+					` (coalesce(nullif(album.sort_album_artist_name,''),album.order_album_artist_name) collate nocase) desc, year desc`))
 		})
 	})
 

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -86,7 +86,7 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 		"title":          "order_title",
 		"artist":         "order_artist_name, order_album_name, release_date, disc_number, track_number",
 		"album_artist":   "order_album_artist_name, order_album_name, release_date, disc_number, track_number",
-		"album":          "order_album_name, album_id, disc_number, track_number, order_artist_name, " + collatedSort("media_file.title"),
+		"album":          "order_album_name, album_id, disc_number, track_number, order_artist_name, " + naturalSort("media_file.title"),
 		"random":         "random",
 		"created_at":     "media_file.created_at",
 		"recently_added": mediaFileRecentlyAddedSort(),

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -86,7 +86,7 @@ func NewMediaFileRepository(ctx context.Context, db dbx.Builder) model.MediaFile
 		"title":          "order_title",
 		"artist":         "order_artist_name, order_album_name, release_date, disc_number, track_number",
 		"album_artist":   "order_album_artist_name, order_album_name, release_date, disc_number, track_number",
-		"album":          "order_album_name, album_id, disc_number, track_number, order_artist_name, title",
+		"album":          "order_album_name, album_id, disc_number, track_number, order_artist_name, " + collatedSort("media_file.title"),
 		"random":         "random",
 		"created_at":     "media_file.created_at",
 		"recently_added": mediaFileRecentlyAddedSort(),

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -60,8 +60,8 @@ func NewPlaylistRepository(ctx context.Context, db dbx.Builder) model.PlaylistRe
 		"starred": annotationBoolFilter("starred"),
 	})
 	r.setSortMappings(map[string]string{
-		"name":       collatedSort("playlist.name"),
-		"owner_name": collatedSort("owner_name"),
+		"name":       naturalSort("playlist.name"),
+		"owner_name": naturalSort("owner_name"),
 	})
 	return r
 }

--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -60,7 +60,8 @@ func NewPlaylistRepository(ctx context.Context, db dbx.Builder) model.PlaylistRe
 		"starred": annotationBoolFilter("starred"),
 	})
 	r.setSortMappings(map[string]string{
-		"owner_name": "owner_name",
+		"name":       collatedSort("playlist.name"),
+		"owner_name": collatedSort("owner_name"),
 	})
 	return r
 }

--- a/persistence/playlist_repository_test.go
+++ b/persistence/playlist_repository_test.go
@@ -5,6 +5,8 @@ import (
 
 	"github.com/Masterminds/squirrel"
 	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/criteria"
@@ -22,6 +24,39 @@ var _ = Describe("PlaylistRepository", func() {
 		ctx := log.NewContext(GinkgoT().Context())
 		ctx = request.WithUser(ctx, model.User{ID: "userid", UserName: "userid", IsAdmin: true})
 		repo = NewPlaylistRepository(ctx, GetDBXBuilder())
+	})
+
+	Describe("natural sorting", func() {
+		var ids []string
+
+		BeforeEach(func() {
+			DeferCleanup(configtest.SetupConfig())
+			conf.Server.EnableNaturalSorting = true
+			ctx := log.NewContext(GinkgoT().Context())
+			ctx = request.WithUser(ctx, model.User{ID: "userid", UserName: "userid", IsAdmin: true})
+			repo = NewPlaylistRepository(ctx, GetDBXBuilder())
+
+			ids = nil
+			for _, n := range []string{"mix 1", "mix 10", "mix 2"} {
+				pls := model.Playlist{Name: n, OwnerID: "userid"}
+				Expect(repo.Put(&pls)).To(Succeed())
+				ids = append(ids, pls.ID)
+			}
+			DeferCleanup(func() {
+				for _, id := range ids {
+					_ = repo.Delete(id)
+				}
+			})
+		})
+
+		It("sorts playlist names by number value", func() {
+			all, err := repo.GetAll(model.QueryOptions{
+				Sort: "name", Filters: squirrel.Eq{"playlist.id": ids},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(slice.Map(all, func(p model.Playlist) string { return p.Name })).To(
+				Equal([]string{"mix 1", "mix 2", "mix 10"}))
+		})
 	})
 
 	Describe("Count", func() {

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -56,7 +56,7 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 			"id":           "playlist_tracks.id",
 			"artist":       "order_artist_name",
 			"album_artist": "order_album_artist_name",
-			"album":        "order_album_name, album_id, disc_number, track_number, order_artist_name, title",
+			"album":        "order_album_name, album_id, disc_number, track_number, order_artist_name, " + collatedSort("f.title"),
 			"title":        "order_title",
 			"random":       "random()",
 			// To make sure these fields will be whitelisted

--- a/persistence/playlist_track_repository.go
+++ b/persistence/playlist_track_repository.go
@@ -56,7 +56,7 @@ func (r *playlistRepository) Tracks(playlistId string, refreshSmartPlaylist bool
 			"id":           "playlist_tracks.id",
 			"artist":       "order_artist_name",
 			"album_artist": "order_album_artist_name",
-			"album":        "order_album_name, album_id, disc_number, track_number, order_artist_name, " + collatedSort("f.title"),
+			"album":        "order_album_name, album_id, disc_number, track_number, order_artist_name, " + naturalSort("f.title"),
 			"title":        "order_title",
 			"random":       "random()",
 			// To make sure these fields will be whitelisted

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -113,10 +113,14 @@ func (r *sqlRepository) setSortMappings(mappings map[string]string, tableName ..
 	if len(tableName) > 0 {
 		tn = tableName[0]
 	}
-	if conf.Server.PreferSortTags {
+	switch {
+	case conf.Server.PreferSortTags:
 		for k, v := range mappings {
-			v = mapSortOrder(tn, v)
-			mappings[k] = v
+			mappings[k] = mapSortOrder(tn, v)
+		}
+	case conf.Server.EnableNaturalSorting:
+		for k, v := range mappings {
+			mappings[k] = mapNaturalOrder(tn, v)
 		}
 	}
 	r.sortMappings = mappings

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -113,14 +113,9 @@ func (r *sqlRepository) setSortMappings(mappings map[string]string, tableName ..
 	if len(tableName) > 0 {
 		tn = tableName[0]
 	}
-	switch {
-	case conf.Server.PreferSortTags:
+	if conf.Server.PreferSortTags || conf.Server.EnableNaturalSorting {
 		for k, v := range mappings {
 			mappings[k] = mapSortOrder(tn, v)
-		}
-	case conf.Server.EnableNaturalSorting:
-		for k, v := range mappings {
-			mappings[k] = mapNaturalOrder(tn, v)
 		}
 	}
 	r.sortMappings = mappings

--- a/utils/natural/natural.go
+++ b/utils/natural/natural.go
@@ -10,10 +10,11 @@ import "strings"
 // or a positive value if a > b using natural sort ordering.
 //
 // When two numeric segments are numerically equal (e.g. "01" vs "1"),
-// comparison continues with the remaining suffixes. If one or both
-// strings end at the digit boundary, the raw strings are compared
-// lexically, which makes leading zeros significant as a tie-breaker
-// (e.g. "a01" < "a1", "a0" < "a00").
+// comparison continues with the remaining suffixes, and the padding
+// difference is kept as a final tie-breaker that only decides strings
+// that are otherwise equal (e.g. "a01" < "a1", "a0" < "a00"). Deferring
+// it that way is what keeps the ordering transitive, which SQLite
+// requires of a collating function.
 func Compare(a, b string) int {
 	return compare(a, b, false)
 }
@@ -26,6 +27,9 @@ func CompareFold(a, b string) int {
 
 func compare(a, b string, fold bool) int {
 	ia, ib := 0, 0
+	// Set when two runs are numerically equal but differently padded. Applying it
+	// immediately would break transitivity, so it only decides otherwise-equal strings.
+	padTie := 0
 	for ia < len(a) && ib < len(b) {
 		ca, cb := a[ia], b[ib]
 		da, db := isDigit(ca), isDigit(cb)
@@ -48,17 +52,11 @@ func compare(a, b string, fold bool) int {
 			if c := compareNumbers(a[ia:endA], b[ib:endB]); c != 0 {
 				return c
 			}
-
-			// Numerically equal. If both sides have trailing data, continue
-			// comparing after the digit runs. Otherwise fall through to
-			// lexical comparison of the full remaining strings (which makes
-			// leading-zero differences significant as a tie-breaker).
-			if endA < len(a) && endB < len(b) {
-				ia = endA
-				ib = endB
-				continue
+			if t := strings.Compare(a[ia:endA], b[ib:endB]); t != 0 {
+				padTie = t
 			}
-			return compareRest(a[ia:], b[ib:], fold)
+			ia = endA
+			ib = endB
 		case da != db:
 			return int(ca) - int(cb)
 		default:
@@ -69,20 +67,10 @@ func compare(a, b string, fold bool) int {
 			ib++
 		}
 	}
-	return (len(a) - ia) - (len(b) - ib)
-}
-
-func compareRest(a, b string, fold bool) int {
-	if !fold {
-		return strings.Compare(a, b)
+	if c := (len(a) - ia) - (len(b) - ib); c != 0 {
+		return c
 	}
-	for i := 0; i < len(a) && i < len(b); i++ {
-		ca, cb := lower(a[i]), lower(b[i])
-		if ca != cb {
-			return int(ca) - int(cb)
-		}
-	}
-	return len(a) - len(b)
+	return padTie
 }
 
 // compareNumbers compares two digit strings numerically.

--- a/utils/natural/natural.go
+++ b/utils/natural/natural.go
@@ -15,10 +15,23 @@ import "strings"
 // lexically, which makes leading zeros significant as a tie-breaker
 // (e.g. "a01" < "a1", "a0" < "a00").
 func Compare(a, b string) int {
+	return compare(a, b, false)
+}
+
+// CompareFold is Compare with ASCII case folding, matching SQLite's NOCASE
+// collation: only A-Z fold, bytes >= 0x80 are compared as-is.
+func CompareFold(a, b string) int {
+	return compare(a, b, true)
+}
+
+func compare(a, b string, fold bool) int {
 	ia, ib := 0, 0
 	for ia < len(a) && ib < len(b) {
 		ca, cb := a[ia], b[ib]
 		da, db := isDigit(ca), isDigit(cb)
+		if fold {
+			ca, cb = lower(ca), lower(cb)
+		}
 
 		switch {
 		case da && db:
@@ -45,7 +58,7 @@ func Compare(a, b string) int {
 				ib = endB
 				continue
 			}
-			return strings.Compare(a[ia:], b[ib:])
+			return compareRest(a[ia:], b[ib:], fold)
 		case da != db:
 			return int(ca) - int(cb)
 		default:
@@ -57,6 +70,19 @@ func Compare(a, b string) int {
 		}
 	}
 	return (len(a) - ia) - (len(b) - ib)
+}
+
+func compareRest(a, b string, fold bool) int {
+	if !fold {
+		return strings.Compare(a, b)
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		ca, cb := lower(a[i]), lower(b[i])
+		if ca != cb {
+			return int(ca) - int(cb)
+		}
+	}
+	return len(a) - len(b)
 }
 
 // compareNumbers compares two digit strings numerically.
@@ -95,4 +121,11 @@ func stripZeros(s string) string {
 
 func isDigit(c byte) bool {
 	return c >= '0' && c <= '9'
+}
+
+func lower(c byte) byte {
+	if c >= 'A' && c <= 'Z' {
+		return c + 'a' - 'A'
+	}
+	return c
 }

--- a/utils/natural/natural_test.go
+++ b/utils/natural/natural_test.go
@@ -73,7 +73,9 @@ var _ = Describe("Compare", func() {
 		Entry("a00b00 < a0b1", "a00b00", "a0b1", -1),
 		Entry("a00b00 > a0b0", "a00b00", "a0b0", 1),
 		Entry("a00b01 > a0b00", "a00b01", "a0b00", 1),
-		Entry("a00b00 == a0b00", "a00b00", "a0b00", 0),
+		// Distinct strings must not compare equal: the padding difference in the first
+		// run decides once everything else matches.
+		Entry("a00b00 > a0b00", "a00b00", "a0b00", 1),
 
 		// Leading zeros at end of string — lexical tie-break
 		Entry("file01 < file1", "file01", "file1", -1),
@@ -115,9 +117,9 @@ var _ = Describe("Compare", func() {
 		Entry("large: equal",
 			"a100000000000000000000", "a100000000000000000000", 0),
 		Entry("large: leading zeros with trailing data",
-			"a00000000000000000000001x", "a1x", 0),
+			"a00000000000000000000001x", "a1x", -1),
 		Entry("large: leading zeros with trailing data (2)",
-			"a099999999999999999999x", "a99999999999999999999x", 0),
+			"a099999999999999999999x", "a99999999999999999999x", -1),
 	)
 })
 
@@ -137,6 +139,50 @@ var _ = Describe("CompareFold", func() {
 		Entry("empty sorts first", "", "a", -1),
 		Entry("non-ASCII is left untouched", "café 2", "café 10", -1),
 	)
+
+	// SQLite requires a collating function to be transitive; if it is not, the behavior of
+	// ORDER BY is undefined and paginated queries can drop or duplicate rows.
+	It("is transitive, as a SQLite collation requires", func() {
+		var corpus []string
+		var build func(prefix string, depth int)
+		build = func(prefix string, depth int) {
+			if prefix != "" {
+				corpus = append(corpus, prefix)
+			}
+			if depth == 0 {
+				return
+			}
+			for _, c := range []string{"0", "1", "a"} {
+				build(prefix+c, depth-1)
+			}
+		}
+		build("", 3)
+
+		sign := func(n int) int {
+			switch {
+			case n < 0:
+				return -1
+			case n > 0:
+				return 1
+			}
+			return 0
+		}
+		for _, a := range corpus {
+			for _, b := range corpus {
+				ab := sign(natural.CompareFold(a, b))
+				for _, c := range corpus {
+					bc := sign(natural.CompareFold(b, c))
+					ac := sign(natural.CompareFold(a, c))
+					if ab == 0 && bc == 0 {
+						Expect(ac).To(Equal(0), "%q==%q and %q==%q but %q vs %q is %d", a, b, b, c, a, c, ac)
+					}
+					if ab < 0 && bc < 0 {
+						Expect(ac).To(BeNumerically("<", 0), "%q<%q<%q but %q vs %q is %d", a, b, c, a, c, ac)
+					}
+				}
+			}
+		}
+	})
 
 	It("matches Compare when both sides are already lowercase", func() {
 		pairs := [][2]string{{"foo 2", "foo 10"}, {"a01", "a1"}, {"a", "aa"}, {"vol 3", "vol 3"}}

--- a/utils/natural/natural_test.go
+++ b/utils/natural/natural_test.go
@@ -114,3 +114,37 @@ var _ = Describe("Compare", func() {
 			"a099999999999999999999x", "a99999999999999999999x", 0),
 	)
 })
+
+var _ = Describe("CompareFold", func() {
+	DescribeTable("orders case-insensitively",
+		func(a, b string, expected int) {
+			result := natural.CompareFold(a, b)
+			switch {
+			case expected < 0:
+				Expect(result).To(BeNumerically("<", 0), "expected %q < %q", a, b)
+			case expected > 0:
+				Expect(result).To(BeNumerically(">", 0), "expected %q > %q", a, b)
+			default:
+				Expect(result).To(Equal(0), "expected %q == %q", a, b)
+			}
+		},
+		Entry("numbers compare numerically", "foo 2", "foo 10", -1),
+		Entry("numbers compare numerically, reversed", "foo 10", "foo 2", 1),
+		Entry("case is ignored", "apple 2", "Banana 10", -1),
+		Entry("case is ignored, reversed", "Banana 10", "apple 2", 1),
+		Entry("same word, different case, is equal", "ABC", "abc", 0),
+		Entry("case ignored while comparing numbers", "Vol 2", "vol 10", -1),
+		Entry("uppercase digits boundary", "Track9", "track10", -1),
+		Entry("empty vs empty", "", "", 0),
+		Entry("empty sorts first", "", "a", -1),
+		Entry("non-ASCII is left untouched", "café 2", "café 10", -1),
+	)
+
+	It("matches Compare when both sides are already lowercase", func() {
+		pairs := [][2]string{{"foo 2", "foo 10"}, {"a01", "a1"}, {"a", "aa"}, {"vol 3", "vol 3"}}
+		for _, p := range pairs {
+			Expect(natural.CompareFold(p[0], p[1])).To(Equal(natural.Compare(p[0], p[1])),
+				"CompareFold(%q,%q) should match Compare", p[0], p[1])
+		}
+	})
+})

--- a/utils/natural/natural_test.go
+++ b/utils/natural/natural_test.go
@@ -13,17 +13,23 @@ func TestNatural(t *testing.T) {
 	RunSpecs(t, "Natural Suite")
 }
 
+// expectOrder asserts the sign of cmp(a, b) matches expected.
+func expectOrder(cmp func(string, string) int, a, b string, expected int) {
+	result := cmp(a, b)
+	switch {
+	case expected < 0:
+		ExpectWithOffset(1, result).To(BeNumerically("<", 0), "expected %q < %q", a, b)
+	case expected > 0:
+		ExpectWithOffset(1, result).To(BeNumerically(">", 0), "expected %q > %q", a, b)
+	default:
+		ExpectWithOffset(1, result).To(Equal(0), "expected %q == %q", a, b)
+	}
+}
+
 var _ = Describe("Compare", func() {
 	DescribeTable("returns correct ordering",
 		func(a, b string, expected int) {
-			result := natural.Compare(a, b)
-			if expected < 0 {
-				Expect(result).To(BeNumerically("<", 0), "expected %q < %q", a, b)
-			} else if expected > 0 {
-				Expect(result).To(BeNumerically(">", 0), "expected %q > %q", a, b)
-			} else {
-				Expect(result).To(Equal(0), "expected %q == %q", a, b)
-			}
+			expectOrder(natural.Compare, a, b, expected)
 		},
 		// Basic string ordering
 		Entry("a < b", "a", "b", -1),
@@ -118,15 +124,7 @@ var _ = Describe("Compare", func() {
 var _ = Describe("CompareFold", func() {
 	DescribeTable("orders case-insensitively",
 		func(a, b string, expected int) {
-			result := natural.CompareFold(a, b)
-			switch {
-			case expected < 0:
-				Expect(result).To(BeNumerically("<", 0), "expected %q < %q", a, b)
-			case expected > 0:
-				Expect(result).To(BeNumerically(">", 0), "expected %q > %q", a, b)
-			default:
-				Expect(result).To(Equal(0), "expected %q == %q", a, b)
-			}
+			expectOrder(natural.CompareFold, a, b, expected)
 		},
 		Entry("numbers compare numerically", "foo 2", "foo 10", -1),
 		Entry("numbers compare numerically, reversed", "foo 10", "foo 2", 1),


### PR DESCRIPTION
### Description

Album, artist, song and playlist lists sort with a plain text comparison, so names with numbers in them come out as `Foo 1, Foo 10, Foo 2` instead of `Foo 1, Foo 2, Foo 10`.

This adds `EnableNaturalSorting`, default off, which switches those sorts to a `NATSORT` collation registered on every SQLite connection and backed by `natural.CompareFold`. `natural.Compare` gained an ASCII case-folding variant because the collation replaces `collate nocase`. The `sort_*` columns hold raw tag values, so without folding they would order uppercase before lowercase.

Two things are worth a reviewer's attention.

Applying the collation only inside `mapSortOrder` would have missed the default configuration completely, because that mapper runs only when `PreferSortTags` is on. `setSortMappings` now also rewrites the `order_*` columns when natural sorting is on by itself. I did not spot that; a test did, after the first version quietly fixed nothing for anyone running defaults.

Sorts over plain text columns that are not `order_*` columns get wrapped by hand: `playlist.name`, `album.name`, `media_file.title`, and the `playlist_tracks` alias of it. Each one is qualified with its table. That qualification is load-bearing for playlists, since the playlist query joins `user`, which also has a `name` column.

The option defaults to off because the collation cannot use the existing indexes. Numbers below.

### Related Issues

Fixes #4554

### Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

Documentation is unchecked because the new option still needs a row in the website's config-options table.

### How to Test

Start the server as usual and confirm the default has not moved. An album list sorted by name should still show `Foo 1, Foo 10, Foo 2, Foo 20`.

Then restart with `ND_ENABLENATURALSORTING=true` and confirm the same list shows `Foo 1, Foo 2, Foo 10, Foo 20`. The same should hold for songs by title, artists by name and playlists by name, on the native API (`/api/album?_sort=name`) and on Subsonic (`getAlbumList2` with `type=alphabeticalByName`, `getPlaylists`, `getAlbum`). Descending order should be the exact reverse.

You need a library with numbered albums or volumes to see anything. If no name in the library contains a digit, the two modes are indistinguishable.

### Additional Notes

#### Performance

I benchmarked this with `testing.B` against the real repository methods on a copy of a production database: 97,041 songs, 6,987 albums, 29,375 artists. Master `fc9d93d22` against this branch, `-benchtime 3s -count 6`, compared with `benchstat`.

With the flag off nothing moves, which is the result that matters for people who never touch the option:

| Query | master | branch (off) | delta |
|---|---|---|---|
| AlbumByName | 958.1µs | 998.2µs | ~ |
| SongByTitle | 2.812ms | 2.981ms | ~ |
| SongByAlbum | 2.377ms | 2.330ms | ~ |
| ArtistByName | 95.96ms | 92.62ms | ~ |
| PlaylistByName | 410.1µs | 407.3µs | ~ |
| CTL_SongByYear (control) | 1.768ms | 1.781ms | ~ |

One case first read +8.71% at p=0.002, on code that is byte-identical between the two revisions. Re-run at `-count 12` it is `~` at p=0.319. That first figure was variance, and I nearly published it.

Turning the option on is expensive, and worse on songs than on albums:

| Query | master | branch (on) | delta |
|---|---|---|---|
| SongByAlbum | 2.335ms | 139.875ms | +5890% |
| SongByTitle | 2.829ms | 74.088ms | +2519% |
| AlbumByName | 972.6µs | 9.424ms | +869% |
| AlbumByName offset 5k | 15.72ms | 102.17ms | +550% |
| PlaylistByName | 402.8µs | 444.2µs | +10.3% |
| ArtistByName | 93.62ms | 96.23ms | ~ |

Memory goes up too: +43% geomean, worst case +454% B/op. `ArtistByName` looks flat only because it already cost about 94ms on master for unrelated reasons, so the extra sort work hides inside what was already slow. Both controls stay flat under either flag state.

`EXPLAIN QUERY PLAN` on the same copy shows why. Every enabled sort loses its index-ordered scan and falls back to a full temp B-tree, because no index in the schema uses `NATSORT` and SQLite can only skip the sort step when the ORDER BY collation matches the index collation:

```
song by album  OFF : SCAN media_file USING INDEX media_file_album_sort
song by album  ON  : SCAN media_file | USE TEMP B-TREE FOR ORDER BY
```

#### Why the expression is not indexed

Adding an index with the custom collation fixes the speed and breaks everything else. With such an index in place, the plain `sqlite3` CLI cannot read the database at all. It fails on `select count(*)`, `pragma integrity_check` and `vacuum`, because it has no `NATSORT` registered. I tested it before ruling it out. Users run backup scripts and we debug with that CLI, so that price is far too high.

#### Alternatives I looked at

Materializing a padded sort key would keep the existing indexes working. The problem is that `order_album_name` goes out to clients as `SortName`, so padding leaks values like `foo 0000000010` into Subsonic and Jellyfin responses and breaks any client that uses it for A-Z jump lists. Doing it properly needs a separate column, a migration and a rescan.

SQLite ships a `uint` collation that sorts embedded numbers correctly, which looked promising for about ten minutes. It lives in `ext/misc`, is not compiled into `mattn/go-sqlite3`, and has no build tag, so using it means vendoring C.

#### What I am not happy with

The mechanism has two channels. `order_*` columns are handled by the regex automatically, while plain text columns have to be wrapped by hand at the call site. Add a tiebreaker on some future `name` or `title` column without `naturalSort()` and it sorts lexicographically in silence, with no test to catch it. Doing it once in `buildSortOrder` would remove the asymmetry, but that is the choke point for every sort including numeric ones, and wrapping `year`, `duration` and `play_count` would block their indexes. So I left it.

One more thing reviewers should know: `persistence/sort_index_coverage_test.go` guards against unindexed sorts, but it runs with the default config, so it cannot see this flag at all. The index loss here is deliberate and it is exactly why the option ships off, but nothing enforces that tradeoff.
