### PR TITLE
fix(subsonic): update the playlist changed timestamp when renaming a smart playlist

### DIFF
--- a/persistence/playlist_repository.go
+++ b/persistence/playlist_repository.go
@@ -316,11 +316,12 @@ func (r *playlistRepository) refreshCounters(pls *model.Playlist) error {
 	}
 
 	// Update playlist's total duration, size and count
+	now := time.Now()
 	upd := Update("playlist").
 		Set("duration", res.Duration).
 		Set("size", res.Size).
 		Set("song_count", res.Count).
-		Set("updated_at", time.Now()).
+		Set("updated_at", now).
 		Where(Eq{"id": pls.ID})
 	_, err = r.executeSQL(upd)
 	if err != nil {
@@ -329,6 +330,7 @@ func (r *playlistRepository) refreshCounters(pls *model.Playlist) error {
 	pls.SongCount = int(res.Count)
 	pls.Duration = res.Duration
 	pls.Size = int64(res.Size)
+	pls.UpdatedAt = now
 	return nil
 }
 

--- a/persistence/smart_playlist_repository.go
+++ b/persistence/smart_playlist_repository.go
@@ -58,7 +58,8 @@ func (r *playlistRepository) refreshSmartPlaylist(pls *model.Playlist) bool {
 		return false
 	}
 
-	now := time.Now()
+	// Reuse the stamp refreshCounters just wrote, so evaluated_at and updated_at agree
+	now := pls.UpdatedAt
 	updSql := Update(r.tableName).Set("evaluated_at", now).Where(Eq{"id": pls.ID})
 	if _, err = r.executeSQL(updSql); err != nil {
 		log.Error(r.ctx, "Error updating smart playlist", "playlist", pls.Name, "id", pls.ID, err)

--- a/persistence/smart_playlist_repository_test.go
+++ b/persistence/smart_playlist_repository_test.go
@@ -45,6 +45,23 @@ var _ = Describe("PlaylistRepository - Smart Playlists", func() {
 			})
 		})
 
