### PR TITLE
ci: run the plugins test suite in parallel processes

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -148,7 +148,12 @@ jobs:
           restore-keys: wazero-${{ runner.os }}-
 
       - name: Test
-        run: go test -shuffle=on -tags netgo,sqlite_fts5 -race ./... -v
+        run: go test -shuffle=on -tags netgo,sqlite_fts5 -race -v $(go list ./... | grep -v '/plugins$')
+
+      # Run separately: this suite is long enough that splitting it across
+      # processes beats running it alongside the other packages.
+      - name: Test plugins
+        run: go tool ginkgo -p -race -tags netgo,sqlite_fts5 ./plugins/
 
       - name: Test ndpgen
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -131,29 +131,14 @@ jobs:
         uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
-        id: setup-go
         with:
           go-version-file: go.mod
 
       - name: Download dependencies
         run: go mod download
 
-      # Without this, the plugins suite recompiles every test plugin WASM module,
-      # which dominates the job runtime under -race.
-      - name: Cache the plugins test suite WASM compilation cache
-        uses: actions/cache@v6
-        with:
-          path: plugins/testdata/.wazero-cache
-          key: wazero-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('plugins/testdata/*/*.go', 'plugins/testdata/*/go.*', 'plugins/pdk/go/**/*.go', 'plugins/pdk/go/go.*') }}
-          restore-keys: wazero-${{ runner.os }}-
-
       - name: Test
         run: go test -shuffle=on -tags netgo,sqlite_fts5 -race -v $(go list ./... | grep -v '/plugins$')
-
-      # Run separately: this suite is long enough that splitting it across
-      # processes beats running it alongside the other packages.
-      - name: Test plugins
-        run: go tool ginkgo -p -race -tags netgo,sqlite_fts5 ./plugins/
 
       - name: Test ndpgen
         run: |
@@ -161,6 +146,30 @@ jobs:
           go test -shuffle=on -v
           go build -o ndpgen .
           ./ndpgen --help
+
+  go-plugins:
+    name: Test Go plugins
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        id: setup-go
+        with:
+          go-version-file: go.mod
+
+      # Without this, the suite recompiles every test plugin WASM module,
+      # which dominates its runtime under -race.
+      - name: Cache the WASM compilation cache
+        uses: actions/cache@v6
+        with:
+          path: plugins/testdata/.wazero-cache
+          key: wazero-${{ runner.os }}-go${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('plugins/testdata/*/*.go', 'plugins/testdata/*/go.*', 'plugins/pdk/go/**/*.go', 'plugins/pdk/go/go.*') }}
+          restore-keys: wazero-${{ runner.os }}-
+
+      - name: Test plugins
+        run: go tool ginkgo -p -race -tags netgo,sqlite_fts5 ./plugins/
 
   go-windows:
     name: Test Go code (Windows)
@@ -299,7 +308,7 @@ jobs:
 
   build:
     name: Build
-    needs: [js, go, go-windows, go-lint, i18n-lint, git-version, check-push-enabled, validate-migrations]
+    needs: [js, go, go-plugins, go-windows, go-lint, i18n-lint, git-version, check-push-enabled, validate-migrations]
     strategy:
       matrix:
         platform: [ linux/amd64, linux/arm64, linux/arm/v5, linux/arm/v6, linux/arm/v7, linux/386, linux/riscv64, darwin/amd64, darwin/arm64, windows/amd64, windows/386 ]

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ zz_*_test.go
 
 # wazero compilation cache for the plugins test suite
 /plugins/testdata/.wazero-cache/
+/plugins/testdata/*.stage/

--- a/plugins/plugins_suite_test.go
+++ b/plugins/plugins_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -39,7 +40,6 @@ var (
 
 func TestPlugins(t *testing.T) {
 	tests.Init(t, false)
-	buildTestPlugins(t, testDataDir)
 
 	// Set globally so tests using configtest.SetupConfig inherit it. The cache
 	// persists between runs; entries are content-addressed, so a stale one only misses.
@@ -51,16 +51,11 @@ func TestPlugins(t *testing.T) {
 	RunSpecs(t, "Plugins Suite")
 }
 
-func buildTestPlugins(t *testing.T, path string) {
-	t.Helper()
+func buildTestPlugins(path string) {
 	start := time.Now()
-	t.Logf("[BeforeSuite] Current working directory: %s", path)
-	cmd := exec.Command("make", "-C", path)
-	out, err := cmd.CombinedOutput()
-	t.Logf("[BeforeSuite] Make output: %s elapsed: %s", string(out), time.Since(start))
-	if err != nil {
-		t.Fatalf("Failed to build test plugins: %v", err)
-	}
+	out, err := exec.Command("make", "-C", path).CombinedOutput()
+	fmt.Fprintf(GinkgoWriter, "[BeforeSuite] built test plugins in %s:\n%s", time.Since(start), out)
+	Expect(err).ToNot(HaveOccurred(), "failed to build test plugins")
 }
 
 // createTestManager creates a new plugin Manager with the given plugin config.
@@ -146,7 +141,10 @@ func createTestManagerWithPluginsAndMetrics(pluginConfig map[string]map[string]s
 	return manager, tmpDir
 }
 
-var _ = BeforeSuite(func() {
+var _ = SynchronizedBeforeSuite(func() {
+	// Build once: the testdata Makefile is not safe to run concurrently.
+	buildTestPlugins(testDataDir)
+}, func() {
 	// Get testdata directory (where test plugin .ndp packages live)
 	_, currentFile, _, ok := runtime.Caller(0)
 	Expect(ok).To(BeTrue())

--- a/plugins/testdata/Makefile
+++ b/plugins/testdata/Makefile
@@ -10,17 +10,19 @@ all: $(PLUGINS:%=%.ndp)
 
 clean:
 	rm -f $(PLUGINS:%=%.ndp) $(PLUGINS:%=%.wasm)
-	rm -rf .wazero-cache
+	rm -rf .wazero-cache $(PLUGINS:%=%.stage)
 
 # PDK source files that trigger rebuild when changed (recursive)
 PDK_SOURCES := $(shell find ../pdk/go -name '*.go' 2>/dev/null)
 
 # Build the .ndp package (zip containing manifest.json + plugin.wasm)
+# Stage under a per-target name: a shared plugin.wasm breaks concurrent builds.
 %.ndp: %.wasm %/manifest.json
 	@rm -f $@
-	@cp $< plugin.wasm
-	zip -j $@ $*/manifest.json plugin.wasm
-	@rm -f plugin.wasm
+	@rm -rf $*.stage && mkdir -p $*.stage
+	@cp $< $*.stage/plugin.wasm
+	zip -j $@ $*/manifest.json $*.stage/plugin.wasm
+	@rm -rf $*.stage
 	@mv $< $<.tmp && mv $<.tmp $<  # Touch wasm to ensure it's older than ndp
 
 # Build the wasm binary. -buildvcs=false keeps the bytes stable across commits, so


