### PR TITLE
ci: exclude tests/ from the coverage report on pull requests too

### DIFF
--- a/.octocov.yml
+++ b/.octocov.yml
@@ -8,8 +8,10 @@ coverage:
   paths:
     - coverage.out
   # Not code under test: tests/ holds the mocks and helpers, *_gen.go is generated.
+  # Both patterns need the '**/' prefix: the comment workflow has no source tree,
+  # so octocov cannot shorten the profile's import paths to repo-relative ones.
   exclude:
-    - 'tests/**'
+    - '**/tests/**'
     - '**/*_gen.go'
 codeToTestRatio:
   # Needs the pull request's own source, which the comment workflow must not


### PR DESCRIPTION
### Description

The `tests/**` exclusion added in b77fb45 only took effect on `master`. Every PR since has reported roughly -3.7% coverage against the base, and the drop has nothing to do with the PR's own changes.

Go coverage profiles name files by import path. octocov shortens those to repo-relative paths using the checked-out source tree — but `coverage-on-pr.yml` deliberately sparse-checks-out only `.octocov.yml`, because that job holds a write token and must never check out a fork. With no source tree present, the paths stay as `github.com/navidrome/navidrome/tests/mock_*.go`, and `tests/**` never matches.

`**/*_gen.go` matched in both contexts, since its leading `**/` absorbs the module prefix. That is why exactly the 30 `tests/` files leaked into the PR side and the 16 `*_gen.go` files did not.

Prefixing the pattern makes it match either path form.

### Evidence

| | base (`master`) | head (PR) |
|---|---|---|
| #6002 | 447 files, 75.9% | 477 files, 72.3% |
| #6069 | 447 files, 75.9% | 480 files, 72.2% |

493 files with no exclusions at all. The base side drops 46 (30 `tests/` + 16 `*_gen.go`); the PR side drops only 16.

Verified the pattern against `bmatcuk/doublestar/v4` (what octocov uses) for both path forms:

```
tests/**      tests/mock_album_repo.go                                 true
tests/**      github.com/navidrome/navidrome/tests/mock_album_repo.go  false
**/tests/**   tests/mock_album_repo.go                                 true
**/tests/**   github.com/navidrome/navidrome/tests/mock_album_repo.go  true
**/tests/**   conf/configuration.go                                    false
```

`tests/` at the repo root is the only directory by that name, so the looser pattern does not over-match.

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### How to Test

The coverage comment on this PR should report the same file count on both sides.