### PR TITLE
fix(deezer): treat an exhausted quota as a throttle, not as a missing artist

### DIFF
--- a/adapters/deezer/client.go
+++ b/adapters/deezer/client.go
@@ -24,10 +24,6 @@ const authBaseURL = "https://auth.deezer.com"
 // and no rate-limit headers, so the body code is the only signal.
 const errCodeQuota = 4
 
-var (
-	errNotFound = errors.New("deezer: not found")
-)
-
 type deezerError struct {
 	Type    string `json:"type"`
 	Message string `json:"message"`
@@ -71,7 +67,7 @@ func (c *client) searchArtists(ctx context.Context, name string, limit int) ([]A
 	}
 
 	if len(results.Data) == 0 {
-		return nil, errNotFound
+		return nil, agents.ErrNotFound
 	}
 	return results.Data, nil
 }

--- a/adapters/deezer/client.go
+++ b/adapters/deezer/client.go
@@ -25,12 +25,13 @@ const authBaseURL = "https://auth.deezer.com"
 const errCodeQuota = 4
 
 var (
-	ErrNotFound = errors.New("deezer: not found")
+	errNotFound = errors.New("deezer: not found")
 )
 
 type deezerError struct {
-	Code    int
-	Message string
+	Type    string `json:"type"`
+	Message string `json:"message"`
+	Code    int    `json:"code"`
 }
 
 func (e *deezerError) Error() string {
@@ -70,7 +71,7 @@ func (c *client) searchArtists(ctx context.Context, name string, limit int) ([]A
 	}
 
 	if len(results.Data) == 0 {
-		return nil, ErrNotFound
+		return nil, errNotFound
 	}
 	return results.Data, nil
 }