### PR DESCRIPTION
### Description

Follow-up to #6049. That PR made the `plugins` suite reuse its wazero compilation cache, taking the `Test Go code` job from 11m49s to 5m41s. With the cache warm the suite is no longer bound by WASM compilation — it is bound by plain spec execution, and that splits cleanly across processes.

Running the suite with the Ginkgo CLI's parallel mode, measured locally with `-race`:

| Cache | Serial | Parallel |
| --- | --- | --- |
| Warm | 69s | **19s** |
| Cold | 256s | **96s** |

Both cases improve, so this helps whether or not the CI cache hits.

Two things had to be fixed before the suite could run in parallel at all.

`buildTestPlugins` ran in every process, so N copies of `make` raced in the same directory. The packaging rule made that worse by staging every plugin through a single shared `plugin.wasm` file, so concurrent targets clobbered each other — the first parallel run failed with `mv: test-artwork.wasm: No such file or directory` and left orphaned zip temp files in `testdata/`. The same flaw also ruled out `make -j`.

The fix is to stage each package under its own per-target directory, and move the build into `SynchronizedBeforeSuite` so process 1 does it once while the other processes wait.

In CI the suite gets its own `Test Go plugins` job, using `go tool ginkgo` — no new tooling needed, since the CLI is already declared in the `tool` block in `go.mod`. The WASM compilation cache step moves into that job, because the `go` job no longer runs the suite. The package is dropped from the main `go test` invocation so it does not run twice, and `build` gates on both jobs.

A separate job rather than a second step in the existing one, because it has to run *concurrently*. I tried the second-step version first and it was worth almost nothing — the suite itself dropped from ~175s to 82s, but serialising it against the other 90 packages gave the win straight back and the job only went from 5m41s to 5m29s.

### Results on CI

The two jobs now start together and the gate is whichever finishes last.

| Stage | Test Go code | Test Go plugins | Gate |
| --- | --- | --- | --- |
| Before #6049 | 11m 49s | — | 11m 49s |
| After #6049 | 5m 41s | — | 5m 41s |
| As a second step (rejected) | 5m 29s | — | 5m 29s |
| **This PR** | **4m 10s** | **2m 29s** | **4m 10s** |

The `go` job is now bound by compile time plus the `scanner` package, not by `plugins`.

### Related Issues

Follow-up to #6049.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI / test-suite performance

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No new tests: this changes how existing tests are executed, not what they assert. The 652 specs in the suite are the regression test.

### How to Test

Run the suite in parallel, exactly as CI now does:

```bash
go tool ginkgo -p -race -tags netgo,sqlite_fts5 ./plugins/
```

And the main job's command, which no longer includes the suite:

```bash
go test -shuffle=on -tags netgo,sqlite_fts5 -race -v $(go list ./... | grep -v '/plugins$')
```

To check the concurrency fix specifically, start from nothing so the build and the cache are both cold:

```bash
make -C plugins/testdata clean
go tool ginkgo -p -race -tags netgo,sqlite_fts5 ./plugins/
```

On master that fails during `make`. Here it passes, and the cache ends up at the same 334MB a serial run produces.

### Additional Notes

The project convention is that tests are deterministic and not run in parallel, so this is a deliberate exception for one suite. Evidence that it holds: 8 consecutive local runs, all 652 specs passing every time — 5 with `-p` and 3 with `-procs=4` to match a CI runner's core count. Ginkgo parallelism is process-based, so each process gets its own copy of the package globals rather than sharing them.

Four processes writing the wazero compilation cache at once is safe: a cold parallel run produces the same 334MB cache as a cold serial one, with no failures.

`make test` is unchanged and still runs the suite serially, so local behaviour only changes for anyone who opts into the ginkgo command above.

The new job duplicates checkout and `setup-go`, which costs about 25s of setup it does not share with the `go` job. That is paid concurrently, so it does not affect the gate.
