### PR TITLE
build(docker): add curl to container image (#6111)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,7 @@ LABEL org.opencontainers.image.source="https://github.com/navidrome/navidrome"
 # - libwebp + symlinks: enables native WebP encoding via purego/dlopen
 # The mesa/LLVM stack mpv pulls in for video output is dropped in this same layer,
 # otherwise the deleted bytes still ship in the image.
-RUN apk add -U --no-cache ffmpeg mpv sqlite libwebp libwebpdemux libwebpmux && \
+RUN apk add -U --no-cache curl ffmpeg mpv sqlite libwebp libwebpdemux libwebpmux && \
     for lib in libwebp libwebpdemux libwebpmux; do \
         target=$(ls /usr/lib/$lib.so.* 2>/dev/null | head -1) && \
         [ -n "$target" ] && ln -sf "$target" /usr/lib/$lib.so; \


### PR DESCRIPTION
### Description
Adds to curl to container image which is useful for healthchecks when exposing the server through a unix socket inside a container.

### Related Issues
Related to #6111

### Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor
- [X] Other (please describe): Add runtime package to container image

### Checklist
Please review and check all that apply:

- [X] My code follows the project’s coding style
- [X] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [ ] I have added tests that prove my fix/feature works (or explain why not)
- [X] All existing and new tests pass

### How to Test
- Example healthcheck with TCP socket
```bash
curl -fs http://localhost:4533/ping
```
- Example healthcheck with UNIX socket
```bash
curl -fs --unix-socket /run/navidrome/navidrome.sock http://localhost/ping
```
This addresses should be adjusted depending on the server listening address

### Additional Notes
I haven't added a HEALTHCHECK to the container image because it would differ when the server is exposed on a Unix Socket or via TCP. 
