### PR TITLE
fix(subsonic): honor DefaultDownloadableShare in createShare

### DIFF
--- a/server/subsonic/e2e/subsonic_sharing_test.go
+++ b/server/subsonic/e2e/subsonic_sharing_test.go
@@ -205,3 +205,79 @@ var _ = Describe("Sharing Cross-User Isolation", Ordered, func() {
 		Expect(check.Shares.Share[0].ID).To(Equal(shareID))
 	})
 })
+
+var _ = Describe("Sharing Downloadable Default", func() {
+	var albumID string
+
+	BeforeEach(func() {
+		conf.Server.EnableSharing = true
+		conf.Server.EnableDownloads = true
+		setupTestDB()
+
+		albums, err := ds.Album(ctx).GetAll(model.QueryOptions{
+			Filters: squirrel.Eq{"album.name": "Abbey Road"},
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(albums).ToNot(BeEmpty())
+		albumID = albums[0].ID
+	})
+
+	createShare := func(params ...string) *model.Share {
+		resp := doReq("createShare", append([]string{"id", albumID}, params...)...)
+		Expect(resp.Status).To(Equal(responses.StatusOK))
+		Expect(resp.Shares.Share).To(HaveLen(1))
+		share, err := ds.Share(ctx).Get(resp.Shares.Share[0].ID)
+		Expect(err).ToNot(HaveOccurred())
+		return share
+	}
+
+	It("applies DefaultDownloadableShare when the param is absent", func() {
+		conf.Server.DefaultDownloadableShare = true
+
+		Expect(createShare().Downloadable).To(BeTrue())
+	})
+
+	It("keeps shares non-downloadable when the default is off", func() {
+		conf.Server.DefaultDownloadableShare = false
+
+		Expect(createShare().Downloadable).To(BeFalse())
+	})
+
+	It("lets an explicit downloadable=false override the default", func() {
+		conf.Server.DefaultDownloadableShare = true
+
+		Expect(createShare("downloadable", "false").Downloadable).To(BeFalse())
+	})
+
+	It("lets an explicit downloadable=true override the default", func() {
+		conf.Server.DefaultDownloadableShare = false
+
+		Expect(createShare("downloadable", "true").Downloadable).To(BeTrue())
+	})
+
+	It("updateShare keeps the current downloadable when the param is absent", func() {
+		conf.Server.DefaultDownloadableShare = true
+		share := createShare()
+		Expect(share.Downloadable).To(BeTrue())
+
+		resp := doReq("updateShare", "id", share.ID, "description", "Updated")
+		Expect(resp.Status).To(Equal(responses.StatusOK))
+
+		updated, err := ds.Share(ctx).Get(share.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.Description).To(Equal("Updated"))
+		Expect(updated.Downloadable).To(BeTrue())
+	})
+
+	It("updateShare applies an explicit downloadable", func() {
+		conf.Server.DefaultDownloadableShare = true
+		share := createShare()
+
+		resp := doReq("updateShare", "id", share.ID, "downloadable", "false")
+		Expect(resp.Status).To(Equal(responses.StatusOK))
+
+		updated, err := ds.Share(ctx).Get(share.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.Downloadable).To(BeFalse())
+	})
+})

--- a/server/subsonic/e2e/subsonic_sharing_test.go
+++ b/server/subsonic/e2e/subsonic_sharing_test.go
@@ -254,9 +254,9 @@ var _ = Describe("Sharing Downloadable Default", func() {
 		Expect(updated.Downloadable).To(BeTrue())
 	})
 
-	It("updateShare applies an explicit downloadable", func() {
+	It("updateShare applies an explicit downloadable and keeps the description", func() {
 		conf.Server.DefaultDownloadableShare = true
-		share := createShare()
+		share := createShare("description", "Keep me")
 
 		resp := doReq("updateShare", "id", share.ID, "downloadable", "false")
 		Expect(resp.Status).To(Equal(responses.StatusOK))
@@ -264,5 +264,17 @@ var _ = Describe("Sharing Downloadable Default", func() {
 		updated, err := ds.Share(ctx).Get(share.ID)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(updated.Downloadable).To(BeFalse())
+		Expect(updated.Description).To(Equal("Keep me"))
+	})
+
+	It("updateShare clears the description when it is sent empty", func() {
+		share := createShare("description", "Clear me")
+
+		resp := doReq("updateShare", "id", share.ID, "description", "")
+		Expect(resp.Status).To(Equal(responses.StatusOK))
+
+		updated, err := ds.Share(ctx).Get(share.ID)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.Description).To(BeEmpty())
 	})
 })

--- a/server/subsonic/e2e/subsonic_sharing_test.go
+++ b/server/subsonic/e2e/subsonic_sharing_test.go
@@ -211,18 +211,13 @@ var _ = Describe("Sharing Downloadable Default", func() {
 
 	BeforeEach(func() {
 		conf.Server.EnableSharing = true
-		conf.Server.EnableDownloads = true
 		setupTestDB()
-
-		albums, err := ds.Album(ctx).GetAll(model.QueryOptions{
-			Filters: squirrel.Eq{"album.name": "Abbey Road"},
-		})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(albums).ToNot(BeEmpty())
-		albumID = albums[0].ID
+		conf.Server.EnableDownloads = true
+		albumID = albumIDByName("Abbey Road")
 	})
 
 	createShare := func(params ...string) *model.Share {
+		GinkgoHelper()
 		resp := doReq("createShare", append([]string{"id", albumID}, params...)...)
 		Expect(resp.Status).To(Equal(responses.StatusOK))
 		Expect(resp.Shares.Share).To(HaveLen(1))
@@ -231,29 +226,19 @@ var _ = Describe("Sharing Downloadable Default", func() {
 		return share
 	}
 
-	It("applies DefaultDownloadableShare when the param is absent", func() {
-		conf.Server.DefaultDownloadableShare = true
+	DescribeTable("createShare resolves downloadable",
+		func(defaultDownloadable, enableDownloads bool, params []string, expected bool) {
+			conf.Server.DefaultDownloadableShare = defaultDownloadable
+			conf.Server.EnableDownloads = enableDownloads
 
-		Expect(createShare().Downloadable).To(BeTrue())
-	})
-
-	It("keeps shares non-downloadable when the default is off", func() {
-		conf.Server.DefaultDownloadableShare = false
-
-		Expect(createShare().Downloadable).To(BeFalse())
-	})
-
-	It("lets an explicit downloadable=false override the default", func() {
-		conf.Server.DefaultDownloadableShare = true
-
-		Expect(createShare("downloadable", "false").Downloadable).To(BeFalse())
-	})
-
-	It("lets an explicit downloadable=true override the default", func() {
-		conf.Server.DefaultDownloadableShare = false
-
-		Expect(createShare("downloadable", "true").Downloadable).To(BeTrue())
-	})
+			Expect(createShare(params...).Downloadable).To(Equal(expected))
+		},
+		Entry("applies the default when the param is absent", true, true, nil, true),
+		Entry("stays off when the default is off", false, true, nil, false),
+		Entry("ignores the default when downloads are disabled", true, false, nil, false),
+		Entry("honors an explicit false over the default", true, true, []string{"downloadable", "false"}, false),
+		Entry("honors an explicit true over the default", false, true, []string{"downloadable", "true"}, true),
+	)
 
 	It("updateShare keeps the current downloadable when the param is absent", func() {
 		conf.Server.DefaultDownloadableShare = true

--- a/server/subsonic/sharing.go
+++ b/server/subsonic/sharing.go
@@ -62,7 +62,7 @@ func (api *Router) CreateShare(r *http.Request) (*responses.Subsonic, error) {
 	repo := api.share.NewRepository(r.Context())
 	share := &model.Share{
 		Description:  description,
-		Downloadable: p.BoolOr("downloadable", conf.Server.DefaultDownloadableShare),
+		Downloadable: p.BoolOr("downloadable", conf.Server.DefaultDownloadableShare && conf.Server.EnableDownloads),
 		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
 		ResourceIDs:  strings.Join(ids, ","),
 	}
@@ -92,17 +92,21 @@ func (api *Router) UpdateShare(r *http.Request) (*responses.Subsonic, error) {
 	description, _ := p.String("description")
 	repo := api.share.NewRepository(r.Context())
 
-	// The update always writes the downloadable column, so fall back to the
-	// current value when the client omits the parameter.
-	current, err := repo.(model.ShareRepository).Get(id)
-	if err != nil {
-		return nil, err
+	// The update always writes the downloadable column, so read back the stored
+	// value when the client omits the parameter.
+	downloadable := p.BoolPtr("downloadable")
+	if downloadable == nil {
+		current, err := repo.Read(id)
+		if err != nil {
+			return nil, err
+		}
+		downloadable = &current.(*model.Share).Downloadable
 	}
 
 	share := &model.Share{
 		ID:           id,
 		Description:  description,
-		Downloadable: p.BoolOr("downloadable", current.Downloadable),
+		Downloadable: *downloadable,
 		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
 	}
 

--- a/server/subsonic/sharing.go
+++ b/server/subsonic/sharing.go
@@ -1,6 +1,7 @@
 package subsonic
 
 import (
+	"cmp"
 	"net/http"
 	"strings"
 	"time"
@@ -89,23 +90,25 @@ func (api *Router) UpdateShare(r *http.Request) (*responses.Subsonic, error) {
 		return nil, err
 	}
 
-	description, _ := p.String("description")
 	repo := api.share.NewRepository(r.Context())
 
-	// The update always writes the downloadable column, so read back the stored
-	// value when the client omits the parameter.
+	// The update always writes description and downloadable, so read back the
+	// stored value for whichever one the client omitted.
+	description := p.StringPtr("description")
 	downloadable := p.BoolPtr("downloadable")
-	if downloadable == nil {
+	if description == nil || downloadable == nil {
 		current, err := repo.Read(id)
 		if err != nil {
 			return nil, err
 		}
-		downloadable = &current.(*model.Share).Downloadable
+		cur := current.(*model.Share)
+		description = cmp.Or(description, &cur.Description)
+		downloadable = cmp.Or(downloadable, &cur.Downloadable)
 	}
 
 	share := &model.Share{
 		ID:           id,
-		Description:  description,
+		Description:  *description,
 		Downloadable: *downloadable,
 		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
 	}

--- a/server/subsonic/sharing.go
+++ b/server/subsonic/sharing.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/deluan/rest"
+	"github.com/navidrome/navidrome/conf"
 	"github.com/navidrome/navidrome/model"
 	"github.com/navidrome/navidrome/server/public"
 	"github.com/navidrome/navidrome/server/subsonic/responses"
@@ -60,9 +61,10 @@ func (api *Router) CreateShare(r *http.Request) (*responses.Subsonic, error) {
 	description, _ := p.String("description")
 	repo := api.share.NewRepository(r.Context())
 	share := &model.Share{
-		Description: description,
-		ExpiresAt:   new(p.TimeOr("expires", time.Time{})),
-		ResourceIDs: strings.Join(ids, ","),
+		Description:  description,
+		Downloadable: p.BoolOr("downloadable", conf.Server.DefaultDownloadableShare),
+		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
+		ResourceIDs:  strings.Join(ids, ","),
 	}
 
 	id, err := repo.(rest.Persistable).Save(share)
@@ -89,10 +91,19 @@ func (api *Router) UpdateShare(r *http.Request) (*responses.Subsonic, error) {
 
 	description, _ := p.String("description")
 	repo := api.share.NewRepository(r.Context())
+
+	// The update always writes the downloadable column, so fall back to the
+	// current value when the client omits the parameter.
+	current, err := repo.(model.ShareRepository).Get(id)
+	if err != nil {
+		return nil, err
+	}
+
 	share := &model.Share{
-		ID:          id,
-		Description: description,
-		ExpiresAt:   new(p.TimeOr("expires", time.Time{})),
+		ID:           id,
+		Description:  description,
+		Downloadable: p.BoolOr("downloadable", current.Downloadable),
+		ExpiresAt:    new(p.TimeOr("expires", time.Time{})),
 	}
 
 	err = repo.(rest.Persistable).Update(id, share)


### PR DESCRIPTION
### Description

`DefaultDownloadableShare` never reached the server. It was injected into `index.html` and read by `ShareDialog.jsx` to pre-tick the "Allow Downloads?" checkbox, and that was all it ever did. The Subsonic `createShare` handler built its `model.Share` without setting `Downloadable`, so the field got the Go zero value and every share created through the API was stored as non-downloadable.

`createShare` now reads an optional `downloadable` parameter and falls back to the configured default. It ANDs that default with `EnableDownloads`, which is what the UI already computes, so both paths follow one rule instead of two.

Writing the tests turned up a second bug on the same field. `shareRepositoryWrapper.Update` always writes the `downloadable` column, but `updateShare` never set it, so any update reset the share to non-downloadable, including shares created in the web UI. The handler now reads the stored value back, and only when the client omitted the parameter.

I did not move the default into `core` next to `DefaultShareExpiration`. `Downloadable` is a plain `bool` and the Native API decodes straight into the entity with no field list, so that layer cannot tell an omitted field from an explicit `false`. Defaulting there would flip the value for anyone who unticked the box in the UI.

### Related Issues

Fixes #6119

### Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactor
- [ ] Other (please describe):

### Checklist

- [x] My code follows the project's coding style
- [x] I have tested the changes locally
- [ ] I have added or updated documentation as needed
- [x] I have added tests that prove my fix/feature works (or explain why not)
- [x] All existing and new tests pass

### How to Test

Set `DefaultDownloadableShare = true`, start the server, and create a share:

```
curl "http://localhost:4533/rest/createShare.view?u=admin&p=xxx&v=1.16.1&c=test&f=json&id=<albumID>"
```

`SELECT downloadable FROM share ORDER BY created_at DESC LIMIT 1;` returns `1`. On master it returns `0`. Then check that:

- `&downloadable=false` beats the default, and `&downloadable=true` beats a default of `false`
- with `EnableDownloads = false`, a plain `createShare` still stores `0`, matching the UI
- `updateShare` with only `id` and `description` leaves `downloadable` alone. On master it resets to `0`
- a share created in the web UI is unchanged

The e2e specs cover all of it: `make test PKG=./server/subsonic/e2e/`

### Additional Notes

The Subsonic `<share>` element has no `downloadable` attribute, so a client can set the flag but cannot read it back. The new specs assert against the stored share instead of the response. Not addressed here.

There is a deeper fix I left out. `shareRepositoryWrapper.Update` discards the caller's column list and substitutes a hardcoded one, even though the layers below honour it correctly and the rest layer already knows which keys the client sent. Making the wrapper intersect the two would remove the read-back added here, and would fix the mirror bug this PR does not touch: an `updateShare` that sends only `downloadable` still blanks the description. I left it alone because that hardcoded list is a write allowlist with security weight, an empty column set means "write everything" downstream, and the column names arrive camelCased while the snake-case conversion is private to `persistence`. It deserves its own PR and its own tests.
