### PR TITLE
fix: add Navidrome UserAgent in all outgoing requests

### DIFF
--- a/adapters/deezer/deezer.go
+++ b/adapters/deezer/deezer.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"slices"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/slice"
 )
 
@@ -36,9 +36,7 @@ func deezerConstructor(dataStore model.DataStore) agents.Interface {
 		dataStore: dataStore,
 		languages: conf.Server.Deezer.Languages,
 	}
-	httpClient := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	httpClient := httpclient.New(consts.DefaultHttpClientTimeOut)
 	cachedHttpClient := cache.NewHTTPClient(httpClient, consts.DefaultHttpClientTimeOut)
 	agent.client = newClient(cachedHttpClient)
 	return agent

--- a/adapters/lastfm/agent.go
+++ b/adapters/lastfm/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"golang.org/x/net/html"
 )
 
@@ -59,9 +60,7 @@ func lastFMConstructor(ds model.DataStore) *lastfmAgent {
 		secret:      conf.Server.LastFM.Secret,
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 	}
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New(consts.DefaultHttpClientTimeOut)
 	chc := cache.NewHTTPClient(hc, consts.DefaultHttpClientTimeOut)
 	l.httpClient = chc
 	l.client = newClient(l.apiKey, l.secret, chc)

--- a/adapters/lastfm/auth_router.go
+++ b/adapters/lastfm/auth_router.go
@@ -18,6 +18,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/req"
 )
 
@@ -41,9 +42,7 @@ func NewRouter(ds model.DataStore) *Router {
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 	}
 	r.Handler = r.routes()
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New(consts.DefaultHttpClientTimeOut)
 	r.client = newClient(r.apiKey, r.secret, hc)
 	return r
 }

--- a/adapters/listenbrainz/agent.go
+++ b/adapters/listenbrainz/agent.go
@@ -3,7 +3,6 @@ package listenbrainz
 import (
 	"context"
 	"errors"
-	"net/http"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/consts"
@@ -12,6 +11,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/cache"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/slice"
 )
 
@@ -33,9 +33,7 @@ func listenBrainzConstructor(ds model.DataStore) *listenBrainzAgent {
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 		baseURL:     conf.Server.ListenBrainz.BaseURL,
 	}
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New(consts.DefaultHttpClientTimeOut)
 	chc := cache.NewHTTPClient(hc, consts.DefaultHttpClientTimeOut)
 	l.client = newClient(l.baseURL, chc)
 	return l

--- a/adapters/listenbrainz/auth_router.go
+++ b/adapters/listenbrainz/auth_router.go
@@ -16,6 +16,7 @@ import (
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/server"
+	"github.com/navidrome/navidrome/utils/httpclient"
 )
 
 type sessionKeysRepo interface {
@@ -37,9 +38,7 @@ func NewRouter(ds model.DataStore) *Router {
 		sessionKeys: &agents.SessionKeys{DataStore: ds, KeyName: sessionKeyProperty},
 	}
 	r.Handler = r.routes()
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New(consts.DefaultHttpClientTimeOut)
 	r.client = newClient(conf.Server.ListenBrainz.BaseURL, hc)
 	return r
 }

--- a/adapters/listenbrainz/client.go
+++ b/adapters/listenbrainz/client.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 
 	"github.com/navidrome/navidrome/conf"
+	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 )
 
@@ -162,6 +163,7 @@ func (c *client) makeAuthenticatedRequest(ctx context.Context, method string, en
 	}
 	req, _ := http.NewRequestWithContext(ctx, method, uri, bytes.NewBuffer(b))
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Add("User-Agent", consts.HTTPUserAgent)
 
 	if r.ApiKey != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Token %s", r.ApiKey))
