### PR TITLE
fix(lyrics): match external sidecar with alternate Unicode normalization - #4148

### DIFF
--- a/core/lyrics/lyrics_test.go
+++ b/core/lyrics/lyrics_test.go
@@ -6,15 +6,19 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing/fstest"
+	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/conf/configtest"
 	"github.com/navidrome/navidrome/core/lyrics"
+	"github.com/navidrome/navidrome/core/storage/storagetest"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/tests"
 	"github.com/navidrome/navidrome/utils"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/text/unicode/norm"
 )
 
 var _ = Describe("Lyrics", func() {
@@ -256,6 +260,38 @@ var _ = Describe("Lyrics", func() {
 		Expect(list[0].Line).To(Equal([]model.Line{
 			{Value: "title: not lyricsfile"},
 		}))
+	})
+
+	It("resolves an external sidecar whose Unicode normalization differs from the track path (issue #4148)", func() {
+		// Reproduces the reported case: a Japanese filename whose sidecar is stored
+		// in a different normalization form than the track. An in-memory FS keeps
+		// the mismatch byte-exact regardless of the host filesystem, which may
+		// normalize names on lookup and hide the bug.
+		const scheme = "fake-lyrics-e2e"
+		fsys := &storagetest.FakeFS{}
+		storagetest.Register(scheme, fsys)
+
+		// "ガ" is katakana KA plus a dakuten, so its NFC and NFD forms differ.
+		const base = "03. 鬱P feat. 初音ミク - ガ"
+		modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+		fsys.SetFiles(fstest.MapFS{
+			norm.NFC.String(base) + ".flac": &fstest.MapFile{Data: []byte("audio"), ModTime: modTime},
+			norm.NFD.String(base) + ".lrc":  &fstest.MapFile{Data: []byte("[00:18.80]We're no strangers to love"), ModTime: modTime},
+		})
+
+		// Default priority from the bug report: ".lrc,.txt,embedded".
+		conf.Server.LyricsPriority = ".lrc,.txt,embedded"
+		svc := lyrics.NewLyrics(nil, nil)
+		list, err := svc.GetLyrics(ctx, &model.MediaFile{
+			LibraryPath: scheme + ":///music",
+			Path:        norm.NFC.String(base) + ".flac",
+		})
+
+		Expect(err).To(BeNil())
+		Expect(list).To(HaveLen(1))
+		Expect(list[0].Synced).To(BeTrue())
+		Expect(list[0].Line).To(HaveLen(1))
+		Expect(list[0].Line[0].Value).To(Equal("We're no strangers to love"))
 	})
 
 	Context("Errors", func() {

--- a/core/lyrics/sources.go
+++ b/core/lyrics/sources.go
@@ -12,6 +12,7 @@ import (
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/utils/ioutils"
+	"golang.org/x/text/unicode/norm"
 )
 
 func fromEmbedded(ctx context.Context, mf *model.MediaFile) (model.LyricList, error) {
@@ -39,7 +40,7 @@ func fromExternalFile(ctx context.Context, mf *model.MediaFile, suffix string) (
 		return nil, fmt.Errorf("opening library filesystem: %w", err)
 	}
 
-	f, err := fsys.Open(sidecarRelPath)
+	f, err := openSidecar(fsys, sidecarRelPath)
 	if errors.Is(err, fs.ErrNotExist) {
 		log.Trace(ctx, "no lyrics found at path")
 		return nil, nil
@@ -66,6 +67,27 @@ func fromExternalFile(ctx context.Context, mf *model.MediaFile, suffix string) (
 
 	log.Trace(ctx, "retrieved lyrics from external file")
 	return list, nil
+}
+
+// openSidecar opens the sidecar lyrics file, retrying with the alternate Unicode
+// normalization form when the exact path is missing. A sidecar written next to a
+// track can use a different form than the path stored for the media file (macOS
+// commonly yields NFD, while Linux and Windows typically keep NFC), so a
+// byte-exact lookup would miss a file that is really on disk. Issue #4148.
+func openSidecar(fsys fs.FS, relPath string) (fs.File, error) {
+	f, err := fsys.Open(relPath)
+	if !errors.Is(err, fs.ErrNotExist) {
+		return f, err
+	}
+
+	altPath := norm.NFD.String(relPath)
+	if altPath == relPath {
+		altPath = norm.NFC.String(relPath)
+	}
+	if altPath == relPath {
+		return f, err
+	}
+	return fsys.Open(altPath)
 }
 
 // fromPlugin attempts to load lyrics from a plugin with the given name.

--- a/core/lyrics/sources_test.go
+++ b/core/lyrics/sources_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"testing/fstest"
+	"time"
 
+	"github.com/navidrome/navidrome/core/storage/storagetest"
 	"github.com/navidrome/navidrome/model"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"golang.org/x/text/unicode/norm"
 )
 
 var _ = Describe("sources", func() {
@@ -148,6 +152,58 @@ var _ = Describe("sources", func() {
 			Expect(lyrics[0].Line[0].Value).To(Equal("UTF16 line one"))
 			Expect(lyrics[0].Line[1].Start).To(Equal(new(int64(22801))))
 			Expect(lyrics[0].Line[1].Value).To(Equal("UTF16 line two"))
+		})
+	})
+
+	// A sidecar written next to a track can use a different Unicode normalization
+	// form than the track's own filename (macOS commonly stores names as NFD,
+	// while Linux and Windows keep NFC). A byte-exact lookup then misses a sidecar
+	// that is really on disk, so the retry has to try the other form. Issue #4148.
+	Describe("fromExternalFile with mismatched Unicode normalization", func() {
+		const scheme = "fake-lyrics-norm"
+		// "ガ" is katakana KA plus a dakuten, so it has distinct NFC (a single
+		// codepoint) and NFD (base plus combining mark) forms, unlike the plain
+		// CJK ideographs around it. It mirrors the filename from the bug report.
+		const base = "03. 鬱P feat. 初音ミク - ガ"
+
+		var fsys *storagetest.FakeFS
+
+		BeforeEach(func() {
+			fsys = &storagetest.FakeFS{}
+			storagetest.Register(scheme, fsys)
+		})
+
+		lyricsFor := func(trackForm, sidecarForm norm.Form) (model.LyricList, error) {
+			trackBase := trackForm.String(base)
+			sidecarBase := sidecarForm.String(base)
+			Expect(trackBase).ToNot(Equal(sidecarBase))
+
+			// A non-zero ModTime is required so the FakeFS directory-timestamp
+			// bookkeeping settles instead of looping.
+			modTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+			fsys.SetFiles(fstest.MapFS{
+				trackBase + ".flac":  &fstest.MapFile{Data: []byte("audio"), ModTime: modTime},
+				sidecarBase + ".lrc": &fstest.MapFile{Data: []byte("[00:18.80]We're no strangers to love"), ModTime: modTime},
+			})
+
+			mf := &model.MediaFile{LibraryPath: scheme + ":///music", Path: trackBase + ".flac"}
+			return fromExternalFile(ctx, mf, ".lrc")
+		}
+
+		It("finds an NFD-encoded sidecar for an NFC track path", func() {
+			lyrics, err := lyricsFor(norm.NFC, norm.NFD)
+
+			Expect(err).To(BeNil())
+			Expect(lyrics).To(HaveLen(1))
+			Expect(lyrics[0].Synced).To(BeTrue())
+		})
+
+		It("finds an NFC-encoded sidecar for an NFD track path", func() {
+			lyrics, err := lyricsFor(norm.NFD, norm.NFC)
+
+			Expect(err).To(BeNil())
+			Expect(lyrics).To(HaveLen(1))
+			Expect(lyrics[0].Synced).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Closes #4148

## Description

External `.lrc` (and other sidecar) lyrics were not showing on the web for tracks whose filenames contain non-ASCII characters. The lyrics resolver looked up the sidecar with a byte-exact path built from the track's stored path, so a sidecar saved in a different Unicode normalization form than the track filename was never found and the UI showed "No lyrics".

This is the classic NFC/NFD mismatch: macOS commonly stores filenames as NFD, while Linux and Windows keep NFC. In the reported case the filename contained `ガ` (katakana KA plus a dakuten), which has genuinely distinct NFC and NFD forms, so the `.flac` and its `.lrc` neighbour did not match byte-for-byte.

## Changes

- `core/lyrics/sources.go`: added `openSidecar`, which retries the sidecar lookup with the alternate NFC/NFD form when the exact path is missing. This reuses the same approach the playlist importer already applies in `findByPathNormalized` for cross-platform path matching. The fix lives at the shared resolution point, so both the Subsonic and Jellyfin lyrics endpoints benefit.
- `core/lyrics/sources_test.go`: added deterministic tests (in-memory FS) covering both the NFC-track/NFD-sidecar and NFD-track/NFC-sidecar directions. An in-memory FS is used so the mismatch stays byte-exact regardless of the host filesystem, which may normalize names on lookup and hide the bug.
- `core/lyrics/lyrics_test.go`: added an end-to-end test through the public `GetLyrics` entrypoint using the default `LyricsPriority` (`.lrc,.txt,embedded`) and the filename shape from the bug report.

## Testing

- `go test -tags=netgo,sqlite_fts5 ./core/lyrics/... ./server/subsonic/... ./server/jellyfin/...` including the Subsonic and Jellyfin e2e suites: all pass.
- Confirmed the new tests fail before the fix and pass after.
- `go vet` and `gofmt` clean.

## Related Issues

Closes #4148