+		Context("after an evaluation", func() {
+			It("stamps updated_at and evaluated_at with the same instant", func() {
+				newPls := model.Playlist{Name: "Evaluated", OwnerID: "userid", Rules: rules}
+				Expect(repo.Put(&newPls)).To(Succeed())
+				DeferCleanup(func() { _ = repo.Delete(newPls.ID) })
+
+				refreshed, err := repo.GetWithTracks(newPls.ID, true, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				stored, err := repo.Get(newPls.ID)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(stored.EvaluatedAt).ToNot(BeNil())
+				Expect(stored.UpdatedAt).To(BeTemporally("==", *stored.EvaluatedAt))
+				Expect(refreshed.UpdatedAt).To(BeTemporally("==", stored.UpdatedAt))
+			})
+		})
+
 		Context("invalid rules", func() {
 			It("fails to Put it in the DB", func() {
 				rules = &criteria.Criteria{

--- a/server/subsonic/playlists.go
+++ b/server/subsonic/playlists.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/log"
@@ -133,15 +132,7 @@ func (api *Router) buildPlaylist(ctx context.Context, p model.Playlist) response
 	pls.SongCount = int32(p.SongCount)
 	pls.Duration = int32(p.Duration)
 	pls.Created = p.CreatedAt
-	if p.IsSmartPlaylist() {
-		if p.EvaluatedAt != nil {
-			pls.Changed = *p.EvaluatedAt
-		} else {
-			pls.Changed = time.Now()
-		}
-	} else {
-		pls.Changed = p.UpdatedAt
-	}
+	pls.Changed = p.UpdatedAt
 
 	player, ok := request.PlayerFrom(ctx)
 	if ok && isClientInList(conf.Server.Subsonic.MinimalClients, player.Client) {

--- a/server/subsonic/playlists_test.go
+++ b/server/subsonic/playlists_test.go
@@ -220,7 +220,7 @@ var _ = Describe("buildPlaylist", func() {
 				Expect(result.SongCount).To(Equal(int32(10)))
 				Expect(result.Duration).To(Equal(int32(600)))
 				Expect(result.Created).To(Equal(playlist.CreatedAt))
-				Expect(result.Changed).To(Equal(evaluatedAt))
+				Expect(result.Changed).To(Equal(playlist.UpdatedAt))
 
 				// These should not be set
 				Expect(result.Comment).To(BeEmpty())
@@ -245,7 +245,7 @@ var _ = Describe("buildPlaylist", func() {
 				Expect(result.SongCount).To(Equal(int32(10)))
 				Expect(result.Duration).To(Equal(int32(600)))
 				Expect(result.Created).To(Equal(playlist.CreatedAt))
-				Expect(result.Changed).To(Equal(*playlist.EvaluatedAt))
+				Expect(result.Changed).To(Equal(playlist.UpdatedAt))
 				Expect(result.Comment).To(Equal("Test comment"))
 				Expect(result.Owner).To(Equal("admin"))
 				Expect(result.Public).To(BeTrue())
@@ -268,6 +268,21 @@ var _ = Describe("buildPlaylist", func() {
 				Expect(result.Owner).To(Equal("admin"))
 				Expect(result.Public).To(BeTrue())
 				Expect(result.OpenSubsonicPlaylist).To(BeNil())
+			})
+		})
+
+		Context("when it was never evaluated", func() {
+			BeforeEach(func() {
+				playlist.EvaluatedAt = nil
+				player := model.Player{Client: "regular-client"}
+				ctx = request.WithPlayer(ctx, player)
+			})
+
+			It("omits validUntil but still reports changed", func() {
+				result := router.buildPlaylist(ctx, playlist)
+
+				Expect(result.ValidUntil).To(BeNil())
+				Expect(result.Changed).To(Equal(playlist.UpdatedAt))
 			})
 		})
 


### PR DESCRIPTION
### Description
For smart playlists, `buildPlaylist` reported `evaluated_at` as the Subsonic `changed` timestamp. Renaming one, or editing its comment, did not move `changed`. Clients that use `changed` to detect edits saw nothing until the next evaluation. A smart playlist that had never been evaluated was worse: it reported `time.Now()` on every call, so `changed` never settled.

This reports `updated_at` for every playlist and drops the smart-playlist branch. To keep the two stamps aligned, `refreshCounters` now writes its timestamp back onto the model, and `refreshSmartPlaylist` reuses it for `evaluated_at`. So `changed` still equals the evaluation time right after an evaluation, and `validUntil` stays anchored to that same instant.

Regular playlists already behaved correctly. Original Subsonic bumps `changed` on any playlist update, so this matches upstream too.

### Related Issues
<!-- none -->

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
Create a smart playlist through the native API, then rename it over Subsonic and watch `changed`:

```bash
A="u=admin&p=admin&v=1.16.1&c=test&f=json"
B="http://localhost:4533/rest"
TOKEN=$(curl -s -X POST http://localhost:4533/auth/login -H 'Content-Type: application/json' \
  -d '{"username":"admin","password":"admin"}' | jq -r .token)

SID=$(curl -s -X POST http://localhost:4533/api/playlist -H "X-ND-Authorization: Bearer $TOKEN" \
  -H 'Content-Type: application/json' \
  -d '{"name":"smart1","rules":{"all":[{"gt":{"playCount":0}}]}}' | jq -r .id)

curl -s "$B/getPlaylist?$A&id=$SID" | jq -c '.["subsonic-response"].playlist | {name,changed,validUntil}'
sleep 2
curl -s "$B/updatePlaylist?$A&playlistId=$SID&name=renamed" > /dev/null
curl -s "$B/getPlaylist?$A&id=$SID" | jq -c '.["subsonic-response"].playlist | {name,changed,validUntil}'
```

`changed` moves after the rename. `validUntil` does not, because the cached track set is still valid. On master, `changed` does not move. Repeat with a regular playlist to confirm it is unaffected.

### Additional Notes
`validUntil` still derives from `evaluated_at`, which is correct. That field is genuinely about evaluation, and a rename does not invalidate the cached tracks.

The `pls.UpdatedAt` sync in `refreshCounters` matters beyond the timestamp alignment: after an evaluation, `GetWithTracks` returns the in-memory playlist, so without the sync the response would carry the `updated_at` read before the refresh.

One behavior change worth flagging. A never-evaluated smart playlist now reports its creation time instead of the current time. That is the point of the fix, but any client caching on `changed` will see one value shift on upgrade.
