### PR TITLE
fix(stream): abort the response when a transcoded stream is truncated

### DIFF
--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -152,8 +152,10 @@ func (s *Stream) EstimatedContentLength() int {
 
 // Serve writes the stream to the HTTP response. For seekable streams it uses http.ServeContent
 // (supporting range requests). For non-seekable streams it writes directly and logs any errors.
-// Returns the number of bytes written and an error only when io.Copy fails with 0 bytes written
+// Returns the number of bytes written and an error only when it fails with 0 bytes written
 // (meaning the HTTP 200 status has not been flushed yet and the caller can still send an error response).
+// Once bytes are on the wire it panics with http.ErrAbortHandler instead, so a truncated body reaches
+// the client as a dropped connection and not as a complete file.
 // Empty output (0 bytes, no error) is logged but not treated as an error.
 func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Request) (int64, error) {
 	if s.Seekable() {
@@ -183,16 +185,33 @@ func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Reque
 			w.Header().Del("Content-Length")
 			return 0, fmt.Errorf("sending transcoded file: %w", err)
 		}
-		return c, nil
+		// The 200 is already on the wire, so killing the connection is the only way
+		// to tell the client the body is truncated instead of complete.
+		panic(http.ErrAbortHandler)
+	}
+	srcErr := sourceErr(s.ReadCloser)
+	if srcErr != nil && c > 0 {
+		log.Error(ctx, "Transcoded file is truncated", "id", id, "size", c, srcErr)
+		panic(http.ErrAbortHandler)
 	}
 	if c == 0 {
+		// Empty output is not an error: callers reply 200 with an empty body.
 		log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
 			"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
-			"id", id, "format", s.ContentType())
+			"id", id, "format", s.ContentType(), srcErr)
 	} else {
 		log.Trace(ctx, "Success sending transcoded file", "id", id, "size", c)
 	}
 	return c, nil
+}
+
+// sourceErr reports a failure that a source can only surface after the reader saw
+// EOF, like a cache entry whose writer died mid-transcode.
+func sourceErr(r io.ReadCloser) error {
+	if er, ok := r.(interface{ Err() error }); ok {
+		return er.Err()
+	}
+	return nil
 }
 
 // NewStream creates a non-seekable Stream from the given components.

--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -154,8 +154,7 @@ func (s *Stream) EstimatedContentLength() int {
 // (supporting range requests). For non-seekable streams it writes directly and logs any errors.
 // Returns the number of bytes written and an error only when it fails with 0 bytes written
 // (meaning the HTTP 200 status has not been flushed yet and the caller can still send an error response).
-// Once bytes are on the wire it panics with http.ErrAbortHandler instead, so a truncated body reaches
-// the client as a dropped connection and not as a complete file.
+// Once bytes are on the wire it panics with http.ErrAbortHandler instead, aborting the response.
 // Empty output (0 bytes, no error) is logged but not treated as an error.
 func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Request) (int64, error) {
 	if s.Seekable() {
@@ -185,8 +184,7 @@ func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Reque
 			w.Header().Del("Content-Length")
 			return 0, fmt.Errorf("sending transcoded file: %w", err)
 		}
-		// The 200 is already on the wire, so killing the connection is the only way
-		// to tell the client the body is truncated instead of complete.
+		// The 200 is already sent, so dropping the connection is the only way to say "truncated".
 		panic(http.ErrAbortHandler)
 	}
 	srcErr := sourceErr(s.ReadCloser)
@@ -204,8 +202,7 @@ func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Reque
 	return c, nil
 }
 
