### PR TITLE
fix(subsonic): honor DefaultDownloadableShare in createShare

### DIFF
--- a/server/subsonic/e2e/subsonic_sharing_test.go
+++ b/server/subsonic/e2e/subsonic_sharing_test.go
@@ -205,3 +205,79 @@ var _ = Describe("Sharing Cross-User Isolation", Ordered, func() {
 		Expect(check.Shares.Share[0].ID).To(Equal(shareID))
 	})
 })
+
+var _ = Describe("Sharing Downloadable Default", func() {
+	var albumID string
+
+	BeforeEach(func() {
+		conf.Server.EnableSharing = true
+		conf.Server.EnableDownloads = true
+		setupTestDB()
+
+		albums, err := ds.Album(ctx).GetAll(model.QueryOptions{
+			Filters: squirrel.Eq{"album.name": "Abbey Road"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(albums).ToNot(BeEmpty())
+		albumID = albums[0].ID
+	})
+
+	createShare := func(params ...string) *model.Share {
+		resp := doReq("createShare", append([]string{"id", albumID}, params...)...)
+		Expect(resp.Status).To(Equal(responses.StatusOK))
+		Expect(resp.Shares.Share).To(HaveLen(1))
+		share, err := ds.Share(ctx).Get(resp.Shares.Share[0].ID)
+		Expect(err).ToNot(HaveOccurred())
+		return share
+	}
+
+	It("applies DefaultDownloadableShare when the param is absent", func() {
+		conf.Server.DefaultDownloadableShare = true
+
+		Expect(createShare().Downloadable).To(BeTrue())
+	})
+
+	It("keeps shares non-downloadable when the default is off", func() {
+		conf.Server.DefaultDownloadableShare = false
+
+		Expect(createShare().Downloadable).To(BeFalse())
+	})
+
+	It("lets an explicit downloadable=false override the default", func() {
+		conf.Server.DefaultDownloadableShare = true
+
+		Expect(createShare("downloadable", "false").Downloadable).To(BeFalse())
+	})
+
+	It("lets an explicit downloadable=true override the default", func() {
+		conf.Server.DefaultDownloadableShare = false
+
+		Expect(createShare("downloadable", "true").Downloadable).To(BeTrue())
+	})
+
+	It("updateShare keeps the current downloadable when the param is absent", func() {
+		conf.Server.DefaultDownloadableShare = true
+		share := createShare()
+		Expect(share.Downloadable).To(BeTrue())
+
+		resp := doReq("updateShare", "id", share.ID, "description", "Updated")
+		Expect(resp.Status).To(Equal(responses.StatusOK))
+
+		updated, err := ds.Share(ctx).Get(share.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.Description).To(Equal("Updated"))
+		Expect(updated.Downloadable).To(BeTrue())
+	})
+
+	It("updateShare applies an explicit downloadable", func() {
+		conf.Server.DefaultDownloadableShare = true
+		share := createShare()
+
+		resp := doReq("updateShare", "id", share.ID, "downloadable", "false")
+		Expect(resp.Status).To(Equal(responses.StatusOK))
+
+		updated, err := ds.Share(ctx).Get(share.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.Downloadable).To(BeFalse())
+	})
+})

--- a/server/subsonic/e2e/subsonic_sharing_test.go
+++ b/server/subsonic/e2e/subsonic_sharing_test.go
@@ -211,18 +211,13 @@ var _ = Describe("Sharing Downloadable Default", func() {
 
 	BeforeEach(func() {
 		conf.Server.EnableSharing = true
-		conf.Server.EnableDownloads = true
 		setupTestDB()
-
-		albums, err := ds.Album(ctx).GetAll(model.QueryOptions{
-			Filters: squirrel.Eq{"album.name": "Abbey Road"},
-		})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(albums).ToNot(BeEmpty())
-		albumID = albums[0].ID
+		conf.Server.EnableDownloads = true
+		albumID = albumIDByName("Abbey Road")
 	})
 
 	createShare := func(params ...string) *model.Share {
+		GinkgoHelper()
 		resp := doReq("createShare", append([]string{"id", albumID}, params...)...)
 		Expect(resp.Status).To(Equal(responses.StatusOK))
 		Expect(resp.Shares.Share).To(HaveLen(1))
@@ -231,29 +226,19 @@ var _ = Describe("Sharing Downloadable Default", func() {
 		return share
 	}
 
-	It("applies DefaultDownloadableShare when the param is absent", func() {
-		conf.Server.DefaultDownloadableShare = true
+	DescribeTable("createShare resolves downloadable",
+		func(defaultDownloadable, enableDownloads bool, params []string, expected bool) {
+			conf.Server.DefaultDownloadableShare = defaultDownloadable
+			conf.Server.EnableDownloads = enableDownloads
 
-		Expect(createShare().Downloadable).To(BeTrue())
-	})
-
-	It("keeps shares non-downloadable when the default is off", func() {
-		conf.Server.DefaultDownloadableShare = false
-
-		Expect(createShare().Downloadable).To(BeFalse())
-	})
-
-	It("lets an explicit downloadable=false override the default", func() {
-		conf.Server.DefaultDownloadableShare = true
-
-		Expect(createShare("downloadable", "false").Downloadable).To(BeFalse())
-	})
-
-	It("lets an explicit downloadable=true override the default", func() {
-		conf.Server.DefaultDownloadableShare = false
-
-		Expect(createShare("downloadable", "true").Downloadable).To(BeTrue())
-	})
+			Expect(createShare(params...).Downloadable).To(Equal(expected))
+		},
+		Entry("applies the default when the param is absent", true, true, nil, true),
+		Entry("stays off when the default is off", false, true, nil, false),
+		Entry("ignores the default when downloads are disabled", true, false, nil, false),
+		Entry("honors an explicit false over the default", true, true, []string{"downloadable", "false"}, false),
+		Entry("honors an explicit true over the default", false, true, []string{"downloadable", "true"}, true),
+	)
 
 	It("updateShare keeps the current downloadable when the param is absent", func() {
 		conf.Server.DefaultDownloadableShare = true

--- a/server/subsonic/sharing.go
+++ b/server/subsonic/sharing.go
@@ -62,7 +62,7 @@ func (api *Router) CreateShare(r *http.Request) (*responses.Subsonic, error) {
 	repo := api.share.NewRepository(r.Context())
 	share := &model.Share{
 		Description:  description,
-		Downloadable: p.BoolOr("downloadable", conf.Server.DefaultDownloadableShare),
+		Downloadable: p.BoolOr("downloadable", conf.Server.DefaultDownloadableShare && conf.Server.EnableDownloads),
 		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
 		ResourceIDs:  strings.Join(ids, ","),
 	}
@@ -92,17 +92,21 @@ func (api *Router) UpdateShare(r *http.Request) (*responses.Subsonic, error) {
 	description, _ := p.String("description")
 	repo := api.share.NewRepository(r.Context())
 
-	// The update always writes the downloadable column, so fall back to the
-	// current value when the client omits the parameter.
-	current, err := repo.(model.ShareRepository).Get(id)
-	if err != nil {
-		return nil, err
+	// The update always writes the downloadable column, so read back the stored
+	// value when the client omits the parameter.
+	downloadable := p.BoolPtr("downloadable")
+	if downloadable == nil {
+		current, err := repo.Read(id)
+		if err != nil {
+			return nil, err
+		}
+		downloadable = &current.(*model.Share).Downloadable
 	}
 
 	share := &model.Share{
 		ID:           id,
 		Description:  description,
-		Downloadable: p.BoolOr("downloadable", current.Downloadable),
+		Downloadable: *downloadable,
 		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
 	}
 

--- a/server/subsonic/sharing.go
+++ b/server/subsonic/sharing.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/public"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
@@ -60,9 +61,10 @@ func (api *Router) CreateShare(r *http.Request) (*responses.Subsonic, error) {
 	description, _ := p.String("description")
 	repo := api.share.NewRepository(r.Context())
 	share := &model.Share{
-		Description: description,
-		ExpiresAt:   new(p.TimeOr("expires", time.Time{})),
-		ResourceIDs: strings.Join(ids, ","),
+		Description:  description,
+		Downloadable: p.BoolOr("downloadable", conf.Server.DefaultDownloadableShare),
+		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
+		ResourceIDs:  strings.Join(ids, ","),
 	}
 
 	id, err := repo.(rest.Persistable).Save(share)
@@ -89,10 +91,19 @@ func (api *Router) UpdateShare(r *http.Request) (*responses.Subsonic, error) {
 
 	description, _ := p.String("description")
 	repo := api.share.NewRepository(r.Context())
+
+	// The update always writes the downloadable column, so fall back to the
+	// current value when the client omits the parameter.
+	current, err := repo.(model.ShareRepository).Get(id)
+	if err != nil {
+		return nil, err
+	}
+
 	share := &model.Share{
-		ID:          id,
-		Description: description,
-		ExpiresAt:   new(p.TimeOr("expires", time.Time{})),
+		ID:           id,
+		Description:  description,
+		Downloadable: p.BoolOr("downloadable", current.Downloadable),
+		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
 	}
 
 	err = repo.(rest.Persistable).Update(id, share)


### PR DESCRIPTION
### Description

`DefaultDownloadableShare` was only ever consumed by the web UI: the server injected it into `index.html` and `ShareDialog.jsx` used it to pre-tick the "Allow Downloads?" checkbox. Nothing on the server side ever read it, so the Subsonic `createShare` endpoint built the `model.Share` without touching `Downloadable` and fell through to the Go zero value. Every share created through the API was stored as non-downloadable, no matter how the server was configured — which is what a Symfonium user hit in #6119.

`createShare` now reads an optional `downloadable` parameter and falls back to the configured default when the client omits it. The default is ANDed with `EnableDownloads`, which is exactly what the UI computes, so both paths now apply the same rule rather than two different ones.

While writing the tests for that I found a second, related problem on the same field. `shareRepositoryWrapper.Update` in `core/share.go` unconditionally includes `downloadable` in the column list it writes, but the Subsonic `updateShare` handler never set the field — so *any* `updateShare` call silently reset the share to non-downloadable, including shares that had been created through the web UI. The handler now reads back the stored value, and only when the client omitted the parameter, so a client that does send it pays no extra query.

I deliberately did not move the default down into `core`, next to where `DefaultShareExpiration` is already applied. `Downloadable` is a plain `bool`, and the Native API's create path decodes straight into the entity with no field list, so that layer cannot distinguish an omitted field from an explicit `false` — defaulting there would flip the value for a user who had deliberately unchecked the box in the UI. Making that work needs either a `*bool` on the model (nullable JSON on the Native API, plus every read path) or a bespoke POST handler, and neither is worth it for one boolean. The per-API default is the smaller correct fix.

### Related Issues

Fixes #6119

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

1. Set `DefaultDownloadableShare = true` in `navidrome.toml` and start the server.
2. Create a share through the Subsonic API:
   ```
   curl "http://localhost:4533/rest/createShare.view?u=admin&p=xxx&v=1.16.1&c=test&f=json&id=<albumID>&description=test"
   ```
3. Check the DB: `SELECT id, downloadable FROM share ORDER BY created_at DESC LIMIT 1;` — it should now be `1`. Before this change it was `0`.
4. Pass `&downloadable=false` on the same call and confirm the explicit value wins over the default.
5. Set `DefaultDownloadableShare = false` and confirm a plain `createShare` stores `0`, and that `&downloadable=true` stores `1`.
6. Set `EnableDownloads = false` with `DefaultDownloadableShare = true` and confirm a plain `createShare` stores `0`, matching what the web UI does with the same config.
7. Take a downloadable share and call `updateShare` with only `id` and `description`. Confirm `downloadable` is still `1` — on master it gets reset to `0`.
8. Create a share through the web UI with `DefaultDownloadableShare = true` and confirm it is still downloadable, i.e. the UI path is unchanged.

The e2e coverage for all of the above lives in `server/subsonic/e2e/subsonic_sharing_test.go`:

```
make test PKG=./server/subsonic/e2e/
```

### Additional Notes

The Subsonic `<share>` response element has no `downloadable` attribute, so a client can set the flag but cannot read it back. That is why the new specs assert against the stored share rather than the API response. Not addressed here.

There is a deeper fix available that I chose not to bundle into this PR. `shareRepositoryWrapper.Update` has the signature `Update(id string, entity any, _ ...string)` — it discards the caller's column list and substitutes a hardcoded one. The layers below it already honour the passed columns correctly, and the rest layer's `Put` already computes the exact keys the client sent, so that information is being thrown away one level up. Teaching the wrapper to intersect the caller's columns with its allowlist would remove the read-back added here and would also fix the mirror-image bug this PR does not touch: a Subsonic `updateShare` that sends only `downloadable` still blanks the description. I left it out because that hardcoded list is a write allowlist with security significance (an empty column set means "write everything" downstream), the column names arrive camelCased and the snake-case conversion is private to `persistence`, and honouring the sent keys verbatim would change how share expiration is written on the Native API path. Worth its own PR with its own tests.
