### PR TITLE
build(docker): upgrade Alpine base image to 3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM --platform=$BUILDPLATFORM ghcr.io/crazy-max/osxcross:14.5-debian AS osxcros
 
 ########################################################################################################################
 ### Build xx (original image: tonistiigi/xx)
-FROM --platform=$BUILDPLATFORM alpine:3.20 AS xx-build
+FROM --platform=$BUILDPLATFORM alpine:3.22 AS xx-build
 
 # v1.9.0
 ENV XX_VERSION=a5592eab7a57895e8d385394ff12241bc65ecd50
@@ -153,18 +153,51 @@ FROM scratch AS binary
 COPY --from=build /out /
 
 ########################################################################################################################
+### Build no-op stubs for mpv's video-output libraries
+# mpv links libEGL/libgbm for video output only; Navidrome drives it headless, for audio.
+# Real mesa pulls in LLVM + gallium (+218MB uncompressed), so ship stubs it never calls.
+FROM --platform=$BUILDPLATFORM alpine:3.22 AS mpv-stubs
+COPY --from=xx / /
+RUN apk add --no-cache clang lld binutils mesa-egl mesa-gbm
+ARG TARGETPLATFORM
+RUN xx-apk add --no-cache musl-dev
+RUN <<EOT
+    set -e
+    mkdir -p /out
+    for so in libEGL.so.1 libgbm.so.1; do
+        readelf -sW /usr/lib/$so \
+            | awk '$5 == "GLOBAL" && $7 != "UND" { print $8 }' \
+            | sed 's/@.*//' \
+            | grep -vE '^(_init|_fini|_edata|_end|__bss_start|_GLOBAL_OFFSET_TABLE_)$' \
+            | sort -u \
+            | awk '{ print "void " $1 "(void) {}" }' > /tmp/stub.c
+        test -s /tmp/stub.c
+        xx-clang -shared -nostdlib -fPIC -Wl,-soname,$so -o /out/$so /tmp/stub.c
+        xx-verify /out/$so
+    done
+EOT
+
+########################################################################################################################
 ### Build Final Image
-FROM alpine:3.20 AS final
+FROM alpine:3.22 AS final
 LABEL maintainer="deluan@navidrome.org"
 LABEL org.opencontainers.image.source="https://github.com/navidrome/navidrome"
 
 # Install runtime dependencies
 # - libwebp + symlinks: enables native WebP encoding via purego/dlopen
+# The mesa/LLVM stack mpv pulls in for video output is dropped in this same layer,
+# otherwise the deleted bytes still ship in the image.
 RUN apk add -U --no-cache ffmpeg mpv sqlite libwebp libwebpdemux libwebpmux && \
     for lib in libwebp libwebpdemux libwebpmux; do \
         target=$(ls /usr/lib/$lib.so.* 2>/dev/null | head -1) && \
         [ -n "$target" ] && ln -sf "$target" /usr/lib/$lib.so; \
-    done
+    done && \
+    rm -rf /usr/lib/gallium-pipe /usr/lib/dri \
+        /usr/lib/libEGL.so* /usr/lib/libgbm.so* /usr/lib/libgallium*.so /usr/lib/libLLVM.so* \
+        /usr/lib/libGL.so* /usr/lib/libGLESv2.so* /usr/lib/libglapi.so*
+
+COPY --from=mpv-stubs /out/ /usr/lib/
+RUN mpv --no-video --ao=null --version > /dev/null
 
 # Copy navidrome binary (musl build for Docker, enables native libwebp)
 COPY --from=build-alpine /out/navidrome /app/


### PR DESCRIPTION
### Description

Moves both Alpine stages in the `Dockerfile` — the `xx-build` cross-compilation toolchain and the `final` runtime image — from `3.20` to `3.22`. Alpine 3.20 is past end of active support.

**Why 3.22 and not the latest (3.24):** ffmpeg stays on 6.1.x through Alpine 3.22 and jumps to 8.0 in 3.23. Stopping at 3.22 means this bump does not change transcoding behavior at all, which keeps it reviewable as a pure base-image update.

