### PR TITLE
docs(jellyfin): correct the rationale for the public image endpoint

### DIFF
--- a/server/jellyfin/images.go
+++ b/server/jellyfin/images.go
@@ -34,8 +34,8 @@ func imageSize(maxWidth, maxHeight int) int {
 }
 
 func (api *Router) getItemImage(w http.ResponseWriter, r *http.Request) {
-	// Public endpoint, like real Jellyfin's image routes: clients fetch cover URLs without credentials
-	// and item ids are unguessable, so resolution runs elevated to bypass the visibility filter.
+	// Public, like Jellyfin's own image routes: clients build cover URLs without credentials, and
+	// upstream resolves them with no visibility check either (LibraryManager.ItemIsVisible, null user).
 	ctx := request.WithUser(r.Context(), model.User{IsAdmin: true})
 	itemId, ok := itemIDParam(w, r, "itemId")
 	if !ok {


### PR DESCRIPTION
### Description

The comment on the anonymous image route justified it with "item ids are unguessable". That is not true — an artist id is a deterministic, unsalted hash of the artist name (`id.NewHash(id.NewHash(str.Clear(lower(name))))`), so it is computable offline. The real reason is that upstream Jellyfin's image route is public too, so the comment now says that instead.

Verified identical on `v12.0`, `master` (13.0.0), `v10.11.9` and `v10.10.7`: `ImageController.GetItemImage` has no `[Authorize]` (other methods in that file do), and an anonymous request hits `LibraryManager.ItemIsVisible` with a null user, which returns `true` unconditionally.

Comment only, no behavior change.

### Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [x] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not) — comment-only change
- [x] All existing and new tests pass

### How to Test

Nothing to exercise at runtime. The diff touches only a comment.
