### PR TITLE
fix(jellyfin): emit TranscodingUrl without the /jellyfin base path

### DIFF
--- a/server/jellyfin/e2e/streaming_test.go
+++ b/server/jellyfin/e2e/streaming_test.go
@@ -113,14 +113,12 @@ var _ = Describe("Streaming", func() {
 			var info dto.PlaybackInfoResponse
 			parseInto(get("/Items/"+enc(id)+"/PlaybackInfo"), &info)
 			streamURL := info.MediaSources[0].TranscodingUrl
-			// The URL includes the /jellyfin mount prefix so a client resolving it as an absolute
-			// host path hits the mounted router.
-			Expect(streamURL).To(HavePrefix(consts.URLPathJellyfinAPI + "/Audio/" + enc(id) + "/universal"))
+			// Server-relative: clients append it to a base URL already carrying /jellyfin.
+			Expect(streamURL).To(HavePrefix("/Audio/" + enc(id) + "/universal"))
+			Expect(streamURL).ToNot(HavePrefix(consts.URLPathJellyfinAPI))
 			Expect(streamURL).To(ContainSubstring("api_key="))
-			// The embedded api_key alone must authenticate the stream — no auth header sent. The e2e
-			// router is mounted at the root, so strip the /jellyfin prefix before replaying.
-			replayURL := strings.TrimPrefix(streamURL, consts.URLPathJellyfinAPI)
-			w := rawReq("GET", replayURL, "")
+			// The embedded api_key alone must authenticate the stream — no auth header sent.
+			w := rawReq("GET", streamURL, "")
 			Expect(w.Code).To(Equal(http.StatusOK))
 			Expect(streamerSpy.LastMediaFile.ID).To(Equal(id))
 		})

--- a/server/jellyfin/stream.go
+++ b/server/jellyfin/stream.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi/v5"
-	"github.com/navidrome/navidrome/consts"
 	"github.com/navidrome/navidrome/log"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/model/request"
@@ -57,13 +56,11 @@ func (api *Router) getPlaybackInfo(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 	}
-	// Embed the caller's token in the stream URL: Jellify's native player fetches TranscodingUrl
-	// verbatim without an auth header, so a non-self-authenticating URL would 401. Direct-play clients
-	// (Finamp) build their own /File?ApiKey URL and ignore this. Include the /jellyfin mount prefix so
-	// a client resolving it as an absolute host path still hits the mounted router.
+	// Self-authenticating: native players fetch this without an auth header. Server-relative:
+	// clients append it to a base URL already carrying /jellyfin.
 	if token := tokenFromRequest(r); token != "" {
 		src.TranscodingSubProtocol = "http"
-		src.TranscodingUrl = consts.URLPathJellyfinAPI + "/Audio/" + src.Id + "/universal?static=true&api_key=" + url.QueryEscape(token)
+		src.TranscodingUrl = "/Audio/" + src.Id + "/universal?static=true&api_key=" + url.QueryEscape(token)
 	}
 	api.ok(w, r, dto.PlaybackInfoResponse{MediaSources: []dto.MediaSourceInfo{src}, PlaySessionId: dto.EncodeID(mf.ID)})
 }


### PR DESCRIPTION
### Description

`PlaybackInfo` returned a `TranscodingUrl` prefixed with the `/jellyfin` mount path. Clients concatenate that value onto a server base URL that already carries the prefix, so the resulting request was `/jellyfin/jellyfin/Audio/{id}/universal` and returned 404 — playback never started.

Real Jellyfin emits this field server-relative: `MediaInfoHelper` calls `StreamInfo.ToUrl` with a nil `baseUrl`, and the network-config base path is never applied on that path. Every client that consumes the field re-prefixes its own configured server URL — Jellify, jellyfin-web (`apiClient.getUrl`), jellyfin-vue and Streamyfin all do plain concatenation. This change emits the path server-relative to match.

Finamp is unaffected: it builds its own stream URLs from the stored base URL and never reads `TranscodingUrl` (on either `main` or `redesign` the field appears only in its generated DTO serializers).

### Related Issues

None.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Run a server with the Jellyfin API enabled and a music library:

```
ND_JELLYFIN_ENABLED=true ND_PORT=4599 ND_MUSICFOLDER=./music ./navidrome
```

Authenticate against `http://localhost:4599/jellyfin/Users/AuthenticateByName`, then `POST /jellyfin/Items/{id}/PlaybackInfo`. The returned `MediaSources[0].TranscodingUrl` should start with `/Audio/{id}/universal` and must not start with `/jellyfin`.

Concatenate it onto the base URL exactly as a client does (`http://localhost:4599/jellyfin` + the returned value) and fetch it — it should return 200 with `Content-Type: audio/*` and real audio bytes. Before this change the same request returned 404.

Regression check for Finamp's own URLs, which should all still return 200: `/jellyfin/Audio/{id}/main.m3u8?ApiKey=…`, `/jellyfin/Items/{id}/File?ApiKey=…`, `/jellyfin/Audio/{id}/stream.aac?api_key=…`.

The e2e spec in `server/jellyfin/e2e/streaming_test.go` covers the URL shape and replays the emitted URL to confirm the embedded `api_key` still authenticates the stream on its own.

### Additional Notes

Verified end-to-end against a local server: Jellify's exact URL construction now yields 200 and a playable MP3, and all of Finamp's stream endpoints still return 200.

One client is knowingly not helped by this: jellyfin-expo resolves the field with `new URL(transcodingUrl, basePath)`, which discards the base path. That is a pre-existing bug on their side — it breaks against real Jellyfin behind a base path too — and keeping our prefix to work around it would break every other client.