**The catch this PR has to deal with.** Alpine 3.21 repackaged mesa. From that release onward `mpv` requires `so:libEGL.so.1` and `so:libgbm.so.1`, which pull in `mesa` → `llvm20-libs` (156MB) plus the `gallium-pipe` GPU drivers (62MB). A plain bump takes the image from 231MB (62MB compressed) to 578MB (147MB compressed) — roughly 2.4x. `mesa-egl` is the only provider of `libEGL.so.1`, and later Alpine releases do not improve on this (3.23 and 3.24 are still ~325MB and ~342MB of `/usr/lib` versus 3.20's 130MB).

Navidrome runs `mpv` headless for jukebox audio playback and never enters a video output path — the entire IPC surface in `core/playback/mpv` is `set pause`, `set volume`, `set time-pos` and `quit`. `libEGL` and `libgbm` are only needed for mpv to *load*, never to run. So this PR adds an `mpv-stubs` stage that reads the exported symbol list out of the real mesa libraries, generates no-op definitions, and cross-compiles them with the `xx` toolchain already present in this Dockerfile. The `final` stage then deletes the mesa/LLVM/gallium stack and drops the stubs in its place.

Because the symbol list is extracted at build time rather than hardcoded, it stays correct across architectures and adapts if Alpine's mesa changes. The `rm` runs in the same `RUN` layer as the `apk add`, otherwise the deleted bytes still ship in the image (that mistake produced a 670MB image during development).

Net result: **323MB → 325MB** (84MB → 86MB compressed).

### Related Issues

Supersedes #5828, which targeted 3.21 and did not account for the mesa/LLVM size regression.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): Build / base-image dependency update

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

The `final` stage now runs `mpv --no-video --ao=null --version` at build time, so a broken or incomplete stub fails the Docker build rather than shipping a container where jukebox silently cannot start. The `mpv-stubs` stage also asserts the generated source is non-empty and runs `xx-verify` on each output. No Go tests were added — there are no code changes.

### How to Test

1. Build the image and confirm the base and ffmpeg versions:
   ```bash
   docker build --target=final -t navidrome-alpine322 .
   docker run --rm --entrypoint sh navidrome-alpine322 -c 'cat /etc/alpine-release; ffmpeg -version | head -1'
   # expect: 3.22.x  /  ffmpeg version 6.1.2
   ```
2. Confirm the mesa/LLVM stack is gone and the stubs are in place:
   ```bash
   docker run --rm --entrypoint sh navidrome-alpine322 -c 'ls /usr/lib/libLLVM* 2>/dev/null || echo "no LLVM (expected)"; ls -la /usr/lib/libEGL.so.1 /usr/lib/libgbm.so.1'
   ```
3. Exercise jukebox playback end to end inside the image:
   ```bash
   docker run --rm --entrypoint sh navidrome-alpine322 -c '
     apk add -U --no-cache socat >/dev/null 2>&1
     ffmpeg -f lavfi -i "sine=frequency=440:duration=8" -y /tmp/a.mp3 >/dev/null 2>&1
     mpv --audio-device=null --no-audio-display /tmp/a.mp3 --input-ipc-server=/tmp/s.sock --ao=null & sleep 3
     i(){ echo "$1" | socat - /tmp/s.sock | head -1; }
     i "{\"command\":[\"set_property\",\"pause\",true]}"
     i "{\"command\":[\"set_property\",\"volume\",42]}"
     i "{\"command\":[\"set_property\",\"time-pos\",5.0]}"
     i "{\"command\":[\"get_property\",\"time-pos\"]}"
     i "{\"command\":[\"quit\"]}"'
   ```
   All five should return `"error":"success"`, and `time-pos` should report a position near 5s, confirming the seek took and audio is decoding.
4. Start the container normally and verify Navidrome boots, serves the web UI, and streams and transcodes as usual.
5. Optionally, compare image sizes against `master` — the difference should be roughly 2MB, not 250MB.

### Additional Notes

**On the stub approach.** This is the unusual part of the PR and worth scrutiny. The reasoning is that `libEGL`/`libgbm` are video-output libraries and this image is headless, so the code paths that would call them are unreachable. To check that rather than assume it, I built instrumented stubs that log to stderr on any call and exercised the full jukebox surface (pause, unpause, volume, seek, quit) across mp3, flac, ogg, opus, m4a and wav — zero calls into either library in every run. I confirmed the logging worked by calling `eglGetError` and `gbm_device_get_fd` directly, which did produce output.

One gap worth stating plainly: I could not get the negative control to fire. Forcing `--vo=gpu --gpu-context=drm` should hit the stubs, but a container has no `/dev/dri` so mpv aborts before reaching EGL. That limitation applies equally to the shipped image, so the GPU path is unreachable in the environment this runs in — but it does mean "no call was ever observed" rests on the audio-path runs plus the direct-call check, not on a triggered GPU path.

**Failure mode if Alpine changes again.** If a future Alpine reorganises mesa so the symbol extraction or the deletion list goes stale, the build-time `mpv` invocation fails the Docker build. This breaks loudly at build time rather than silently at runtime.

**Alternatives considered.** Accepting the +85MB compressed download; deleting only `gallium-pipe` (saves 60MB, not enough); and dropping `libLLVM` while keeping real mesa (does not work — `libgallium` needs it and mpv then fails to relocate `libEGL`). Jumping straight to 3.24 was also rejected for this PR because of the ffmpeg 6.1 → 8.1 jump, which deserves its own change with transcoding testing.
