### PR TITLE
ci: comment coverage on pull requests from forks

### DIFF
--- a/.github/workflows/coverage-on-pr.yml
+++ b/.github/workflows/coverage-on-pr.yml
@@ -1,0 +1,53 @@
+name: Report coverage on PR
+on:
+  workflow_run:
+    workflows: ['Pipeline: Test, Lint, Build']
+    types: [completed]
+jobs:
+  comment:
+    name: Comment coverage report
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    env:
+      COVERAGE_COMMENT: 'true'
+    steps:
+      - name: Check out the pull request code
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
+
+      # This job holds a write token, so the config that drives it must come
+      # from the base branch and never from the fork.
+      - name: Check out the trusted octocov config
+        uses: actions/checkout@v7
+        with:
+          path: .base
+          sparse-checkout: .octocov.yml
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: octocov-pr
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ github.token }}
+
+      - name: Read the pull request number
+        id: pr
+        run: echo "number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
+
+      - uses: k1LoW/octocov-action@v1
+        with:
+          config: .base/.octocov.yml
+        env:
+          # A workflow_run job looks like a push to the default branch. Point
+          # octocov back at the pull request and at the run that produced it.
+          GITHUB_PULL_REQUEST_NUMBER: ${{ steps.pr.outputs.number }}
+          OCTOCOV_GITHUB_REF: refs/pull/${{ steps.pr.outputs.number }}/merge
+          OCTOCOV_GITHUB_SHA: ${{ github.event.workflow_run.head_sha }}
+          OCTOCOV_GITHUB_RUN_ID: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/coverage-on-pr.yml
+++ b/.github/workflows/coverage-on-pr.yml
@@ -15,18 +15,11 @@ jobs:
     env:
       COVERAGE_COMMENT: 'true'
     steps:
-      - name: Check out the pull request code
+      # Only the config, from the base branch: this job holds a write token, so
+      # it must never check out the fork.
+      - name: Check out the octocov config
         uses: actions/checkout@v7
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-          persist-credentials: false
-
-      # This job holds a write token, so the config that drives it must come
-      # from the base branch and never from the fork.
-      - name: Check out the trusted octocov config
-        uses: actions/checkout@v7
-        with:
-          path: .base
           sparse-checkout: .octocov.yml
           sparse-checkout-cone-mode: false
           persist-credentials: false
@@ -42,8 +35,6 @@ jobs:
         run: echo "number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
 
       - uses: k1LoW/octocov-action@v1
-        with:
-          config: .base/.octocov.yml
         env:
           # A workflow_run job looks like a push to the default branch. Point
           # octocov back at the pull request and at the run that produced it.

--- a/.github/workflows/coverage-on-pr.yml
+++ b/.github/workflows/coverage-on-pr.yml
@@ -24,15 +24,31 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
+      # Into a subdirectory. A pull_request run executes the fork's own copy of
+      # pipeline.yml, so every file in here is attacker-controlled.
       - uses: actions/download-artifact@v8
         with:
           name: octocov-pr
+          path: untrusted
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ github.token }}
 
-      - name: Read the pull request number
+      - name: Verify the artifact and take the coverage profile
         id: pr
-        run: echo "number=$(cat pr_number)" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          number=$(head -c 20 untrusted/pr_number | tr -d '[:space:]')
+          case "$number" in ''|*[!0-9]*)
+            echo "::error::artifact pr_number is not a number"; exit 1;;
+          esac
+          sha=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$number" --jq .head.sha)
+          if [ "$sha" != "$HEAD_SHA" ]; then
+            echo "::error::artifact claims PR #$number, but its head $sha is not $HEAD_SHA"; exit 1
+          fi
+          cp untrusted/coverage.out coverage.out
+          echo "number=$number" >> "$GITHUB_OUTPUT"
 
       - uses: k1LoW/octocov-action@v1
         env:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -193,8 +193,9 @@ jobs:
     needs: [go, go-plugins]
     permissions:
       contents: read
-      pull-requests: write
       actions: write
+    env:
+      COVERAGE_COMMENT: 'false'
     steps:
       - uses: actions/checkout@v7
 
@@ -211,6 +212,20 @@ jobs:
             octocov-*/coverage.out | sort >> coverage.out
 
       - uses: k1LoW/octocov-action@v1