@@ -102,17 +103,17 @@ func (c *client) makeRequest(req *http.Request, response any) error {
 
 // parseBodyError returns the error Deezer reported in the body, or nil when it reported none.
 func parseBodyError(data []byte) error {
-	var body Error
-	// Discarded: a payload that is not an error object leaves Code zero, which is the "no error" answer.
+	var body errorResponse
+	// Discarded: a payload that is not an error object leaves Error nil, which is the "none" answer.
 	_ = json.Unmarshal(data, &body)
-	if body.Error.Code == 0 {
+	switch {
+	case body.Error == nil:
 		return nil
+	case body.Error.Code == errCodeQuota:
+		return errors.Join(body.Error, agents.ErrRetryLater)
+	default:
+		return body.Error
 	}
-	err := error(&deezerError{Code: body.Error.Code, Message: body.Error.Message})
-	if body.Error.Code == errCodeQuota {
-		err = errors.Join(err, &agents.RetryLaterError{})
-	}
-	return err
 }
 
 func (c *client) getRelatedArtists(ctx context.Context, artistID int) ([]Artist, error) {

--- a/adapters/deezer/client.go
+++ b/adapters/deezer/client.go
@@ -13,15 +13,29 @@ import (
 	"strings"
 
 	"github.com/microcosm-cc/bluemonday"
+	"github.com/navidrome/navidrome/core/agents"
 	"github.com/navidrome/navidrome/log"
 )
 
 const apiBaseURL = "https://api.deezer.com"
 const authBaseURL = "https://auth.deezer.com"
 
+// errCodeQuota is Deezer's "Quota limit exceeded"; it arrives in the body, with HTTP 200
+// and no rate-limit headers, so the body code is the only signal.
+const errCodeQuota = 4
+
 var (
 	ErrNotFound = errors.New("deezer: not found")
 )
+
+type deezerError struct {
+	Code    int
+	Message string
+}
+
+func (e *deezerError) Error() string {
+	return fmt.Sprintf("deezer error(%d): %s", e.Code, e.Message)
+}
 
 type httpDoer interface {
 	Do(req *http.Request) (*http.Response, error)
@@ -74,20 +88,31 @@ func (c *client) makeRequest(req *http.Request, response any) error {
 		return err
 	}
 
+	// Checked before the status: a throttled request still answers 200, and decoding its body
+	// into a result type yields an empty one, which reads as "nothing found".
+	if err := parseBodyError(data); err != nil {
+		return err
+	}
 	if resp.StatusCode != 200 {
-		return c.parseError(data)
+		return fmt.Errorf("deezer http status: (%d)", resp.StatusCode)
 	}
 
 	return json.Unmarshal(data, response)
 }
 
-func (c *client) parseError(data []byte) error {
-	var deezerError Error
-	err := json.Unmarshal(data, &deezerError)
-	if err != nil {
-		return err
+// parseBodyError returns the error Deezer reported in the body, or nil when it reported none.
+func parseBodyError(data []byte) error {
+	var body Error
+	// Discarded: a payload that is not an error object leaves Code zero, which is the "no error" answer.
+	_ = json.Unmarshal(data, &body)
+	if body.Error.Code == 0 {
+		return nil
 	}
-	return fmt.Errorf("deezer error(%d): %s", deezerError.Error.Code, deezerError.Error.Message)
+	err := error(&deezerError{Code: body.Error.Code, Message: body.Error.Message})
+	if body.Error.Code == errCodeQuota {
+		err = errors.Join(err, &agents.RetryLaterError{})
+	}
+	return err
 }
 
 func (c *client) getRelatedArtists(ctx context.Context, artistID int) ([]Artist, error) {

--- a/adapters/deezer/client_test.go
+++ b/adapters/deezer/client_test.go
@@ -43,7 +43,7 @@ var _ = Describe("client", func() {
 			})
 
 			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
-			Expect(err).To(MatchError(ErrNotFound))
+			Expect(err).To(MatchError(errNotFound))
 		})
 
 		// Deezer answers 200 with no rate-limit headers when throttling, so this body is the only signal.
@@ -56,7 +56,7 @@ var _ = Describe("client", func() {
 
 			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
 			Expect(err).To(HaveOccurred())
-			Expect(err).ToNot(MatchError(ErrNotFound),
+			Expect(err).ToNot(MatchError(errNotFound),
 				"a throttled lookup would otherwise settle the artist as having no image")
 			Expect(errors.Is(err, agents.ErrRetryLater)).To(BeTrue())
 			Expect(err.Error()).To(ContainSubstring("Quota limit exceeded"))
@@ -71,7 +71,7 @@ var _ = Describe("client", func() {
 
 			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
 			Expect(err).To(HaveOccurred())
-			Expect(err).ToNot(MatchError(ErrNotFound))
+			Expect(err).ToNot(MatchError(errNotFound))
 			Expect(errors.Is(err, agents.ErrRetryLater)).To(BeFalse(),
 				"only a throttle asks the caller to come back later")
 		})

--- a/adapters/deezer/client_test.go
+++ b/adapters/deezer/client_test.go
@@ -2,12 +2,14 @@ package deezer
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
 	"time"
 
+	"github.com/navidrome/navidrome/core/agents"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -42,6 +44,36 @@ var _ = Describe("client", func() {
 
 			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
 			Expect(err).To(MatchError(ErrNotFound))
+		})
+
+		// Deezer answers 200 with no rate-limit headers when throttling, so this body is the only signal.
+		It("reports an exhausted quota as a retryable error, not as a missing artist", func() {
+			httpClient.mock("https://api.deezer.com/search/artist", http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"error":{"type":"Exception","message":"Quota limit exceeded","code":4}}`)),
+			})
+
+			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
+			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(MatchError(ErrNotFound),
+				"a throttled lookup would otherwise settle the artist as having no image")
+			Expect(errors.Is(err, agents.ErrRetryLater)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("Quota limit exceeded"))
+		})
+
+		It("reports a non-quota body error as a plain error", func() {
+			httpClient.mock("https://api.deezer.com/search/artist", http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"error":{"type":"Exception","message":"Invalid query","code":100}}`)),
+			})
+
+			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
+			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(MatchError(ErrNotFound))
+			Expect(errors.Is(err, agents.ErrRetryLater)).To(BeFalse(),
+				"only a throttle asks the caller to come back later")
 		})
 	})
 

--- a/adapters/deezer/client_test.go
+++ b/adapters/deezer/client_test.go
@@ -43,7 +43,7 @@ var _ = Describe("client", func() {
 			})
 
 			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
-			Expect(err).To(MatchError(errNotFound))
+			Expect(err).To(MatchError(agents.ErrNotFound))
 		})
 
 		// Deezer answers 200 with no rate-limit headers when throttling, so this body is the only signal.
