### PR TITLE
docs: fix broken links in Jellyfin and plugin documentation

### DIFF
--- a/plugins/examples/README.md
+++ b/plugins/examples/README.md
@@ -108,7 +108,7 @@ Generate boilerplate from a schema:
 # Install XTP: https://docs.xtp.dylibso.com/docs/cli
 
 xtp plugin init \
-  --schema-file ../schemas/metadata_agent.yaml \
+  --schema-file ../capabilities/metadata_agent.yaml \
   --template go \
   --path ./my-plugin \
   --name my-plugin
@@ -119,7 +119,7 @@ xtp plugin build
 zip -j my-plugin.ndp manifest.json dist/plugin.wasm
 ```
 
-Available schemas in [../schemas/](../schemas/):
+Available schemas in [../capabilities/](../capabilities/):
 - `metadata_agent.yaml` – Artist/album metadata
 - `scrobbler.yaml` – Scrobbling integration
 - `lifecycle.yaml` – Init callbacks

--- a/plugins/pdk/rust/nd-pdk-host/README.md
+++ b/plugins/pdk/rust/nd-pdk-host/README.md
@@ -84,4 +84,4 @@ Rust plugins must be compiled to WebAssembly:
 cargo build --target wasm32-wasip1 --release
 ```
 
-See the [webhook-rs](../../examples/webhook-rs/) example for a complete plugin implementation.
+See the [webhook-rs](../../../examples/webhook-rs/) example for a complete plugin implementation.

--- a/server/jellyfin/README.md
+++ b/server/jellyfin/README.md
@@ -3,7 +3,7 @@
 This package implements a subset of the [Jellyfin](https://jellyfin.org/) REST API on top of
 Navidrome's existing library, users, playlists and scrobbling infrastructure. It lets
 Jellyfin-compatible clients (e.g. [Finamp](https://github.com/jmshrv/finamp),
-[jftui](https://github.com/dylanmtaylor/jftui)) browse and stream a Navidrome library without
+[jftui](https://github.com/Aanok/jftui)) browse and stream a Navidrome library without
 requiring a real Jellyfin server.
 
 It is **not** a full Jellyfin server implementation: only the endpoints needed to browse a music


### PR DESCRIPTION
Fixes three dead or incorrect links found while checking documentation links:

- `server/jellyfin/README.md`: the jftui client link pointed to `dylanmtaylor/jftui`, which no longer exists. It now points to the canonical repository, `Aanok/jftui` (confirmed via the GitHub API).
- `plugins/pdk/rust/nd-pdk-host/README.md`: the relative link to the webhook-rs example was missing one directory level, so it resolved to a non-existent path (`plugins/pdk/examples/webhook-rs`). It now resolves to the actual example at `plugins/examples/webhook-rs`.
- `plugins/examples/README.md`: referenced `../schemas/`, which does not exist — the capability schema files live in `plugins/capabilities/`. Updated both the `--schema-file` example and the directory link; all five schema files listed in that section exist there.

Verified by resolving the relative paths locally and checking the replacement GitHub repository exists.