### PR TITLE
fix(ui): round the album grid hover overlay in the Nautiline theme

### DIFF
--- a/ui/src/themes/nautiline.js
+++ b/ui/src/themes/nautiline.js
@@ -598,11 +598,9 @@ const NautilineTheme = {
       },
     },
     NDAlbumGridView: {
-      albumContainer: {
+      link: {
         borderRadius: radii.md,
-        '& img': {
-          borderRadius: radii.md,
-        },
+        overflow: 'hidden',
       },
       albumTitle: {
         fontWeight: 600,

--- a/ui/src/themes/theme.test.js
+++ b/ui/src/themes/theme.test.js
@@ -12,3 +12,25 @@ describe('NDPlaylistDetails styles', () => {
     },
   )
 })
+
+describe('NDAlbumGridView styles', () => {
+  const themeEntries = Object.entries(themes)
+
+  // The hover overlay is a sibling of the image, so it keeps square corners.
+  it.each(themeEntries)(
+    '%s should not round the grid cover image on its own',
+    (themeName, theme) => {
+      const container = theme.overrides?.NDAlbumGridView?.albumContainer
+      expect(container?.['& img']?.borderRadius).toBeUndefined()
+    },
+  )
+
+  it.each(themeEntries)(
+    '%s should clip the grid cover link when it is rounded',
+    (themeName, theme) => {
+      const link = theme.overrides?.NDAlbumGridView?.link
+      if (!link?.borderRadius) return
+      expect(link.overflow).toBe('hidden')
+    },
+  )
+})


### PR DESCRIPTION
### Description
The Nautiline theme rounded the album grid cover by setting `borderRadius` on the image itself, plus a `borderRadius` on `albumContainer`. That container has no background and no clipping, so its radius rounded nothing. The hover overlay (`GridListTileBar`) is a sibling of the image inside the same link, so it kept square corners that poked out over the rounded cover on hover.

This moves the radius onto that link and adds `overflow: hidden`, so the image and the overlay are clipped by the same rounded box. It also covers the mobile variant, where the bar is always visible.

I also added a cross-theme test in `theme.test.js` (same style as the existing `NDPlaylistDetails` one) so no theme can round the grid cover image on its own again, and so any theme that rounds the cover link must also clip it.

### Related Issues
Fixes #6110

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [ ] Other (please describe):

### Checklist
Please review and check all that apply:

- [x] My code follows the project’s coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test
1. Start the server and open the web UI.
2. In Personal settings, select the **Nautiline** theme.
3. Go to the Albums page and switch to grid view.
4. Hover an album cover and look at the bottom corners: they should stay rounded, matching the cover.
5. Repeat at a narrow viewport (mobile breakpoint), where the bar is always visible — its bottom corners should be rounded too.
6. Open the three-dot context menu on a tile to confirm the popup is not clipped by the new `overflow: hidden`.
7. Spot-check another rounded-container theme (e.g. Spotify-ish or Nord) to confirm nothing changed there.

Verified in a browser: before the fix, the pixel at the overlay's bottom-left corner belonged to `GridListTileBar`; after, it is clipped away.

### Additional Notes
`albumContainer` in this theme had no background or border, so dropping its `borderRadius` is a no-op visually. Themes that round `albumContainer` and also set `padding` (Spotify-ish, Nord, Dracula, Tokyo Night, Ligera, SquiddiesGlass) are unaffected — their padding keeps the overlay away from the rounded corners, so they never showed this.