@@ -56,7 +56,7 @@ var _ = Describe("client", func() {
 
 			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
 			Expect(err).To(HaveOccurred())
-			Expect(err).ToNot(MatchError(errNotFound),
+			Expect(err).ToNot(MatchError(agents.ErrNotFound),
 				"a throttled lookup would otherwise settle the artist as having no image")
 			Expect(errors.Is(err, agents.ErrRetryLater)).To(BeTrue())
 			Expect(err.Error()).To(ContainSubstring("Quota limit exceeded"))
@@ -71,7 +71,7 @@ var _ = Describe("client", func() {
 
 			_, err := client.searchArtists(GinkgoT().Context(), "Michael Jackson", 20)
 			Expect(err).To(HaveOccurred())
-			Expect(err).ToNot(MatchError(errNotFound))
+			Expect(err).ToNot(MatchError(agents.ErrNotFound))
 			Expect(errors.Is(err, agents.ErrRetryLater)).To(BeFalse(),
 				"only a throttle asks the caller to come back later")
 		})

--- a/adapters/deezer/deezer.go
+++ b/adapters/deezer/deezer.go
@@ -91,9 +91,6 @@ func isPlaceholderPicture(url string) bool {
 
 func (s *deezerAgent) searchArtist(ctx context.Context, name string) (*Artist, error) {
 	artists, err := s.client.searchArtists(ctx, name, deezerArtistSearchLimit)
-	if errors.Is(err, errNotFound) {
-		return nil, agents.ErrNotFound
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/deezer/deezer.go
+++ b/adapters/deezer/deezer.go
@@ -91,15 +91,11 @@ func isPlaceholderPicture(url string) bool {
 
 func (s *deezerAgent) searchArtist(ctx context.Context, name string) (*Artist, error) {
 	artists, err := s.client.searchArtists(ctx, name, deezerArtistSearchLimit)
-	switch {
-	case errors.Is(err, ErrNotFound):
+	if errors.Is(err, errNotFound) {
 		return nil, agents.ErrNotFound
-	// Ordered before the empty-result check: a failed search also returns no artists, and
-	// reporting that as not-found would settle the artist as having no image.
-	case err != nil:
+	}
+	if err != nil {
 		return nil, err
-	case len(artists) == 0:
-		return nil, agents.ErrNotFound
 	}
 
 	log.Trace(ctx, "Artists found", "count", len(artists), "searched_name", name)

--- a/adapters/deezer/deezer.go
+++ b/adapters/deezer/deezer.go
@@ -91,11 +91,15 @@ func isPlaceholderPicture(url string) bool {
 
 func (s *deezerAgent) searchArtist(ctx context.Context, name string) (*Artist, error) {
 	artists, err := s.client.searchArtists(ctx, name, deezerArtistSearchLimit)
-	if errors.Is(err, ErrNotFound) || len(artists) == 0 {
+	switch {
+	case errors.Is(err, ErrNotFound):
 		return nil, agents.ErrNotFound
-	}
-	if err != nil {
+	// Ordered before the empty-result check: a failed search also returns no artists, and
+	// reporting that as not-found would settle the artist as having no image.
+	case err != nil:
 		return nil, err
+	case len(artists) == 0:
+		return nil, agents.ErrNotFound
 	}
 
 	log.Trace(ctx, "Artists found", "count", len(artists), "searched_name", name)

--- a/adapters/deezer/deezer_test.go
+++ b/adapters/deezer/deezer_test.go
@@ -3,6 +3,7 @@ package deezer
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,6 +79,22 @@ var _ = Describe("deezerAgent", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(artist.ID).To(Equal(2))
+		})
+
+		// The artwork worker settles an artist as "no image" on agents.ErrNotFound, so a throttled
+		// lookup reaching that here would record a permanent absence.
+		It("surfaces an exhausted quota instead of reporting the artist as not found", func() {
+			httpClient.mock("https://api.deezer.com/search/artist", http.Response{
+				StatusCode: 200,
+				Body: io.NopCloser(bytes.NewBufferString(
+					`{"error":{"type":"Exception","message":"Quota limit exceeded","code":4}}`)),
+			})
+
+			_, err := agent.searchArtist(ctx, "Queen")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(MatchError(agents.ErrNotFound))
+			Expect(errors.Is(err, agents.ErrRetryLater)).To(BeTrue())
 		})
 
 		It("returns ErrNotFound when no result matches the name exactly", func() {

--- a/adapters/deezer/responses.go
+++ b/adapters/deezer/responses.go
@@ -22,12 +22,8 @@ type Artist struct {
 	Type          string `json:"type"`
 }
 
-type Error struct {
-	Error struct {
-		Type    string `json:"type"`
-		Message string `json:"message"`
-		Code    int    `json:"code"`
-	} `json:"error"`
+type errorResponse struct {
+	Error *deezerError `json:"error"`
 }
 
 type RelatedArtists struct {

--- a/adapters/deezer/responses_test.go
+++ b/adapters/deezer/responses_test.go
@@ -26,7 +26,7 @@ var _ = Describe("Responses", func() {
 
 	Describe("Error", func() {
 		It("parses the error response correctly", func() {
-			var errorResp Error
+			var errorResp errorResponse
 			body := []byte(`{"error":{"type":"MissingParameterException","message":"Missing parameters: q","code":501}}`)
 			err := json.Unmarshal(body, &errorResp)
 			Expect(err).To(BeNil())

--- a/core/scrobbler/buffered_scrobbler_test.go
+++ b/core/scrobbler/buffered_scrobbler_test.go
@@ -251,12 +251,13 @@ func TestBufferedScrobblerTakesTheLongestServerDelayAcrossUsers(t *testing.T) {
 			"user1": 10 * time.Second,
 			"user2": 45 * time.Second,
 		}}
+		// Both are buffered before the drain goroutine exists: it drains once on startup, and
+		// seeing only one user there would park it on that user's delay, ignoring the other.
+		_ = buffer.Enqueue("test", "user1", "1", time.Now())
+		_ = buffer.Enqueue("test", "user2", "2", time.Now())
 		bs := newBufferedScrobbler(ds, scr, "test")
 		defer bs.Stop()
 
-		// user2 is enqueued directly so both are buffered before the first drain wakes.
-		_ = buffer.Enqueue("test", "user2", "2", time.Now())
-		_ = bs.Scrobble(context.Background(), "user1", Scrobble{MediaFile: model.MediaFile{ID: "1"}, TimeStamp: time.Now()})
 		synctest.Wait()
 		if got := scr.count.Load(); got != 2 {
 			t.Fatalf("expected both users drained, got %d attempts", got)


### PR DESCRIPTION
### Description

Deezer reports quota exhaustion **in the response body, with HTTP 200 and no rate-limit headers**. The client only parsed errors when the status was *not* 200, so a throttled reply fell through to `json.Unmarshal` into a result type, produced an empty one, and `len(results.Data) == 0` turned it into `ErrNotFound`.

The agent compounded it. `searchArtist` tested `errors.Is(err, ErrNotFound) || len(artists) == 0` *before* testing `err`, and a failed search also returns no artists — so any real error was reported as not-found as well.

That matters because the artwork worker settles an entity as "no image" on `agents.ErrNotFound`. Being throttled did not make Navidrome back off. It made it record the artist as having no artwork and move on to do the same to the next one, converting a temporary rate limit into stored state.

This parses errors out of the body regardless of status, and joins the quota code with `agents.RetryLaterError` so the artwork circuit breaker and retry budget see a throttle for what it is. The agent now checks `err` before the empty-result case.

Last.fm already handles this exact shape — `adapters/lastfm/client.go` has `errCodeRateLimit` with a comment noting the 200-with-body-error pattern. This brings Deezer in line with it, including the zero-delay `RetryLaterError`, so both providers share the default cooldown rather than each carrying its own number.

I measured the live API to pin the shape rather than guess it. A 120-request burst returned 54 results and 66 quota replies, every one HTTP 200 with `{"error":{"type":"Exception","message":"Quota limit exceeded","code":4}}` and no `Retry-After` or rate-limit headers. A single request 5s later succeeded, so the window is short and a cooldown clears it.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

The unit tests use the exact body captured from the live API, at both layers that were dropping it:

- `adapters/deezer/client_test.go` — a quota body yields a retryable error, not `ErrNotFound`; a non-quota body error yields a plain error; `{"data":[],"total":0}` still yields `ErrNotFound`.
- `adapters/deezer/deezer_test.go` — the same body survives `searchArtist` instead of becoming `agents.ErrNotFound`.

`go test ./adapters/deezer/...`

I verified both tests bite by sabotaging each fix in turn, keeping the build compiling: setting `errCodeQuota` to a value Deezer never sends fails both quota specs, and restoring the old `errors.Is(err, ErrNotFound) || len(artists) == 0` ordering fails the agent-level spec specifically — which is the one the client-level test alone would not catch.

To see it end to end against the real API, burst more than ~50 requests at `https://api.deezer.com/search/artist` within 5 seconds from one IP.

### Additional Notes

**Why the `RetryLaterError` carries no delay.** The measured window is ~5s, but supplying an explicit `RetryIn` opens the artwork breaker for exactly that long (`core/artwork/gate.go`), which would be *more* permissive than the default cooldown. Matching Last.fm's zero-delay form is both more conservative and one less per-provider constant.

**Scope.** Only the search path is covered here. Other Deezer endpoints route through the same `makeRequest`, so they get the body-error parsing too, but I have not audited every caller for the same `len(x) == 0` ordering bug — `searchArtist` was the one on the artwork path.

**Sequencing.** This is worth landing before #6054. Today a quota reply is undone by the 30-day stale-absent recheck; #6054 removes that recheck, at which point the misclassification becomes permanent. Fixing it first means "absent" genuinely means absent by the time the retries go away.


**Unrelated flake fixed here (last commit).** `TestBufferedScrobblerTakesTheLongestServerDelayAcrossUsers` was failing CI on this branch and had already failed on an unrelated branch earlier the same day. It is a test bug, not a product bug: `run()` drains once before it waits on the wake signal, so the startup drain could land between the test's two enqueues, see only `user2`, take its 45s delay and set `backingOff` — after which the second enqueue's wake is deliberately ignored, so `user1` was never attempted. Buffering both users before the goroutine starts removes the window. I reproduced it deterministically by forcing that interleaving with a `synctest.Wait` and got CI's exact message; with the fix, the same forced drain passes. Kept as its own commit so it can be dropped or cherry-picked independently.