@@ -199,6 +201,8 @@ type lbzHttpError struct {
 func (c *client) makeGenericRequest(ctx context.Context, method string, endpoint string, params url.Values) (*http.Response, error) {
 	req, _ := http.NewRequestWithContext(ctx, method, lbzApiUrl+endpoint, nil)
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
+	req.Header.Add("User-Agent", consts.HTTPUserAgent)
+
 	req.URL.RawQuery = params.Encode()
 
 	log.Trace(ctx, fmt.Sprintf("Sending ListenBrainz %s request", req.Method), "url", req.URL)

--- a/adapters/listenbrainz/client.go
+++ b/adapters/listenbrainz/client.go
@@ -13,7 +13,6 @@ import (
 	"slices"
 
 	"github.com/navidrome/navidrome/conf"
-	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 )
 
@@ -163,7 +162,6 @@ func (c *client) makeAuthenticatedRequest(ctx context.Context, method string, en
 	}
 	req, _ := http.NewRequestWithContext(ctx, method, uri, bytes.NewBuffer(b))
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Add("User-Agent", consts.HTTPUserAgent)
 
 	if r.ApiKey != "" {
 		req.Header.Add("Authorization", fmt.Sprintf("Token %s", r.ApiKey))
@@ -201,8 +199,6 @@ type lbzHttpError struct {
 func (c *client) makeGenericRequest(ctx context.Context, method string, endpoint string, params url.Values) (*http.Response, error) {
 	req, _ := http.NewRequestWithContext(ctx, method, lbzApiUrl+endpoint, nil)
 	req.Header.Add("Content-Type", "application/json; charset=UTF-8")
-	req.Header.Add("User-Agent", consts.HTTPUserAgent)
-
 	req.URL.RawQuery = params.Encode()
 
 	log.Trace(ctx, fmt.Sprintf("Sending ListenBrainz %s request", req.Method), "url", req.URL)

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -201,7 +201,7 @@ var (
 	}
 )
 
-var HTTPUserAgent = "Navidrome" + "/" + Version
+var HTTPUserAgent = "Navidrome/" + Version + " - https://github.com/navidrome"
 
 var (
 	VariousArtists = "Various Artists"

--- a/core/metrics/insights.go
+++ b/core/metrics/insights.go
@@ -26,6 +26,7 @@ import (
 	"github.com/navidrome/navidrome/model/request"
 	"github.com/navidrome/navidrome/plugins"
 	"github.com/navidrome/navidrome/server/events"
+	"github.com/navidrome/navidrome/utils/httpclient"
 	"github.com/navidrome/navidrome/utils/singleton"
 )
 
@@ -95,9 +96,7 @@ func (c *insightsCollector) sendInsights(ctx context.Context) {
 		log.Trace(ctx, "No users found, skipping Insights data collection")
 		return
 	}
-	hc := &http.Client{
-		Timeout: consts.DefaultHttpClientTimeOut,
-	}
+	hc := httpclient.New(consts.DefaultHttpClientTimeOut)
 	data := c.collect(ctx)
 	if data == nil {
 		return

--- a/plugins/host_httpclient.go
+++ b/plugins/host_httpclient.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/plugins/host"
+	"github.com/navidrome/navidrome/utils/httpclient"
 )
 
 const (
@@ -46,7 +47,7 @@ func newHTTPService(pluginName string, permission *HTTPPermission) *httpServiceI
 		requiredHosts: requiredHosts,
 	}
 	svc.client = &http.Client{
-		Transport: http.DefaultTransport,
+		Transport: httpclient.NewTransport(nil),
 		// Timeout is set per-request via context deadline, not here.
 		// CheckRedirect validates hosts and enforces redirect limits.
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {

--- a/utils/httpclient/httpclient.go
+++ b/utils/httpclient/httpclient.go
@@ -1,0 +1,35 @@
+// Package httpclient provides a shared http.Client factory that identifies
+// Navidrome via the User-Agent header on all outgoing requests.
+package httpclient
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/navidrome/navidrome/consts"
+)
+
+type uaTransport struct {
+	base http.RoundTripper
+}
+
+func (t *uaTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if _, ok := req.Header["User-Agent"]; !ok {
+		req = req.Clone(req.Context())
+		req.Header.Set("User-Agent", consts.HTTPUserAgent)
+	}
+	return t.base.RoundTrip(req)
+}
+
+// NewTransport wraps base (or http.DefaultTransport if nil) to set the
+// Navidrome User-Agent on requests that don't have one.
+func NewTransport(base http.RoundTripper) http.RoundTripper {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &uaTransport{base: base}
+}
+
+func New(timeout time.Duration) *http.Client {
+	return &http.Client{Timeout: timeout, Transport: NewTransport(nil)}
+}

--- a/utils/httpclient/httpclient_suite_test.go
+++ b/utils/httpclient/httpclient_suite_test.go
@@ -1,0 +1,17 @@
+package httpclient_test
+
+import (
+	"testing"
+
+	"github.com/navidrome/navidrome/log"
+	"github.com/navidrome/navidrome/tests"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHTTPClient(t *testing.T) {
+	tests.Init(t, false)
+	log.SetLevel(log.LevelFatal)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "HTTPClient Suite")
+}

--- a/utils/httpclient/httpclient_test.go
+++ b/utils/httpclient/httpclient_test.go
@@ -1,0 +1,76 @@
+package httpclient_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/navidrome/navidrome/consts"
+	"github.com/navidrome/navidrome/utils/httpclient"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("httpclient", func() {
+	var server *httptest.Server
+	var receivedUA string
+
+	BeforeEach(func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedUA = r.Header.Get("User-Agent")
+		}))
+		DeferCleanup(server.Close)
+	})
+
+	Describe("New", func() {
+		It("sets the Navidrome User-Agent when the request has none", func() {
+			c := httpclient.New(time.Second)
+			resp, err := c.Get(server.URL)
+			Expect(err).ToNot(HaveOccurred())
+			resp.Body.Close()
+			Expect(receivedUA).To(Equal(consts.HTTPUserAgent))
+		})
+
+		It("keeps a User-Agent already set by the caller", func() {
+			c := httpclient.New(time.Second)
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			Expect(err).ToNot(HaveOccurred())
+			req.Header.Set("User-Agent", "CustomAgent/1.0")
+			resp, err := c.Do(req)
+			Expect(err).ToNot(HaveOccurred())
+			resp.Body.Close()
+			Expect(receivedUA).To(Equal("CustomAgent/1.0"))
+		})
+
+		It("applies the given timeout", func() {
+			c := httpclient.New(5 * time.Second)
+			Expect(c.Timeout).To(Equal(5 * time.Second))
+		})
+	})
+
+	Describe("NewTransport", func() {
+		It("uses the default transport when base is nil", func() {
+			c := &http.Client{Transport: httpclient.NewTransport(nil)}
+			resp, err := c.Get(server.URL)
+			Expect(err).ToNot(HaveOccurred())
+			resp.Body.Close()
+			Expect(receivedUA).To(Equal(consts.HTTPUserAgent))
+		})
+
+		It("does not modify the original request", func() {
+			c := &http.Client{Transport: httpclient.NewTransport(nil)}
+			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+			Expect(err).ToNot(HaveOccurred())
+			resp, err := c.Do(req)
+			Expect(err).ToNot(HaveOccurred())
+			resp.Body.Close()
+			Expect(req.Header).ToNot(HaveKey("User-Agent"))
+		})
+	})
+
+	Describe("HTTPUserAgent", func() {
+		It("identifies Navidrome with version and project URL", func() {
+			Expect(consts.HTTPUserAgent).To(Equal("Navidrome/" + consts.Version + " - https://github.com/navidrome"))
+		})
+	})
+})


### PR DESCRIPTION
### Description

EDIT:

ListenBrainz asked us to send a proper User-Agent so they can tell Navidrome apart from generic Go clients when they need to block abusive traffic. This builds on the original commit and moves the header out of the ListenBrainz client into a new utils/httpclient package, a shared `http.Client` factory whose transport sets `Navidrome/{version} - https://github.com/navidrome` on any outgoing request that doesn't already have one. Everything that builds an HTTP client now uses it: the Last.fm, ListenBrainz and Deezer agents and auth routers, the insights collector, the backgrounds handler, and the plugin host HTTP service. Plugins that set their own User-Agent keep it.

<!-- Please provide a clear and concise description of what this PR does and why it is needed. -->

### Original description by @mintsoft 

There has been a report about navidrome hitting listenbrainz hard
and the listenbrainz guys wanting to be able to distinguish navidrome 
from I'm guessing the logs etc.


### Related Issues
<!-- List any related issues, e.g., "Fixes #123" or "Related to #456". -->

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [ ] All existing and new tests pass

### How to Test
<!-- Describe the steps to test your changes. Include setup, commands, and expected results. -->

### Screenshots / Demos (if applicable)
<!-- Add screenshots, GIFs, or links to demos if your change includes UI updates or visual changes. -->

### Additional Notes
<!-- Anything else the maintainer should know? Potential side effects, breaking changes, or areas of concern? -->

<!-- 
**Tips for Contributors:**
- Be concise but thorough.
- If your PR is large, consider breaking it into smaller PRs.
- Tag the maintainer if you need a prompt review.
- Avoid force pushing to the branch after opening the PR, as it can complicate the review process.
-->