### PR TITLE
test(scanner): fix Windows flake in the quick-scan artist image spec

### DIFF
--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -387,6 +387,11 @@ var _ = Describe("Scanner", Ordered, func() {
 			files := fsys.MapFS
 			files["Kraftwerk/Autobahn/01 - Autobahn.mp3"] = kraftwerk(track(1, "Autobahn"))
 			fsys.SetFiles(files)
+			// Backdate the previous scan so this one's new artists are unambiguously newer:
+			// RefreshStats picks touched artists with a strict artist.updated_at >
+			// library.last_scan_at, and Windows' coarse clock can put both in one tick.
+			_, err := db.Db().ExecContext(ctx, "UPDATE library SET last_scan_at = ?", time.Now().Add(-time.Hour))
+			Expect(err).ToNot(HaveOccurred())
 			Expect(runScanner(ctx, false)).To(Succeed())
 			resolveQueuedArtwork()
 


### PR DESCRIPTION
### Description

The scanner spec "enqueues the artist when an image lands in a folder first seen by a quick scan" fails intermittently on the Windows CI job. It failed on master in run 34007786228 on a commit whose Windows job had passed minutes earlier on its own PR.

The symptom is misleading. The assertion that fails is inside the `artistID("Kraftwerk")` helper, which finds zero artists, so it looks like the scan never imported the file. It did. The artist row is created and still exists; it is just unreachable.

`RefreshStats` selects touched artists with a strict `artist.updated_at > (SELECT last_scan_at FROM library ...)` (`persistence/artist_repository.go:466`). Windows' wall clock has ~15.6 ms granularity, so an artist first written by a quick scan can land in the same tick as the previous scan's `last_scan_at` and be excluded. Its `library_artist.stats` then stays at the `'{}'` column default, the cleanup `DELETE FROM library_artist WHERE stats = '{}'` removes the row, and `selectArtist`'s INNER JOIN on `library_artist` hides the artist from `GetAll`.

It needs a *partial* tie, which is why it is rare: Kraftwerk must tie with `last_scan_at` while another artist written by the same scan lands in the next tick, so the touched set is non-empty and the code does not take the early return that would skip the cleanup.

The fix backdates `last_scan_at` before the scan so the comparison is unambiguous. This is the same fix already applied to the "repopulates a stale search_normalized on a full rescan" spec a few lines below.

### Related Issues

None.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [x] Other (please describe): test-only fix for a CI flake

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

No new test: the change makes an existing test deterministic. See below for how the failure was reproduced.

### How to Test

`make test PKG=./scanner/` passes, as does the full suite.

Reproducing the original flake needs a coarse clock, since it cannot be triggered on macOS or Linux. It was reproduced by rebuilding the Go toolchain with `runtime/timestub.go` patched to quantize both the wall and monotonic values from `time.Now()` to Windows' 15.625 ms granularity. That is faithful to the platform: Go's Windows `nanotime1`/`walltime1` read `_INTERRUPT_TIME`/`_SYSTEM_TIME`, so both clocks are coarse there.

Under that toolchain, the unmodified spec failed **1 time in 100 runs** with the identical `to have length 1` signature. With this change, **0 failures in 300 runs**. Database state captured from a natural failure showed Kraftwerk with `updated_at` exactly equal to `library.last_scan_at`, `stats=NULL` and `missing=true`, while `[Unknown Artist]`, written ~230 µs later in the same loop, fell in the next tick and kept its stats.

### Additional Notes

Backdating only widens `GetTouchedAlbums`' `album.imported_at > library.last_scan_at`, which phase 3's `filterUnmodified` absorbs, so there is no side effect on the rest of the suite.

**This same tie is reachable in production on Windows**, and that is not fixed here. An artist first imported by a quick scan in the same tick as the previous scan's `last_scan_at` loses its `library_artist` row to the unscoped cleanup and is then marked missing, disappearing from the UI until the next full scan. Two independent hardenings would close it: make the comparison at `artist_repository.go:466` `>=`, and scope the cleanup at `:582` to the current batch rather than the whole table. Both are worth their own PR, with their own tests.
