### PR TITLE
ci: cache the plugins test suite WASM compilation across runs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -143,7 +143,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: plugins/testdata/.wazero-cache
-          key: wazero-${{ runner.os }}-${{ hashFiles('plugins/testdata/*/*.go', 'plugins/testdata/*/go.sum', 'plugins/pdk/go/**/*.go', 'go.mod', 'go.sum') }}
+          key: wazero-${{ runner.os }}-${{ hashFiles('plugins/testdata/*/*.go', 'plugins/testdata/*/go.*', 'plugins/pdk/go/**/*.go', 'plugins/pdk/go/go.*', 'go.mod') }}
           restore-keys: wazero-${{ runner.os }}-
 
       - name: Test

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -137,6 +137,15 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
+      # Without this, the plugins suite recompiles every test plugin WASM module,
+      # which dominates the job runtime under -race.
+      - name: Cache the plugins test suite WASM compilation cache
+        uses: actions/cache@v6
+        with:
+          path: plugins/testdata/.wazero-cache
+          key: wazero-${{ runner.os }}-${{ hashFiles('plugins/testdata/*/*.go', 'plugins/testdata/*/go.sum', 'plugins/pdk/go/**/*.go', 'go.mod', 'go.sum') }}
+          restore-keys: wazero-${{ runner.os }}-
+
       - name: Test
         run: go test -shuffle=on -tags netgo,sqlite_fts5 -race ./... -v
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -131,6 +131,7 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
+        id: setup-go
         with:
           go-version-file: go.mod
 
@@ -143,7 +144,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: plugins/testdata/.wazero-cache
-          key: wazero-${{ runner.os }}-${{ hashFiles('plugins/testdata/*/*.go', 'plugins/testdata/*/go.*', 'plugins/pdk/go/**/*.go', 'plugins/pdk/go/go.*', 'go.mod') }}
+          key: wazero-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('plugins/testdata/*/*.go', 'plugins/testdata/*/go.*', 'plugins/pdk/go/**/*.go', 'plugins/pdk/go/go.*') }}
           restore-keys: wazero-${{ runner.os }}-
 
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ go.work*
 
 # Temp benchmark files
 zz_*_test.go
+
+# wazero compilation cache for the plugins test suite
+/plugins/testdata/.wazero-cache/

