### PR TITLE
perf(persistence): avoid a full media_file scan when resolving playlist paths

### DIFF
--- a/core/playlists/parse_m3u.go
+++ b/core/playlists/parse_m3u.go
@@ -25,8 +25,8 @@ func (s *playlists) parseM3U(ctx context.Context, pls *model.Playlist, folder *m
 		return err
 	}
 	var mfs model.MediaFiles
-	// Chunk size of 100 lines, as each line can generate up to 4 lookup candidates
-	// (NFC/NFD × raw/lowercase), and SQLite has a max expression tree depth of 1000.
+	// Chunked so a huge playlist is not held in memory at once. Each line yields up to
+	// 4 lookup candidates (NFC/NFD × raw/lowercase), far below SQLite's 32766 variables.
 	for lines := range slice.CollectChunks(slice.LinesFrom(reader), 100) {
 		filteredLines := make([]string, 0, len(lines))
 		for _, line := range lines {

--- a/persistence/mediafile_repository.go
+++ b/persistence/mediafile_repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"maps"
 	"slices"
 	"strconv"
 	"strings"
@@ -355,7 +356,10 @@ func (r *mediaFileRepository) GetCursorWithArtwork(options ...model.QueryOptions
 // Library-qualified paths search within the specified library, while unqualified paths
 // search across all libraries for backward compatibility.
 func (r *mediaFileRepository) FindByPaths(paths []string) (model.MediaFiles, error) {
-	query := Or{}
+	// One IN list per library instead of one OR term per path: SQLite abandons the
+	// path index at just two OR-ed equality terms and scans the whole table.
+	byLibrary := map[int][]string{}
+	var unqualified []string
 
 	for _, path := range paths {
 		parts := strings.SplitN(path, ":", 2)
@@ -366,15 +370,22 @@ func (r *mediaFileRepository) FindByPaths(paths []string) (model.MediaFiles, err
 				// Invalid format, skip
 				continue
 			}
-			relativePath := parts[1]
-			query = append(query, And{
-				Eq{"path collate nocase": relativePath},
-				Eq{"library_id": libraryID},
-			})
+			byLibrary[libraryID] = append(byLibrary[libraryID], parts[1])
 		} else {
 			// Unqualified path: search across all libraries
-			query = append(query, Eq{"path collate nocase": path})
+			unqualified = append(unqualified, path)
 		}
+	}
+
+	query := Or{}
+	for _, libraryID := range slices.Sorted(maps.Keys(byLibrary)) {
+		query = append(query, And{
+			Eq{"path collate nocase": byLibrary[libraryID]},
+			Eq{"library_id": libraryID},
+		})
+	}
+	if len(unqualified) > 0 {
+		query = append(query, Eq{"path collate nocase": unqualified})
 	}
 
 	if len(query) == 0 {

--- a/persistence/mediafile_repository_test.go
+++ b/persistence/mediafile_repository_test.go
@@ -1055,6 +1055,28 @@ var _ = Describe("MediaRepository", func() {
 				Expect(results).To(HaveLen(1))
 				Expect(results[0].ID).To(Equal("otherlib-track"))
 			})
+
+			It("resolves paths from multiple libraries in a single call", func() {
+				adminMr := NewMediaFileRepository(request.WithUser(GinkgoT().Context(), adminUser), GetDBXBuilder())
+				results, err := adminMr.FindByPaths([]string{
+					"1:artist/Album/track.mp3",
+					fmt.Sprintf("%d:hidden/test.mp3", otherLib.ID),
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).To(HaveLen(2))
+				Expect([]string{results[0].ID, results[1].ID}).To(ConsistOf("findpath-1", "otherlib-track"))
+			})
+
+			It("keeps each path scoped to its own library when several are queried", func() {
+				adminMr := NewMediaFileRepository(request.WithUser(GinkgoT().Context(), adminUser), GetDBXBuilder())
+				// Each path exists, but under the other library's ID, so neither must match.
+				results, err := adminMr.FindByPaths([]string{
+					fmt.Sprintf("%d:artist/Album/track.mp3", otherLib.ID),
+					"1:hidden/test.mp3",
+				})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(results).To(BeEmpty())
+			})
 		})
 	})
 


### PR DESCRIPTION
### Description

`FindByPaths` resolves a batch of paths to media files. It built the WHERE clause as one OR-ed equality term per path: `(path collate nocase = ? AND library_id = ?) OR (...) OR ...`. On the real `media_file` schema SQLite abandons the path index at just **two** OR-ed terms and falls back to `SCAN media_file`, re-testing every OR term against every row. The cost therefore grows with (rows × terms) instead of staying an index lookup. `ANALYZE` does not change the plan.

This change groups the candidate paths by library and emits one `IN` list per library instead, which plans as `SEARCH media_file USING INDEX media_file_path_nocase`. The `COLLATE NOCASE` is kept so ASCII case-insensitive matching still behaves the same, and unqualified paths keep their existing "search across all libraries" behaviour. Library IDs are iterated in sorted order so the generated SQL is deterministic.

This is the dominant cost of M3U playlist import, which re-resolves every track in every playlist on every scan. Measured with a 1000-track playlist running the real import path against a migrated database:

| media_file rows | before | after |
| --- | --- | --- |
| 100,000 | 397 tracks/sec | 51,414 tracks/sec |
| 500,000 | 78.5 tracks/sec | 47,174 tracks/sec |

Before the change the rate fell off linearly as the table grew; after it, it is flat, which is the expected shape for an index lookup.

### Related Issues

Related to #6043

That report is a 2M-song library where an 8 hour scan spent 7h52m in the playlist phase (phase 1 was 23m, GC and all the final steps together were about 2.5 minutes). A single 90,535-track M3U took 3h25m on its own. This addresses the query behind that; the issue also covers separate points about interrupted scans resuming.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

The existing `FindByPaths` specs in `persistence/mediafile_repository_test.go` cover the behaviour that must not change (exact match, NOCASE matching, the fullwidth non-ASCII limitation, per-library scoping, and the restricted-user library filter).

Two specs are added for the path this change introduces, resolving several libraries in one call:

```
make test PKG=./persistence/
```

- `resolves paths from multiple libraries in a single call` returns both tracks.
- `keeps each path scoped to its own library when several are queried` returns nothing when each path is queried under the wrong library ID.

Both fail if the `library_id` condition is dropped from the grouped query, which I verified by mutating the implementation.

To see the effect end to end, import an M3U on a library large enough for the scan to matter (100k+ tracks) and compare the `Scanner: Imported playlist` elapsed time in the logs before and after.

### Additional Notes

Scope: this only changes how the WHERE clause is built. The set of rows returned is unchanged, so callers other than the playlist importer (the scanner's move detection uses it too) get the same results, just faster.

Not addressed here, both still open and worth their own PRs:

- `scanner/phase_4_playlists.go` re-imports every playlist in a folder whenever anything in that folder changes, with no per-file check (there is already a `BFR:` comment marking this).
- `core/playlists/import.go` gates the `ImportedHash` skip on `IsSmartPlaylist()`, so an M3U is always fully re-imported. Note that check currently runs *after* `parsePlaylist`, so enabling it for M3U would save the write but not the lookup unless it moves earlier.

Those reduce redundant work; this PR makes the work itself cheap.