+
+      - name: Save the PR number for the comment workflow
+        if: github.event_name == 'pull_request'
+        run: echo "${{ github.event.pull_request.number }}" > pr_number
+
+      - name: Upload the merged profile for the comment workflow
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: octocov-pr
+          path: |
+            coverage.out
+            pr_number
+          if-no-files-found: error
 
   go-windows:
     name: Test Go code (Windows)

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -8,6 +8,9 @@ coverage:
   paths:
     - coverage.out
 codeToTestRatio:
+  # Needs the pull request's own source, which the comment workflow must not
+  # check out: it holds a write token.
+  if: env.COVERAGE_COMMENT != 'true'
   code:
     - '**/*.go'
     - '!**/*_test.go'

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -23,7 +23,9 @@ diff:
   datastores:
     - artifact://${GITHUB_REPOSITORY}
 comment:
-  if: is_pull_request
+  # Only the 'Report coverage on PR' workflow sets this: a pull_request run from
+  # a fork gets a read-only token, so commenting from here 403s.
+  if: env.COVERAGE_COMMENT == 'true'
   updatePrevious: true
 summary:
   if: true


### PR DESCRIPTION
### Description
Coverage comments never appeared on pull requests from forks — which is most outside contributions. A `pull_request` run from a fork gets a read-only `GITHUB_TOKEN`, so octocov's comment call returned `403 Resource not accessible by integration`. It logs that and exits 0, so the job stayed green and the PR stayed silent. The `permissions:` block cannot grant what the token does not have. Latest example: #6063, where the job computed 70.0% and could only write it to the job summary.

The comment now comes from a `workflow_run` workflow, the same pattern `download-link-on-pr.yml` already uses. That workflow runs on the base repository and does get a write token, so it can comment on fork PRs. The pipeline job keeps the job summary and the default-branch baseline store, and hands the merged coverage profile plus the PR number to the new workflow as an artifact.

A `workflow_run` job otherwise looks like a push to the default branch, so octocov is pointed back at the pull request through its `OCTOCOV_`-prefixed environment overrides. Two of those matter: without `OCTOCOV_GITHUB_RUN_ID` the test execution time would be read from the wrong run, and without `OCTOCOV_GITHUB_REF` octocov would consider itself on the default branch and store a fork PR's coverage as the master baseline.

The comment job holds a write token, so it never checks out the pull request — only `.octocov.yml` from the base branch. The consequence is that the PR comment loses the **Code to Test Ratio** row, since that metric is computed by globbing the working tree and there is no safe tree to glob. Coverage, its delta against master, and test execution time all come from the uploaded profile and the pipeline run, so they are unaffected. The ratio is still computed on the pipeline job's summary and still recorded in the master baseline.

### Related Issues
Follow-up to #6061.

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): CI configuration

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [ ] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
GitHub only fires `workflow_run` from workflows that exist on the default branch, so **this cannot be exercised by this PR** — it starts working on the next PR opened after it merges.

What is verifiable now:

1. `actionlint .github/workflows/coverage-on-pr.yml .github/workflows/pipeline.yml` passes.
2. On this PR, the `Report coverage` job should still post its job summary and should no longer log the `403 Resource not accessible by integration` line, since it no longer attempts to comment.
3. Its run should now produce an `octocov-pr` artifact containing `coverage.out` and `pr_number`, and that artifact should not appear in the download-link comment.
4. After merge, open any PR (ideally one from a fork) and confirm a single coverage comment appears, showing coverage, the delta against master, and a non-zero test execution time.

The gating expression `env.COVERAGE_COMMENT == 'true'` was checked directly against octocov's expression engine: `true` comments, `false` skips, and unset skips without erroring.

### Additional Notes
Two `workflow_run` workflows now comment on the same PR. They cannot clobber each other: the download-link job matches its own comment by body prefix, and octocov's `updatePrevious` matches its own marker.

The new artifact is deliberately named `octocov-pr` so it keeps the `octocov-` prefix that `download-link-on-pr.yml` already filters out of the download list, while avoiding `octocov-report`, which is the name octocov itself uses for the baseline datastore.

The `Report coverage` check on a PR now reflects only the summary and the merge; the comment arrives from a separate workflow shortly after the pipeline completes, so it will land a little later than it did for same-repo branches before.

Unrelated to this PR: the first pipeline run here failed on `TestBufferedScrobblerTakesTheLongestServerDelayAcrossUsers` (`core/scrobbler/buffered_scrobbler_test.go:262`, "expected both users drained, got 1 attempts"). It passed on Windows in the same run, and this branch changes no Go code.
