### PR TITLE
Add RepoCloud deploy button to Cloud Hosting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ See instructions on the [project's website](https://www.navidrome.org/docs/insta
 A share of the revenue helps fund the development of Navidrome at no additional cost for you.
 
 [![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=navidrome)
-
-[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Navidrome/)
+<a href="https://repocloud.io/details/Navidrome/"><img src="https://d16t0pc4846x52.cloudfront.net/deploylobe.svg" alt="Deploy on RepoCloud" height="32"></a>
 
 ## Features
  

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ A share of the revenue helps fund the development of Navidrome at no additional 
 
 [![PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=navidrome)
 
+[![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Navidrome/)
+
 ## Features
  
  - Handles very **large music collections**


### PR DESCRIPTION
### Description
This PR adds a [RepoCloud](https://repocloud.io/details/Navidrome/) deploy button to the "Cloud Hosting" section of the README, alongside the existing PikaPods button.

RepoCloud provides one-click cloud deployment for open-source applications, giving users another affordable option for hosting Navidrome without managing their own server.


### Type of Change
- [x] Documentation update

### Checklist
Please review and check all that apply:
- [x] I have added or updated documentation as needed