### PR TITLE
ci: report Go test coverage on pull requests

### DIFF
--- a/.github/workflows/download-link-on-pr.yml
+++ b/.github/workflows/download-link-on-pr.yml
@@ -34,16 +34,19 @@ jobs:
             }
 
             const {data: {artifacts}} = await github.rest.actions.listWorkflowRunArtifacts({owner, repo, run_id});
-            if (!artifacts.length) {
+            const downloadable = artifacts.filter((art) => !art.name.startsWith('octocov-'));
+            if (!downloadable.length) {
               return core.error(`No artifacts found`);
             }
-            let body = `Download the artifacts for this pull request:\n`;
-            for (const art of artifacts) {
+            const header = `Download the artifacts for this pull request:`;
+            let body = `${header}\n`;
+            for (const art of downloadable) {
               body += `\n* [${art.name}.zip](https://nightly.link/${owner}/${repo}/actions/artifacts/${art.id}.zip)`;
             }
 
             const {data: comments} = await github.rest.issues.listComments({repo, owner, issue_number});
-            const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]');
+            // Match on the body too: octocov also comments as github-actions[bot].
+            const existing_comment = comments.find((c) => c.user.login === 'github-actions[bot]' && c.body.startsWith(header));
             if (existing_comment) {
               core.info(`Updating comment ${existing_comment.id}`);
               await github.rest.issues.updateComment({repo, owner, comment_id: existing_comment.id, body});

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -126,6 +126,10 @@ jobs:
   go:
     name: Test Go code
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7
@@ -138,7 +142,7 @@ jobs:
         run: go mod download
 
       - name: Test
-        run: go test -shuffle=on -tags netgo,sqlite_fts5 -race -v $(go list ./... | grep -v '/plugins$')
+        run: go test -shuffle=on -tags netgo,sqlite_fts5 -race -v -covermode=atomic -coverprofile=coverage.out $(go list ./... | grep -v '/plugins$')
 
       - name: Test ndpgen
         run: |
@@ -146,6 +150,9 @@ jobs:
           go test -shuffle=on -v
           go build -o ndpgen .
           ./ndpgen --help
+
+      - name: Report coverage
+        uses: k1LoW/octocov-action@v1
 
   go-plugins:
     name: Test Go plugins

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -126,10 +126,6 @@ jobs:
   go:
     name: Test Go code
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      actions: write
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v7
@@ -151,8 +147,12 @@ jobs:
           go build -o ndpgen .
           ./ndpgen --help
 
-      - name: Report coverage
-        uses: k1LoW/octocov-action@v1
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v7
+        with:
+          name: octocov-go
+          path: coverage.out
+          if-no-files-found: error
 
   go-plugins:
     name: Test Go plugins
@@ -176,7 +176,31 @@ jobs:
           restore-keys: wazero-${{ runner.os }}-
 
       - name: Test plugins
-        run: go tool ginkgo -p -race -tags netgo,sqlite_fts5 ./plugins/
+        run: go tool ginkgo -p -race -tags netgo,sqlite_fts5 --cover --covermode=atomic --coverprofile=coverage.out --output-dir=. ./plugins/
+
+      - name: Upload coverage profile
+        uses: actions/upload-artifact@v7
+        with:
+          name: octocov-plugins
+          path: coverage.out
+          if-no-files-found: error
+
+  coverage:
+    name: Report coverage
+    runs-on: ubuntu-latest
+    needs: [go, go-plugins]
+    permissions:
+      contents: read
+      pull-requests: write
+      actions: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: octocov-*
+
+      - uses: k1LoW/octocov-action@v1
 
   go-windows:
     name: Test Go code (Windows)

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -137,7 +137,9 @@ jobs:
       - name: Download dependencies
         run: go mod download
 
-      - name: Test
+      # Name must stay unique across the workflow: octocov matches step names
+      # by name across every job, and waits for each match to finish.
+      - name: Test with coverage
         run: go test -shuffle=on -tags netgo,sqlite_fts5 -race -v -covermode=atomic -coverprofile=coverage.out $(go list ./... | grep -v '/plugins$')
 
       - name: Test ndpgen

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -202,6 +202,14 @@ jobs:
         with:
           pattern: octocov-*
 
+      # Merge here rather than letting octocov do it: octocov reports statement
+      # coverage for a single profile, but switches to line counting for several.
+      - name: Merge coverage profiles
+        run: |
+          echo "mode: atomic" > coverage.out
+          awk 'FNR==1 && /^mode:/ {next} {k=$1" "$2; c[k]+=$3} END {for (k in c) print k, c[k]}' \
+            octocov-*/coverage.out | sort >> coverage.out
+
       - uses: k1LoW/octocov-action@v1
 
   go-windows:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,7 +1,9 @@
 # Code coverage reporting for pull requests. See https://github.com/k1LoW/octocov
 coverage:
+  # Artifact names uploaded by the test jobs; octocov merges the profiles it finds in each.
   paths:
-    - coverage.out
+    - octocov-go
+    - octocov-plugins
 codeToTestRatio:
   code:
     - '**/*.go'
@@ -11,6 +13,9 @@ codeToTestRatio:
     - '**/*_test.go'
 testExecutionTime:
   if: true
+  steps:
+    - Test
+    - Test plugins
 diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -3,10 +3,10 @@
 # eats most of it, leaving none for the report upload.
 timeout: 5m
 coverage:
-  # Artifact names uploaded by the test jobs; octocov merges the profiles it finds in each.
+  # A single pre-merged profile: octocov reports statements for one path, but
+  # switches to line counting when it merges several itself.
   paths:
-    - octocov-go
-    - octocov-plugins
+    - coverage.out
 codeToTestRatio:
   code:
     - '**/*.go'

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -28,6 +28,6 @@ comment:
 summary:
   if: true
 report:
-  if: true # TEMP: seed a baseline artifact so the diff table can be demoed on this PR
+  if: is_default_branch
   datastores:
     - artifact://${GITHUB_REPOSITORY}

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,4 +1,7 @@
 # Code coverage reporting for pull requests. See https://github.com/k1LoW/octocov
+# The 30s default is not enough: scanning this repo's artifacts for the baseline
+# eats most of it, leaving none for the report upload.
+timeout: 5m
 coverage:
   # Artifact names uploaded by the test jobs; octocov merges the profiles it finds in each.
   paths:
@@ -14,7 +17,7 @@ codeToTestRatio:
 testExecutionTime:
   if: true
   steps:
-    - Test
+    - Test with coverage
     - Test plugins
 diff:
   datastores:

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,24 @@
+# Code coverage reporting for pull requests. See https://github.com/k1LoW/octocov
+coverage:
+  paths:
+    - coverage.out
+codeToTestRatio:
+  code:
+    - '**/*.go'
+    - '!**/*_test.go'
+    - '!**/*_gen.go'
+  test:
+    - '**/*_test.go'
+testExecutionTime:
+  if: true
+diff:
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}
+comment:
+  if: is_pull_request
+summary:
+  if: true
+report:
+  if: is_default_branch
+  datastores:
+    - artifact://${GITHUB_REPOSITORY}

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -21,9 +21,10 @@ diff:
     - artifact://${GITHUB_REPOSITORY}
 comment:
   if: is_pull_request
+  updatePrevious: true
 summary:
   if: true
 report:
-  if: is_default_branch
+  if: true # TEMP: seed a baseline artifact so the diff table can be demoed on this PR
   datastores:
     - artifact://${GITHUB_REPOSITORY}


### PR DESCRIPTION
### Description
Adds Go test coverage reporting to pull requests using [octocov](https://github.com/k1LoW/octocov). `Test Go code` and `Test Go plugins` each write a coverage profile and upload it as an artifact; a new `Report coverage` job merges them and posts a single comment with the coverage percentage, the delta against `master`, the code-to-test ratio, the combined test execution time, and a per-file breakdown of what moved. The same report goes to the job summary page, which is what forked PRs get since their token cannot comment.

The baseline for the delta is the report from the last `master` run, stored as a GitHub Actions artifact. Everything stays inside GitHub — no Codecov/Coveralls account, no repository secret, no third-party upload.

### Related Issues
<!-- none -->

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI / tooling

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No unit tests: the change is entirely CI configuration. It was validated by running `octocov` locally against the real CI profiles and end-to-end on this PR — a baseline was temporarily seeded from this branch so the full diff report could be verified before merge, then reverted to `is_default_branch`.

### How to Test
1. There should be a `Report coverage` job that runs after `Test Go code` and `Test Go plugins`.
2. Exactly one octocov comment should be on the PR, updated in place on each push, showing the metrics table, a `Details` diff block, and a per-file table.
3. The `Report coverage` job summary page should carry the same report.
4. The reported percentage should agree with `go tool cover -func` over the merged profile.

The two baseline columns on this PR both read `#6061` because the baseline was seeded from this branch for validation. After merge they will read `master`.

### Additional Notes

**The reported number is statement coverage**, matching `go tool cover -func`. This needs the two job profiles merged into one file *before* octocov sees them: given a single path octocov counts statements, but given several paths it merges them itself and switches to counting lines. That difference is not small — the same tree reads 69.9% by statements and 66.8% by lines, because an untested three-line `if err != nil` block costs one statement but three lines. Verified per file: `adapters/deezer/client.go` is 85/111 statements (76.6%) and 96/138 lines (69.6%), and octocov reports each accordingly. The merge step sums counts per block, so a block appearing in both profiles is not double-counted.

Three settings are load-bearing, each of which fails quietly if changed:
- **`timeout: 5m`** — octocov's default is 30s total. Scanning this repository's artifacts for the baseline consumes most of it and the report upload then dies with `context deadline exceeded`, which would mean `master` never stores a baseline and the diff table never appears.
- **The `Test with coverage` step name must be unique across the workflow.** octocov matches `testExecutionTime.steps` by name across every job in the run and waits for each match to finish. While it was named `Test` it also matched the Windows job's step, waited on a job still running, and silently dropped the execution-time column.
- **`comment.updatePrevious: true`** — otherwise octocov collapses the previous comment and posts a new one on every push.

**`download-link-on-pr.yml` needed a fix to coexist.** It updated the first `github-actions[bot]` comment it found, and octocov comments as the same bot. On a new PR the coverage comment is created first, so the download list would have overwritten it. It now matches on the comment body as well, and filters the coverage profiles out of the download list. This cannot be verified on this PR: `workflow_run` workflows always run from the default branch, so the fix only takes effect once merged.

Smaller notes:
- Coverage moves by ~0.1% between identical commits. The affected files are concurrency/timing code (`nowplaying_worker.go`, `middlewares.go`, `pipelines.go`), so treat small deltas as noise.
- The `Report coverage` job declares explicit `permissions` (`contents: read`, `pull-requests: write`, `actions: write`). The test jobs keep the default permissions.
- Coverage is Go-only; the UI is not measured. Only packages with at least one test file appear in a Go profile, so untested packages are skipped entirely — read the number as a trend, not an absolute.
- `-covermode=atomic` is required in both jobs because they already run with `-race`. The plugins job runs through Ginkgo, so it uses `--cover --covermode=atomic --coverprofile=... --output-dir=.`; with `-p`, Ginkgo merges its parallel nodes into that single profile.
- Measured cost: `Test Go code` went from 3m24s to 4m37s (+~70s), plus the new `Report coverage` job, which is short but adds a runner and waits on both test jobs.
