### PR TITLE
feat(ui): show sample rate and bit depth for lossless tracks

### DIFF
--- a/ui/src/common/QualityInfo.jsx
+++ b/ui/src/common/QualityInfo.jsx
@@ -9,6 +9,24 @@ import { calculateGain } from '../utils/calculateReplayGain'
 const llFormats = new Set(config.losslessFormats.split(','))
 const placeholder = 'N/A'
 
+// Lossless streams have no meaningful bitrate to show, so their quality is
+// described by the PCM characteristics instead: `FLAC 96/24`.
+const formatSampleRate = (sampleRate) => {
+  const khz = sampleRate / 1000
+  return Number.isInteger(khz) ? String(khz) : khz.toFixed(1)
+}
+
+const losslessDetail = (sampleRate, bitDepth) => {
+  // DSD carries a 1-bit stream at MHz rates, where `2822.4/1` would say
+  // nothing useful. Those formats keep showing the container alone until
+  // modulation gets its own representation.
+  if (bitDepth === 1 || !(sampleRate > 0)) {
+    return ''
+  }
+  const rate = formatSampleRate(sampleRate)
+  return bitDepth > 0 ? `${rate}/${bitDepth}` : rate
+}
+
 const useStyle = makeStyles(
   (theme) => ({
     chip: {
@@ -30,14 +48,27 @@ export const QualityInfo = ({
   isDirectPlay,
 }) => {
   const classes = useStyle()
-  let { suffix, bitRate, rgAlbumGain, rgAlbumPeak, rgTrackGain, rgTrackPeak } =
-    record
+  let {
+    suffix,
+    bitRate,
+    sampleRate,
+    bitDepth,
+    rgAlbumGain,
+    rgAlbumPeak,
+    rgTrackGain,
+    rgTrackPeak,
+  } = record
   let info = placeholder
 
   if (suffix) {
     suffix = suffix.toUpperCase()
     info = suffix
-    if (!llFormats.has(suffix) && bitRate > 0) {
+    if (llFormats.has(suffix)) {
+      const detail = losslessDetail(sampleRate, bitDepth)
+      if (detail) {
+        info += ' ' + detail
+      }
+    } else if (bitRate > 0) {
       info += ' ' + bitRate
     }
   }

--- a/ui/src/common/QualityInfo.test.jsx
+++ b/ui/src/common/QualityInfo.test.jsx
@@ -5,10 +5,50 @@ import { QualityInfo } from './QualityInfo'
 describe('<QualityInfo />', () => {
   afterEach(cleanup)
 
-  it('only render suffix for lossless formats', () => {
+  it('only renders suffix for lossless formats without stream details', () => {
     const info = { suffix: 'FLAC', bitRate: 1008 }
     render(<QualityInfo record={info} />)
     expect(screen.getByText('FLAC')).toBeInTheDocument()
+  })
+  it('renders sample rate and bit depth for lossless formats', () => {
+    const info = {
+      suffix: 'FLAC',
+      bitRate: 1008,
+      sampleRate: 96000,
+      bitDepth: 24,
+    }
+    render(<QualityInfo record={info} />)
+    expect(screen.getByText('FLAC 96/24')).toBeInTheDocument()
+  })
+  it('renders CD quality without a trailing zero', () => {
+    const info = { suffix: 'FLAC', sampleRate: 44100, bitDepth: 16 }
+    render(<QualityInfo record={info} />)
+    expect(screen.getByText('FLAC 44.1/16')).toBeInTheDocument()
+  })
+  it('keeps one decimal for rates that are not whole kHz', () => {
+    const info = { suffix: 'FLAC', sampleRate: 88200, bitDepth: 24 }
+    render(<QualityInfo record={info} />)
+    expect(screen.getByText('FLAC 88.2/24')).toBeInTheDocument()
+  })
+  it('renders the sample rate alone when bit depth is unknown', () => {
+    const info = { suffix: 'FLAC', sampleRate: 192000 }
+    render(<QualityInfo record={info} />)
+    expect(screen.getByText('FLAC 192')).toBeInTheDocument()
+  })
+  it('renders stream details for other lossless containers', () => {
+    const info = { suffix: 'WAV', sampleRate: 48000, bitDepth: 32 }
+    render(<QualityInfo record={info} />)
+    expect(screen.getByText('WAV 48/32')).toBeInTheDocument()
+  })
+  it('leaves DSD showing the container alone', () => {
+    const info = { suffix: 'DSF', sampleRate: 2822400, bitDepth: 1 }
+    render(<QualityInfo record={info} />)
+    expect(screen.getByText('DSF')).toBeInTheDocument()
+  })
+  it('ignores stream details for lossy formats', () => {
+    const info = { suffix: 'MP3', bitRate: 320, sampleRate: 44100 }
+    render(<QualityInfo record={info} />)
+    expect(screen.getByText('MP3 320')).toBeInTheDocument()
   })
   it('only render suffix and bitrate for lossy formats', () => {
     const info = {


### PR DESCRIPTION
Part of #1438 — the Web UI item *"concatenate relevant info in one `Quality` column, i.e. MP3 320, AAC 5.1, FLAC 96/24"*.

## Problem

The Quality column already appends the bitrate for lossy formats, so `MP3 320` tells you what you are listening to. Lossless formats have no meaningful bitrate to append, so every one of them renders as a bare `FLAC`.

That makes duplicates indistinguishable. This is a real library, sorted by title:

| Title | Album | Before | After |
| --- | --- | --- | --- |
| Babe I'm Gonna Leave You | Mothership | `FLAC` | `FLAC 44.1/24` |
| Babe I'm Gonna Leave You (Remaster) | HD Remastered Deluxe Edition | `FLAC` | `FLAC 96/24` |
| Black Dog | Mothership | `FLAC` | `FLAC 44.1/24` |
| Black Dog (Basic Track with Guitar Overdubs) | Led Zeppelin IV (HD Remastered) | `FLAC` | `FLAC 96/24` |

Before, those rows are four identical chips. The original request in #1571 put it well: *"I might have it once in mp3 from the old days, a FLAC from a physical CD and a Hi-Res flac from 7digital. This would allow me to easily pick the quality I need."*

## Change

`QualityInfo` appends the PCM stream characteristics for lossless formats, mirroring what it already does with bitrate for lossy ones. `bitRate`, `sampleRate` and `bitDepth` are all already on the song API, so this is UI-only.

| Record | Rendered |
| --- | --- |
| `FLAC` 96000 / 24 | `FLAC 96/24` |
| `FLAC` 44100 / 16 | `FLAC 44.1/16` |
| `FLAC` 88200 / 24 | `FLAC 88.2/24` |
| `WAV` 48000 / 32 | `WAV 48/32` |
| `FLAC` 192000, no depth | `FLAC 192` |
| `FLAC`, neither known | `FLAC` (unchanged) |
| `MP3` 320 | `MP3 320` (unchanged) |

Sample rate is rendered in kHz and drops a trailing zero, so 96000 reads as `96` rather than `96.0`, while 44100 keeps its decimal.

### DSD

DSD keeps showing the container alone. It carries a 1-bit stream at MHz rates, so the same formula would produce `DSF 2822.4/1`, which says nothing useful. `modulation` is still an open checkbox in #1438 and deserves its own representation (`DSD64`, `DSD128`) rather than being forced through the PCM path here.

### Lossy formats

Untouched. `sampleRate` is present on many lossy records too, but as noted in #1571, bit depth and sample rate do not describe a format that has been transformed into the frequency domain, so appending them there would be misleading.

## Verification

- Seven new cases in `QualityInfo.test.jsx`, covering each row of the table above. The five that assert new output fail without the change; the DSD and lossy cases guard the behaviour that must *not* change.
- `npm test` — 77 files, 665 tests passing.
- `npm run lint` (`--max-warnings 0`) and Prettier are clean.
- Checked in a running instance against a library holding both 44.1/24 and 96/24 copies of the same album. The chips render as `FLAC 44.1/24` and `FLAC 96/24`, which is where the table above comes from.

## Notes

Rolling `hd` and `lossless` up to the album level, the quality filter dropdown, and the HD icon are the larger items in #1438 and are not touched here. This is the smallest slice that needs no schema or API change.
