### PR TITLE
fix(nativeapi): stop partial PUTs from clearing untouched columns

### DIFF
--- a/core/library.go
+++ b/core/library.go
@@ -191,7 +191,7 @@ func (r *libraryRepositoryWrapper) Save(entity any) (string, error) {
 	return strconv.Itoa(lib.ID), nil
 }
 
-func (r *libraryRepositoryWrapper) Update(id string, entity any, _ ...string) error {
+func (r *libraryRepositoryWrapper) Update(id string, entity any, cols ...string) error {
 	lib := entity.(*model.Library)
 	libID, err := strconv.Atoi(id)
 	if err != nil {
@@ -211,7 +211,7 @@ func (r *libraryRepositoryWrapper) Update(id string, entity any, _ ...string) er
 
 	pathChanged := originalLib.Path != lib.Path
 
-	err = r.LibraryRepository.Put(lib)
+	err = r.LibraryRepository.Put(lib, cols...)
 	if err != nil {
 		return r.mapError(err)
 	}

--- a/core/library_test.go
+++ b/core/library_test.go
@@ -188,6 +188,15 @@ var _ = Describe("Library Service", func() {
 				Expect(libraryRepo.Data[1].Path).To(Equal(newTempDir))
 			})
 
+			It("forwards the columns sent by the client to the repository", func() {
+				library := &model.Library{ID: 1, Name: "Updated Library", Path: tempDir}
+
+				err := repo.Update("1", library, "name", "path")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(libraryRepo.PutCols).To(Equal([]string{"name", "path"}))
+			})
+
 			It("fails when library doesn't exist", func() {
 				// Create a unique temporary directory to avoid path conflicts
 				uniqueTempDir, err := os.MkdirTemp("", "navidrome-nonexistent-")

--- a/model/library.go
+++ b/model/library.go
@@ -45,7 +45,7 @@ type LibraryRepository interface {
 	GetPath(id int) (string, error)
 	GetAll(...QueryOptions) (Libraries, error)
 	CountAll(...QueryOptions) (int64, error)
-	Put(*Library) error
+	Put(l *Library, colsToUpdate ...string) error
 	Delete(id int) error
 	StoreMusicFolder() error
 	AddArtist(id int, artistID string) error

--- a/persistence/library_repository.go
+++ b/persistence/library_repository.go
@@ -70,7 +70,7 @@ func (r *libraryRepository) GetPath(id int) (string, error) {
 	}
 }
 
-func (r *libraryRepository) Put(l *model.Library) error {
+func (r *libraryRepository) Put(l *model.Library, colsToUpdate ...string) error {
 	if l.ID == model.DefaultLibraryID {
 		currentLib, err := r.Get(1)
 		// if we are creating it, it's ok.
@@ -89,13 +89,13 @@ func (r *libraryRepository) Put(l *model.Library) error {
 		err = r.db.Model(l).Insert()
 	} else {
 		// Try to update first
-		cols := map[string]any{
+		cols := selectUpdateColumns(map[string]any{
 			"name":              l.Name,
 			"path":              l.Path,
 			"remote_path":       l.RemotePath,
 			"default_new_users": l.DefaultNewUsers,
-			"updated_at":        l.UpdatedAt,
-		}
+		}, colsToUpdate...)
+		cols["updated_at"] = l.UpdatedAt
 		sq := Update(r.tableName).SetMap(cols).Where(Eq{"id": l.ID})
 		rowsAffected, updateErr := r.executeSQL(sq)
 		if updateErr != nil {
@@ -340,7 +340,7 @@ func (r *libraryRepository) Update(id string, entity any, cols ...string) error 
 	}
 
 	lib.ID = idInt
-	return r.Put(lib)
+	return r.Put(lib, cols...)
 }
 
 var _ model.LibraryRepository = (*libraryRepository)(nil)

--- a/persistence/library_repository_test.go
+++ b/persistence/library_repository_test.go
@@ -52,6 +52,26 @@ var _ = Describe("LibraryRepository", func() {
 			})
 		})
 
+		Context("when colsToUpdate is specified", func() {
+			It("only writes the requested columns", func() {
+				lib := &model.Library{
+					Name:            "Original Library",
+					Path:            "/music/original",
+					RemotePath:      "/remote/original",
+					DefaultNewUsers: true,
+				}
+				Expect(repo.Put(lib)).To(Succeed())
+
+				Expect(repo.Put(&model.Library{ID: lib.ID, Name: "Renamed", Path: lib.Path}, "name", "path")).To(Succeed())
+
+				saved, err := repo.Get(lib.ID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(saved.Name).To(Equal("Renamed"))
+				Expect(saved.RemotePath).To(Equal("/remote/original"))
+				Expect(saved.DefaultNewUsers).To(BeTrue())
+			})
+		})
+
 		Context("when ID is non-zero and record exists", func() {
 			It("updates the existing record", func() {
 				// First create a library

--- a/persistence/plugin_repository.go
+++ b/persistence/plugin_repository.go
@@ -141,31 +141,5 @@ func (r *pluginRepository) ReadAll(options ...rest.QueryOptions) (any, error) {
 	return r.GetAll(r.parseRestOptions(r.ctx, options...))
 }
 
-func (r *pluginRepository) Save(entity any) (string, error) {
-	p := entity.(*model.Plugin)
-	if !r.isPermitted() {
-		return "", rest.ErrPermissionDenied
-	}
-	err := r.Put(p)
-	if errors.Is(err, model.ErrNotFound) {
-		return "", rest.ErrNotFound
-	}
-	return p.ID, err
-}
-
-func (r *pluginRepository) Update(id string, entity any, cols ...string) error {
-	p := entity.(*model.Plugin)
-	p.ID = id
-	if !r.isPermitted() {
-		return rest.ErrPermissionDenied
-	}
-	err := r.Put(p)
-	if errors.Is(err, model.ErrNotFound) {
-		return rest.ErrNotFound
-	}
-	return err
-}
-
 var _ model.PluginRepository = (*pluginRepository)(nil)
 var _ rest.Repository = (*pluginRepository)(nil)
-var _ rest.Persistable = (*pluginRepository)(nil)

--- a/persistence/radio_repository.go
+++ b/persistence/radio_repository.go
@@ -152,7 +152,7 @@ func (r *radioRepository) Update(id string, entity any, cols ...string) error {
 	if !r.isPermitted() {
 		return rest.ErrPermissionDenied
 	}
-	err := r.Put(t)
+	err := r.Put(t, cols...)
 	if errors.Is(err, model.ErrNotFound) {
 		return rest.ErrNotFound
 	}

--- a/persistence/radio_repository_test.go
+++ b/persistence/radio_repository_test.go
@@ -141,6 +141,24 @@ var _ = Describe("RadioRepository", func() {
 				)))
 			})
 		})
+
+		Describe("Update", func() {
+			It("only writes the columns sent by the client", func() {
+				radio := radioWithHomePage
+				radio.UploadedImage = "cover.png"
+				Expect(repo.Put(&radio)).To(Succeed())
+
+				persistable := repo.(rest.Persistable)
+				Expect(persistable.Update(radio.ID, &model.Radio{Name: "Renamed"}, "name")).To(Succeed())
+
+				item, err := repo.Get(radio.ID)
+				Expect(err).To(BeNil())
+				Expect(item.Name).To(Equal("Renamed"))
+				Expect(item.UploadedImage).To(Equal("cover.png"))
+				Expect(item.StreamUrl).To(Equal(radio.StreamUrl))
+				Expect(item.HomePageUrl).To(Equal(radio.HomePageUrl))
+			})
+		})
 	})
 
 	Describe("Regular User", func() {

--- a/persistence/sql_base_repository.go
+++ b/persistence/sql_base_repository.go
@@ -560,13 +560,11 @@ func (r sqlRepository) putByMatch(filter Sqlizer, id string, m any, colsToUpdate
 	return r.put(res.ID, m, colsToUpdate...)
 }
 
-// filterUpdateValues selects, from a marshaled column map, the values to write in an UPDATE on the
-// row identified by id: only the requested colsToUpdate (or all columns when none are specified),
-// dropping columns that must never be overwritten on update (created_at, birth_time).
-func filterUpdateValues(values map[string]any, id string, colsToUpdate ...string) map[string]any {
+// selectUpdateColumns keeps only the requested colsToUpdate (or all columns when none are
+// specified), dropping columns that must never be overwritten on update (created_at, birth_time).
+func selectUpdateColumns(values map[string]any, colsToUpdate ...string) map[string]any {
 	updateValues := map[string]any{}
 
-	// This is a map of the columns that need to be updated, if specified
 	c2upd := slice.ToMap(colsToUpdate, func(s string) (string, struct{}) {
 		return toSnakeCase(s), struct{}{}
 	})
@@ -576,11 +574,16 @@ func filterUpdateValues(values map[string]any, id string, colsToUpdate ...string
 		}
 	}
 
-	updateValues["id"] = id
 	delete(updateValues, "created_at")
 	// To avoid updating the media_file birth_time on each scan. Not the best solution, but it works for now
 	// TODO move to mediafile_repository when each repo has its own upsert method
 	delete(updateValues, "birth_time")
+	return updateValues
+}
+
+func filterUpdateValues(values map[string]any, id string, colsToUpdate ...string) map[string]any {
+	updateValues := selectUpdateColumns(values, colsToUpdate...)
+	updateValues["id"] = id
 	return updateValues
 }
 

--- a/tests/mock_library_repo.go
+++ b/tests/mock_library_repo.go
@@ -14,9 +14,10 @@ import (
 
 type MockLibraryRepo struct {
 	model.LibraryRepository
-	Data  map[int]model.Library
-	Err   error
-	PutFn func(*model.Library) error // Allow custom Put behavior for testing
+	Data    map[int]model.Library
+	Err     error
+	PutFn   func(*model.Library) error // Allow custom Put behavior for testing
+	PutCols []string
 }
 
 func (m *MockLibraryRepo) SetData(data model.Libraries) {
@@ -90,7 +91,8 @@ func (m *MockLibraryRepo) GetPath(id int) (string, error) {
 	return "", model.ErrNotFound
 }
 
-func (m *MockLibraryRepo) Put(library *model.Library) error {
+func (m *MockLibraryRepo) Put(library *model.Library, colsToUpdate ...string) error {
+	m.PutCols = colsToUpdate
 	if m.PutFn != nil {
 		return m.PutFn(library)
 	}


### PR DESCRIPTION
### Description
The native API's `PUT` handler parses the request body's top-level JSON keys and passes them to `Repository.Update` as `colsToUpdate`. Repositories are expected to forward that list down to `Put` so only the fields the client actually sent get written. The radio and library repositories discarded the list and issued a full-row `UPDATE`, so every column absent from the body was written as its zero value.

For radio this cleared `uploaded_image`, deleting the station's cover art on any partial update. The Web UI is unaffected because its edit form is initialised from the full record and submits every field, which is why this only surfaced through API clients. The Subsonic endpoint is also unaffected — `updateInternetRadioStation` already names its columns explicitly. For library the same defect silently cleared `remote_path` and `default_new_users`; `name` and `path` are required by validation, so that path fails loudly rather than losing those two.

The fix threads the column list through to `Put` in both repositories. `libraryRepository.Put` hand-builds its update map (it deliberately writes a four-column whitelist and never routes through `sqlRepository.put`), so rather than duplicate the selection rule I extracted the column-selection half of `filterUpdateValues` into `selectUpdateColumns` and had both call sites share it. `model.LibraryRepository.Put` gains a variadic `colsToUpdate` parameter, matching the signature `model.RadioRepository.Put` already had; every existing caller is unchanged.

The second commit removes `pluginRepository`'s `Save`, `Update` and its `rest.Persistable` assertion. They had no callers — `PUT /api/plugin/{id}` is served by the hand-written `updatePlugin` handler over a typed request struct, and the route only wires `rest.GetAll` and `rest.Get`. Both methods delegated to `pluginRepository.Put`, a raw `INSERT ... ON CONFLICT DO UPDATE` over all twelve columns, so wiring `rest.Put` to this repository would have reintroduced exactly the bug the first commit fixes, in its worst form. Removing them turns that into a compile error. `Put` itself is untouched and still backs plugin discovery.

### Related Issues
Fixes #6057

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Automated: `make test`. Three new specs cover the three layers — `persistence/radio_repository_test.go` (the shared `sqlRepository.put` path), `persistence/library_repository_test.go` (library's hand-built `SetMap` path) and `core/library_test.go` (the REST wrapper forwarding `cols`). All three fail on `master` and pass here.

Manual, reproducing the issue report against a running server:

1. Start the server and create a radio station in the Web UI, then upload a cover image for it.
2. Authenticate:
   ```
   curl -X POST "http://localhost:4533/auth/login" \
     -H "Content-Type: application/json" \
     --data '{"username":"<USER>","password":"<PASS>"}'
   ```
3. Send a partial update that omits `uploadedImage`:
   ```
   curl -X PUT "http://localhost:4533/api/radio/<RADIO_ID>" \
     -H "Content-Type: application/json" \
     -H "x-nd-authorization: Bearer <TOKEN>" \
     --data '{"name":"My Updated Radio","streamUrl":"https://example.com/new-stream","homePageUrl":"https://example.com"}'
   ```
4. `GET /api/radio/<RADIO_ID>`. The name and stream URL are updated and `uploadedImage` is still populated. On `master` the same sequence returns `uploadedImage` cleared and the cover is gone from the UI.

For library, `PUT /api/library/<ID>` with `name` and `path` but no `remotePath` now leaves `remote_path` and `default_new_users` intact.