--- a/plugins/plugins_suite_test.go
+++ b/plugins/plugins_suite_test.go
@@ -25,7 +25,10 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-const testDataDir = "plugins/testdata"
+const (
+	testDataDir    = "plugins/testdata"
+	wazeroCacheDir = ".wazero-cache"
+)
 
 // Shared test state initialized in BeforeSuite
 var (
@@ -38,18 +41,10 @@ func TestPlugins(t *testing.T) {
 	tests.Init(t, false)
 	buildTestPlugins(t, testDataDir)
 
-	// Create a shared wazero compilation cache directory.
-	// All test managers will point CacheFolder here so that WASM compilation
-	// is done once per binary and then reused from disk cache.
-	sharedCacheDir, err := os.MkdirTemp("", "plugins-shared-cache-*")
-	if err != nil {
-		t.Fatalf("Failed to create shared cache dir: %v", err)
-	}
-	t.Cleanup(func() { os.RemoveAll(sharedCacheDir) })
-
-	// Set CacheFolder globally so all tests (including those using
-	// configtest.SetupConfig) inherit it without needing to set it manually.
-	conf.Server.CacheFolder = conf.NewDir(sharedCacheDir)
+	// Set globally so tests using configtest.SetupConfig inherit it. The cache
+	// persists between runs; entries are content-addressed, so a stale one only misses.
+	conf.Server.CacheFolder = conf.NewDir(filepath.Join(testDataDir, wazeroCacheDir))
+	conf.Server.Plugins.CacheSize = "1GB" // the default evicts the cache mid-run
 
 	log.SetLevel(log.LevelFatal)
 	RegisterFailHandler(Fail)

--- a/plugins/testdata/Makefile
+++ b/plugins/testdata/Makefile
@@ -10,6 +10,7 @@ all: $(PLUGINS:%=%.ndp)
 
 clean:
 	rm -f $(PLUGINS:%=%.ndp) $(PLUGINS:%=%.wasm)
+	rm -rf .wazero-cache
 
 # PDK source files that trigger rebuild when changed (recursive)
 PDK_SOURCES := $(shell find ../pdk/go -name '*.go' 2>/dev/null)
@@ -22,10 +23,11 @@ PDK_SOURCES := $(shell find ../pdk/go -name '*.go' 2>/dev/null)
 	@rm -f plugin.wasm
 	@mv $< $<.tmp && mv $<.tmp $<  # Touch wasm to ensure it's older than ndp
 
-# Build the wasm binary
+# Build the wasm binary. -buildvcs=false keeps the bytes stable across commits, so
+# the test suite's wazero compilation cache still hits after a rebuild.
 %.wasm: %/*.go %/go.mod $(PDK_SOURCES)
 ifdef TINYGO
 	cd $* && tinygo build -target wasip1 -buildmode=c-shared -o ../$@ .
 else
-	cd $* && GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared -o ../$@ .
+	cd $* && GOOS=wasip1 GOARCH=wasm go build -buildvcs=false -buildmode=c-shared -o ../$@ .
 endif


### PR DESCRIPTION
### Description

The `Test Go code` job takes ~11m50s, and one package accounts for most of it: `plugins` runs for 541s of the 699s test step. The suite builds 25 test plugins as full-Go `wasip1` modules of ~4.5MB each, and wazero has to compile every one of them to machine code. Under `-race` that compiler work is instrumented, which is what makes it expensive — profiling shows the race runtime (`racecall`, `racecalladdr`) sitting on top of wazero's register allocator and arm64 backend. Measured locally, the package takes 291s with `-race` and 26s without.

The suite already pointed every test Manager at a shared wazero compilation cache, and that cache does work — loading the same plugin a second time drops from ~11s to ~0.5s. Three things stopped it from paying off across runs:

1. The cache lived in an `os.MkdirTemp` directory that was removed after the suite, so nothing survived a run.
2. `plugins.cachesize` defaults to 200MB, but the cache needs 334MB. `purgeCacheBySize` runs on every Manager creation, so the suite kept evicting its own entries mid-run.
3. The test plugins embedded VCS stamps (`vcs.revision`, `vcs.time`, `vcs.modified`), so every commit produced different wasm bytes. Since wazero keys the cache on module content, CI would have missed on every run regardless.

This PR fixes all three: the cache moves to `plugins/testdata/.wazero-cache`, the suite raises its own size limit past what it needs, the wasm build gets `-buildvcs=false`, and CI restores the directory with `actions/cache`.

Entries are content-addressed and wazero stores them under a `wazero-<version>-<goarch>-<goos>` subdirectory, so a stale cache can only miss — it can never make a test see the wrong module. The size limit still bounds growth, and `make -C plugins/testdata clean` removes the directory.

### Results on CI

Measured on this branch. The first run had nothing to restore and populated the cache; the second is a re-run of the same job with the cache in place.

| Run | Test step | Whole job |
| --- | --- | --- |
| master, before this PR | 674s | 11m 49s |
| Attempt 1 — cold, cache being built | 674s | 10m 45s |
| Attempt 2 — cache restored | **308s** | **5m 41s** |

The cache restore step takes 1s and the stored entry is 48MB compressed (334MB on disk).

Note that a cache saved on a PR branch is only visible to that PR. Other branches will not benefit until this lands on master and a master run populates it.

### Related Issues

N/A

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI / test-suite performance

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No new tests: this changes where an existing cache lives and how the test wasm is built. The existing 652 specs in the `plugins` suite are the regression test, and they pass both cold and warm.

### How to Test

Simulate what CI does — a fresh checkout that restores only the cache directory:

```bash
# Cold: no cache, wasm built from scratch
make -C plugins/testdata clean
go test -tags netgo,sqlite_fts5 -race -count=1 ./plugins/

# Warm: drop the build artifacts but keep the cache, exactly like a new CI checkout
rm -f plugins/testdata/*.ndp plugins/testdata/*.wasm
go test -tags netgo,sqlite_fts5 -race -count=1 ./plugins/
```

Measured on an M-series Mac: 256s cold, 74s warm. The cache settles at 334MB and does not grow between runs.

To confirm the wasm is now stable across commits:

```bash
make -C plugins/testdata clean && make -C plugins/testdata
unzip -p plugins/testdata/test-kvstore.ndp plugin.wasm | shasum -a 256
# make a commit, then repeat — the hash should be unchanged
```

### Additional Notes

The cache key covers only what changes the compiled modules: the test plugin sources and their `go.mod`/`go.sum`, the Go PDK and its `go.mod`/`go.sum`, and the Go toolchain version from `setup-go`'s `go-version` output. The root `go.mod` and `go.sum` are deliberately excluded — the test plugins are separate modules that never read either, the only part of `go.mod` that reaches them is the toolchain version (taken directly instead), and the wazero version `go.sum` pins is already namespaced by wazero's own cache layout. Keying on either would rotate the cache on every unrelated dependency bump. A `restore-keys` prefix fallback means a partial hit still avoids the compile work.

The stored cache is ~48MB per key. GitHub's per-repo limit is 10GB with LRU eviction, and only this one job uses it.

This does not touch the `Test Go code (Windows)` job — the plugins suite is `//go:build !windows`.

Remaining headroom, not done here: running the `plugins` suite with parallel Ginkgo processes measured 291s → 99s under `-race`, and could stack with this change. It needs the `ginkgo` CLI in CI, so I left it for a separate PR.