-// sourceErr reports a failure that a source can only surface after the reader saw
-// EOF, like a cache entry whose writer died mid-transcode.
+// sourceErr reports a failure a source can only surface after the reader saw EOF.
 func sourceErr(r io.ReadCloser) error {
 	if er, ok := r.(interface{ Err() error }); ok {
 		return er.Err()

--- a/core/stream/media_streamer.go
+++ b/core/stream/media_streamer.go
@@ -195,7 +195,6 @@ func (s *Stream) Serve(ctx context.Context, w http.ResponseWriter, r *http.Reque
 		panic(http.ErrAbortHandler)
 	}
 	if c == 0 {
-		// Empty output is not an error: callers reply 200 with an empty body.
 		log.Error(ctx, "Transcoding returned empty output, ffmpeg may have failed. "+
 			"Check that ffmpeg supports the requested codec. Enable Trace logging for ffmpeg stderr details",
 			"id", id, "format", s.ContentType(), srcErr)

--- a/core/stream/media_streamer_test.go
+++ b/core/stream/media_streamer_test.go
@@ -155,8 +155,7 @@ var _ = Describe("MediaStreamer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		// expectAbortedBody serves src over a real HTTP connection and requires the
-		// client to fail reading the body, which only happens if the response was aborted.
+		// A client-side read failure is the only observable proof the response was aborted.
 		expectAbortedBody := func(src io.ReadCloser) {
 			GinkgoHelper()
 			server := httptest.NewServer(serveHandler(stream.NewStream(mf, "mp3", 128, src)))
@@ -199,8 +198,7 @@ var _ = Describe("MediaStreamer", func() {
 	})
 })
 
-// serveHandler exercises Serve through the same Recoverer used by the real server,
-// so an aborted response is only observable if the middleware lets the panic through.
+// Serve runs behind the real server's Recoverer, which must let ErrAbortHandler through.
 func serveHandler(s *stream.Stream) http.Handler {
 	return middleware.Recoverer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = s.Serve(r.Context(), w, r)

--- a/core/stream/media_streamer_test.go
+++ b/core/stream/media_streamer_test.go
@@ -8,9 +8,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"testing/iotest"
 	"time"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/navidrome/navidrome/conf"
@@ -155,8 +155,10 @@ var _ = Describe("MediaStreamer", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("aborts the response when the source fails after sending data", func() {
-			src := &failingReader{data: bytes.Repeat([]byte("a"), 64*1024), err: errors.New("no data available")}
+		// expectAbortedBody serves src over a real HTTP connection and requires the
+		// client to fail reading the body, which only happens if the response was aborted.
+		expectAbortedBody := func(src io.ReadCloser) {
+			GinkgoHelper()
 			server := httptest.NewServer(serveHandler(stream.NewStream(mf, "mp3", 128, src)))
 			DeferCleanup(server.Close)
 
@@ -166,6 +168,13 @@ var _ = Describe("MediaStreamer", func() {
 
 			_, err = io.ReadAll(resp.Body)
 			Expect(err).To(HaveOccurred())
+		}
+
+		It("aborts the response when the source fails after sending data", func() {
+			expectAbortedBody(io.NopCloser(io.MultiReader(
+				bytes.NewReader(bytes.Repeat([]byte("a"), 64*1024)),
+				iotest.ErrReader(errors.New("no data available")),
+			)))
 		})
 
 		It("keeps empty output a non-error, so callers still reply 200 with an empty body", func() {
@@ -182,19 +191,10 @@ var _ = Describe("MediaStreamer", func() {
 		})
 
 		It("aborts the response when the source reports a failure after a clean EOF", func() {
-			src := &truncatedSource{
+			expectAbortedBody(&truncatedSource{
 				Reader: bytes.NewReader(bytes.Repeat([]byte("a"), 64*1024)),
 				err:    errors.New("transcoder died"),
-			}
-			server := httptest.NewServer(serveHandler(stream.NewStream(mf, "mp3", 128, src)))
-			DeferCleanup(server.Close)
-
-			resp, err := http.Get(server.URL)
-			Expect(err).ToNot(HaveOccurred())
-			defer resp.Body.Close()
-
-			_, err = io.ReadAll(resp.Body)
-			Expect(err).To(HaveOccurred())
+			})
 		})
 	})
 })
@@ -202,30 +202,10 @@ var _ = Describe("MediaStreamer", func() {
 // serveHandler exercises Serve through the same Recoverer used by the real server,
 // so an aborted response is only observable if the middleware lets the panic through.
 func serveHandler(s *stream.Stream) http.Handler {
-	r := chi.NewRouter()
-	r.Use(middleware.Recoverer)
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+	return middleware.Recoverer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = s.Serve(r.Context(), w, r)
-	})
-	return r
+	}))
 }
-
-type failingReader struct {
-	data []byte
-	err  error
-	pos  int
-}
-
-func (r *failingReader) Read(p []byte) (int, error) {
-	if r.pos >= len(r.data) {
-		return 0, r.err
-	}
-	n := copy(p, r.data[r.pos:])
-	r.pos += n
-	return n, nil
-}
-
-func (r *failingReader) Close() error { return nil }
 
 // truncatedSource reads to a clean EOF but reports that the data behind it is incomplete.
 type truncatedSource struct {

--- a/core/stream/media_streamer_test.go
+++ b/core/stream/media_streamer_test.go
@@ -1,11 +1,17 @@
 package stream_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
@@ -140,4 +146,92 @@ var _ = Describe("MediaStreamer", func() {
 			Expect(s.Seekable()).To(BeTrue())
 		})
 	})
+
+	Context("Serve", func() {
+		var mf *model.MediaFile
+		BeforeEach(func() {
+			var err error
+			mf, err = ds.MediaFile(ctx).Get("123")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("aborts the response when the source fails after sending data", func() {
+			src := &failingReader{data: bytes.Repeat([]byte("a"), 64*1024), err: errors.New("no data available")}
+			server := httptest.NewServer(serveHandler(stream.NewStream(mf, "mp3", 128, src)))
+			DeferCleanup(server.Close)
+
+			resp, err := http.Get(server.URL)
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+
+			_, err = io.ReadAll(resp.Body)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("keeps empty output a non-error, so callers still reply 200 with an empty body", func() {
+			src := &truncatedSource{Reader: bytes.NewReader(nil), err: errors.New("no such codec")}
+			s := stream.NewStream(mf, "mp3", 128, src)
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+
+			n, err := s.Serve(ctx, w, r)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(n).To(BeZero())
+			Expect(w.Code).To(Equal(http.StatusOK))
+		})
+
+		It("aborts the response when the source reports a failure after a clean EOF", func() {
+			src := &truncatedSource{
+				Reader: bytes.NewReader(bytes.Repeat([]byte("a"), 64*1024)),
+				err:    errors.New("transcoder died"),
+			}
+			server := httptest.NewServer(serveHandler(stream.NewStream(mf, "mp3", 128, src)))
+			DeferCleanup(server.Close)
+
+			resp, err := http.Get(server.URL)
+			Expect(err).ToNot(HaveOccurred())
+			defer resp.Body.Close()
+
+			_, err = io.ReadAll(resp.Body)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })
+
+// serveHandler exercises Serve through the same Recoverer used by the real server,
+// so an aborted response is only observable if the middleware lets the panic through.
+func serveHandler(s *stream.Stream) http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.Recoverer)
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		_, _ = s.Serve(r.Context(), w, r)
+	})
+	return r
+}
+
+type failingReader struct {
+	data []byte
+	err  error
+	pos  int
+}
+
+func (r *failingReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}
+
+func (r *failingReader) Close() error { return nil }
+
+// truncatedSource reads to a clean EOF but reports that the data behind it is incomplete.
+type truncatedSource struct {
+	io.Reader
+	err error
+}
+
+func (r *truncatedSource) Close() error { return nil }
+func (r *truncatedSource) Err() error   { return r.err }

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -203,8 +203,22 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 		}()
 	}
 
+	if writeErr == nil {
+		if v, ok := fc.inflight.Load(key); ok {
+			writeErr = v.(*atomic.Pointer[error])
+		}
+	}
+
 	// If it is in the cache, check if the stream is done being written. If so, return a ReadSeeker
 	if cached {
+		// Closing a failed writer also marks the entry final, so refuse it before it
+		// looks like a complete, seekable file.
+		if writeErr != nil {
+			if err := writeErr.Load(); err != nil {
+				_ = r.Close()
+				return nil, *err
+			}
+		}
 		size := getFinalCachedSize(r)
 		if size >= 0 {
 			log.Trace(ctx, "Cache HIT", "cache", fc.name, "key", key, "size", size)
@@ -217,12 +231,6 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 			}, nil
 		} else {
 			log.Trace(ctx, "Cache HIT", "cache", fc.name, "key", key)
-		}
-	}
-
-	if writeErr == nil {
-		if v, ok := fc.inflight.Load(key); ok {
-			writeErr = v.(*atomic.Pointer[error])
 		}
 	}
 

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -211,15 +211,15 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 
 	// If it is in the cache, check if the stream is done being written. If so, return a ReadSeeker
 	if cached {
-		// Closing a failed writer also marks the entry final, so refuse it before it
-		// looks like a complete, seekable file.
+		size := getFinalCachedSize(r)
+		// Read the outcome after the size: a final entry means the writer already closed,
+		// and it stores any failure before closing.
 		if writeErr != nil {
 			if err := writeErr.Load(); err != nil {
 				_ = r.Close()
 				return nil, *err
 			}
 		}
-		size := getFinalCachedSize(r)
 		if size >= 0 {
 			log.Trace(ctx, "Cache HIT", "cache", fc.name, "key", key, "size", size)
 			sr := io.NewSectionReader(r, 0, size)

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -117,8 +117,7 @@ type fileCache struct {
 	disabled    bool
 	ready       atomic.Bool
 	mutex       *sync.RWMutex
-	// inflight holds the write outcome of each entry still being filled, keyed by
-	// cache key, so every reader attached to it learns the writer failed.
+	// Write outcome of each entry still being filled, so every reader of it learns a failure.
 	inflight sync.Map
 }
 
@@ -216,7 +215,6 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 		}
 	}
 
-	// Readers that joined an entry another request is still filling share its outcome.
 	if writeErr == nil {
 		if v, ok := fc.inflight.Load(key); ok {
 			writeErr = v.(*atomic.Pointer[error])
@@ -236,8 +234,8 @@ type CachedStream struct {
 	writeErr *atomic.Pointer[error]
 }
 
-// Err reports a failure of the goroutine that filled the cache entry. It is only
-// meaningful after the reader reached EOF: a truncated entry ends in a clean EOF.
+// Err reports a failure of the goroutine filling the entry. Only meaningful after EOF,
+// since a truncated entry ends in a clean EOF.
 func (s *CachedStream) Err() error {
 	if s.writeErr == nil {
 		return nil

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -83,6 +83,7 @@ func NewFileCache(name, cacheSize, cacheFolder string, maxItems int, getReader R
 		maxItems:    maxItems,
 		getReader:   getReader,
 		mutex:       &sync.RWMutex{},
+		inflight:    map[string]*atomic.Pointer[error]{},
 	}
 
 	go func() {
@@ -118,7 +119,8 @@ type fileCache struct {
 	ready       atomic.Bool
 	mutex       *sync.RWMutex
 	// Write outcome of each entry still being filled, so every reader of it learns a failure.
-	inflight sync.Map
+	inflightMu sync.Mutex
+	inflight   map[string]*atomic.Pointer[error]
 }
 
 func (fc *fileCache) Available(_ context.Context) bool {
@@ -150,6 +152,43 @@ func (fc *fileCache) invalidate(ctx context.Context, key string) error {
 	return err
 }
 
+// reserve opens the cache entry and binds its write outcome in one step, so a reader
+// cannot pick up the outcome of a newer entry that reused the same key.
+func (fc *fileCache) reserve(ctx context.Context, key string) (fscache.ReadAtCloser, io.WriteCloser, *atomic.Pointer[error], error) {
+	fc.inflightMu.Lock()
+	defer fc.inflightMu.Unlock()
+
+	r, w, err := fc.cache.Get(key)
+	if errors.Is(err, fs.ErrNotExist) {
+		// The entry outlived its data file. Drop it and retry, or every future Get
+		// for this key fails for the rest of the process's life.
+		log.Debug(ctx, "Cache entry lost its data file. Re-fetching", "cache", fc.name, "key", key)
+		// invalidate waits on open handles, so it must never run under the lock.
+		fc.inflightMu.Unlock()
+		_ = fc.invalidate(ctx, key)
+		fc.inflightMu.Lock()
+		r, w, err = fc.cache.Get(key)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if w != nil {
+		outcome := &atomic.Pointer[error]{}
+		fc.inflight[key] = outcome
+		return r, w, outcome, nil
+	}
+	return r, w, fc.inflight[key], nil
+}
+
+// forget drops the outcome only if it is still ours: a later entry may have replaced it.
+func (fc *fileCache) forget(key string, outcome *atomic.Pointer[error]) {
+	fc.inflightMu.Lock()
+	defer fc.inflightMu.Unlock()
+	if fc.inflight[key] == outcome {
+		delete(fc.inflight, key)
+	}
+}
+
 func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 	if !fc.Available(ctx) {
 		log.Debug(ctx, "Cache not initialized yet. Reading data directly from reader", "cache", fc.name)
@@ -161,39 +200,26 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 	}
 
 	key := arg.Key()
-	r, w, err := fc.cache.Get(key)
-	if errors.Is(err, fs.ErrNotExist) {
-		// The entry outlived its data file. Drop it and retry, or every future Get
-		// for this key fails for the rest of the process's life.
-		log.Debug(ctx, "Cache entry lost its data file. Re-fetching", "cache", fc.name, "key", key)
-		_ = fc.invalidate(ctx, key)
-		r, w, err = fc.cache.Get(key)
-	}
+	r, w, writeErr, err := fc.reserve(ctx, key)
 	if err != nil {
 		return nil, err
 	}
 
 	cached := w == nil
-	var writeErr *atomic.Pointer[error]
 
 	if !cached {
 		log.Trace(ctx, "Cache MISS", "cache", fc.name, "key", key)
-		// Register before the source starts: cache.Get already exposed the entry, so a
-		// concurrent request can attach while getReader is still bringing it up.
-		writeErr = &atomic.Pointer[error]{}
-		fc.inflight.Store(key, writeErr)
 		reader, err := fc.getReader(ctx, arg)
 		if err != nil {
 			writeErr.Store(&err)
-			fc.inflight.CompareAndDelete(key, writeErr)
 			_ = r.Close()
 			_ = w.Close()
 			_ = fc.invalidate(ctx, key)
+			fc.forget(key, writeErr)
 			return nil, err
 		}
 		go func() {
-			// Delete only our own entry: a later miss may already have replaced it.
-			defer fc.inflight.CompareAndDelete(key, writeErr)
+			defer fc.forget(key, writeErr)
 			if err := fc.copyAndClose(ctx, key, w, reader, writeErr); err != nil {
 				log.Debug(ctx, "Error storing file in cache", "cache", fc.name, "key", key, err)
 				_ = fc.invalidate(ctx, key)
@@ -201,12 +227,6 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 				log.Trace(ctx, "File successfully stored in cache", "cache", fc.name, "key", key)
 			}
 		}()
-	}
-
-	if writeErr == nil {
-		if v, ok := fc.inflight.Load(key); ok {
-			writeErr = v.(*atomic.Pointer[error])
-		}
 	}
 
 	// If it is in the cache, check if the stream is done being written. If so, return a ReadSeeker

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -178,17 +178,22 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 
 	if !cached {
 		log.Trace(ctx, "Cache MISS", "cache", fc.name, "key", key)
+		// Register before the source starts: cache.Get already exposed the entry, so a
+		// concurrent request can attach while getReader is still bringing it up.
+		writeErr = &atomic.Pointer[error]{}
+		fc.inflight.Store(key, writeErr)
 		reader, err := fc.getReader(ctx, arg)
 		if err != nil {
+			writeErr.Store(&err)
+			fc.inflight.CompareAndDelete(key, writeErr)
 			_ = r.Close()
 			_ = w.Close()
 			_ = fc.invalidate(ctx, key)
 			return nil, err
 		}
-		writeErr = &atomic.Pointer[error]{}
-		fc.inflight.Store(key, writeErr)
 		go func() {
-			defer fc.inflight.Delete(key)
+			// Delete only our own entry: a later miss may already have replaced it.
+			defer fc.inflight.CompareAndDelete(key, writeErr)
 			if err := fc.copyAndClose(ctx, key, w, reader, writeErr); err != nil {
 				log.Debug(ctx, "Error storing file in cache", "cache", fc.name, "key", key, err)
 				_ = fc.invalidate(ctx, key)

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -318,7 +318,9 @@ func (fc *fileCache) copyAndClose(ctx context.Context, key string, w io.WriteClo
 		writeErr.Store(&err)
 	}
 	if cErr := w.Close(); cErr != nil {
-		err = multierror.Append(err, fmt.Errorf("closing cache writer: %w", cErr))
+		// Join instead of Append: the published error must not be mutated once readers
+		// have been released, and Append writes through to the same value.
+		return errors.Join(err, fmt.Errorf("closing cache writer: %w", cErr))
 	}
 	return err
 }

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -117,6 +117,9 @@ type fileCache struct {
 	disabled    bool
 	ready       atomic.Bool
 	mutex       *sync.RWMutex
+	// inflight holds the write outcome of each entry still being filled, keyed by
+	// cache key, so every reader attached to it learns the writer failed.
+	inflight sync.Map
 }
 
 func (fc *fileCache) Available(_ context.Context) bool {
@@ -184,7 +187,9 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 			return nil, err
 		}
 		writeErr = &atomic.Pointer[error]{}
+		fc.inflight.Store(key, writeErr)
 		go func() {
+			defer fc.inflight.Delete(key)
 			if err := fc.copyAndClose(ctx, key, w, reader, writeErr); err != nil {
 				log.Debug(ctx, "Error storing file in cache", "cache", fc.name, "key", key, err)
 				_ = fc.invalidate(ctx, key)
@@ -208,6 +213,13 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 			}, nil
 		} else {
 			log.Trace(ctx, "Cache HIT", "cache", fc.name, "key", key)
+		}
+	}
+
+	// Readers that joined an entry another request is still filling share its outcome.
+	if writeErr == nil {
+		if v, ok := fc.inflight.Load(key); ok {
+			writeErr = v.(*atomic.Pointer[error])
 		}
 	}
 

--- a/utils/cache/file_caches.go
+++ b/utils/cache/file_caches.go
@@ -172,6 +172,7 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 	}
 
 	cached := w == nil
+	var writeErr *atomic.Pointer[error]
 
 	if !cached {
 		log.Trace(ctx, "Cache MISS", "cache", fc.name, "key", key)
@@ -182,8 +183,9 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 			_ = fc.invalidate(ctx, key)
 			return nil, err
 		}
+		writeErr = &atomic.Pointer[error]{}
 		go func() {
-			if err := fc.copyAndClose(ctx, key, w, reader); err != nil {
+			if err := fc.copyAndClose(ctx, key, w, reader, writeErr); err != nil {
 				log.Debug(ctx, "Error storing file in cache", "cache", fc.name, "key", key, err)
 				_ = fc.invalidate(ctx, key)
 			} else {
@@ -210,7 +212,7 @@ func (fc *fileCache) Get(ctx context.Context, arg Item) (*CachedStream, error) {
 	}
 
 	// All other cases, just return the cache reader, without Seek capabilities
-	return &CachedStream{Reader: r, Cached: cached}, nil
+	return &CachedStream{Reader: r, Cached: cached, writeErr: writeErr}, nil
 }
 
 // CachedStream is a wrapper around an io.ReadCloser that allows reading from a cache.
@@ -218,7 +220,20 @@ type CachedStream struct {
 	io.Reader
 	io.Seeker
 	io.Closer
-	Cached bool
+	Cached   bool
+	writeErr *atomic.Pointer[error]
+}
+
+// Err reports a failure of the goroutine that filled the cache entry. It is only
+// meaningful after the reader reached EOF: a truncated entry ends in a clean EOF.
+func (s *CachedStream) Err() error {
+	if s.writeErr == nil {
+		return nil
+	}
+	if err := s.writeErr.Load(); err != nil {
+		return *err
+	}
+	return nil
 }
 
 func (s *CachedStream) Close() error {
@@ -243,7 +258,7 @@ func getFinalCachedSize(r fscache.ReadAtCloser) int64 {
 }
 
 // copyAndClose marks the entry complete before closing w, so EOF implies the entry is settled on disk.
-func (fc *fileCache) copyAndClose(ctx context.Context, key string, w io.WriteCloser, r io.Reader) error {
+func (fc *fileCache) copyAndClose(ctx context.Context, key string, w io.WriteCloser, r io.Reader, writeErr *atomic.Pointer[error]) error {
 	_, err := io.Copy(w, r)
 	if err != nil {
 		err = fmt.Errorf("copying data to cache: %w", err)
@@ -255,6 +270,9 @@ func (fc *fileCache) copyAndClose(ctx context.Context, key string, w io.WriteClo
 	}
 	if err == nil {
 		fc.markComplete(ctx, key)
+	} else {
+		// Store before Close: closing w is what releases readers waiting on EOF.
+		writeErr.Store(&err)
 	}
 	if cErr := w.Close(); cErr != nil {
 		err = multierror.Append(err, fmt.Errorf("closing cache writer: %w", cErr))

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -291,6 +291,30 @@ var _ = Describe("File Caches", func() {
 				Expect(io.ReadAll(s)).To(Equal([]byte("PARTIAL-OUTPUT")))
 				Expect(s.Err()).To(MatchError(ContainSubstring("transcoder died")))
 			})
+
+			It("reports the write failure to a second reader that joined mid-write", func() {
+				pr, pw := io.Pipe()
+				fc := callNewFileCache("test", "10MB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+					return pr, nil
+				})
+				s1, err := fc.Get(context.Background(), &testArg{"shared"})
+				Expect(err).To(BeNil())
+				DeferCleanup(func() { _ = s1.Close() })
+
+				// The blocking pipe write gives a happens-before: the entry is now in flight.
+				_, err = pw.Write([]byte("PARTIAL"))
+				Expect(err).To(BeNil())
+
+				s2, err := fc.Get(context.Background(), &testArg{"shared"})
+				Expect(err).To(BeNil())
+				DeferCleanup(func() { _ = s2.Close() })
+				Expect(s2.Cached).To(BeTrue())
+
+				Expect(pw.CloseWithError(errors.New("transcoder died"))).To(Succeed())
+
+				Expect(io.ReadAll(s2)).To(Equal([]byte("PARTIAL")))
+				Expect(s2.Err()).To(MatchError(ContainSubstring("transcoder died")))
+			})
 		})
 
 		Context("entry outliving its data file", func() {

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -278,6 +278,19 @@ var _ = Describe("File Caches", func() {
 					return os.IsNotExist(e)
 				}).Should(BeTrue())
 			})
+
+			It("reports the write failure to the in-flight reader", func() {
+				fc := callNewFileCache("test", "10MB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+					return &partialThenErrReader{data: []byte("PARTIAL-OUTPUT"), err: errors.New("transcoder died")}, nil
+				})
+				s, err := fc.Get(context.Background(), &testArg{"partial-reader"})
+				Expect(err).To(BeNil())
+				DeferCleanup(func() { _ = s.Close() })
+
+				// The reader still sees a clean EOF: only Err can tell it the entry is truncated.
+				Expect(io.ReadAll(s)).To(Equal([]byte("PARTIAL-OUTPUT")))
+				Expect(s.Err()).To(MatchError(ContainSubstring("transcoder died")))
+			})
 		})
 
 		Context("entry outliving its data file", func() {

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -338,6 +338,25 @@ var _ = Describe("File Caches", func() {
 				Expect(err).To(MatchError(ContainSubstring("transcoder died")))
 			})
 
+			It("publishes an error that a later close failure cannot mutate", func() {
+				fc := callNewFileCache("test", "10MB", "test", 0, nil)
+				outcome := &atomic.Pointer[error]{}
+				w := failingCloseWriter{err: errors.New("CLOSE-BOOM")}
+				src := errFakeReader{err: errors.New("SOURCE-BOOM")}
+
+				err := fc.copyAndClose(context.Background(), "k", w, src, outcome)
+
+				// The caller still learns about both failures.
+				Expect(err).To(MatchError(ContainSubstring("SOURCE-BOOM")))
+				Expect(err).To(MatchError(ContainSubstring("CLOSE-BOOM")))
+
+				// Readers only learn what actually shortened the stream.
+				published := outcome.Load()
+				Expect(published).ToNot(BeNil())
+				Expect((*published).Error()).To(ContainSubstring("SOURCE-BOOM"))
+				Expect((*published).Error()).ToNot(ContainSubstring("closing cache writer"))
+			})
+
 			It("binds the outcome to the entry it opened, not to a later one", func() {
 				pr, pw := io.Pipe()
 				var n atomic.Int32
@@ -512,6 +531,11 @@ var _ = Describe("File Caches", func() {
 type testArg struct{ s string }
 
 func (t *testArg) Key() string { return t.s }
+
+type failingCloseWriter struct{ err error }
+
+func (f failingCloseWriter) Write(p []byte) (int, error) { return len(p), nil }
+func (f failingCloseWriter) Close() error                { return f.err }
 
 type errFakeReader struct{ err error }
 

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -316,6 +316,26 @@ var _ = Describe("File Caches", func() {
 				Expect(s2.Err()).To(MatchError(ContainSubstring("transcoder died")))
 			})
 
+			It("refuses an entry whose writer already failed", func() {
+				fc := callNewFileCache("test", "10MB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+					return strings.NewReader("PARTIAL"), nil
+				})
+				s, err := fc.Get(context.Background(), &testArg{"failed"})
+				Expect(err).To(BeNil())
+				Expect(io.ReadAll(s)).To(Equal([]byte("PARTIAL")))
+				Expect(s.Close()).To(Succeed())
+
+				// Closing a failed writer also marks the entry final at its partial size,
+				// so without the guard the next reader gets a seekable short file.
+				failed := errors.New("transcoder died")
+				outcome := &atomic.Pointer[error]{}
+				outcome.Store(&failed)
+				fc.inflight.Store((&testArg{"failed"}).Key(), outcome)
+
+				_, err = fc.Get(context.Background(), &testArg{"failed"})
+				Expect(err).To(MatchError(ContainSubstring("transcoder died")))
+			})
+
 			It("reports the write failure to a reader that joined while the source was starting", func() {
 				pr, pw := io.Pipe()
 				starting := make(chan struct{})

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -315,6 +315,46 @@ var _ = Describe("File Caches", func() {
 				Expect(io.ReadAll(s2)).To(Equal([]byte("PARTIAL")))
 				Expect(s2.Err()).To(MatchError(ContainSubstring("transcoder died")))
 			})
+
+			It("reports the write failure to a reader that joined while the source was starting", func() {
+				pr, pw := io.Pipe()
+				starting := make(chan struct{})
+				release := make(chan struct{})
+				fc := callNewFileCache("test", "10MB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+					close(starting)
+					<-release
+					return pr, nil
+				})
+
+				var s1 *CachedStream
+				done := make(chan struct{})
+				go func() {
+					defer GinkgoRecover()
+					defer close(done)
+					var err error
+					s1, err = fc.Get(context.Background(), &testArg{"starting"})
+					Expect(err).To(BeNil())
+				}()
+
+				// The entry is visible to other requests as soon as the first Get reserves
+				// it, which is before the source has produced anything.
+				Eventually(starting).Should(BeClosed())
+				s2, err := fc.Get(context.Background(), &testArg{"starting"})
+				Expect(err).To(BeNil())
+				DeferCleanup(func() { _ = s2.Close() })
+				Expect(s2.Cached).To(BeTrue())
+
+				close(release)
+				Eventually(done).Should(BeClosed())
+				DeferCleanup(func() { _ = s1.Close() })
+
+				_, err = pw.Write([]byte("PARTIAL"))
+				Expect(err).To(BeNil())
+				Expect(pw.CloseWithError(errors.New("transcoder died"))).To(Succeed())
+
+				Expect(io.ReadAll(s2)).To(Equal([]byte("PARTIAL")))
+				Expect(s2.Err()).To(MatchError(ContainSubstring("transcoder died")))
+			})
 		})
 
 		Context("entry outliving its data file", func() {

--- a/utils/cache/file_caches_test.go
+++ b/utils/cache/file_caches_test.go
@@ -330,10 +330,54 @@ var _ = Describe("File Caches", func() {
 				failed := errors.New("transcoder died")
 				outcome := &atomic.Pointer[error]{}
 				outcome.Store(&failed)
-				fc.inflight.Store((&testArg{"failed"}).Key(), outcome)
+				fc.inflightMu.Lock()
+				fc.inflight[(&testArg{"failed"}).Key()] = outcome
+				fc.inflightMu.Unlock()
 
 				_, err = fc.Get(context.Background(), &testArg{"failed"})
 				Expect(err).To(MatchError(ContainSubstring("transcoder died")))
+			})
+
+			It("binds the outcome to the entry it opened, not to a later one", func() {
+				pr, pw := io.Pipe()
+				var n atomic.Int32
+				fc := callNewFileCache("test", "10MB", "test", 0, func(ctx context.Context, arg Item) (io.Reader, error) {
+					if n.Add(1) == 1 {
+						return pr, nil
+					}
+					return strings.NewReader("GOOD"), nil
+				})
+				key := (&testArg{"generations"}).Key()
+
+				s1, err := fc.Get(context.Background(), &testArg{"generations"})
+				Expect(err).To(BeNil())
+				_, err = pw.Write([]byte("PARTIAL"))
+				Expect(err).To(BeNil())
+
+				// A reader joining now binds this entry's outcome as it opens it.
+				r, w, outcome, err := fc.reserve(context.Background(), key)
+				Expect(err).To(BeNil())
+				Expect(w).To(BeNil())
+				Expect(outcome).ToNot(BeNil())
+
+				// The entry fails, and a later one takes over the same key while the
+				// joining reader still holds the old one open.
+				Expect(pw.CloseWithError(errors.New("transcoder died"))).To(Succeed())
+				Eventually(func() bool { return fc.cache.Exists(key) }).Should(BeFalse())
+				s2, err := fc.Get(context.Background(), &testArg{"generations"})
+				Expect(err).To(BeNil())
+				Expect(io.ReadAll(s2)).To(Equal([]byte("GOOD")))
+				Expect(s2.Close()).To(Succeed())
+
+				Eventually(func() error {
+					if e := outcome.Load(); e != nil {
+						return *e
+					}
+					return nil
+				}).Should(MatchError(ContainSubstring("transcoder died")))
+
+				Expect(r.Close()).To(Succeed())
+				Expect(s1.Close()).To(Succeed())
 			})
 
 			It("reports the write failure to a reader that joined while the source was starting", func() {


### PR DESCRIPTION
### Description

A transcode that fails after some audio has already gone out used to finish the HTTP response normally. `Serve` logged the error and returned `nil`, so Go wrote the terminating chunk and the client received what looks like a complete file. It is short, and nothing in the protocol says so. Symfonium users hit this during large offline syncs, with 5 to 10% of tracks landing truncated and unplayable.

Two separate paths produce a silently short body, and only the first was visible in the logs at all.

First, the read from the cache entry fails mid-copy. Users see this as `ENODATA` on Docker for Windows and other FUSE-backed cache folders, where reading a file while another goroutine extends it does not behave like a local disk. `io.Copy` returns an error with bytes already written.

Second, ffmpeg dies mid-transcode. `copyAndClose` closed the cache writer plainly, so readers streaming that entry got a clean EOF and `io.Copy` returned no error at all. This case logged nothing above Debug, which is why several reports had no server-side trace to go on.

Once the 200 is on the wire the status can no longer change, so the only honest signal left is to drop the connection. Both paths now panic with `http.ErrAbortHandler`. Go aborts the response without the terminating chunk, sends `RST_STREAM` on HTTP/2, and skips the usual stack trace. chi's `Recoverer` re-panics that exact value, and the deferred `stream.Close()` in each handler still runs, so the transcode limiter slot is released as before.

For the second path the write outcome now belongs to the cache entry rather than to the request that started it, and `CachedStream.Err` reports it. Any reader attached to an entry that is still being filled learns it was truncated, not only the request that triggered the transcode. The error is recorded before the writer is closed, because closing the writer is what releases readers waiting on EOF.

The zero-byte contract from #5227 does not change. A failure before the first byte still returns 200 with an empty body for `stream` and `download`, since the response can still be controlled at that point. That error now goes into the empty-output log, which shows ffmpeg's stderr on the cached path, where it had only ever been logged at Debug.

### Related Issues

Reported at: https://support.symfonium.app/t/offline-cache-high-number-of-failed-tracks-on-large-re-sync/14493

This sits between two earlier fixes and replaces neither. #5227 handles failures before the first byte. #5657 stops a partially written entry from being served to later requests. Neither can reach a response that is already in flight.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Fake a transcoder that produces real output and then dies:

```sh
printf '#!/bin/sh\nhead -c 300000 /dev/zero\nsleep 1.5\nexit 1\n' > /tmp/badtranscode.sh
chmod +x /tmp/badtranscode.sh
sqlite3 data/navidrome.db "update transcoding set command='/tmp/badtranscode.sh %s %b' where target_format='opus';"
```

Start the server and stream that format:

```sh
curl -s -o /tmp/out.bin -w 'exit=%{exitcode} size=%{size_download}\n' \
  'http://localhost:4533/rest/stream.view?u=admin&p=admin&c=test&v=1.16.1&id=<ID>&format=opus&maxBitRate=128'
```

On this branch curl exits 18 (`transfer closed with outstanding read data`) and the log shows `Transcoded file is truncated` with ffmpeg's exit status. On master curl exits 0, and with the transcoding cache on nothing is logged at all. Both runs download the same 300000 bytes, so the only difference is whether the client is told.

Worth checking as well:

1. Two concurrent requests for the same failing track. Both should exit 18. Before the last commit only the first one did.
2. `ND_TRANSCODINGCACHESIZE=0` with the same script, which exercises the read-error path instead of the writer path. Also exits 18.
3. A transcoder that fails immediately (`#!/bin/sh\nexit 1\n`) still returns 200 with an empty body, and the empty-output log now names the cause.
4. Restore the real ffmpeg command and confirm normal streaming, a cache hit, a range request, and a raw stream all behave as before, with `ffprobe` reading the result as valid audio.
5. With `ND_TRANSCODING_MAXCONCURRENT=1`, several aborted streams in a row must not exhaust the limiter, since the deferred `Close` still runs while the panic unwinds.

### Additional Notes

I checked whether the panic belongs in `core/stream` rather than in the handlers. It does. `Serve` is the only place that knows how many bytes reached the wire, and the four callers would each have to re-derive that invariant. Two of them currently respond to a returned error by writing an error body, which is exactly what corrupts an already committed 200. The doc comment on `Serve` states the panic, since the signature cannot.

Codex suggested a bounded retry on `ENODATA` in the forum thread. I left it out. Nobody has confirmed the reporter's filesystem yet, so there is no evidence the error is transient there, and a retry would hide real corruption. Aborting lets the client retry the whole request, which restarts the transcode cleanly. Worth revisiting if the storage layer turns out to return `ENODATA` for "not written yet".

One gap I am deliberately leaving for a separate PR: `utils/cache` is shared, and `core/artwork` plus `server/backgrounds` also read `CachedStream` without consulting `Err`. Truncated images are arguably worse than truncated audio, because the image handler sets `immutable, max-age=31536000` and the browser then keeps the broken file. `Err` is at the right layer to fix that, it just is not wired up yet.
