### PR TITLE
fix(jellyfin): add the /Items/Latest route, and scope it by ParentId

### DIFF
--- a/server/jellyfin/api.go
+++ b/server/jellyfin/api.go
@@ -118,6 +118,7 @@ func (api *Router) routes() http.Handler {
 			r.Use(throttleStreams(conf.Server.Jellyfin.MaxConcurrentStreams))
 			r.Get("/items", api.getItems)
 			r.Get("/users/{userId}/items", api.getItems)
+			r.Get("/items/latest", api.getLatest)
 			r.Get("/users/{userId}/items/latest", api.getLatest)
 			r.Get("/artists", api.getArtists)
 			r.Get("/artists/albumartists", api.getAlbumArtists)

--- a/server/jellyfin/e2e/browsing_test.go
+++ b/server/jellyfin/e2e/browsing_test.go
@@ -563,6 +563,43 @@ var _ = Describe("Browsing", func() {
 		})
 	})
 
+	Describe("GET /Items/Latest", func() {
+		// Jellyfin marks the /Users/{userId} form obsolete and hides it from the OpenAPI spec, so
+		// SDK-generated clients (Jellify) only ever call this one.
+		It("serves the same response as the legacy /Users/{userId} route", func() {
+			Expect(get("/Items/Latest?Limit=3").Body.String()).
+				To(Equal(get("/Users/admin-1/Items/Latest?Limit=3").Body.String()))
+		})
+
+		It("scopes to ParentId when it names a library", func() {
+			var items []dto.BaseItemDto
+			parseInto(get("/Items/Latest?ParentId="+dto.EncodeLibraryID(1)), &items)
+			Expect(names(items)).To(ConsistOf("Abbey Road", "Help!", "IV", "Kind of Blue", "Singles"))
+		})
+
+		It("scopes to ParentId when it names an artist", func() {
+			var items []dto.BaseItemDto
+			parseInto(get("/Items/Latest?ParentId="+enc(artistID("The Beatles"))), &items)
+			Expect(names(items)).To(ConsistOf("Abbey Road", "Help!"))
+		})
+
+		It("returns nothing for a library the user cannot access", func() {
+			var items []dto.BaseItemDto
+			parseInto(get("/Items/Latest?ParentId="+dto.EncodeLibraryID(99)), &items)
+			Expect(items).To(BeEmpty())
+		})
+
+		It("returns nothing for an id that is neither a library nor an artist", func() {
+			var items []dto.BaseItemDto
+			parseInto(get("/Items/Latest?ParentId="+enc(testID("does-not-exist"))), &items)
+			Expect(items).To(BeEmpty())
+		})
+
+		It("404s a malformed ParentId, like every other filtered endpoint", func() {
+			Expect(get("/Items/Latest?ParentId=not-a-valid-id").Code).To(Equal(http.StatusNotFound))
+		})
+	})
+
 	Describe("GET /Artists and /Genres", func() {
 		It("lists album artists only on /Artists/AlbumArtists (excludes performer-only artists)", func() {
 			names := names(queryResult(get("/Artists/AlbumArtists")).Items)

--- a/server/jellyfin/items.go
+++ b/server/jellyfin/items.go
@@ -938,7 +938,18 @@ func (api *Router) getLatest(w http.ResponseWriter, r *http.Request) {
 	fields := dto.ParseFields(p.Strings("fields")...)
 	opts := filter.AlbumsByNewest()
 	opts.Max = p.IntOr("limit", 20)
-	opts = filter.ApplyLibraryFilter(opts, accessibleLibraryIDs(ctx))
+	parentID, ok := decodeFilterParam(p.StringOr("parentid", ""))
+	if !ok {
+		http.Error(w, "Not Found", http.StatusNotFound)
+		return
+	}
+	// A ParentId naming neither a library nor an artist (a stale id, an album) narrows to nothing
+	// rather than widening back to every library.
+	scopeIDs, isLibrary := resolveLibraryScope(ctx, parentID)
+	if parentID != "" && !isLibrary {
+		opts.Filters = squirrel.And{opts.Filters, filter.AlbumsByArtistID(parentID).Filters}
+	}
+	opts = filter.ApplyLibraryFilter(opts, scopeIDs)
 	repo := api.ds.Album(ctx)
 	open := streamCursor(func() (func(func(model.Album, error) bool), error) {
 		return repo.GetCursor(opts)


### PR DESCRIPTION
### Description

Jellify's Discover tab calls `GET /Items/Latest`. We returned 404. The only route we had was `/Users/{userId}/Items/Latest`, which Jellyfin marks `[Obsolete]` and hides from its OpenAPI spec, so generated clients never call it. This adds the current route next to the old one, both on the same handler.

`getLatest` also ignored `ParentId` and always returned the newest albums across every library the user can see. It now scopes to the library when `ParentId` names one, and otherwise filters to that artist's albums. An id that matches no artist returns an empty array.

Returning albums only matches Jellyfin `master`, whose music path returns `MusicAlbum` rows and ignores `IncludeItemTypes`.

### Related Issues

None.

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

With the Jellyfin API enabled, authenticate, take a library id from `GET /jellyfin/UserViews`, then send what Jellify sends:

```
GET /jellyfin/Items/Latest?parentId=<libraryId>&includeItemTypes=Audio&includeItemTypes=MusicAlbum&limit=50
```

Expect 200 and a top-level JSON array of `MusicAlbum` entries, newest `DateCreated` first. It was 404 before. An artist id returns that artist's albums. An unknown id, an album id, or a library the user cannot reach returns `[]`.

### Additional Notes

Real Jellyfin takes any folder as `ParentId` and ignores an id it cannot resolve, falling back to the whole library. We return `[]` instead. Handing back someone's entire library because an id went stale is the worse failure.
